### PR TITLE
Feature/200 fix broken samples

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -50,3 +50,7 @@ jobs:
           echo "Checking Sample 02"
           java -jar samples/02-health-endpoint/build/libs/connector-health.jar > /dev/null $
           kill -INT $!
+
+          echo "Checking Sample 03"
+          java -jar samples/03-configuration/build/libs/filsystem-config-connector.jar > /dev/null $
+          kill -INT $!

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Check Sample 04 (Consumer)
         run: |
-          ./gradlew :samples:04-file-transfer:shadowJar
+          ./gradlew :samples:04-file-transfer:consumer:shadowJar
           echo "Checking Sample 04 - Consumer"
           java -Dedc.fs.config=samples/04-file-transfer/consumer/config.properties -jar samples/04-file-transfer/consumer/build/libs/consumer.jar > log.txt &
           sleep 5
@@ -86,6 +86,7 @@ jobs:
       - name: Check Sample 04 (Provider)
         run: |
           echo "Checking Sample 04 - Provider"
+          ./gradlew :samples:04-file-transfer:provider:shadowJar
           java -Dedc.fs.config=samples/04-file-transfer/provider/config.properties -jar samples/04-file-transfer/provider/build/libs/provider.jar > log.txt &
           sleep 5
           grep "INFO.*edc-.*ready" log.txt

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -45,24 +45,31 @@ jobs:
           ./gradlew :samples:01-basic-connector:shadowJar
           echo "Checking Sample 01"
           java -jar samples/01-basic-connector/build/libs/basic-connector.jar > log.txt &
+          pid=$!
           sleep 5
-          grep "ready" log.txt
+          grep "INFO.*edc-.*ready" log.txt
           rm log.txt
+          kill -INT $pid
+
 
       - name: Check Sample 02
         run: |
           ./gradlew :samples:02-health-endpoint:shadowJar
           echo "Checking Sample 02"
           java -jar samples/02-health-endpoint/build/libs/connector-health.jar > log.txt &
+          pid=$!
           sleep 5
-          grep "ready" log.txt
+          grep "INFO.*edc-.*ready" log.txt
           rm log.txt
+          kill -INT $pid
 
       - name: Check Sample 03
         run: |
           ./gradlew :samples:03-configuration:shadowJar
           echo "Checking Sample 03"
           java -Dedc.fs.config=samples/03-configuration/config.properties -jar samples/03-configuration/build/libs/filsystem-config-connector.jar > log.txt &
+          pid=$!
           sleep 5
-          grep "ready" log.txt
+          grep "INFO.*edc-.*ready" log.txt
           rm log.txt
+          kill -INT $pid

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -40,20 +40,24 @@ jobs:
         with:
           java-version: '11'
 
-      - name: Sanity-check samples
+      - name: Check Sample 01
         run: |
-          ./gradlew shadowJar
+          ./gradlew :samples:01-basic-connector:shadowJar
           echo "Checking Sample 01"
           java -jar samples/01-basic-connector/build/libs/basic-connector.jar > /dev/null &
           sleep 1
           kill -INT $!
 
+      - name: Check Sample 02
+          ./gradlew :samples:02-health-endpoint:shadowJar
           echo "Checking Sample 02"
           java -jar samples/02-health-endpoint/build/libs/connector-health.jar > /dev/null &
-          sleep 1
+          sleep 5
           kill -INT $!
 
+      - name: Check Sample 03
+          ./gradlew :samples:03-configuration:shadowJar
           echo "Checking Sample 03"
-          java -jar samples/03-configuration/build/libs/filsystem-config-connector.jar > /dev/null &
-          sleep 1
+          java -Dedc.fs.config=samples/03-configuration/config.properties -jar samples/03-configuration/build/libs/filsystem-config-connector.jar
+          sleep 5
           kill -INT $!

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -3,7 +3,35 @@ name: Test Code (Style, Tests)
 on: [ push, pull_request ]
 
 jobs:
-  Unit-Test:
+  #  Unit-Test:
+  #    runs-on: ubuntu-latest
+  #    steps:
+  #      - uses: actions/checkout@v2
+  #      - name: Set up JDK 11
+  #        uses: actions/setup-java@v1
+  #        with:
+  #          java-version: '11'
+  #
+  #      # lets run Checkstyle explicitly (as opposed to within gradle) due to better reporting capabilities
+  #      - name: Run Checkstyle
+  #        uses: nikitasavinov/checkstyle-action@0.4.0
+  #        with:
+  #          checkstyle_config: resources/edc-checkstyle-config.xml
+  #          level: error
+  #          github_token: ${{ secrets.GITHUB_TOKEN }}
+  #          tool_name: 'checkstyle'
+  #          checkstyle_version: '9.0'
+  #          reporter: 'github-check'
+  #          filter_mode: 'nofilter'
+  #
+  #
+  #      - name: Gradle Test Core
+  #        env:
+  #          INTEGRATION_TEST: false
+  #        # checkstyle would also run as part of the `check` task
+  #        run: ./gradlew clean check -x checkstyleMain -x checkstyleTest
+
+  Sanity-Check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -12,30 +40,13 @@ jobs:
         with:
           java-version: '11'
 
-      #      # lets run Checkstyle explicitly (as opposed to within gradle) due to better reporting capabilities
-      #      - name: Run Checkstyle
-      #        uses: nikitasavinov/checkstyle-action@0.4.0
-      #        with:
-      #          checkstyle_config: resources/edc-checkstyle-config.xml
-      #          level: error
-      #          github_token: ${{ secrets.GITHUB_TOKEN }}
-      #          tool_name: 'checkstyle'
-      #          checkstyle_version: '9.0'
-      #          reporter: 'github-check'
-      #          filter_mode: 'nofilter'
-      #
-      #
-      #      - name: Gradle Test Core
-      #        env:
-      #          INTEGRATION_TEST: false
-      #        # checkstyle would also run as part of the `check` task
-      #        run: ./gradlew clean check -x checkstyleMain -x checkstyleTest
-
       - name: Sanity-check samples
         run: |
           ./gradlew shadowJar
+          echo "Checking Sample 01"
           java -jar samples/01-basic-connector/build/libs/basic-connector.jar > /dev/null &
           kill -INT $!
 
+          echo "Checking Sample 02"
           java -jar samples/02-health-endpoint/build/libs/connector-health.jar > /dev/null $
           kill -INT $!

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -3,33 +3,33 @@ name: Test Code (Style, Tests)
 on: [ push, pull_request ]
 
 jobs:
-  #  Unit-Test:
-  #    runs-on: ubuntu-latest
-  #    steps:
-  #      - uses: actions/checkout@v2
-  #      - name: Set up JDK 11
-  #        uses: actions/setup-java@v1
-  #        with:
-  #          java-version: '11'
-  #
-  #      # lets run Checkstyle explicitly (as opposed to within gradle) due to better reporting capabilities
-  #      - name: Run Checkstyle
-  #        uses: nikitasavinov/checkstyle-action@0.4.0
-  #        with:
-  #          checkstyle_config: resources/edc-checkstyle-config.xml
-  #          level: error
-  #          github_token: ${{ secrets.GITHUB_TOKEN }}
-  #          tool_name: 'checkstyle'
-  #          checkstyle_version: '9.0'
-  #          reporter: 'github-check'
-  #          filter_mode: 'nofilter'
-  #
-  #
-  #      - name: Gradle Test Core
-  #        env:
-  #          INTEGRATION_TEST: false
-  #        # checkstyle would also run as part of the `check` task
-  #        run: ./gradlew clean check -x checkstyleMain -x checkstyleTest
+  Unit-Test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+
+      # lets run Checkstyle explicitly (as opposed to within gradle) due to better reporting capabilities
+      - name: Run Checkstyle
+        uses: nikitasavinov/checkstyle-action@0.4.0
+        with:
+          checkstyle_config: resources/edc-checkstyle-config.xml
+          level: error
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tool_name: 'checkstyle'
+          checkstyle_version: '9.0'
+          reporter: 'github-check'
+          filter_mode: 'nofilter'
+
+
+      - name: Gradle Test Core
+        env:
+          INTEGRATION_TEST: false
+        # checkstyle would also run as part of the `check` task
+        run: ./gradlew clean check -x checkstyleMain -x checkstyleTest
 
   Sanity-Check:
     runs-on: ubuntu-latest
@@ -92,3 +92,5 @@ jobs:
           grep "INFO.*edc-.*ready" log.txt
           rm log.txt
           killall java
+
+      # we cannot check sample 5 currently because we'd need repo secrets for that (client id,...)

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -40,6 +40,8 @@ jobs:
         with:
           java-version: '11'
 
+      # c
+
       - name: Check Sample 01
         run: |
           ./gradlew :samples:01-basic-connector:shadowJar
@@ -66,6 +68,25 @@ jobs:
           ./gradlew :samples:03-configuration:shadowJar
           echo "Checking Sample 03"
           java -Dedc.fs.config=samples/03-configuration/config.properties -jar samples/03-configuration/build/libs/filsystem-config-connector.jar > log.txt &
+          sleep 5
+          grep "INFO.*edc-.*ready" log.txt
+          rm log.txt
+          killall java
+
+      - name: Check Sample 04 (Consumer)
+        run: |
+          ./gradlew :samples:04-file-transfer:shadowJar
+          echo "Checking Sample 04 - Consumer"
+          java -Dedc.fs.config=samples/04-file-transfer/consumer/config.properties -jar samples/04-file-transfer/consumer/build/libs/consumer.jar > log.txt &
+          sleep 5
+          grep "INFO.*edc-.*ready" log.txt
+          rm log.txt
+          killall java
+
+      - name: Check Sample 04 (Provider)
+        run: |
+          echo "Checking Sample 04 - Provider"
+          java -Dedc.fs.config=samples/04-file-transfer/provider/config.properties -jar samples/04-file-transfer/provider/build/libs/provider.jar > log.txt &
           sleep 5
           grep "INFO.*edc-.*ready" log.txt
           rm log.txt

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -45,11 +45,10 @@ jobs:
           ./gradlew :samples:01-basic-connector:shadowJar
           echo "Checking Sample 01"
           java -jar samples/01-basic-connector/build/libs/basic-connector.jar > log.txt &
-          pid=$!
           sleep 5
           grep "INFO.*edc-.*ready" log.txt
           rm log.txt
-          kill -INT $pid
+          killall java
 
 
       - name: Check Sample 02
@@ -57,19 +56,17 @@ jobs:
           ./gradlew :samples:02-health-endpoint:shadowJar
           echo "Checking Sample 02"
           java -jar samples/02-health-endpoint/build/libs/connector-health.jar > log.txt &
-          pid=$!
           sleep 5
           grep "INFO.*edc-.*ready" log.txt
           rm log.txt
-          kill -INT $pid
+          killall java
 
       - name: Check Sample 03
         run: |
           ./gradlew :samples:03-configuration:shadowJar
           echo "Checking Sample 03"
           java -Dedc.fs.config=samples/03-configuration/config.properties -jar samples/03-configuration/build/libs/filsystem-config-connector.jar > log.txt &
-          pid=$!
           sleep 5
           grep "INFO.*edc-.*ready" log.txt
           rm log.txt
-          kill -INT $pid
+          killall java

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -48,7 +48,7 @@ jobs:
           echo "Checking Sample 01"
           java -jar samples/01-basic-connector/build/libs/basic-connector.jar > log.txt &
           sleep 5
-          grep "INFO.*edc-.*ready" log.txt
+          grep "INFO.*edc-.*readasdfy" log.txt 
           rm log.txt
           killall java
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -49,6 +49,7 @@ jobs:
           kill -INT $!
 
       - name: Check Sample 02
+        run: |
           ./gradlew :samples:02-health-endpoint:shadowJar
           echo "Checking Sample 02"
           java -jar samples/02-health-endpoint/build/libs/connector-health.jar > /dev/null &
@@ -56,6 +57,7 @@ jobs:
           kill -INT $!
 
       - name: Check Sample 03
+        run: |
           ./gradlew :samples:03-configuration:shadowJar
           echo "Checking Sample 03"
           java -Dedc.fs.config=samples/03-configuration/config.properties -jar samples/03-configuration/build/libs/filsystem-config-connector.jar

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -48,9 +48,9 @@ jobs:
           kill -INT $!
 
           echo "Checking Sample 02"
-          java -jar samples/02-health-endpoint/build/libs/connector-health.jar > /dev/null $
+          java -jar samples/02-health-endpoint/build/libs/connector-health.jar > /dev/null &
           kill -INT $!
 
           echo "Checking Sample 03"
-          java -jar samples/03-configuration/build/libs/filsystem-config-connector.jar > /dev/null $
+          java -jar samples/03-configuration/build/libs/filsystem-config-connector.jar > /dev/null &
           kill -INT $!

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -48,7 +48,7 @@ jobs:
           echo "Checking Sample 01"
           java -jar samples/01-basic-connector/build/libs/basic-connector.jar > log.txt &
           sleep 5
-          grep "INFO.*edc-.*readasdfy" log.txt 
+          grep "INFO.*edc-.*ready" log.txt
           rm log.txt
           killall java
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -12,22 +12,30 @@ jobs:
         with:
           java-version: '11'
 
-      # lets run Checkstyle explicitly (as opposed to within gradle) due to better reporting capabilities
-      - name: Run Checkstyle
-        uses: nikitasavinov/checkstyle-action@0.4.0
-        with:
-          checkstyle_config: resources/edc-checkstyle-config.xml
-          level: error
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tool_name: 'checkstyle'
-          checkstyle_version: '9.0'
-          reporter: 'github-check'
-          filter_mode: 'nofilter'
+      #      # lets run Checkstyle explicitly (as opposed to within gradle) due to better reporting capabilities
+      #      - name: Run Checkstyle
+      #        uses: nikitasavinov/checkstyle-action@0.4.0
+      #        with:
+      #          checkstyle_config: resources/edc-checkstyle-config.xml
+      #          level: error
+      #          github_token: ${{ secrets.GITHUB_TOKEN }}
+      #          tool_name: 'checkstyle'
+      #          checkstyle_version: '9.0'
+      #          reporter: 'github-check'
+      #          filter_mode: 'nofilter'
+      #
+      #
+      #      - name: Gradle Test Core
+      #        env:
+      #          INTEGRATION_TEST: false
+      #        # checkstyle would also run as part of the `check` task
+      #        run: ./gradlew clean check -x checkstyleMain -x checkstyleTest
 
+      - name: Sanity-check samples
+        run: |
+          ./gradlew shadowJar
+          java -jar samples/01-basic-connector/build/libs/basic-connector.jar > /dev/null &
+          kill -INT $!
 
-      - name: Gradle Test Core
-        env:
-          INTEGRATION_TEST: false
-        # checkstyle would also run as part of the `check` task
-        run: ./gradlew clean check -x checkstyleMain -x checkstyleTest
-
+          java -jar samples/02-health-endpoint/build/libs/connector-health.jar > /dev/null $
+          kill -INT $!

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -45,12 +45,15 @@ jobs:
           ./gradlew shadowJar
           echo "Checking Sample 01"
           java -jar samples/01-basic-connector/build/libs/basic-connector.jar > /dev/null &
+          sleep 1
           kill -INT $!
 
           echo "Checking Sample 02"
           java -jar samples/02-health-endpoint/build/libs/connector-health.jar > /dev/null &
+          sleep 1
           kill -INT $!
 
           echo "Checking Sample 03"
           java -jar samples/03-configuration/build/libs/filsystem-config-connector.jar > /dev/null &
+          sleep 1
           kill -INT $!

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -44,22 +44,25 @@ jobs:
         run: |
           ./gradlew :samples:01-basic-connector:shadowJar
           echo "Checking Sample 01"
-          java -jar samples/01-basic-connector/build/libs/basic-connector.jar > /dev/null &
-          sleep 1
-          kill -INT $!
+          java -jar samples/01-basic-connector/build/libs/basic-connector.jar > log.txt &
+          sleep 5
+          grep "ready" log.txt
+          rm log.txt
 
       - name: Check Sample 02
         run: |
           ./gradlew :samples:02-health-endpoint:shadowJar
           echo "Checking Sample 02"
-          java -jar samples/02-health-endpoint/build/libs/connector-health.jar > /dev/null &
+          java -jar samples/02-health-endpoint/build/libs/connector-health.jar > log.txt &
           sleep 5
-          kill -INT $!
+          grep "ready" log.txt
+          rm log.txt
 
       - name: Check Sample 03
         run: |
           ./gradlew :samples:03-configuration:shadowJar
           echo "Checking Sample 03"
-          java -Dedc.fs.config=samples/03-configuration/config.properties -jar samples/03-configuration/build/libs/filsystem-config-connector.jar
+          java -Dedc.fs.config=samples/03-configuration/config.properties -jar samples/03-configuration/build/libs/filsystem-config-connector.jar > log.txt &
           sleep 5
-          kill -INT $!
+          grep "ready" log.txt
+          rm log.txt

--- a/samples/01-basic-connector/build.gradle.kts
+++ b/samples/01-basic-connector/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
 dependencies {
     implementation(project(":core"))
     implementation(project(":extensions:in-memory:transfer-store-memory"))
+    implementation(project(":extensions:in-memory:assetindex-memory"))
 }
 
 application {

--- a/samples/02-health-endpoint/build.gradle.kts
+++ b/samples/02-health-endpoint/build.gradle.kts
@@ -23,6 +23,7 @@ val rsApi: String by project
 dependencies {
     implementation(project(":core"))
     implementation(project(":extensions:in-memory:transfer-store-memory"))
+    implementation(project(":extensions:in-memory:assetindex-memory"))
 
     implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
 }

--- a/samples/03-configuration/build.gradle.kts
+++ b/samples/03-configuration/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation(project(":core"))
     implementation(project(":extensions:in-memory:transfer-store-memory"))
     implementation(project(":extensions:filesystem:configuration-fs"))
+    implementation(project(":extensions:in-memory:assetindex-memory"))
 
     implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
 }

--- a/samples/04-file-transfer/consumer/build.gradle.kts
+++ b/samples/04-file-transfer/consumer/build.gradle.kts
@@ -27,7 +27,9 @@ dependencies {
     implementation(project(":extensions:in-memory:transfer-store-memory"))
     implementation(project(":extensions:in-memory:policy-registry-memory"))
     implementation(project(":extensions:in-memory:metadata-memory"))
-    
+    implementation(project(":extensions:in-memory:assetindex-memory"))
+
+
     implementation(project(":extensions:filesystem:configuration-fs"))
     implementation(project(":extensions:iam:iam-mock"))
 

--- a/samples/05-file-transfer-cloud/consumer/build.gradle.kts
+++ b/samples/05-file-transfer-cloud/consumer/build.gradle.kts
@@ -31,6 +31,8 @@ dependencies {
     implementation(project(":extensions:in-memory:transfer-store-memory"))
     implementation(project(":extensions:in-memory:policy-registry-memory"))
     implementation(project(":extensions:filesystem:configuration-fs"))
+    implementation(project(":extensions:in-memory:assetindex-memory"))
+
     implementation(project(":extensions:iam:iam-mock"))
     implementation(project(":extensions:in-memory:metadata-memory"))
     implementation(project(":extensions:azure:vault"))

--- a/samples/05-file-transfer-cloud/provider/build.gradle.kts
+++ b/samples/05-file-transfer-cloud/provider/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
     implementation(project(":extensions:iam:iam-mock"))
     implementation(project(":extensions:in-memory:policy-registry-memory"))
     implementation(project(":extensions:in-memory:metadata-memory"))
+    implementation(project(":extensions:in-memory:assetindex-memory"))
+
     implementation(project(":extensions:azure:vault"))
 
     implementation(project(":data-protocols:ids"))


### PR DESCRIPTION
This PR fixes the broken samples (01-05) and adds steps to the pipeline which compile and run the samples and verify their readiness state. 
This is basically done in three steps: 
1) run the sample, pipe the command line output into a file
2) wait for some time, make sure the log file contains a line `"INFO.*edc-.*ready"`, which is logged whenever a runtime has finished booting.
3) kill the java process

_Note: at this time we can only do this for samples that don't rely on external systems such as cloud storage etc. That's why sample 05 is **not** verified._