### PR TITLE
ids-spi: fixed typo in artifactId of `data-protocols.ids-spi`

### DIFF
--- a/data-protocols/ids/ids-spi/build.gradle.kts
+++ b/data-protocols/ids/ids-spi/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
 publishing {
     publications {
         create<MavenPublication>("data-protocols.ids-spi") {
-            artifactId = "data-protocols..ids-spi"
+            artifactId = "data-protocols.ids-spi"
             from(components["java"])
         }
     }


### PR DESCRIPTION
Just a small typo that results in a weird package name when published to maven local.