### PR TITLE
Feature/cosmos cli loader

### DIFF
--- a/extensions/azure/assetindex-cosmos/build.gradle.kts
+++ b/extensions/azure/assetindex-cosmos/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     api(project(":spi"))
     api(project(":common:util"))
     api(project(":extensions:azure:cosmos-common"))
+    api(project(":extensions:dataloading:dataloading-asset"))
     implementation("com.azure:azure-cosmos:${cosmosSdkVersion}")
 
     testImplementation(testFixtures(project(":common:util")))

--- a/extensions/azure/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndex.java
+++ b/extensions/azure/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndex.java
@@ -19,18 +19,25 @@ import net.jodah.failsafe.RetryPolicy;
 import org.eclipse.dataspaceconnector.assetindex.azure.model.AssetDocument;
 import org.eclipse.dataspaceconnector.cosmos.azure.CosmosDbApi;
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
+import org.eclipse.dataspaceconnector.spi.asset.AssetIndexLoader;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
+import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataAddress;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static net.jodah.failsafe.Failsafe.with;
 
-public class CosmosAssetIndex implements AssetIndex {
+public class CosmosAssetIndex implements AssetIndex, DataAddressResolver, AssetIndexLoader {
 
-    private final CosmosDbApi cosmosDbApi;
+    private final CosmosDbApi assetDb;
+    private final String partitionKey;
     private final TypeManager typeManager;
     private final RetryPolicy<Object> retryPolicy;
     private final CosmosAssetQueryBuilder queryBuilder;
@@ -38,12 +45,14 @@ public class CosmosAssetIndex implements AssetIndex {
     /**
      * Creates a new instance of the CosmosDB-based for Asset storage.
      *
-     * @param cosmosDbApi Api to interact with Cosmos container.
-     * @param typeManager The {@link TypeManager} that's used for serialization and deserialization.
-     * @param retryPolicy Retry policy if query to CosmosDB fails.
+     * @param assetDb      Api to interact with Cosmos container.
+     * @param partitionKey The CosmosDB partition key
+     * @param typeManager  The {@link TypeManager} that's used for serialization and deserialization.
+     * @param retryPolicy  Retry policy if query to CosmosDB fails.
      */
-    public CosmosAssetIndex(CosmosDbApi cosmosDbApi, TypeManager typeManager, RetryPolicy<Object> retryPolicy) {
-        this.cosmosDbApi = Objects.requireNonNull(cosmosDbApi);
+    public CosmosAssetIndex(CosmosDbApi assetDb, String partitionKey, TypeManager typeManager, RetryPolicy<Object> retryPolicy) {
+        this.assetDb = Objects.requireNonNull(assetDb);
+        this.partitionKey = partitionKey;
         this.typeManager = Objects.requireNonNull(typeManager);
         this.retryPolicy = Objects.requireNonNull(retryPolicy);
         queryBuilder = new CosmosAssetQueryBuilder();
@@ -54,21 +63,45 @@ public class CosmosAssetIndex implements AssetIndex {
         Objects.requireNonNull(expression, "AssetSelectorExpression can not be null!");
 
         SqlQuerySpec query = queryBuilder.from(expression);
-        var response = with(retryPolicy).get(() -> cosmosDbApi.queryItems(query.getQueryText()));
+
+        var response = with(retryPolicy).get(() -> assetDb.queryItems(query.getQueryText()));
         return response.stream()
                 .map(this::convertObject)
-                .map(AssetDocument::getWrappedInstance);
+                .map(AssetDocument::getWrappedAsset);
     }
 
     @Override
     public Asset findById(String assetId) {
-        // we need to read the AssetDocument as Object, because no custom JSON deserialization can be registered
-        // with the CosmosDB SDK, so it would not know about subtypes, etc.
-        var obj = with(retryPolicy).get(() -> cosmosDbApi.queryItemById(assetId));
-        return obj != null ? convertObject(obj).getWrappedInstance() : null;
+        var result = queryByIdInternal(assetId);
+        return result.map(AssetDocument::getWrappedAsset).orElse(null);
     }
 
+    @Override
+    public DataAddress resolveForAsset(String assetId) {
+        return queryByIdInternal(assetId).map(AssetDocument::getDataAddress).orElse(null);
+    }
+
+    @Override
+    public void insert(Asset asset, DataAddress address) {
+        var assetDocument = new AssetDocument(asset, partitionKey, address);
+        assetDb.createItem(assetDocument);
+    }
+
+    @Override
+    public void insertAll(List<Map.Entry<Asset, DataAddress>> entries) {
+        // no transaction here, just for now
+        entries.forEach(e -> insert(e.getKey(), e.getValue()));
+    }
+
+    // we need to read the AssetDocument as Object, because no custom JSON deserialization can be registered
+    // with the CosmosDB SDK, so it would not know about subtypes, etc.
     private AssetDocument convertObject(Object databaseDocument) {
         return typeManager.readValue(typeManager.writeValueAsString(databaseDocument), AssetDocument.class);
     }
+
+    private Optional<AssetDocument> queryByIdInternal(String assetId) {
+        var result = with(retryPolicy).get(() -> assetDb.queryItemById(assetId));
+        return Optional.ofNullable(result).map(this::convertObject);
+    }
+
 }

--- a/extensions/azure/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexExtension.java
+++ b/extensions/azure/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexExtension.java
@@ -18,8 +18,8 @@ import net.jodah.failsafe.RetryPolicy;
 import org.eclipse.dataspaceconnector.assetindex.azure.model.AssetDocument;
 import org.eclipse.dataspaceconnector.cosmos.azure.CosmosDbApi;
 import org.eclipse.dataspaceconnector.cosmos.azure.CosmosDbApiImpl;
+import org.eclipse.dataspaceconnector.dataloading.AssetLoader;
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
-import org.eclipse.dataspaceconnector.spi.asset.AssetIndexLoader;
 import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
@@ -39,7 +39,7 @@ public class CosmosAssetIndexExtension implements ServiceExtension {
 
     @Override
     public Set<String> provides() {
-        return Set.of(AssetIndex.FEATURE, AssetIndexLoader.FEATURE, DataAddressResolver.FEATURE);
+        return Set.of(AssetIndex.FEATURE, AssetLoader.FEATURE, DataAddressResolver.FEATURE);
     }
 
     @Override
@@ -53,7 +53,7 @@ public class CosmosAssetIndexExtension implements ServiceExtension {
         CosmosDbApi cosmosDbApi = new CosmosDbApiImpl(vault, configuration);
         var assetIndex = new CosmosAssetIndex(cosmosDbApi, configuration.getPartitionKey(), context.getTypeManager(), context.getService(RetryPolicy.class));
         context.registerService(AssetIndex.class, assetIndex);
-        context.registerService(AssetIndexLoader.class, assetIndex);
+        context.registerService(AssetLoader.class, assetIndex);
         context.registerService(DataAddressResolver.class, assetIndex);
 
         context.getTypeManager().registerTypes(AssetDocument.class);

--- a/extensions/azure/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexIntegrationTest.java
+++ b/extensions/azure/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexIntegrationTest.java
@@ -28,6 +28,7 @@ import org.eclipse.dataspaceconnector.cosmos.azure.CosmosDbApiImpl;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataAddress;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -52,6 +53,7 @@ class CosmosAssetIndexIntegrationTest {
     private static final String TEST_PARTITION_KEY = "test-partitionkey";
     private static CosmosContainer container;
     private static CosmosDatabase database;
+    private final DataAddress dataAddress = DataAddress.Builder.newInstance().type("testtype").build();
     private CosmosAssetIndex assetIndex;
 
     @BeforeAll
@@ -85,8 +87,8 @@ class CosmosAssetIndexIntegrationTest {
         container = database.getContainer(containerIfNotExists.getProperties().getId());
         TypeManager typeManager = new TypeManager();
         typeManager.registerTypes(Asset.class, AssetDocument.class);
-        CosmosDbApi api = new CosmosDbApiImpl(container, TEST_PARTITION_KEY, true);
-        assetIndex = new CosmosAssetIndex(api, typeManager, new RetryPolicy<>());
+        CosmosDbApi api = new CosmosDbApiImpl(container, true);
+        assetIndex = new CosmosAssetIndex(api, TEST_PARTITION_KEY, typeManager, new RetryPolicy<>());
     }
 
     @Test
@@ -101,8 +103,8 @@ class CosmosAssetIndexIntegrationTest {
                 .property("foo", "bar")
                 .build();
 
-        container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY));
-        container.createItem(new AssetDocument(asset2, TEST_PARTITION_KEY));
+        container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY, dataAddress));
+        container.createItem(new AssetDocument(asset2, TEST_PARTITION_KEY, dataAddress));
 
         List<Asset> assets = assetIndex.queryAssets(AssetSelectorExpression.SELECT_ALL).collect(Collectors.toList());
 
@@ -123,8 +125,8 @@ class CosmosAssetIndexIntegrationTest {
                 .property("test", "bar")
                 .build();
 
-        container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY));
-        container.createItem(new AssetDocument(asset2, TEST_PARTITION_KEY));
+        container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY, dataAddress));
+        container.createItem(new AssetDocument(asset2, TEST_PARTITION_KEY, dataAddress));
 
         AssetSelectorExpression expression = AssetSelectorExpression.Builder.newInstance()
                 .whenEquals(Asset.PROPERTY_ID, "456")
@@ -148,8 +150,8 @@ class CosmosAssetIndexIntegrationTest {
                 .property("test:value", "bar")
                 .build();
 
-        container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY));
-        container.createItem(new AssetDocument(asset2, TEST_PARTITION_KEY));
+        container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY, dataAddress));
+        container.createItem(new AssetDocument(asset2, TEST_PARTITION_KEY, dataAddress));
 
         AssetSelectorExpression expression = AssetSelectorExpression.Builder.newInstance()
                 .whenEquals("test:value", "bar")
@@ -173,8 +175,8 @@ class CosmosAssetIndexIntegrationTest {
                 .property("test", "bar")
                 .build();
 
-        container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY));
-        container.createItem(new AssetDocument(asset2, TEST_PARTITION_KEY));
+        container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY, dataAddress));
+        container.createItem(new AssetDocument(asset2, TEST_PARTITION_KEY, dataAddress));
 
         Asset asset = assetIndex.findById("456");
 

--- a/extensions/azure/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexTest.java
+++ b/extensions/azure/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexTest.java
@@ -42,12 +42,13 @@ import static org.easymock.EasyMock.verify;
 
 class CosmosAssetIndexTest {
 
+    private static final String TEST_PARTITION_KEY = "test-partition-key";
     private CosmosDbApi api;
     private TypeManager typeManager;
     private RetryPolicy<Object> retryPolicy;
 
     private static AssetDocument createDocument(String id) {
-        return new AssetDocument(Asset.Builder.newInstance().id(id).build(), "partitionkey-test");
+        return new AssetDocument(Asset.Builder.newInstance().id(id).build(), "partitionkey-test", null);
     }
 
     @BeforeEach
@@ -67,15 +68,15 @@ class CosmosAssetIndexTest {
     void inputValidation() {
         // null cosmos api
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> new CosmosAssetIndex(null, null, retryPolicy));
+                .isThrownBy(() -> new CosmosAssetIndex(null, TEST_PARTITION_KEY, null, retryPolicy));
 
         // type manager is null
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> new CosmosAssetIndex(api, null, retryPolicy));
+                .isThrownBy(() -> new CosmosAssetIndex(api, TEST_PARTITION_KEY, null, retryPolicy));
 
         // retry policy is null
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> new CosmosAssetIndex(api, typeManager, null));
+                .isThrownBy(() -> new CosmosAssetIndex(api, TEST_PARTITION_KEY, typeManager, null));
     }
 
     @Test
@@ -86,10 +87,10 @@ class CosmosAssetIndexTest {
 
         replay(api);
 
-        CosmosAssetIndex assetIndex = new CosmosAssetIndex(api, typeManager, retryPolicy);
+        CosmosAssetIndex assetIndex = new CosmosAssetIndex(api, TEST_PARTITION_KEY, typeManager, retryPolicy);
 
         Asset actualAsset = assetIndex.findById(id);
-        assertThat(actualAsset.getProperties()).isEqualTo(document.getWrappedInstance().getProperties());
+        assertThat(actualAsset.getProperties()).isEqualTo(document.getWrappedAsset().getProperties());
 
         verify(api);
     }
@@ -103,7 +104,7 @@ class CosmosAssetIndexTest {
 
         replay(api);
 
-        CosmosAssetIndex assetIndex = new CosmosAssetIndex(api, typeManager, retryPolicy);
+        CosmosAssetIndex assetIndex = new CosmosAssetIndex(api, TEST_PARTITION_KEY, typeManager, retryPolicy);
 
         assertThatExceptionOfType(EdcException.class).isThrownBy(() -> assetIndex.findById(id));
 
@@ -117,7 +118,7 @@ class CosmosAssetIndexTest {
 
         replay(api);
 
-        CosmosAssetIndex assetIndex = new CosmosAssetIndex(api, typeManager, retryPolicy);
+        CosmosAssetIndex assetIndex = new CosmosAssetIndex(api, TEST_PARTITION_KEY, typeManager, retryPolicy);
 
         Asset actualAsset = assetIndex.findById(id);
         assertThat(actualAsset).isNull();
@@ -133,7 +134,7 @@ class CosmosAssetIndexTest {
 
         replay(api);
 
-        CosmosAssetIndex assetIndex = new CosmosAssetIndex(api, typeManager, retryPolicy);
+        CosmosAssetIndex assetIndex = new CosmosAssetIndex(api, TEST_PARTITION_KEY, typeManager, retryPolicy);
 
         List<Asset> assets = assetIndex.queryAssets(AssetSelectorExpression.SELECT_ALL).collect(Collectors.toList());
         assertThat(assets)
@@ -152,7 +153,7 @@ class CosmosAssetIndexTest {
 
         replay(api);
 
-        CosmosAssetIndex assetIndex = new CosmosAssetIndex(api, typeManager, retryPolicy);
+        CosmosAssetIndex assetIndex = new CosmosAssetIndex(api, TEST_PARTITION_KEY, typeManager, retryPolicy);
 
         var selectByName = AssetSelectorExpression.Builder.newInstance().whenEquals(Asset.PROPERTY_NAME, "somename").build();
         List<Asset> assets = assetIndex.queryAssets(selectByName).collect(Collectors.toList());

--- a/extensions/azure/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetQueryBuilderTest.java
+++ b/extensions/azure/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetQueryBuilderTest.java
@@ -34,7 +34,7 @@ class CosmosAssetQueryBuilderTest {
 
         SqlQuerySpec query = builder.from(expression);
 
-        assertThat(query.getQueryText()).isEqualTo("SELECT * FROM AssetDocument WHERE AssetDocument.sanitizedProperties.id = 'id-test' AND AssetDocument.sanitizedProperties.name = 'name-test'");
+        assertThat(query.getQueryText()).isEqualTo("SELECT * FROM AssetDocument WHERE AssetDocument.wrappedInstance.id = 'id-test' AND AssetDocument.wrappedInstance.name = 'name-test'");
     }
 
     @Test
@@ -46,7 +46,7 @@ class CosmosAssetQueryBuilderTest {
 
         SqlQuerySpec query = builder.from(expression);
 
-        assertThat(query.getQueryText()).isEqualTo("SELECT * FROM AssetDocument WHERE AssetDocument.sanitizedProperties.test_id = 'id-test' AND AssetDocument.sanitizedProperties.test_name = 'name-test'");
+        assertThat(query.getQueryText()).isEqualTo("SELECT * FROM AssetDocument WHERE AssetDocument.wrappedInstance.test_id = 'id-test' AND AssetDocument.wrappedInstance.test_name = 'name-test'");
     }
 
     @Test

--- a/extensions/azure/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/model/AssetDocumentSerializationTest.java
+++ b/extensions/azure/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/model/AssetDocumentSerializationTest.java
@@ -16,6 +16,7 @@ package org.eclipse.dataspaceconnector.assetindex.azure.model;
 
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataAddress;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -24,6 +25,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AssetDocumentSerializationTest {
 
     private TypeManager typeManager;
+
+    private static Asset createAsset() {
+        return Asset.Builder.newInstance()
+                .id("id-test")
+                .name("node-test")
+                .contentType("application/json")
+                .version("123")
+                .property("foo", "bar")
+                .build();
+    }
 
     @BeforeEach
     void setup() {
@@ -35,41 +46,30 @@ class AssetDocumentSerializationTest {
     void testSerialization() {
         var asset = createAsset();
 
-        var document = new AssetDocument(asset, "partitionkey-test");
+        var document = new AssetDocument(asset, "partitionkey-test", DataAddress.Builder.newInstance().build());
 
         String s = typeManager.writeValueAsString(document);
 
         assertThat(s).isNotNull()
                 .contains("\"partitionKey\":\"partitionkey-test\"")
-                .contains("\"asset:prop:id\":\"id-test\"")
-                .contains("\"asset:prop:name\":\"node-test\"")
-                .contains("\"asset:prop:version\":\"123\"")
-                .contains("\"asset:prop:contenttype\":\"application/json\"")
-                .contains("\"foo\":\"bar\"")
-                .contains("\"sanitizedProperties\":")
-                .contains("\"id\":\"id-test\"")
                 .contains("\"asset_prop_id\":\"id-test\"")
-                .contains("\"asset_prop_name\":\"node-test\"");
+                .contains("\"asset_prop_name\":\"node-test\"")
+                .contains("\"asset_prop_version\":\"123\"")
+                .contains("\"asset_prop_contenttype\":\"application/json\"")
+                .contains("\"foo\":\"bar\"")
+                .contains("\"wrappedInstance\":")
+                .contains("\"id\":\"id-test\"");
     }
 
     @Test
     void testDeserialization() {
         var asset = createAsset();
 
-        var document = new AssetDocument(asset, "partitionkey-test");
+        var document = new AssetDocument(asset, "partitionkey-test", DataAddress.Builder.newInstance()
+                .type("testtype").build());
         String json = typeManager.writeValueAsString(document);
 
         var deserialized = typeManager.readValue(json, AssetDocument.class);
         assertThat(deserialized.getWrappedInstance()).usingRecursiveComparison().isEqualTo(document.getWrappedInstance());
-    }
-
-    private static Asset createAsset() {
-        return Asset.Builder.newInstance()
-                .id("id-test")
-                .name("node-test")
-                .contentType("application/json")
-                .version("123")
-                .property("foo", "bar")
-                .build();
     }
 }

--- a/extensions/azure/cosmos-common/build.gradle.kts
+++ b/extensions/azure/cosmos-common/build.gradle.kts
@@ -23,6 +23,9 @@ dependencies {
     api(project(":common:util"))
 
     implementation("com.azure:azure-cosmos:${cosmosSdkVersion}")
+
+    testImplementation(testFixtures(project(":common:util")))
+
 }
 
 

--- a/extensions/azure/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/cosmos/azure/CosmosDbApi.java
+++ b/extensions/azure/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/cosmos/azure/CosmosDbApi.java
@@ -6,9 +6,13 @@ import java.util.List;
 
 public interface CosmosDbApi {
 
-    void createItem(Object item);
+    void createItem(CosmosDocument<?> item);
 
     @Nullable Object queryItemById(String id);
+
+    @Nullable Object queryItemById(String id, String partitionKey);
+
+    List<Object> queryAllItems(String partitionKey);
 
     List<Object> queryAllItems();
 

--- a/extensions/azure/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/cosmos/azure/CosmosDocument.java
+++ b/extensions/azure/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/cosmos/azure/CosmosDocument.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Some features or requirements of CosmosDB don't fit into an object data model,
  * such as the "partition key", which is required by CosmosDB to achieve a better distribution of read/write load.
  */
-public class CosmosDocument<T> {
+public abstract class CosmosDocument<T> {
 
     @JsonProperty
     private final T wrappedInstance;
@@ -30,4 +30,6 @@ public class CosmosDocument<T> {
     public T getWrappedInstance() {
         return wrappedInstance;
     }
+
+    public abstract String getId();
 }

--- a/extensions/azure/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/cosmos/azure/CosmosDbApiImplIntegrationTest.java
+++ b/extensions/azure/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/cosmos/azure/CosmosDbApiImplIntegrationTest.java
@@ -1,0 +1,149 @@
+package org.eclipse.dataspaceconnector.cosmos.azure;
+
+import com.azure.cosmos.ConsistencyLevel;
+import com.azure.cosmos.CosmosClientBuilder;
+import com.azure.cosmos.CosmosContainer;
+import com.azure.cosmos.CosmosDatabase;
+import com.azure.cosmos.models.CosmosContainerResponse;
+import com.azure.cosmos.models.CosmosDatabaseResponse;
+import com.azure.cosmos.models.CosmosItemRequestOptions;
+import com.azure.cosmos.models.PartitionKey;
+import org.eclipse.dataspaceconnector.common.annotations.IntegrationTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.common.configuration.ConfigurationFunctions.propOrEnv;
+
+@IntegrationTest
+class CosmosDbApiImplIntegrationTest {
+
+    public static final String REGION = "westeurope";
+    public static final String PARTITION_KEY = "partitionKey";
+    private static final String TEST_ID = UUID.randomUUID().toString();
+    private static final String ACCOUNT_NAME = "cosmos-itest";
+    private static final String DATABASE_NAME = "connector-itest-" + TEST_ID;
+    private static final String CONTAINER_NAME = "CosmosAssetIndexTest-" + TEST_ID;
+    private static CosmosContainer container;
+    private static CosmosDatabase database;
+    private CosmosDbApi cosmosDbApi;
+    private ArrayList<TestCosmosDocument> record;
+
+    @BeforeAll
+    static void prepare() {
+        var key = propOrEnv("COSMOS_KEY", "RYNecVDtJq2WKAcIoONBLzuTBys06kUcP8Rw9Yz5zOzsOQFVGaP8oGuI5qgF5ONQY4VukjkpQ4x7a2jwVvo7SQ==");
+        if (key != null) {
+            var client = new CosmosClientBuilder()
+                    .key(key)
+                    .preferredRegions(Collections.singletonList(REGION))
+                    .consistencyLevel(ConsistencyLevel.SESSION)
+                    .endpoint("https://" + ACCOUNT_NAME + ".documents.azure.com:443/")
+                    .buildClient();
+
+            CosmosDatabaseResponse response = client.createDatabaseIfNotExists(DATABASE_NAME);
+            database = client.getDatabase(response.getProperties().getId());
+        }
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (database != null) {
+            CosmosDatabaseResponse delete = database.delete();
+            assertThat(delete.getStatusCode()).isGreaterThanOrEqualTo(200).isLessThan(300);
+        }
+    }
+
+    @BeforeEach
+    void setup() {
+        assertThat(database).describedAs("CosmosDB database is null - did something go wrong during initialization?").isNotNull();
+        CosmosContainerResponse containerIfNotExists = database.createContainerIfNotExists(CONTAINER_NAME, "/partitionKey");
+        container = database.getContainer(containerIfNotExists.getProperties().getId());
+        cosmosDbApi = new CosmosDbApiImpl(container, true);
+
+        record = new ArrayList<>();
+    }
+
+    @AfterEach
+    void teardown() {
+        record.forEach(td -> container.deleteItem(td, new CosmosItemRequestOptions()));
+    }
+
+    @Test
+    void createItem() {
+        var testItem = new TestCosmosDocument("payload", PARTITION_KEY);
+        cosmosDbApi.createItem(testItem);
+        record.add(testItem);
+
+        assertThat(container.readAllItems(new PartitionKey(PARTITION_KEY), Object.class)).hasSize(1);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void queryItemById() {
+        var testItem = new TestCosmosDocument("payload", PARTITION_KEY);
+        container.createItem(testItem);
+        record.add(testItem);
+
+        var queryResult = cosmosDbApi.queryItemById(testItem.getId());
+        assertThat(queryResult).isNotNull().isInstanceOf(LinkedHashMap.class);
+
+        assertThat((LinkedHashMap) queryResult).containsEntry("id", testItem.getId())
+                .containsEntry("partitionKey", PARTITION_KEY)
+                .containsEntry("wrappedInstance", "payload");
+
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void queryAllItems() {
+        var testItem = new TestCosmosDocument("payload", PARTITION_KEY);
+        container.createItem(testItem);
+        record.add(testItem);
+
+        var testItem2 = new TestCosmosDocument("payload", PARTITION_KEY);
+        container.createItem(testItem2);
+        record.add(testItem2);
+
+        assertThat(cosmosDbApi.queryAllItems()).hasSize(2)
+                .allSatisfy(o -> {
+                    assertThat(o).isInstanceOf(LinkedHashMap.class);
+                    assertThat((LinkedHashMap) o).containsEntry("wrappedInstance", "payload");
+                    assertThat(((LinkedHashMap) o).get("id")).isIn(testItem.getId(), testItem2.getId());
+                });
+    }
+
+    @Test
+    void queryItems() {
+        // not picked up, wrong payload
+        var testItem = new TestCosmosDocument("payload", PARTITION_KEY);
+        container.createItem(testItem);
+        record.add(testItem);
+
+        var testItem2 = new TestCosmosDocument("payload-two", PARTITION_KEY);
+        container.createItem(testItem2);
+        record.add(testItem2);
+
+        //should not be picked up - wrong case
+        var testItem3 = new TestCosmosDocument("Payload-two", PARTITION_KEY);
+        container.createItem(testItem3);
+        record.add(testItem3);
+
+        // should be picked up, despite the different partition key
+        var testItem4 = new TestCosmosDocument("payload-two", "another-partkey");
+        container.createItem(testItem4);
+        record.add(testItem4);
+
+        var query = "SELECT * FROM t WHERE t.wrappedInstance='payload-two'";
+        var result = cosmosDbApi.queryItems(query);
+        assertThat(result).hasSize(2);
+    }
+
+}

--- a/extensions/azure/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/cosmos/azure/TestCosmosDocument.java
+++ b/extensions/azure/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/cosmos/azure/TestCosmosDocument.java
@@ -1,0 +1,17 @@
+package org.eclipse.dataspaceconnector.cosmos.azure;
+
+import java.util.UUID;
+
+public class TestCosmosDocument extends CosmosDocument<String> {
+    private final String id;
+
+    public TestCosmosDocument(String wrappedInstance, String partitionKey) {
+        super(wrappedInstance, partitionKey);
+        id = UUID.randomUUID().toString();
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+}

--- a/extensions/azure/fcc-node-directory-cosmos/src/main/java/org/eclipse/dataspaceconnector/catalog/node/directory/azure/CosmosFederatedCacheNodeDirectory.java
+++ b/extensions/azure/fcc-node-directory-cosmos/src/main/java/org/eclipse/dataspaceconnector/catalog/node/directory/azure/CosmosFederatedCacheNodeDirectory.java
@@ -49,7 +49,7 @@ public class CosmosFederatedCacheNodeDirectory implements FederatedCacheNodeDire
 
     @Override
     public List<FederatedCacheNode> getAll() {
-        var response = with(retryPolicy).get(cosmosDbApi::queryAllItems);
+        var response = with(retryPolicy).get(() -> cosmosDbApi.queryAllItems(partitionKey));
         return response.stream()
                 .map(databaseDocument -> typeManager.readValue(typeManager.writeValueAsString(databaseDocument), FederatedCacheNodeDocument.class))
                 .map(FederatedCacheNodeDocument::getWrappedInstance)

--- a/extensions/azure/fcc-node-directory-cosmos/src/test/java/org/eclipse/dataspaceconnector/catalog/node/directory/azure/CosmosFederatedCacheNodeDirectoryTest.java
+++ b/extensions/azure/fcc-node-directory-cosmos/src/test/java/org/eclipse/dataspaceconnector/catalog/node/directory/azure/CosmosFederatedCacheNodeDirectoryTest.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
@@ -31,6 +32,20 @@ class CosmosFederatedCacheNodeDirectoryTest {
 
     private CosmosDbApi api;
     private CosmosFederatedCacheNodeDirectory directory;
+
+    private static void assertNodesAreEqual(FederatedCacheNode node1, FederatedCacheNode node2) {
+        assertThat(node1.getName()).isEqualTo(node2.getName());
+        assertThat(node1.getTargetUrl()).isEqualTo(node2.getTargetUrl());
+        assertThat(node1.getSupportedProtocols()).isEqualTo(node2.getSupportedProtocols());
+    }
+
+    private static FederatedCacheNodeDocument createDocument(FederatedCacheNode node) {
+        return new FederatedCacheNodeDocument(node, PARTITION_KEY);
+    }
+
+    private static FederatedCacheNode createNode() {
+        return new FederatedCacheNode(UUID.randomUUID().toString(), UUID.randomUUID().toString(), Collections.singletonList(UUID.randomUUID().toString()));
+    }
 
     @BeforeEach
     public void setUp() {
@@ -83,7 +98,7 @@ class CosmosFederatedCacheNodeDirectoryTest {
                 .map(CosmosFederatedCacheNodeDirectoryTest::createDocument)
                 .collect(Collectors.toList());
 
-        expect(api.queryAllItems()).andReturn(documents);
+        expect(api.queryAllItems(anyString())).andReturn(documents);
 
         replay(api);
 
@@ -92,19 +107,5 @@ class CosmosFederatedCacheNodeDirectoryTest {
         nodes.forEach(expected -> assertThat(result).anySatisfy(node -> assertNodesAreEqual(expected, node)));
 
         verify(api);
-    }
-
-    private static void assertNodesAreEqual(FederatedCacheNode node1, FederatedCacheNode node2) {
-        assertThat(node1.getName()).isEqualTo(node2.getName());
-        assertThat(node1.getTargetUrl()).isEqualTo(node2.getTargetUrl());
-        assertThat(node1.getSupportedProtocols()).isEqualTo(node2.getSupportedProtocols());
-    }
-
-    private static FederatedCacheNodeDocument createDocument(FederatedCacheNode node) {
-        return new FederatedCacheNodeDocument(node, PARTITION_KEY);
-    }
-
-    private static FederatedCacheNode createNode() {
-        return new FederatedCacheNode(UUID.randomUUID().toString(), UUID.randomUUID().toString(), Collections.singletonList(UUID.randomUUID().toString()));
     }
 }

--- a/extensions/in-memory/assetindex-memory/src/main/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetLoader.java
+++ b/extensions/in-memory/assetindex-memory/src/main/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetLoader.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * An ephemeral asset index, that is also a DataAddressResolver and an AssetIndexLoader
+ * An ephemeral asset index, that is also a DataAddressResolver and an AssetLoader
  */
 public class InMemoryAssetLoader implements AssetIndex, DataAddressResolver, AssetLoader {
     private final Map<String, Asset> cache = new ConcurrentHashMap<>();

--- a/launchers/data-loader-cli/README.md
+++ b/launchers/data-loader-cli/README.md
@@ -15,10 +15,19 @@ java -jar <path-to-jar> --assets <path-to-file.json>
 
 ## A few things to notice
 
-- by default no `AssetIndex` implementation is configured! Please adapt the `build.gradle.kts` file to suit your
-  particular needs! The app _will_ log an error if you don't do this.
-- If a database-backed AssetIndex is used, you'll likely also need a configuration extension plus a vault extension to
-  handle credentials.
+- by default an `AssetIndex` based on CosmosDB is configured. Please adapt the `build.gradle.kts` file to suit your
+  particular needs! 
+- Please add a `*.properties` file that contains the following properties. The app _will not_ function properly unless you do this.
+  - `edc.vault.clientid=<az-clientid>`
+  - `edc.vault.tenantid=<az-tenantid>`
+  - `edc.vault.certificate=/path/to/cert.pfx`
+  - `edc.vault.name=<vault-name>`
+  - `edc.assetindex.cosmos.account-name=<cosmos-account>`
+  - `edc.assetindex.cosmos.database-name=<cosmos-db-name>`
+  - `edc.cosmos.partition-key=<partition-key>`
+  - `edc.assetindex.cosmos.preferred-region=westeurope`
+  - `edc.assetindex.cosmos.container-name=<container-name>`
+  - `edc.cosmos.query-metrics-enabled=true`
 - The commandline tool is intended to run as standalone program
 - Currently only Asset/DataEntry objects are supported, more commands will follow. This might change the synopsis of the
   tool.

--- a/launchers/data-loader-cli/build.gradle.kts
+++ b/launchers/data-loader-cli/build.gradle.kts
@@ -26,9 +26,9 @@ dependencies {
 
     // uncomment the following lines to use the CosmosDB-based Asset index:
     //
-    // implementation(project(":extensions:azure:assetindex-cosmos"))
-    // implementation(project(":extensions:filesystem:configuration-fs"))
-    // implementation(project(":extensions:azure:vault"))
+    implementation(project(":extensions:azure:assetindex-cosmos"))
+    implementation(project(":extensions:filesystem:configuration-fs"))
+    implementation(project(":extensions:azure:vault"))
 
     // alternatively uncomment the following line to use the in-memory AssetIndex
     //


### PR DESCRIPTION
This PR adds some fixes to the CosmosDB backend and enables it for the DataLoader-CLI. Now we can use the DataLoader-CLI tool to insert `AssetEntry` objects into the `AssetIndex`.