### PR TITLE
Added CosmosDB-based AssetIndex  integrationtest to i-test workflow

### DIFF
--- a/.github/workflows/integrationtests.yaml
+++ b/.github/workflows/integrationtests.yaml
@@ -30,6 +30,12 @@ jobs:
           COSMOS_KEY: ${{ secrets.COSMOS_KEY }}
         run: ./gradlew extensions:azure:transfer-process-store-cosmos:check
 
+      - name: Cosmos-based Asset Index test
+        env:
+          RUN_INTEGRATION_TEST: true
+          COSMOS_KEY: ${{ secrets.COSMOS_KEY }}
+        run: ./gradlew extensions:azure:assetindex-cosmos:check
+
   Aws-Integration-Test:
     # run only on upstream repo
     if: github.repository_owner == 'eclipse-dataspaceconnector'

--- a/.github/workflows/integrationtests.yaml
+++ b/.github/workflows/integrationtests.yaml
@@ -36,6 +36,13 @@ jobs:
           COSMOS_KEY: ${{ secrets.COSMOS_KEY }}
         run: ./gradlew extensions:azure:assetindex-cosmos:check
 
+
+      - name: Cosmos-based FCN Directory test
+        env:
+          RUN_INTEGRATION_TEST: true
+          COSMOS_KEY: ${{ secrets.COSMOS_KEY }}
+        run: ./gradlew extensions:azure:fcc-node-directory-cosmos:check
+
   Aws-Integration-Test:
     # run only on upstream repo
     if: github.repository_owner == 'eclipse-dataspaceconnector'


### PR DESCRIPTION
I-Tests need to be enabled explicitly by adding a job to the workflow file.