### PR TITLE
[Bugfix] Fix stuck TransferProcesses when resources are not managed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ distributions/azure/azure.properties
 **/terraform.tfvars
 **/.terraform*
 launchers/demo-e2e/edc-config.properties
+**/out

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
@@ -32,11 +32,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import static java.lang.String.format;
+import static java.util.UUID.randomUUID;
 import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess.Type.CLIENT;
 import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess.Type.PROVIDER;
 import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.*;
-import static java.lang.String.format;
-import static java.util.UUID.randomUUID;
 
 /**
  *
@@ -182,7 +182,8 @@ public class TransferProcessManagerImpl extends TransferProcessObservable implem
         List<TransferProcess> requestAcked = transferProcessStore.nextForState(TransferProcessStates.REQUESTED_ACK.code(), batchSize);
 
         for (var process : requestAcked) {
-            if (process.getProvisionedResourceSet() != null && !process.getProvisionedResourceSet().empty()) {
+            // process must either have a non-empty list of provisioned resources, or not have managed resources at all.
+            if (!process.getDataRequest().isManagedResources() || (process.getProvisionedResourceSet() != null && !process.getProvisionedResourceSet().empty())) {
 
                 if (process.getDataRequest().getTransferType().isFinite()) {
                     process.transitionInProgress();
@@ -194,6 +195,7 @@ public class TransferProcessManagerImpl extends TransferProcessObservable implem
             } else {
                 monitor.debug("Process " + process.getId() + " does not yet have provisioned resources, will stay in " + TransferProcessStates.REQUESTED_ACK);
             }
+
             transferProcessStore.update(process);
         }
 
@@ -212,14 +214,20 @@ public class TransferProcessManagerImpl extends TransferProcessObservable implem
 
         for (var process : processesInProgress.stream().filter(p -> p.getType() == CLIENT).collect(Collectors.toList())) {
 
-            List<ProvisionedResource> resources = process.getProvisionedResourceSet().getResources().stream().filter(this::hasChecker).collect(Collectors.toList());
+            if (process.getDataRequest().isManagedResources()) {
+                List<ProvisionedResource> resources = process.getProvisionedResourceSet().getResources().stream().filter(this::hasChecker).collect(Collectors.toList());
 
-            // update the process once ALL resources are completed
-            if (resources.stream().allMatch(this::isComplete)) {
+                // update the process once ALL resources are completed
+                if (resources.stream().allMatch(this::isComplete)) {
+                    process.transitionCompleted();
+                    monitor.debug("Process " + process.getId() + " is now " + TransferProcessStates.COMPLETED);
+                    invokeForEach(listener -> listener.completed(process));
+                }
+            } else {
+                //no managed resources, just update
                 process.transitionCompleted();
                 monitor.debug("Process " + process.getId() + " is now " + TransferProcessStates.COMPLETED);
                 invokeForEach(listener -> listener.completed(process));
-
             }
             transferProcessStore.update(process);
         }

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplConsumerTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplConsumerTest.java
@@ -51,6 +51,8 @@ class TransferProcessManagerImplConsumerTest {
         DataFlowManager dataFlowManager = mock(DataFlowManager.class);
         dispatcherRegistry = mock(RemoteMessageDispatcherRegistry.class);
         ResourceManifestGenerator manifestGenerator = mock(ResourceManifestGenerator.class);
+        expect(manifestGenerator.generateClientManifest(anyObject(TransferProcess.class))).andReturn(new ResourceManifest()).anyTimes();
+        replay(manifestGenerator);
 
         statusCheckerRegistry = mock(StatusCheckerRegistry.class);
 
@@ -379,6 +381,7 @@ class TransferProcessManagerImplConsumerTest {
 
         DataRequest mock = niceMock(DataRequest.class);
         expect(mock.getTransferType()).andReturn(type).anyTimes();
+        expect(mock.isManagedResources()).andReturn(true).anyTimes();
         expect(mock.getId()).andReturn(processId).anyTimes();
         replay(mock);
         return TransferProcess.Builder.newInstance()


### PR DESCRIPTION
In the current implementation of the `TransferProcessManager` there was a bug that caused transfer processes, that have no managed resources, to be stuck in `REQUESTED_ACK` state. This PR fixes that by adding several checks.