### PR TITLE
extensions: prefer TypeManager over ObjectMapper

### DIFF
--- a/docs/architecture-principles.md
+++ b/docs/architecture-principles.md
@@ -47,3 +47,6 @@
 ### IX. Handling Null Return Values
 1. In certain situations, `null` may need to be returned from a method, passed as a parameter, or set on a field. Only use `Optional` if a method is part of a fluent API. 
    Since the runtime will rarely require this, the project standard is to use the `org.jetbrains.annotations.Nullable` and `org.jetbrains.annotations.NotNull` annotations. 
+
+### X. Objects Serialization/Deserialization
+1. `TypeManager` is the component responsible for json ser/des, you can also use the `ObjectMapper` inside it, but there should be no other `ObjectMapper` instance.

--- a/extensions/iam/distributed-identity/registration-service/src/main/java/org/eclipse/dataspaceconnector/iam/registrationservice/crawler/CrawlerContext.java
+++ b/extensions/iam/distributed-identity/registration-service/src/main/java/org/eclipse/dataspaceconnector/iam/registrationservice/crawler/CrawlerContext.java
@@ -17,6 +17,7 @@ import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidResolverRegistry
 import org.eclipse.dataspaceconnector.iam.did.spi.store.DidStore;
 import org.eclipse.dataspaceconnector.iam.registrationservice.events.CrawlerEventPublisher;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 
 /**
  * Stores parameters (such as the DID Type) and necessary objects (such as the IonClient or the DidStore)
@@ -30,6 +31,7 @@ public class CrawlerContext {
     private String ionHost;
     private String didTypes;
     private DidResolverRegistry resolverRegistry;
+    private TypeManager typeManager;
 
     public DidStore getDidStore() {
         return didStore;
@@ -55,6 +57,10 @@ public class CrawlerContext {
         return resolverRegistry;
     }
 
+    public TypeManager getTypeManager() {
+        return typeManager;
+    }
+
     public static final class Builder {
         private DidStore didStore;
         private Monitor monitor;
@@ -62,6 +68,7 @@ public class CrawlerContext {
         private String ionHost;
         private String didTypes;
         private DidResolverRegistry resolverRegistry;
+        private TypeManager typeManager;
 
         private Builder() {
         }
@@ -100,11 +107,17 @@ public class CrawlerContext {
             return this;
         }
 
+        public Builder typeManager(TypeManager typeManager) {
+            this.typeManager = typeManager;
+            return this;
+        }
+
         public CrawlerContext build() {
             CrawlerContext crawlerConfig = new CrawlerContext();
             crawlerConfig.didTypes = didTypes;
             crawlerConfig.ionHost = ionHost;
             crawlerConfig.publisher = publisher;
+            crawlerConfig.typeManager = typeManager;
             crawlerConfig.didStore = didStore;
             crawlerConfig.monitor = monitor;
             crawlerConfig.resolverRegistry = resolverRegistry;

--- a/extensions/iam/distributed-identity/registration-service/src/main/java/org/eclipse/dataspaceconnector/iam/registrationservice/crawler/CrawlerExtension.java
+++ b/extensions/iam/distributed-identity/registration-service/src/main/java/org/eclipse/dataspaceconnector/iam/registrationservice/crawler/CrawlerExtension.java
@@ -23,6 +23,7 @@ import org.eclipse.dataspaceconnector.spi.EdcSetting;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
 import org.quartz.Scheduler;
@@ -105,6 +106,7 @@ public class CrawlerExtension implements ServiceExtension {
                 .didStore(didStore)
                 .ionHost(context.getSetting(ION_URL_SETTING, "http://gx-ion-node.westeurope.cloudapp.azure.com:3000/"))
                 .monitor(context.getMonitor())
+                .typeManager(context.getTypeManager())
                 .publisher(publisher)
                 .didTypes(context.getSetting(ION_CRAWLER_TYPE_SETTING, "aW9u"))
                 .resolverRegistry(resolverRegistry)

--- a/extensions/iam/oauth2/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/Oauth2Extension.java
+++ b/extensions/iam/oauth2/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/Oauth2Extension.java
@@ -82,7 +82,7 @@ public class Oauth2Extension implements ServiceExtension {
 
         // setup the provider key resolver, which will be scheduled for refresh at runtime start
         String jwksUrl = context.getSetting(PROVIDER_JWKS_URL, "http://localhost/empty_jwks_url");
-        providerKeyResolver = new IdentityProviderKeyResolver(jwksUrl, context.getMonitor(), httpClient);
+        providerKeyResolver = new IdentityProviderKeyResolver(jwksUrl, context.getMonitor(), httpClient, context.getTypeManager());
         keyRefreshInterval = Integer.parseInt(context.getSetting(PROVIDER_JWKS_REFRESH, "5"));
 
         // setup the OAuth2 service

--- a/extensions/iam/oauth2/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/impl/IdentityProviderKeyResolver.java
+++ b/extensions/iam/oauth2/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/impl/IdentityProviderKeyResolver.java
@@ -19,6 +19,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -48,12 +49,13 @@ public class IdentityProviderKeyResolver implements PublicKeyResolver, Runnable 
      * Ctor.
      *
      * @param jwksUrl the URL specified by 'jwks_uri' in the document returned by the identity provider's metadata endpoint.
+     * @param typeManager the type manager
      */
-    public IdentityProviderKeyResolver(String jwksUrl, Monitor monitor, OkHttpClient httpClient) {
+    public IdentityProviderKeyResolver(String jwksUrl, Monitor monitor, OkHttpClient httpClient, TypeManager typeManager) {
         this.jwksUrl = jwksUrl;
         this.monitor = monitor;
         this.httpClient = httpClient;
-        mapper = new ObjectMapper();
+        mapper = typeManager.getMapper();
     }
 
     @Override

--- a/extensions/iam/oauth2/src/test/java/org/eclipse/dataspaceconnector/iam/oauth2/impl/IdentityProviderKeyResolverTest.java
+++ b/extensions/iam/oauth2/src/test/java/org/eclipse/dataspaceconnector/iam/oauth2/impl/IdentityProviderKeyResolverTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.OkHttpClient;
 import org.easymock.EasyMock;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,7 +45,7 @@ class IdentityProviderKeyResolverTest {
     @BeforeEach
     void setUp() throws JsonProcessingException {
         resolver = new IdentityProviderKeyResolver(URL, new Monitor() {
-        }, EasyMock.niceMock(OkHttpClient.class));
+        }, EasyMock.niceMock(OkHttpClient.class), new TypeManager());
 
         keys = new ObjectMapper().readValue(JWKS_URI_RESPONSE, JwkKeys.class);
     }

--- a/extensions/ion/ion-core/src/main/java/org/eclipse/dataspaceconnector/ion/util/JsonCanonicalizer.java
+++ b/extensions/ion/ion-core/src/main/java/org/eclipse/dataspaceconnector/ion/util/JsonCanonicalizer.java
@@ -3,6 +3,7 @@ package org.eclipse.dataspaceconnector.ion.util;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.dataspaceconnector.ion.IonException;
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 
 import java.io.IOException;
 
@@ -13,7 +14,7 @@ public class JsonCanonicalizer {
     private static final ObjectMapper MAPPER;
 
     static {
-        MAPPER = new ObjectMapper();
+        MAPPER = new TypeManager().getMapper();
         MAPPER.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
     }
 

--- a/samples/other/copy-file-to-s3bucket/src/main/java/org/eclipse/dataspaceconnector/transfer/demo/AwsDemoExtension.java
+++ b/samples/other/copy-file-to-s3bucket/src/main/java/org/eclipse/dataspaceconnector/transfer/demo/AwsDemoExtension.java
@@ -29,7 +29,7 @@ public class AwsDemoExtension implements ServiceExtension {
 
         var dataFlowMgr = context.getService(DataFlowManager.class);
 
-        var flowController = new DemoS3FlowController(context.getService(Vault.class), monitor);
+        var flowController = new DemoS3FlowController(context.getService(Vault.class), monitor, context.getTypeManager());
 
         dataFlowMgr.register(flowController);
     }

--- a/samples/other/file-transfer-s3-to-s3/src/main/java/org/eclipse/dataspaceconnector/transfer/demo/controller/DemoExtension.java
+++ b/samples/other/file-transfer-s3-to-s3/src/main/java/org/eclipse/dataspaceconnector/transfer/demo/controller/DemoExtension.java
@@ -28,6 +28,7 @@ import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowManager;
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.metadata.DataCatalogEntry;
 import org.eclipse.dataspaceconnector.spi.types.domain.metadata.DataEntry;
 import org.eclipse.dataspaceconnector.spi.types.domain.metadata.GenericDataCatalogEntry;
@@ -51,13 +52,14 @@ public class DemoExtension implements ServiceExtension {
         this.context = context;
         monitor = context.getMonitor();
 
-        var objectMapper = context.getTypeManager().getMapper();
+        TypeManager typeManager = context.getTypeManager();
+        var objectMapper = typeManager.getMapper();
         registerTypes(objectMapper);
 
         var dataFlowMgr = context.getService(DataFlowManager.class);
         var dataAddressResolver = context.getService(DataAddressResolver.class);
 
-        var flowController = new S3toS3TransferFlowController(context.getService(Vault.class), monitor, dataAddressResolver);
+        var flowController = new S3toS3TransferFlowController(context.getService(Vault.class), monitor, dataAddressResolver, typeManager);
 
         dataFlowMgr.register(flowController);
     }


### PR DESCRIPTION
Ref #193 
Update the `architecture-principles.md` file and replaced the `ObjectMapper` instantiations in the production code.