### PR TITLE
corrected the lazy-instantiation of the ContrDefStore

### DIFF
--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
@@ -64,7 +64,12 @@ public class ContractServiceExtension implements ServiceExtension {
     @Override
     public void start() {
         // load the store in the start method so it can be overridden by an extension
-        definitionService.initialize(context.getService(ContractDefinitionStore.class));
+        var store = context.getService(ContractDefinitionStore.class, true);
+        if (store == null) {
+            store = new InMemoryContractDefinitionStore();
+            context.registerService(ContractDefinitionStore.class, store);
+        }
+        definitionService.initialize(store);
         monitor.info(String.format("Started %s", NAME));
     }
 
@@ -86,9 +91,6 @@ public class ContractServiceExtension implements ServiceExtension {
 
         var policyEngine = new PolicyEngineImpl();
         context.registerService(PolicyEngine.class, policyEngine);
-
-        var definitionsStore = new InMemoryContractDefinitionStore();
-        context.registerService(ContractDefinitionStore.class, definitionsStore);
 
         definitionService = new ContractDefinitionServiceImpl(policyEngine, monitor);
         var contractOfferService = new ContractOfferServiceImpl(agentService, definitionService, assetIndex);

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
@@ -35,7 +35,7 @@ import java.util.Set;
 
 public class ContractServiceExtension implements ServiceExtension {
     private static final String NAME = "Core Contract Service Extension";
-    private static final Set<String> PROVIDES = Set.of("edc:core:contract");
+    private static final Set<String> PROVIDES = Set.of("edc:core:contract", ContractDefinitionStore.FEATURE);
 
     private Monitor monitor;
     private ServiceExtensionContext context;
@@ -63,12 +63,9 @@ public class ContractServiceExtension implements ServiceExtension {
 
     @Override
     public void start() {
-        // load the store in the start method so it can be overridden by an extension
-        var store = context.getService(ContractDefinitionStore.class, true);
-        if (store == null) {
-            store = new InMemoryContractDefinitionStore();
-            context.registerService(ContractDefinitionStore.class, store);
-        }
+        // load the store in the start method, so it can be overridden by an extension
+
+        var store = context.getService(ContractDefinitionStore.class);
         definitionService.initialize(store);
         monitor.info(String.format("Started %s", NAME));
     }
@@ -95,6 +92,12 @@ public class ContractServiceExtension implements ServiceExtension {
         definitionService = new ContractDefinitionServiceImpl(policyEngine, monitor);
         var contractOfferService = new ContractOfferServiceImpl(agentService, definitionService, assetIndex);
         context.registerService(ContractDefinitionService.class, definitionService);
+
+        var store = context.getService(ContractDefinitionStore.class, true);
+        if (store == null) {
+            store = new InMemoryContractDefinitionStore();
+            context.registerService(ContractDefinitionStore.class, store);
+        }
 
         // Register the created contract offer service with the service extension context.
         context.registerService(ContractOfferService.class, contractOfferService);

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
@@ -35,7 +35,6 @@ import java.util.Set;
 
 public class ContractServiceExtension implements ServiceExtension {
     private static final String NAME = "Core Contract Service Extension";
-    private static final Set<String> PROVIDES = Set.of("edc:core:contract", ContractDefinitionStore.FEATURE);
 
     private Monitor monitor;
     private ServiceExtensionContext context;
@@ -43,7 +42,7 @@ public class ContractServiceExtension implements ServiceExtension {
 
     @Override
     public final Set<String> provides() {
-        return PROVIDES;
+        return Set.of("edc:core:contract", ContractDefinitionStore.FEATURE);
     }
 
     @Override

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/build.gradle.kts
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/build.gradle.kts
@@ -32,8 +32,6 @@ dependencies {
     testImplementation(testFixtures(project(":launchers:junit")))
     testImplementation(project(":core:protocol:web"))
     testImplementation(project(":data-protocols:ids:ids-api-multipart-endpoint-v1"))
-    testImplementation(project(":extensions:in-memory:assetindex-memory"))
-    testImplementation(project(":core:contract"))
 }
 
 publishing {

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/build.gradle.kts
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/build.gradle.kts
@@ -32,6 +32,8 @@ dependencies {
     testImplementation(testFixtures(project(":launchers:junit")))
     testImplementation(project(":core:protocol:web"))
     testImplementation(project(":data-protocols:ids:ids-api-multipart-endpoint-v1"))
+    testImplementation(project(":extensions:in-memory:assetindex-memory"))
+    testImplementation(project(":core:contract"))
 }
 
 publishing {

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
@@ -65,7 +65,7 @@ class IdsApiMultipartDispatcherV1IntegrationTestServiceExtension implements Serv
 
     @Override
     public Set<String> provides() {
-        return Set.of("edc:iam", "edc:core:contract", "dataspaceconnector:transferprocessstore", "dataspaceconnector:dispatcher");
+        return Set.of("edc:iam", "edc:core:contract", "dataspaceconnector:transferprocessstore", "dataspaceconnector:dispatcher", ContractDefinitionStore.FEATURE);
     }
 
     @Override

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/build.gradle.kts
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/build.gradle.kts
@@ -34,8 +34,6 @@ dependencies {
     testImplementation(testFixtures(project(":launchers:junit")))
     testImplementation(project(":core:protocol:web"))
 
-    testImplementation(project(":extensions:in-memory:assetindex-memory"))
-    testImplementation(project(":core:contract"))
 }
 
 publishing {

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/build.gradle.kts
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/build.gradle.kts
@@ -33,6 +33,9 @@ dependencies {
     testImplementation("net.javacrumbs.json-unit:json-unit:2.28.0")
     testImplementation(testFixtures(project(":launchers:junit")))
     testImplementation(project(":core:protocol:web"))
+
+    testImplementation(project(":extensions:in-memory:assetindex-memory"))
+    testImplementation(project(":core:contract"))
 }
 
 publishing {

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsMultipartApiServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsMultipartApiServiceExtension.java
@@ -69,16 +69,17 @@ public final class IdsMultipartApiServiceExtension implements ServiceExtension {
     private Monitor monitor;
 
     @Override
+    public Set<String> provides() {
+        return Set.of("edc:ids:api:multipart:endpoint:v1");
+    }
+
+    @Override
     public Set<String> requires() {
         return Set.of(IdentityService.FEATURE,
                 "dataspaceconnector:transferprocessstore",
                 "edc:ids:core",
+                ContractDefinitionStore.FEATURE,
                 "edc:ids:transform:v1");
-    }
-
-    @Override
-    public Set<String> provides() {
-        return Set.of("edc:ids:api:multipart:endpoint:v1");
     }
 
     @Override

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
@@ -66,7 +66,7 @@ class IdsApiMultipartEndpointV1IntegrationTestServiceExtension implements Servic
 
     @Override
     public Set<String> provides() {
-        return Set.of("edc:iam", "edc:core:contract", "dataspaceconnector:transferprocessstore");
+        return Set.of("edc:iam", "edc:core:contract", "dataspaceconnector:transferprocessstore", ContractDefinitionStore.FEATURE);
     }
 
     @Override

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/MultipartControllerIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/MultipartControllerIntegrationTest.java
@@ -44,17 +44,6 @@ public class MultipartControllerIntegrationTest extends AbstractMultipartControl
                 .build();
     }
 
-    @Override
-    protected Map<String, String> getSystemProperties() {
-        return new HashMap<>() {
-            {
-                put("web.http.port", String.valueOf(getPort()));
-                put("edc.ids.id", "urn:connector:" + CONNECTOR_ID);
-                put("edc.ids.catalog.id", "urn:catalog:" + CATALOG_ID);
-            }
-        };
-    }
-
     @Test
     void testRequestConnectorSelfDescriptionWithoutId() throws Exception {
         // prepare
@@ -476,5 +465,16 @@ public class MultipartControllerIntegrationTest extends AbstractMultipartControl
         jsonPayload.inPath("$.ids:representation[0].ids:instance[0].ids:fileName").isString().isEqualTo("test.txt");
         jsonPayload.inPath("$.ids:representation[0].ids:mediaType.@type").isString().isEqualTo("ids:CustomMediaType");
         jsonPayload.inPath("$.ids:representation[0].ids:mediaType.ids:filenameExtension").isString().matches("txt");
+    }
+
+    @Override
+    protected Map<String, String> getSystemProperties() {
+        return new HashMap<>() {
+            {
+                put("web.http.port", String.valueOf(getPort()));
+                put("edc.ids.id", "urn:connector:" + CONNECTOR_ID);
+                put("edc.ids.catalog.id", "urn:catalog:" + CATALOG_ID);
+            }
+        };
     }
 }

--- a/extensions/aws/s3/provision/src/test/java/org/eclipse/dataspaceconnector/provision/aws/s3/S3StatusCheckerIntegrationTest.java
+++ b/extensions/aws/s3/provision/src/test/java/org/eclipse/dataspaceconnector/provision/aws/s3/S3StatusCheckerIntegrationTest.java
@@ -38,6 +38,7 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.easymock.EasyMock.anyString;
+import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
@@ -52,11 +53,12 @@ class S3StatusCheckerIntegrationTest extends AbstractS3Test {
     void setup() {
         RetryPolicy<Object> retryPolicy = new RetryPolicy<>().withMaxRetries(3).withBackoff(200, 1000, ChronoUnit.MILLIS);
         ClientProvider providerMock = mock(ClientProvider.class);
-        expect(providerMock.clientFor(S3AsyncClient.class, anyString()))
-                .anyTimes()
+        expect(providerMock.clientFor(eq(S3AsyncClient.class), anyString()))
+
                 .andReturn(S3AsyncClient.builder()
                         .region(Region.of(REGION))
-                        .credentialsProvider(() -> AwsBasicCredentials.create(credentials.getAWSAccessKeyId(), credentials.getAWSSecretKey())).build());
+                        .credentialsProvider(() -> AwsBasicCredentials.create(credentials.getAWSAccessKeyId(), credentials.getAWSSecretKey())).build())
+                .anyTimes();
         replay(providerMock);
         checker = new S3StatusChecker(providerMock, retryPolicy);
     }


### PR DESCRIPTION
The old implementation made it possible for a `ContractDefinitionStore` supplied by an extension to get overwritten by the `InMemory...` one. That should now be corrected - the in-mem one is only used as fallback.