### PR TITLE
Feature/183 remove reflective access from criterionconverter

### DIFF
--- a/extensions/iam/oauth2/src/test/java/org/eclipse/dataspaceconnector/iam/oauth2/impl/Oauth2ServiceImplTest.java
+++ b/extensions/iam/oauth2/src/test/java/org/eclipse/dataspaceconnector/iam/oauth2/impl/Oauth2ServiceImplTest.java
@@ -81,7 +81,7 @@ class Oauth2ServiceImplTest {
     @Test
     void verifyValidJwt() {
 
-        var jwt = createJwt("test.audience", new Date(System.currentTimeMillis() - 1000), new Date(System.currentTimeMillis() + 1000));
+        var jwt = createJwt("test.audience", new Date(System.currentTimeMillis() - 10000000), new Date(System.currentTimeMillis() + 10000000));
         var result = authService.verifyJwtToken(jwt.serialize(), "test.audience");
         assertThat(result.valid()).isTrue();
         assertThat(result.errors()).isNotNull().isEmpty();

--- a/extensions/in-memory/assetindex-memory/src/main/java/org/eclipse/dataspaceconnector/metadata/memory/CriterionToPredicateConverter.java
+++ b/extensions/in-memory/assetindex-memory/src/main/java/org/eclipse/dataspaceconnector/metadata/memory/CriterionToPredicateConverter.java
@@ -4,7 +4,6 @@ import org.eclipse.dataspaceconnector.spi.asset.Criterion;
 import org.eclipse.dataspaceconnector.spi.asset.CriterionConverter;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 
-import java.lang.reflect.Field;
 import java.util.Objects;
 import java.util.function.Predicate;
 
@@ -20,24 +19,14 @@ public class CriterionToPredicateConverter implements CriterionConverter<Predica
     @Override
     public Predicate<Asset> convert(Criterion criterion) {
         if ("=".equals(criterion.getOperator())) {
-            return asset -> Objects.equals(field((String) criterion.getOperandLeft(), asset), criterion.getOperandRight()) ||
-                    Objects.equals(label((String) criterion.getOperandLeft(), asset), criterion.getOperandRight());
+            return asset -> Objects.equals(property((String) criterion.getOperandLeft(), asset), criterion.getOperandRight());
         }
         throw new IllegalArgumentException(String.format("Operator [%s] is not supported by this converter!", criterion.getOperator()));
     }
 
-    private Object field(String fieldName, Asset asset) {
-        try {
-            Field declaredField = asset.getClass().getDeclaredField(fieldName);
-            declaredField.setAccessible(true);
-            return declaredField.get(asset);
-        } catch (IllegalAccessException | NoSuchFieldException e) {
-            return null;
-        }
-    }
 
-    private Object label(String key, Asset asset) {
-        if (asset.getProperties() == null || !asset.getProperties().isEmpty()) {
+    private Object property(String key, Asset asset) {
+        if (asset.getProperties() == null || asset.getProperties().isEmpty()) {
             return null;
         }
         return asset.getProperty(key);

--- a/extensions/in-memory/assetindex-memory/src/main/java/org/eclipse/dataspaceconnector/metadata/memory/CriterionToPredicateConverter.java
+++ b/extensions/in-memory/assetindex-memory/src/main/java/org/eclipse/dataspaceconnector/metadata/memory/CriterionToPredicateConverter.java
@@ -19,7 +19,13 @@ public class CriterionToPredicateConverter implements CriterionConverter<Predica
     @Override
     public Predicate<Asset> convert(Criterion criterion) {
         if ("=".equals(criterion.getOperator())) {
-            return asset -> Objects.equals(property((String) criterion.getOperandLeft(), asset), criterion.getOperandRight());
+            return asset -> {
+                Object property = property((String) criterion.getOperandLeft(), asset);
+                if (property == null) {
+                    return false; //property does not exist on asset
+                }
+                return Objects.equals(property, criterion.getOperandRight());
+            };
         }
         throw new IllegalArgumentException(String.format("Operator [%s] is not supported by this converter!", criterion.getOperator()));
     }

--- a/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/CriterionToPredicateConverterTest.java
+++ b/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/CriterionToPredicateConverterTest.java
@@ -5,8 +5,6 @@ import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.UUID;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -20,9 +18,38 @@ class CriterionToPredicateConverterTest {
     }
 
     @Test
-    void convert() {
-        var criterion = new Criterion("name", "=", "test-asset");
-        var asset = createAsset("test-asset");
+    void convert_nameEquals() {
+        var criterion = new Criterion(Asset.PROPERTY_NAME, "=", "test-asset");
+        var asset = Asset.Builder.newInstance()
+                .name("test-asset")
+                .build();
+        var predicate = converter.convert(criterion);
+
+        assertThat(predicate).isNotNull();
+        assertThat(predicate.test(asset)).isTrue();
+    }
+
+    @Test
+    void convert_versionEquals() {
+        var criterion = new Criterion(Asset.PROPERTY_VERSION, "=", "6.9");
+        var asset = Asset.Builder.newInstance()
+                .name("test-asset")
+                .version("6.9")
+                .build();
+        var predicate = converter.convert(criterion);
+
+        assertThat(predicate).isNotNull();
+        assertThat(predicate.test(asset)).isTrue();
+    }
+
+    @Test
+    void convert_anotherPropertyEquals() {
+        var criterion = new Criterion("test-property", "=", "somevalue");
+        var asset = Asset.Builder.newInstance()
+                .name("test-asset")
+                .version("6.9")
+                .property("test-property", "somevalue")
+                .build();
         var predicate = converter.convert(criterion);
 
         assertThat(predicate).isNotNull();
@@ -37,10 +64,4 @@ class CriterionToPredicateConverterTest {
 
     }
 
-    private Asset createAsset(String name) {
-        return Asset.Builder.newInstance()
-                .name(name)
-                .id(UUID.randomUUID().toString())
-                .build();
-    }
 }

--- a/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetIndexTest.java
+++ b/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetIndexTest.java
@@ -29,7 +29,7 @@ class InMemoryAssetIndexTest {
     void queryAssets() {
         var testAsset = createAsset("foobar");
         index.insert(testAsset, createDataAddress(testAsset));
-        var assets = index.queryAssets(AssetSelectorExpression.Builder.newInstance().whenEquals("name", "foobar").build());
+        var assets = index.queryAssets(AssetSelectorExpression.Builder.newInstance().whenEquals(Asset.PROPERTY_NAME, "foobar").build());
         assertThat(assets).hasSize(1).containsExactly(testAsset);
     }
 
@@ -37,7 +37,7 @@ class InMemoryAssetIndexTest {
     void queryAssets_notFound() {
         var testAsset = createAsset("foobar");
         index.insert(testAsset, createDataAddress(testAsset));
-        var assets = index.queryAssets(AssetSelectorExpression.Builder.newInstance().whenEquals("name", "barbaz").build());
+        var assets = index.queryAssets(AssetSelectorExpression.Builder.newInstance().whenEquals(Asset.PROPERTY_NAME, "barbaz").build());
         assertThat(assets).isEmpty();
     }
 

--- a/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetIndexTest.java
+++ b/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetIndexTest.java
@@ -19,7 +19,6 @@ import static org.easymock.EasyMock.niceMock;
 class InMemoryAssetIndexTest {
     private InMemoryAssetIndex index;
 
-
     @BeforeEach
     void setUp() {
         index = new InMemoryAssetIndex(new CriterionToPredicateConverter());

--- a/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetIndexTest.java
+++ b/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetIndexTest.java
@@ -28,7 +28,7 @@ class InMemoryAssetIndexTest {
     @Test
     void queryAssets() {
         var testAsset = createAsset("foobar");
-        index.insert(testAsset, niceMock(DataAddress.class));
+        index.insert(testAsset, createDataAddress(testAsset));
         var assets = index.queryAssets(AssetSelectorExpression.Builder.newInstance().whenEquals("name", "foobar").build());
         assertThat(assets).hasSize(1).containsExactly(testAsset);
     }
@@ -36,7 +36,7 @@ class InMemoryAssetIndexTest {
     @Test
     void queryAssets_notFound() {
         var testAsset = createAsset("foobar");
-        index.insert(testAsset, niceMock(DataAddress.class));
+        index.insert(testAsset, createDataAddress(testAsset));
         var assets = index.queryAssets(AssetSelectorExpression.Builder.newInstance().whenEquals("name", "barbaz").build());
         assertThat(assets).isEmpty();
     }
@@ -44,7 +44,7 @@ class InMemoryAssetIndexTest {
     @Test
     void queryAssets_fieldNull() {
         var testAsset = createAsset("foobar");
-        index.insert(testAsset, niceMock(DataAddress.class));
+        index.insert(testAsset, createDataAddress(testAsset));
         var assets = index.queryAssets(AssetSelectorExpression.Builder.newInstance().whenEquals("description", "barbaz").build());
         assertThat(assets).isEmpty();
     }
@@ -58,8 +58,8 @@ class InMemoryAssetIndexTest {
         index.insert(testAsset2, niceMock(DataAddress.class));
         index.insert(testAsset3, niceMock(DataAddress.class));
         var assets = index.queryAssets(AssetSelectorExpression.Builder.newInstance()
-                .whenEquals("name", "barbaz")
-                .whenEquals("version", "1")
+                .whenEquals(Asset.PROPERTY_NAME, "barbaz")
+                .whenEquals(Asset.PROPERTY_VERSION, "1")
                 .build());
         assertThat(assets).hasSize(2).containsExactlyInAnyOrder(testAsset2, testAsset3);
     }

--- a/samples/demo-contract-framework/src/test/java/org/eclipse/dataspaceconnector/demo/contracts/DemoContractOfferFrameworkExtensionTest.java
+++ b/samples/demo-contract-framework/src/test/java/org/eclipse/dataspaceconnector/demo/contracts/DemoContractOfferFrameworkExtensionTest.java
@@ -23,6 +23,7 @@ import okhttp3.Response;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
 import org.eclipse.dataspaceconnector.spi.system.ConfigurationExtension;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,13 +48,13 @@ public class DemoContractOfferFrameworkExtensionTest {
     @Test
     void retrieveContractOffers(OkHttpClient httpClient, TypeManager typeManager) {
         ConnectorClient client = new ConnectorClient(httpClient, typeManager);
-        client.indexAsset(Map.of("id", "anId", "path", "/a/valid/path"));
+        client.indexAsset(Map.of(Asset.PROPERTY_ID, "anId", "path", "/a/valid/path"));
 
         List<Map<String, Object>> contractOffers = client.getAllContractOffers();
 
         assertThat(contractOffers).hasSize(1).element(0)
                 .extracting("assets").asList().element(0)
-                .extracting("asset").extracting("id")
+                .extracting("asset").extracting("properties").extracting(Asset.PROPERTY_ID)
                 .isEqualTo("anId");
     }
 
@@ -96,7 +97,8 @@ public class DemoContractOfferFrameworkExtensionTest {
 
             try (Response response = httpClient.newCall(request).execute()) {
                 assertThat(response.code()).isEqualTo(200);
-                return typeManager.readValue(response.body().string(), new TypeReference<>() {});
+                return typeManager.readValue(response.body().string(), new TypeReference<>() {
+                });
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/samples/demo-contract-framework/src/test/java/org/eclipse/dataspaceconnector/demo/contracts/DemoContractOfferFrameworkExtensionTest.java
+++ b/samples/demo-contract-framework/src/test/java/org/eclipse/dataspaceconnector/demo/contracts/DemoContractOfferFrameworkExtensionTest.java
@@ -48,6 +48,8 @@ public class DemoContractOfferFrameworkExtensionTest {
     @Test
     void retrieveContractOffers(OkHttpClient httpClient, TypeManager typeManager) {
         ConnectorClient client = new ConnectorClient(httpClient, typeManager);
+        // for the 'id' we must actually use the constant from Asset, otherwise an exception gets raised during
+        // the adding of the asset to the index
         client.indexAsset(Map.of(Asset.PROPERTY_ID, "anId", "path", "/a/valid/path"));
 
         List<Map<String, Object>> contractOffers = client.getAllContractOffers();

--- a/spi/build.gradle.kts
+++ b/spi/build.gradle.kts
@@ -11,7 +11,6 @@ val jodahFailsafeVersion: String by project
 plugins {
     `java-library`
     `maven-publish`
-    `java-test-fixtures`
 }
 
 dependencies {

--- a/spi/build.gradle.kts
+++ b/spi/build.gradle.kts
@@ -11,6 +11,7 @@ val jodahFailsafeVersion: String by project
 plugins {
     `java-library`
     `maven-publish`
+    `java-test-fixtures`
 }
 
 dependencies {
@@ -23,6 +24,8 @@ dependencies {
     api("net.jodah:failsafe:${jodahFailsafeVersion}")
 
     api(project(":core:policy:policy-model"))
+
+    testImplementation(testFixtures(project(":common:util")))
 }
 
 publishing {

--- a/spi/src/main/java/org/eclipse/dataspaceconnector/spi/asset/Criterion.java
+++ b/spi/src/main/java/org/eclipse/dataspaceconnector/spi/asset/Criterion.java
@@ -31,9 +31,9 @@ public class Criterion {
     }
 
     public Criterion(String left, String op, String right) {
-        this.operandLeft = left;
-        this.operator = op;
-        this.operandRight = right;
+        operandLeft = Objects.requireNonNull(left);
+        operator = Objects.requireNonNull(op);
+        operandRight = right; // null may be allowed, for example when the operator is unary, like NOT_NULL
     }
 
     public Object getOperandLeft() {
@@ -49,15 +49,19 @@ public class Criterion {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Criterion criterion = (Criterion) o;
-        return Objects.equals(operandLeft, criterion.operandLeft) && Objects.equals(operator, criterion.operator) && Objects.equals(operandRight, criterion.operandRight);
+    public int hashCode() {
+        return Objects.hash(operandLeft, operator, operandRight);
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(operandLeft, operator, operandRight);
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Criterion criterion = (Criterion) o;
+        return Objects.equals(operandLeft, criterion.operandLeft) && Objects.equals(operator, criterion.operator) && Objects.equals(operandRight, criterion.operandRight);
     }
 }

--- a/spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/asset/Asset.java
+++ b/spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/asset/Asset.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 
 /**
@@ -29,10 +30,10 @@ import java.util.Map;
 @JsonDeserialize(builder = Asset.Builder.class)
 public class Asset {
 
-    private static final String PROP_KEY_ID = "asset:prop:key";
-    private static final String PROP_KEY_NAME = "asset:prop:name";
-    private static final String PROP_KEY_VERSION = "asset:prop:version";
-    private static final String PROP_KEY_CONTENT_TYPE = "asset:prop:contenttype";
+    public static final String PROPERTY_ID = "asset:prop:key";
+    public static final String PROPERTY_NAME = "asset:prop:name";
+    public static final String PROPERTY_VERSION = "asset:prop:version";
+    public static final String PROPERTY_CONTENT_TYPE = "asset:prop:contenttype";
     private Map<String, Object> properties;
 
     private Asset() {
@@ -41,22 +42,22 @@ public class Asset {
 
     @JsonIgnore
     public String getId() {
-        return getPropertyAsString(PROP_KEY_ID);
+        return getPropertyAsString(PROPERTY_ID);
     }
 
     @JsonIgnore
     public String getName() {
-        return getPropertyAsString(PROP_KEY_NAME);
+        return getPropertyAsString(PROPERTY_NAME);
     }
 
     @JsonIgnore
     public String getVersion() {
-        return getPropertyAsString(PROP_KEY_VERSION);
+        return getPropertyAsString(PROPERTY_VERSION);
     }
 
     @JsonIgnore
     public String getContentType() {
-        return getPropertyAsString(PROP_KEY_CONTENT_TYPE);
+        return getPropertyAsString(PROPERTY_CONTENT_TYPE);
     }
 
     public Map<String, Object> getProperties() {
@@ -79,6 +80,7 @@ public class Asset {
 
         private Builder() {
             asset = new Asset();
+            asset.properties.put(PROPERTY_ID, UUID.randomUUID().toString()); //must always have an ID
         }
 
         @JsonCreator
@@ -87,22 +89,22 @@ public class Asset {
         }
 
         public Builder id(String id) {
-            asset.properties.put(PROP_KEY_ID, id);
+            asset.properties.put(PROPERTY_ID, id);
             return this;
         }
 
         public Builder name(String title) {
-            asset.properties.put(PROP_KEY_NAME, title);
+            asset.properties.put(PROPERTY_NAME, title);
             return this;
         }
 
         public Builder version(String version) {
-            asset.properties.put(PROP_KEY_VERSION, version);
+            asset.properties.put(PROPERTY_VERSION, version);
             return this;
         }
 
         public Builder contentType(String contentType) {
-            asset.properties.put(PROP_KEY_CONTENT_TYPE, contentType);
+            asset.properties.put(PROPERTY_CONTENT_TYPE, contentType);
             return this;
         }
 

--- a/spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/asset/Asset.java
+++ b/spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/asset/Asset.java
@@ -15,65 +15,70 @@
 package org.eclipse.dataspaceconnector.spi.types.domain.asset;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.Map;
+
 
 /**
  * The {@link Asset} contains the metadata and describes the data itself or a collection of data.
  */
 @JsonDeserialize(builder = Asset.Builder.class)
 public class Asset {
-    private final String id;
-    private final String name;
-    private final String version;
-    private final String contentType;
-    private final Map<String, Object> properties;
 
-    private Asset(@NotNull String id, @NotNull String name, @NotNull String version, @NotNull String contentType, @NotNull Map<String, Object> properties) {
-        this.id = id;
-        this.name = name;
-        this.version = version;
-        this.contentType = contentType;
-        this.properties = properties;
+    private static final String PROP_KEY_ID = "asset:prop:key";
+    private static final String PROP_KEY_NAME = "asset:prop:name";
+    private static final String PROP_KEY_VERSION = "asset:prop:version";
+    private static final String PROP_KEY_CONTENT_TYPE = "asset:prop:contenttype";
+    private Map<String, Object> properties;
+
+    private Asset() {
+        properties = new HashMap<>();
     }
 
+    @JsonIgnore
     public String getId() {
-        return id;
+        return getPropertyAsString(PROP_KEY_ID);
     }
 
+    @JsonIgnore
     public String getName() {
-        return name;
+        return getPropertyAsString(PROP_KEY_NAME);
     }
 
+    @JsonIgnore
     public String getVersion() {
-        return version;
+        return getPropertyAsString(PROP_KEY_VERSION);
     }
 
+    @JsonIgnore
     public String getContentType() {
-        return contentType;
-    }
-
-    public Object getProperty(String key) {
-        return properties.get(key);
+        return getPropertyAsString(PROP_KEY_CONTENT_TYPE);
     }
 
     public Map<String, Object> getProperties() {
         return properties;
     }
 
+    @JsonIgnore
+    public Object getProperty(String key) {
+        return properties.get(key);
+    }
+
+    private String getPropertyAsString(String key) {
+        var val = getProperty(key);
+        return val != null ? val.toString() : null;
+    }
+
     @JsonPOJOBuilder(withPrefix = "")
     public static final class Builder {
-        private String id;
-        private String name;
-        private String version;
-        private String contentType;
-        private Map<String, Object> properties = new HashMap<>();
+        private final Asset asset;
 
-        protected Builder() {
+        private Builder() {
+            asset = new Asset();
         }
 
         @JsonCreator
@@ -82,37 +87,37 @@ public class Asset {
         }
 
         public Builder id(String id) {
-            this.id = id;
+            asset.properties.put(PROP_KEY_ID, id);
             return this;
         }
 
         public Builder name(String title) {
-            this.name = title;
+            asset.properties.put(PROP_KEY_NAME, title);
             return this;
         }
 
         public Builder version(String version) {
-            this.version = version;
+            asset.properties.put(PROP_KEY_VERSION, version);
             return this;
         }
 
         public Builder contentType(String contentType) {
-            this.contentType = contentType;
+            asset.properties.put(PROP_KEY_CONTENT_TYPE, contentType);
             return this;
         }
 
         public Builder properties(Map<String, Object> properties) {
-            this.properties = properties;
+            asset.properties = properties;
             return this;
         }
 
         public Builder property(String key, Object value) {
-            this.properties.put(key, value);
+            asset.properties.put(key, value);
             return this;
         }
 
         public Asset build() {
-            return new Asset(id, name, version, contentType, properties);
+            return asset;
         }
     }
 

--- a/spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/asset/Asset.java
+++ b/spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/asset/Asset.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 
@@ -30,7 +31,7 @@ import java.util.UUID;
 @JsonDeserialize(builder = Asset.Builder.class)
 public class Asset {
 
-    public static final String PROPERTY_ID = "asset:prop:key";
+    public static final String PROPERTY_ID = "asset:prop:id";
     public static final String PROPERTY_NAME = "asset:prop:name";
     public static final String PROPERTY_VERSION = "asset:prop:version";
     public static final String PROPERTY_CONTENT_TYPE = "asset:prop:contenttype";
@@ -109,7 +110,7 @@ public class Asset {
         }
 
         public Builder properties(Map<String, Object> properties) {
-            asset.properties = properties;
+            asset.properties = Objects.requireNonNull(properties);
             return this;
         }
 

--- a/spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/asset/AssetTest.java
+++ b/spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/asset/AssetTest.java
@@ -1,0 +1,65 @@
+package org.eclipse.dataspaceconnector.spi.types.domain.asset;
+
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.getResourceFileContentAsString;
+
+class AssetTest {
+
+    private TypeManager typeManager;
+
+    @BeforeEach
+    void setUp() {
+        typeManager = new TypeManager();
+    }
+
+    @Test
+    void verifySerialization() {
+        var asset = Asset.Builder.newInstance().id("abcd123")
+                .contentType("application/json")
+                .version("1.0")
+                .name("testasset")
+                .property("some-critical.value", 21347)
+                .build();
+
+        var json = typeManager.writeValueAsString(asset);
+        assertThat(json).isNotNull();
+
+        assertThat(json).contains("abcd123")
+                .contains("application/json")
+                .contains("testasset")
+                .contains("some-critical.value")
+                .contains("21347")
+                .contains("1.0");
+    }
+
+    @Test
+    void verifyDeserialization() {
+        var json = getResourceFileContentAsString("serialized_asset.json");
+        var asset = typeManager.readValue(json, Asset.class);
+
+        assertThat(asset).isNotNull();
+        assertThat(asset.getId()).isEqualTo("abcd123");
+        assertThat(asset.getContentType()).isEqualTo("application/json");
+        assertThat(asset.getName()).isNull();
+
+        assertThat(asset.getProperties()).hasSize(5);
+
+    }
+
+    @Test
+    void getProperty_whenNotPresent_shouldReturnNull() {
+        var asset = Asset.Builder.newInstance().build();
+        assertThat(asset.getProperty("notexist")).isNull();
+    }
+
+    @Test
+    void getNamedProperty_whenNotPresent_shouldReturnNull() {
+        var asset = Asset.Builder.newInstance().build();
+        assertThat(asset.getName()).isNull();
+        assertThat(asset.getVersion()).isNull();
+    }
+}

--- a/spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/asset/AssetTest.java
+++ b/spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/asset/AssetTest.java
@@ -45,6 +45,7 @@ class AssetTest {
         assertThat(asset.getId()).isEqualTo("abcd123");
         assertThat(asset.getContentType()).isEqualTo("application/json");
         assertThat(asset.getName()).isNull();
+        assertThat(asset.getProperty("numberVal")).isInstanceOf(Integer.class).isEqualTo(42069);
 
         assertThat(asset.getProperties()).hasSize(5);
 

--- a/spi/src/test/resources/serialized_asset.json
+++ b/spi/src/test/resources/serialized_asset.json
@@ -2,7 +2,7 @@
   "properties": {
     "asset:prop:contenttype": "application/json",
     "asset:prop:version": "1.0",
-    "asset:prop:key": "abcd123",
+    "asset:prop:id": "abcd123",
     "anotherProperty": "some value",
     "numberVal": 42069
   }

--- a/spi/src/test/resources/serialized_asset.json
+++ b/spi/src/test/resources/serialized_asset.json
@@ -1,0 +1,9 @@
+{
+  "properties": {
+    "asset:prop:contenttype": "application/json",
+    "asset:prop:version": "1.0",
+    "asset:prop:key": "abcd123",
+    "anotherProperty": "some value",
+    "numberVal": 42069
+  }
+}


### PR DESCRIPTION
This removes the reflective access from the `CriterionToPredicateConverter`, closes #183 .