### PR TITLE
Small fix for PermissionToPermissionTransformer

### DIFF
--- a/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/dataspaceconnector/ids/transform/PermissionToPermissionTransformer.java
+++ b/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/dataspaceconnector/ids/transform/PermissionToPermissionTransformer.java
@@ -66,9 +66,8 @@ public class PermissionToPermissionTransformer implements IdsTypeTransformer<Per
         }
 
         if (object.getDuty() != null) {
-            // TODO Fix after the issue in the Information Model, asking about non-compliance between IDS and ODRL, is resolved
-            // Link https://github.com/International-Data-Spaces-Association/InformationModel/issues/523
-            context.reportProblem("Not supported transformation: EDC-Duty to IDS Pre-/Post-Duty");
+            var duty = context.transform(object.getDuty(), de.fraunhofer.iais.eis.Duty.class);
+            permissionBuilder._preDuty_(new ArrayList<>(Collections.singletonList(duty)));
         }
 
         return permissionBuilder.build();

--- a/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/dataspaceconnector/ids/transform/PermissionToPermissionTransformerTest.java
+++ b/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/dataspaceconnector/ids/transform/PermissionToPermissionTransformerTest.java
@@ -85,10 +85,8 @@ public class PermissionToPermissionTransformerTest {
         EasyMock.expect(permission.getAction()).andReturn(edcAction).anyTimes();
         EasyMock.expect(context.transform(EasyMock.eq(edcAction), EasyMock.eq(de.fraunhofer.iais.eis.Action.class))).andReturn(idsAction);
         EasyMock.expect(context.transform(EasyMock.eq(edcConstraint), EasyMock.eq(de.fraunhofer.iais.eis.Constraint.class))).andReturn(idsConstraint);
+        EasyMock.expect(context.transform(EasyMock.eq(edcDuty), EasyMock.eq(de.fraunhofer.iais.eis.Duty.class))).andReturn(idsDuty);
         EasyMock.expect(context.transform(EasyMock.isA(IdsId.class), EasyMock.eq(URI.class))).andReturn(PERMISSION_ID);
-
-        context.reportProblem(EasyMock.anyString());
-        EasyMock.expectLastCall().once();
 
         // record
         EasyMock.replay(permission, context);


### PR DESCRIPTION
Hello everyone,

the code contained  a ToDo (that was wrongly added by me) explaining, that it's not defined where how a EDC/ODRL duty should be mapped to IDS Permission (pre- or post-duty).
But that's not correct. In ODRL a duty in a permission is always a pre-duty. Therefore we are able to map it from EDC to IDS. It only doesn't work the other way around.

<sub>Dominik Pinsel <dominik.pinsel@daimler.com>, Daimler TSS GmbH, [legal info/Impressum](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md) </sub>