### PR TITLE
extensions: add ids policy extension

### DIFF
--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/policy/IdsPolicyExpressions.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/policy/IdsPolicyExpressions.java
@@ -24,7 +24,6 @@ public interface IdsPolicyExpressions {
     String PAY_AMOUNT = "idsc:PAY_AMOUNT";
 
     String ABS_SPATIAL_POSITION = "ids:absoluteSpatialPosition";
-    String PARTNER_LEVEL = "ids:partnerLevel";
 
     LiteralExpression ABS_SPATIAL_POSITION_EXPRESSION = new LiteralExpression(ABS_SPATIAL_POSITION);
 

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/policy/IdsPolicyExpressions.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/policy/IdsPolicyExpressions.java
@@ -24,6 +24,7 @@ public interface IdsPolicyExpressions {
     String PAY_AMOUNT = "idsc:PAY_AMOUNT";
 
     String ABS_SPATIAL_POSITION = "ids:absoluteSpatialPosition";
+    String PARTNER_LEVEL = "ids:partnerLevel";
 
     LiteralExpression ABS_SPATIAL_POSITION_EXPRESSION = new LiteralExpression(ABS_SPATIAL_POSITION);
 

--- a/extensions/policy/ids-policy/build.gradle.kts
+++ b/extensions/policy/ids-policy/build.gradle.kts
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2021 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+val infoModelVersion: String by project
+val rsApi: String by project
+
+plugins {
+    `java-library`
+}
+
+
+dependencies {
+    api(project(":core:contract"))
+    api(project(":spi"))
+    implementation(project(":data-protocols:ids:ids-spi"))
+}
+
+
+publishing {
+    publications {
+        create<MavenPublication>("extensions.policy.ids-policy") {
+            artifactId = "extensions.policy.ids-policy"
+            from(components["java"])
+        }
+    }
+}

--- a/extensions/policy/ids-policy/src/main/java/org/eclipse/dataspaceconnector/ids/policy/AbsSpatialPositionConstraintFunction.java
+++ b/extensions/policy/ids-policy/src/main/java/org/eclipse/dataspaceconnector/ids/policy/AbsSpatialPositionConstraintFunction.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2021 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.ids.policy;
+
+import org.eclipse.dataspaceconnector.policy.model.Operator;
+import org.eclipse.dataspaceconnector.policy.model.Permission;
+import org.eclipse.dataspaceconnector.spi.contract.policy.AtomicConstraintFunction;
+import org.eclipse.dataspaceconnector.spi.contract.policy.PolicyContext;
+
+import java.util.Collection;
+import java.util.Objects;
+
+public class AbsSpatialPositionConstraintFunction implements AtomicConstraintFunction<Permission> {
+
+    @Override
+    public boolean evaluate(Operator operator, Object rightValue, Permission rule, PolicyContext context) {
+        var region = context.getParticipantAgent().getClaims().get("region");
+        switch (operator) {
+            case EQ:
+                return Objects.equals(region, rightValue);
+            case NEQ:
+                return !Objects.equals(region, rightValue);
+            case IN:
+                return ((Collection<?>) rightValue).contains(region);
+            default:
+                return false;
+        }
+    }
+
+}

--- a/extensions/policy/ids-policy/src/main/java/org/eclipse/dataspaceconnector/ids/policy/IdsPolicyExtension.java
+++ b/extensions/policy/ids-policy/src/main/java/org/eclipse/dataspaceconnector/ids/policy/IdsPolicyExtension.java
@@ -21,13 +21,13 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
 import java.util.Set;
 
-import static org.eclipse.dataspaceconnector.ids.spi.policy.IdsPolicyExpressions.ABS_SPATIAL_POSITION;
-import static org.eclipse.dataspaceconnector.ids.spi.policy.IdsPolicyExpressions.PARTNER_LEVEL;
-
 /**
  * Registers test policy functions.
  */
 public class IdsPolicyExtension implements ServiceExtension {
+
+    public static String ABS_SPATIAL_POSITION = "ids:absoluteSpatialPosition";
+    public static String PARTNER_LEVEL = "ids:partnerLevel";
 
     @Override
     public Set<String> requires() {

--- a/extensions/policy/ids-policy/src/main/java/org/eclipse/dataspaceconnector/ids/policy/IdsPolicyExtension.java
+++ b/extensions/policy/ids-policy/src/main/java/org/eclipse/dataspaceconnector/ids/policy/IdsPolicyExtension.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2021 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.ids.policy;
+
+import org.eclipse.dataspaceconnector.policy.model.Permission;
+import org.eclipse.dataspaceconnector.spi.contract.policy.PolicyEngine;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+
+import java.util.Set;
+
+import static org.eclipse.dataspaceconnector.ids.spi.policy.IdsPolicyExpressions.ABS_SPATIAL_POSITION;
+import static org.eclipse.dataspaceconnector.ids.spi.policy.IdsPolicyExpressions.PARTNER_LEVEL;
+
+/**
+ * Registers test policy functions.
+ */
+public class IdsPolicyExtension implements ServiceExtension {
+
+    @Override
+    public Set<String> requires() {
+        return Set.of("edc:ids:core");
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var monitor = context.getMonitor();
+
+        var policyEngine = context.getService(PolicyEngine.class);
+
+        policyEngine.registerFunction(Permission.class, ABS_SPATIAL_POSITION, new AbsSpatialPositionConstraintFunction());
+        policyEngine.registerFunction(Permission.class, PARTNER_LEVEL, new PartnerLevelConstraintFunction());
+
+        monitor.info("Initialized IDS Mock Policy extension");
+    }
+
+}

--- a/extensions/policy/ids-policy/src/main/java/org/eclipse/dataspaceconnector/ids/policy/PartnerLevelConstraintFunction.java
+++ b/extensions/policy/ids-policy/src/main/java/org/eclipse/dataspaceconnector/ids/policy/PartnerLevelConstraintFunction.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2021 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.ids.policy;
+
+import org.eclipse.dataspaceconnector.policy.model.Operator;
+import org.eclipse.dataspaceconnector.policy.model.Permission;
+import org.eclipse.dataspaceconnector.spi.contract.policy.AtomicConstraintFunction;
+import org.eclipse.dataspaceconnector.spi.contract.policy.PolicyContext;
+
+import java.util.Collection;
+import java.util.Objects;
+
+public class PartnerLevelConstraintFunction implements AtomicConstraintFunction<Permission> {
+    @Override
+    public boolean evaluate(Operator operator, Object rightValue, Permission rule, PolicyContext context) {
+        String partnerLevel = context.getParticipantAgent().getClaims().get("partnerLevel");
+        switch (operator) {
+            case EQ:
+                return Objects.equals(partnerLevel, rightValue);
+            case NEQ:
+                return !Objects.equals(partnerLevel, rightValue);
+            case IN:
+                return ((Collection<?>) rightValue).contains(partnerLevel);
+            default:
+                return false;
+        }
+    }
+
+}

--- a/extensions/policy/ids-policy/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
+++ b/extensions/policy/ids-policy/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2021 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+#
+#
+
+org.eclipse.dataspaceconnector.ids.policy.IdsPolicyExtension

--- a/extensions/policy/ids-policy/src/test/java/org/eclipse/dataspaceconnector/ids/policy/AbsSpatialPositionConstraintFunctionTest.java
+++ b/extensions/policy/ids-policy/src/test/java/org/eclipse/dataspaceconnector/ids/policy/AbsSpatialPositionConstraintFunctionTest.java
@@ -1,0 +1,91 @@
+package org.eclipse.dataspaceconnector.ids.policy;
+
+import org.eclipse.dataspaceconnector.contract.policy.PolicyContextImpl;
+import org.eclipse.dataspaceconnector.policy.model.Permission;
+import org.eclipse.dataspaceconnector.spi.contract.agent.ParticipantAgent;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.policy.model.Operator.EQ;
+import static org.eclipse.dataspaceconnector.policy.model.Operator.GEQ;
+import static org.eclipse.dataspaceconnector.policy.model.Operator.GT;
+import static org.eclipse.dataspaceconnector.policy.model.Operator.IN;
+import static org.eclipse.dataspaceconnector.policy.model.Operator.NEQ;
+
+class AbsSpatialPositionConstraintFunctionTest {
+
+    private final AbsSpatialPositionConstraintFunction constraintFunction = new AbsSpatialPositionConstraintFunction();
+
+    @Test
+    void shouldVerifyEqConstraint() {
+        var euAgent = new ParticipantAgent(Map.of("region", "eu"), emptyMap());
+        var permission = dummyPermission();
+
+        boolean result = constraintFunction.evaluate(EQ, "eu", permission, new PolicyContextImpl(euAgent));
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void shouldNotVerifyEqConstraint() {
+        var euAgent = new ParticipantAgent(Map.of("region", "eu"), emptyMap());
+        var permission = dummyPermission();
+
+        boolean result = constraintFunction.evaluate(EQ, "us", permission, new PolicyContextImpl(euAgent));
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void shouldVerifyInConstraint() {
+        var euAgent = new ParticipantAgent(Map.of("region", "eu"), emptyMap());
+
+        boolean result = constraintFunction.evaluate(IN, List.of("eu"), dummyPermission(), new PolicyContextImpl(euAgent));
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void shouldNotVerifyInConstraint() {
+        var euAgent = new ParticipantAgent(Map.of("region", "eu"), emptyMap());
+
+        boolean result = constraintFunction.evaluate(IN, List.of("us"), dummyPermission(), new PolicyContextImpl(euAgent));
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void shouldVerifyNotEqConstraint() {
+        var euAgent = new ParticipantAgent(Map.of("region", "eu"), emptyMap());
+
+        boolean result = constraintFunction.evaluate(NEQ, "us", dummyPermission(), new PolicyContextImpl(euAgent));
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void shouldNotVerifyNotEqConstraint() {
+        var euAgent = new ParticipantAgent(Map.of("region", "eu"), emptyMap());
+
+        boolean result = constraintFunction.evaluate(NEQ, "eu", dummyPermission(), new PolicyContextImpl(euAgent));
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void shouldVerifyGreatherThanConstraint() {
+        var euAgent = new ParticipantAgent(Map.of("region", "eu"), emptyMap());
+
+        boolean result = constraintFunction.evaluate(GT, "eu", dummyPermission(), new PolicyContextImpl(euAgent));
+
+        assertThat(result).isFalse();
+    }
+
+    private Permission dummyPermission() {
+        return Permission.Builder.newInstance().build();
+    }
+}

--- a/extensions/policy/ids-policy/src/test/java/org/eclipse/dataspaceconnector/ids/policy/PartnerLevelConstraintFunctionTest.java
+++ b/extensions/policy/ids-policy/src/test/java/org/eclipse/dataspaceconnector/ids/policy/PartnerLevelConstraintFunctionTest.java
@@ -1,0 +1,75 @@
+package org.eclipse.dataspaceconnector.ids.policy;
+
+import org.eclipse.dataspaceconnector.contract.policy.PolicyContextImpl;
+import org.eclipse.dataspaceconnector.policy.model.Operator;
+import org.eclipse.dataspaceconnector.policy.model.Permission;
+import org.eclipse.dataspaceconnector.spi.contract.agent.ParticipantAgent;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.policy.model.Operator.EQ;
+import static org.eclipse.dataspaceconnector.policy.model.Operator.NEQ;
+
+class PartnerLevelConstraintFunctionTest {
+
+    private final PartnerLevelConstraintFunction constraintFunction = new PartnerLevelConstraintFunction();
+
+    @Test
+    void shouldVerifyEqConstraint() {
+        var agent = new ParticipantAgent(Map.of("partnerLevel", "gold"), emptyMap());
+
+        boolean result = constraintFunction.evaluate(EQ, "gold", Permission.Builder.newInstance().build(), new PolicyContextImpl(agent));
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void shouldNotVerifyEqConstraint() {
+        var agent = new ParticipantAgent(Map.of("partnerLevel", "gold"), emptyMap());
+
+        boolean result = constraintFunction.evaluate(EQ, "silver", Permission.Builder.newInstance().build(), new PolicyContextImpl(agent));
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void shouldVerifyNotEqConstraint() {
+        var agent = new ParticipantAgent(Map.of("partnerLevel", "gold"), emptyMap());
+
+        boolean result = constraintFunction.evaluate(NEQ, "silver", Permission.Builder.newInstance().build(), new PolicyContextImpl(agent));
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void shouldNotVerifyNotEqConstraint() {
+        var agent = new ParticipantAgent(Map.of("partnerLevel", "gold"), emptyMap());
+
+        boolean result = constraintFunction.evaluate(NEQ, "gold", Permission.Builder.newInstance().build(), new PolicyContextImpl(agent));
+
+        assertThat(result).isFalse();
+    }
+
+
+    @Test
+    void shouldVerifyInConstraint() {
+        var agent = new ParticipantAgent(Map.of("partnerLevel", "gold"), emptyMap());
+
+        boolean result = constraintFunction.evaluate(Operator.IN, List.of("gold"), Permission.Builder.newInstance().build(), new PolicyContextImpl(agent));
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void shouldNotVerifyInConstraint() {
+        var agent = new ParticipantAgent(Map.of("partnerLevel", "silver"), emptyMap());
+
+        boolean result = constraintFunction.evaluate(Operator.IN, List.of("gold"), Permission.Builder.newInstance().build(), new PolicyContextImpl(agent));
+
+        assertThat(result).isFalse();
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -91,6 +91,7 @@ include(":extensions:transfer-functions:transfer-functions-spi")
 include(":extensions:transfer-functions:transfer-functions-core")
 include(":extensions:dataloading:dataloading-spi")
 include(":extensions:dataloading:dataloading-asset")
+include(":extensions:policy:ids-policy")
 
 // modules for launchers, i.e. runnable compositions of the app
 include(":launchers:basic")


### PR DESCRIPTION
Add an extension that defines two functions for ids policy validation:
* `AbsSpatialPositionConstraintFunction` that checks the region
* `PartnerLevelConstraintFunction` that checks the partner level