### PR TITLE
Adds monitor logger extension

### DIFF
--- a/extensions/jdk-logger-monitor/README.md
+++ b/extensions/jdk-logger-monitor/README.md
@@ -1,0 +1,25 @@
+# JDK Logger Monitor
+
+This extension provides a `Logger` which is an implementation of edc `Monitor` interface. It is based on `java.util.logging` package so it doesn't introduce any additional dependencies. As this extension is based on `MonitorExtension` which means this logger extension will load during the runtime initialization and all monitor logs (including edc core framework) will be forwarded to this logger.
+
+## Usages
+
+To use this logger extension just add this jdk-logger-monitor extension package in your project dependency.
+
+## Logging Configuration
+
+As this extension usages `java.util.logging` so to specify logger handler, format, level etc. provide a java properties file e.g. logging.properties
+
+```text
+handlers = java.util.logging.ConsoleHandler
+.level = INFO
+java.util.logging.ConsoleHandler.level = ALL
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format = %1$tF %1$tT %4$s : %5$s %n
+```
+
+To use this file pass it as jvm arguments `-Djava.util.logging.config.file=logging.properties`
+
+## Know limitation
+
+A class level logger cannot be created as current Monitor interface methods does not have class as method arguments . So instead a global or extension level can be used.

--- a/extensions/jdk-logger-monitor/build.gradle.kts
+++ b/extensions/jdk-logger-monitor/build.gradle.kts
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *      Catena-X Consortium - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    `maven-publish`
+}
+
+
+dependencies {
+    api(project(":spi"))
+
+    testImplementation("com.github.javafaker:javafaker:1.0.2")
+    testImplementation("org.assertj:assertj-core:3.21.0")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:5.8.1")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.8.1")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.1")
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("jdk-logger-monitor") {
+            groupId = "org.eclipse.dataspaceconnector.logger"
+            artifactId = "jdk-logger-monitor"
+            version = "0.1"
+            from(components["java"])
+        }
+    }
+}

--- a/extensions/jdk-logger-monitor/src/main/java/org/eclipse/dataspaceconnector/logger/LoggerMonitor.java
+++ b/extensions/jdk-logger-monitor/src/main/java/org/eclipse/dataspaceconnector/logger/LoggerMonitor.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *      Catena-X Consortium - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.logger;
+
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Logging monitor using java.util.logging.
+ */
+public class LoggerMonitor implements Monitor {
+
+    /**
+     * Global logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(LoggerMonitor.class.getName());
+
+    @Override
+    public void severe(final Supplier<String> supplier, final Throwable... errors) {
+        log(supplier, Level.SEVERE, errors);
+    }
+
+    @Override
+    public void severe(final Map<String, Object> data) {
+        data.forEach((key, value) -> LOGGER.log(Level.SEVERE, key, value));
+    }
+
+    @Override
+    public void warning(final Supplier<String> supplier, final Throwable... errors) {
+        log(supplier, Level.WARNING, errors);
+    }
+
+    @Override
+    public void info(final Supplier<String> supplier, final Throwable... errors) {
+        log(supplier, Level.INFO, errors);
+    }
+
+    @Override
+    public void debug(final Supplier<String> supplier, final Throwable... errors) {
+        log(supplier, Level.FINE, errors);
+    }
+
+    private void log(final Supplier<String> supplier, final Level level, final Throwable... errors) {
+        if (errors == null || errors.length == 0) {
+            LOGGER.log(level, supplier);
+        } else {
+            Arrays.stream(errors).forEach(error -> LOGGER.log(level, supplier.get(), error));
+        }
+    }
+
+}

--- a/extensions/jdk-logger-monitor/src/main/java/org/eclipse/dataspaceconnector/logger/LoggerMonitorExtension.java
+++ b/extensions/jdk-logger-monitor/src/main/java/org/eclipse/dataspaceconnector/logger/LoggerMonitorExtension.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *      Catena-X Consortium - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.logger;
+
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.system.MonitorExtension;
+
+/**
+ * Extension adding logging monitor.
+ */
+public class LoggerMonitorExtension implements MonitorExtension {
+
+    @Override
+    public Monitor getMonitor() {
+        return new LoggerMonitor();
+    }
+}

--- a/extensions/jdk-logger-monitor/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.MonitorExtension
+++ b/extensions/jdk-logger-monitor/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.MonitorExtension
@@ -1,0 +1,1 @@
+org.eclipse.dataspaceconnector.logger.LoggerMonitorExtension

--- a/extensions/jdk-logger-monitor/src/test/java/org/eclipse/dataspaceconnector/logger/LoggerMonitorTests.java
+++ b/extensions/jdk-logger-monitor/src/test/java/org/eclipse/dataspaceconnector/logger/LoggerMonitorTests.java
@@ -1,0 +1,187 @@
+/*
+ *  Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *      Catena-X Consortium - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.logger;
+
+import com.github.javafaker.Faker;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+/**
+ * Collection of unit tests for {@link LoggerMonitor}
+ */
+public class LoggerMonitorTests {
+
+    static Faker faker = new Faker();
+    final String message = faker.lorem().sentence();
+    final String extraParams = faker.lorem().sentence();
+    TestLogHandler handler = new TestLogHandler();
+    LoggerMonitor sut = new LoggerMonitor();
+
+    @BeforeEach
+    public void setUp() {
+        Logger logger = Logger.getLogger(LoggerMonitor.class.getName());
+        handler.setLevel(Level.ALL);
+        //To prevent forwarding to other handlers.
+        logger.setUseParentHandlers(false);
+        logger.addHandler(handler);
+        logger.setLevel(Level.ALL);
+    }
+
+    private static Stream<Arguments> provideLogDataWithErrors() {
+        return Stream.of(
+                Arguments.of(faker.lorem().sentence(), new Throwable[]{new RuntimeException()}),
+                Arguments.of(faker.lorem().sentence(), new Throwable[]{new RuntimeException(), new Exception()})
+        );
+    }
+
+    @ParameterizedTest(name = "{index} {1}")
+    @MethodSource("provideLogDataWithErrors")
+    public void loggedOnInfoLevel_WithErrors(String message, Throwable... errors) {
+
+        //Act
+        sut.info(() -> message, errors);
+
+        //Assert
+        assertLogWithErrors(message, Level.INFO, errors);
+    }
+
+    @ParameterizedTest(name = "{index} {1}")
+    @MethodSource("provideLogDataWithErrors")
+    public void loggedOnWarningLevel_WithErrors(String message, Throwable... errors) {
+
+        //Act
+        sut.warning(() -> message, errors);
+
+        //Assert
+        assertLogWithErrors(message, Level.WARNING, errors);
+    }
+
+    @ParameterizedTest(name = "{index} {1}")
+    @MethodSource("provideLogDataWithErrors")
+    public void loggedOnSevereLevel_WithErrors(String message, Throwable... errors) {
+
+        //Act
+        sut.severe(() -> message, errors);
+
+        //Assert
+        assertLogWithErrors(message, Level.SEVERE, errors);
+    }
+
+    @ParameterizedTest(name = "{index} {1}")
+    @MethodSource("provideLogDataWithErrors")
+    public void loggedOnDebugLevel_WithErrors(String message, Throwable... errors) {
+
+        //Act
+        sut.debug(() -> message, errors);
+
+        //Assert
+        assertLogWithErrors(message, Level.FINE, errors);
+    }
+
+    @Test
+    public void loggedOnSevereLevel_WithParams() {
+
+        // Arrange
+        Map<String, Object> errors = Map.of(message, extraParams);
+
+        //Act
+        sut.severe(errors);
+
+        //Assert
+        assertThat(handler.getRecords()).extracting(
+                        LogRecord::getMessage, LogRecord::getLevel, LogRecord::getThrown, LogRecord::getParameters)
+                .containsExactly(
+                        tuple(message, Level.SEVERE, null, new Object[]{extraParams}));
+    }
+
+    @Test
+    public void loggedOnInfoLevel() {
+
+        //Act
+        sut.info(() -> message);
+
+        assertLog(message, Level.INFO);
+    }
+
+    @Test
+    public void loggedOnSevereLevel() {
+
+        //Act
+        sut.severe(() -> message);
+
+        //Assert
+        assertLog(message, Level.SEVERE);
+    }
+
+    @Test
+    public void loggedOnWarningLevel() {
+
+        //Act
+        sut.warning(() -> message);
+
+        //Assert
+        assertLog(message, Level.WARNING);
+    }
+
+    @Test
+    public void loggedOnDebugLevel() {
+
+        //Act
+        sut.debug(() -> message);
+
+        //Assert
+        assertLog(message, Level.FINE);
+    }
+
+    /**
+     * Additional test to verify {@link LoggerMonitor} varargs null check is in place.
+     */
+    @Test
+    public void loggedOnSevereLevel_WithNullVarArgs() {
+
+        //Act
+        sut.severe(() -> message, null);
+
+        //Assert
+        assertLog(message, Level.SEVERE);
+    }
+
+    private void assertLog(String message, Level level) {
+        assertThat(handler.getRecords()).extracting(
+                        LogRecord::getMessage, LogRecord::getLevel, LogRecord::getThrown)
+                .containsExactly(
+                        tuple(message, level, null));
+    }
+
+    private void assertLogWithErrors(String message, Level level, Throwable... errors) {
+        assertThat(handler.getRecords()).extracting(
+                        LogRecord::getMessage, LogRecord::getLevel, LogRecord::getThrown)
+                .containsExactlyInAnyOrder(
+                        Arrays.stream(errors).map(e -> tuple(message, level, e)).toArray(Tuple[]::new));
+    }
+}

--- a/extensions/jdk-logger-monitor/src/test/java/org/eclipse/dataspaceconnector/logger/TestLogHandler.java
+++ b/extensions/jdk-logger-monitor/src/test/java/org/eclipse/dataspaceconnector/logger/TestLogHandler.java
@@ -1,0 +1,38 @@
+package org.eclipse.dataspaceconnector.logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+
+/**
+ * A simple log handler to validate logger under unit tests {@link org.eclipse.dataspaceconnector.logger.LoggerMonitorTests}.
+ */
+public class TestLogHandler extends Handler {
+
+    private final List<LogRecord> records = new ArrayList<>();
+
+    @Override
+    public void publish(LogRecord record) {
+        records.add(record);
+    }
+
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public void close() throws SecurityException {
+        throw new RuntimeException("TestLogHandler shouldn't be reused outside tests scope.");
+    }
+
+    /**
+     * Gets list of log records.
+     *
+     * @return List of see {@link LogRecord}
+     */
+    public List<LogRecord> getRecords() {
+        return records;
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -95,6 +95,7 @@ include(":extensions:dataloading:dataloading-spi")
 include(":extensions:dataloading:dataloading-asset")
 include(":extensions:dataloading:dataloading-contractdef")
 include(":extensions:policy:ids-policy")
+include(":extensions:jdk-logger-monitor")
 
 // modules for launchers, i.e. runnable compositions of the app
 include(":launchers:basic")


### PR DESCRIPTION
- Adds a monitor logger extension.
- java.util.logging is used for logger. This will not introduce any additional dependency.
- Adds unit tests.
- Adds documentation.

Closes #297 (https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/297)