### PR TITLE
initialize MonitorProvider correctly

### DIFF
--- a/core/bootstrap/src/main/java/org/eclipse/dataspaceconnector/monitor/MonitorProvider.java
+++ b/core/bootstrap/src/main/java/org/eclipse/dataspaceconnector/monitor/MonitorProvider.java
@@ -20,6 +20,8 @@ import org.slf4j.IMarkerFactory;
 import org.slf4j.Marker;
 import org.slf4j.event.Level;
 import org.slf4j.helpers.AbstractLogger;
+import org.slf4j.helpers.BasicMarkerFactory;
+import org.slf4j.helpers.NOPMDCAdapter;
 import org.slf4j.spi.MDCAdapter;
 import org.slf4j.spi.SLF4JServiceProvider;
 
@@ -28,6 +30,9 @@ import org.slf4j.spi.SLF4JServiceProvider;
  */
 public class MonitorProvider implements SLF4JServiceProvider {
     private static Monitor INSTANCE;
+    private IMarkerFactory markerFactory = new BasicMarkerFactory();
+    private MDCAdapter mdcAdapter = new NOPMDCAdapter();
+
 
     public static void setInstance(Monitor monitor) {
         INSTANCE = monitor;
@@ -40,12 +45,12 @@ public class MonitorProvider implements SLF4JServiceProvider {
 
     @Override
     public IMarkerFactory getMarkerFactory() {
-        return null;
+        return markerFactory;
     }
 
     @Override
     public MDCAdapter getMDCAdapter() {
-        return null;
+        return mdcAdapter;
     }
 
     @Override


### PR DESCRIPTION
When pulling in dependencies that rely on certain logging functionality [you can hit this error ](http://www.slf4j.org/codes.html#null_MDCA). It looks like this is caused by the returned nulls in the MonitorProvider, which [in this code ](http://www.slf4j.org/api/src-html/org/slf4j/MarkerFactory.html#line.44) result in the MarkerFactory/MDCAdapter to be null. 

Updated the provider to match the [NOPProvider that can be found here](http://www.slf4j.org/api/src-html/org/slf4j/helpers/NOPServiceProvider.html#line.8) for the MarkerFactory and MDCAdapter.