### PR TITLE
spi: extend DataRequest with custom properties field

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,6 +87,7 @@ allprojects {
             testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")
             testImplementation("org.easymock:easymock:4.2")
             testImplementation("org.assertj:assertj-core:3.19.0")
+            testImplementation("com.github.javafaker:javafaker:1.0.2")
         }
 
         publishing {

--- a/data-protocols/ids/ids-api-transfer/build.gradle.kts
+++ b/data-protocols/ids/ids-api-transfer/build.gradle.kts
@@ -30,8 +30,6 @@ dependencies {
     implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
 
     testImplementation("org.glassfish.jersey.core:jersey-common:${jerseyVersion}")
-    testImplementation("com.github.javafaker:javafaker:1.0.2")
-
 }
 
 publishing {

--- a/data-protocols/ids/ids-api-transfer/build.gradle.kts
+++ b/data-protocols/ids/ids-api-transfer/build.gradle.kts
@@ -14,6 +14,7 @@
 
 val infoModelVersion: String by project
 val rsApi: String by project
+val jerseyVersion: String by project
 
 plugins {
     `java-library`
@@ -27,6 +28,9 @@ dependencies {
     api("de.fraunhofer.iais.eis.ids.infomodel:java:${infoModelVersion}")
 
     implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
+
+    testImplementation("org.glassfish.jersey.core:jersey-common:${jerseyVersion}")
+    testImplementation("com.github.javafaker:javafaker:1.0.2")
 
 }
 

--- a/data-protocols/ids/ids-api-transfer/src/test/java/org/eclipse/dataspaceconnector/ids/api/transfer/ArtifactRequestControllerTest.java
+++ b/data-protocols/ids/ids-api-transfer/src/test/java/org/eclipse/dataspaceconnector/ids/api/transfer/ArtifactRequestControllerTest.java
@@ -1,0 +1,138 @@
+/*
+ *  Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Catena-X Consortium - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.ids.api.transfer;
+
+import com.github.javafaker.Faker;
+import de.fraunhofer.iais.eis.ArtifactRequestMessage;
+import de.fraunhofer.iais.eis.ArtifactRequestMessageBuilder;
+import de.fraunhofer.iais.eis.DynamicAttributeTokenBuilder;
+import org.easymock.Capture;
+import org.eclipse.dataspaceconnector.ids.spi.daps.DapsService;
+import org.eclipse.dataspaceconnector.ids.spi.policy.IdsPolicyService;
+import org.eclipse.dataspaceconnector.policy.engine.PolicyEvaluationResult;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
+import org.eclipse.dataspaceconnector.spi.iam.VerificationResult;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.policy.PolicyRegistry;
+import org.eclipse.dataspaceconnector.spi.security.Vault;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferInitiateResponse;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.anyString;
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.newCapture;
+import static org.easymock.EasyMock.niceMock;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.same;
+import static org.easymock.EasyMock.verify;
+import static org.eclipse.dataspaceconnector.ids.spi.Protocols.IDS_REST;
+
+public class ArtifactRequestControllerTest {
+
+    public static final String DESTINATION_KEY = "dataspaceconnector-data-destination";
+    public static final String PROPERTIES_KEY = "dataspaceconnector-properties";
+    static Faker faker = new Faker();
+
+    private ArtifactRequestController controller;
+    private TransferProcessManager manager;
+
+    private final String consumerConnectorAddress = faker.internet().url();
+    private final String artifactMessageId = faker.internet().uuid();
+    private final String assetId = faker.internet().url();
+
+
+    @BeforeEach
+    public void setUp() {
+        manager = mock(TransferProcessManager.class);
+
+        DapsService dapsService = niceMock(DapsService.class);
+        VerificationResult verificationResult = niceMock(VerificationResult.class);
+        AssetIndex assetIndex = niceMock(AssetIndex.class);
+        Asset asset = niceMock(Asset.class);
+        PolicyRegistry policyRegistry = niceMock(PolicyRegistry.class);
+        IdsPolicyService policyService = niceMock(IdsPolicyService.class);
+        PolicyEvaluationResult policyEvaluationResult = niceMock(PolicyEvaluationResult.class);
+
+        expect(dapsService.verifyAndConvertToken(anyString())).andReturn(verificationResult);
+        expect(verificationResult.valid()).andReturn(true);
+        expect(assetIndex.findById(assetId)).andReturn(asset);
+        expect(asset.getId()).andReturn(assetId);
+        expect(policyRegistry.resolvePolicy(anyObject())).andReturn(niceMock(Policy.class));
+        expect(policyEvaluationResult.valid()).andReturn(true);
+        expect(policyService.evaluateRequest(same(consumerConnectorAddress), same(artifactMessageId), anyObject(), anyObject())).andReturn(policyEvaluationResult);
+
+        replay(dapsService, verificationResult, assetIndex, asset, policyRegistry, policyService, policyEvaluationResult);
+
+        controller = new ArtifactRequestController(dapsService, assetIndex, manager, policyService, policyRegistry, mock(Vault.class), mock(Monitor.class));
+    }
+
+
+    @Test
+    public void initiateDataRequest() {
+
+        // prepare
+        var requestProperties = Map.of(faker.lorem().word(), faker.lorem().word(), faker.lorem().word(), faker.lorem().word());
+        var type = faker.lorem().word();
+        var secretName = faker.lorem().word();
+        var destinationMap = Map.of("type", type, "keyName", secretName, "properties", Map.of());
+        ArtifactRequestMessage artifactRequestMessage = createArtifactRequestMessage(requestProperties, destinationMap);
+
+        // record
+        Capture<DataRequest> requestCapture = newCapture();
+        expect(manager.initiateProviderRequest(capture(requestCapture))).andReturn(TransferInitiateResponse.Builder.newInstance().build()).times(1);
+        replay(manager);
+
+        // invoke
+        controller.request(artifactRequestMessage);
+
+        // verify
+        DataRequest dataRequest = requestCapture.getValue();
+        assertThat(dataRequest.getAssetId()).isEqualTo(assetId);
+        assertThat(dataRequest.getProperties()).isEqualTo(requestProperties);
+        assertThat(dataRequest.getProtocol()).isEqualTo(IDS_REST);
+        assertThat(dataRequest.getDataDestination().getKeyName()).isEqualTo(secretName);
+        assertThat(dataRequest.getDataDestination().getType()).isEqualTo(type);
+        assertThat(dataRequest.getDataDestination().getProperties()).isEqualTo(Map.of("type", type, "keyName", secretName));
+        verify(manager);
+    }
+
+    @NotNull
+    private ArtifactRequestMessage createArtifactRequestMessage(Map<String, String> additionalProperties, Map<String, Object> destinationMap) {
+        ArtifactRequestMessage artifactRequestMessage = new ArtifactRequestMessageBuilder(URI.create(artifactMessageId))
+                ._securityToken_(new DynamicAttributeTokenBuilder()
+                        ._tokenValue_(faker.lorem().word())
+                        .build())
+                ._requestedArtifact_(URI.create(assetId))
+                ._issuerConnector_(URI.create(consumerConnectorAddress))
+                .build();
+
+        artifactRequestMessage.setProperty(DESTINATION_KEY, destinationMap);
+        artifactRequestMessage.setProperty(PROPERTIES_KEY, additionalProperties);
+        return artifactRequestMessage;
+    }
+
+}

--- a/data-protocols/ids/ids-core/build.gradle.kts
+++ b/data-protocols/ids/ids-core/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
 
     implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
     implementation(project(":core:policy:policy-engine"))
+    testImplementation("com.github.javafaker:javafaker:1.0.2")
 }
 
 

--- a/data-protocols/ids/ids-core/build.gradle.kts
+++ b/data-protocols/ids/ids-core/build.gradle.kts
@@ -29,7 +29,6 @@ dependencies {
 
     implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
     implementation(project(":core:policy:policy-engine"))
-    testImplementation("com.github.javafaker:javafaker:1.0.2")
 }
 
 

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/message/DataRequestMessageSender.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/message/DataRequestMessageSender.java
@@ -30,7 +30,6 @@ import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.net.URI;
 import java.util.Objects;
@@ -92,6 +91,8 @@ public class DataRequestMessageSender implements IdsMessageSender<DataRequest, V
                 ._requestedArtifact_(URI.create(dataRequest.getAssetId()))
                 .build();
         artifactMessage.setProperty("dataspaceconnector-data-destination", dataRequest.getDataDestination());
+
+        artifactMessage.setProperty("dataspaceconnector-properties", dataRequest.getProperties());
 
         var processId = context.getProcessId();
 

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/message/DataRequestMessageSenderTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/message/DataRequestMessageSenderTest.java
@@ -1,0 +1,123 @@
+/*
+ *  Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Catena-X Consortium - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.ids.core.message;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.javafaker.Faker;
+import de.fraunhofer.iais.eis.ArtifactRequestMessageImpl;
+import okhttp3.Call;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okio.Buffer;
+import org.easymock.Capture;
+import org.easymock.EasyMock;
+import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
+import org.eclipse.dataspaceconnector.spi.iam.TokenResult;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.security.Vault;
+import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static java.util.Map.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.newCapture;
+import static org.easymock.EasyMock.niceMock;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.eclipse.dataspaceconnector.ids.spi.Protocols.IDS_REST;
+
+class DataRequestMessageSenderTest {
+
+    public static final String DESTINATION_KEY = "dataspaceconnector-data-destination";
+    public static final String PROPERTIES_KEY = "dataspaceconnector-properties";
+    static Faker faker = new Faker();
+    private final String connectorAddress = "http://" + faker.internet().url();
+    private final String connectorId = faker.internet().url();
+    private final String processId = faker.internet().uuid();
+    private final ObjectMapper mapper = new ObjectMapper();
+
+
+    private DataRequestMessageSender sender;
+    private OkHttpClient httpClient;
+
+    @BeforeEach
+    public void setUp() {
+        httpClient = niceMock(OkHttpClient.class);
+
+        IdentityService identityService = niceMock(IdentityService.class);
+        TokenResult tokenResult = niceMock(TokenResult.class);
+        expect(tokenResult.getToken()).andReturn(faker.lorem().characters());
+        expect(identityService.obtainClientCredentials(connectorId)).andReturn(tokenResult);
+        replay(identityService, tokenResult);
+        sender = new DataRequestMessageSender(connectorId, identityService, niceMock(TransferProcessStore.class), EasyMock.mock(Vault.class), httpClient, mapper, niceMock(Monitor.class));
+    }
+
+    @Test
+    public void initiateIdsMessage() throws IOException {
+        DataRequest dataRequest = createDataRequest();
+        DataAddress dataDestination = dataRequest.getDataDestination();
+
+        // record
+        Capture<Request> requestCapture = newCapture();
+        expect(httpClient.newCall(capture(requestCapture))).andReturn(niceMock(Call.class)).times(1);
+        replay(httpClient);
+
+        // invoke
+        sender.send(dataRequest, () -> processId);
+
+        //verify
+        verify(httpClient);
+
+        var artifactMessageRequest = getArtifactMessageRequest(requestCapture.getValue());
+        assertThat(artifactMessageRequest.getIssuerConnector()).isEqualTo(URI.create(connectorId));
+        assertThat(artifactMessageRequest.getRequestedArtifact()).isEqualTo(URI.create(dataRequest.getAssetId()));
+
+        var properties = artifactMessageRequest.getProperties();
+        assertThat((Map<String, Object>) properties.get(DESTINATION_KEY)).contains(entry("keyName", dataDestination.getKeyName()), entry("type", dataDestination.getType()));
+        assertThat(properties.get(PROPERTIES_KEY)).isEqualTo(dataRequest.getProperties());
+
+    }
+
+    private DataRequest createDataRequest() {
+        var requestProperties = Map.of(faker.internet().uuid(), faker.lorem().word(), faker.internet().uuid(), faker.lorem().word());
+        var keyName = faker.lorem().word();
+        var type = faker.lorem().word();
+        return DataRequest.Builder.newInstance()
+                .connectorId(connectorId)
+                .assetId(faker.internet().url())
+                .dataDestination(DataAddress.Builder.newInstance().keyName(keyName).type(type).build())
+                .protocol(IDS_REST)
+                .properties(requestProperties)
+                .connectorAddress(connectorAddress)
+                .build();
+    }
+
+    private ArtifactRequestMessageImpl getArtifactMessageRequest(Request request) throws IOException {
+        Buffer buffer = new Buffer();
+        request.body().writeTo(buffer);
+        String json = buffer.readString(StandardCharsets.UTF_8);
+        return mapper.readValue(json, ArtifactRequestMessageImpl.class);
+    }
+
+}

--- a/extensions/jdk-logger-monitor/build.gradle.kts
+++ b/extensions/jdk-logger-monitor/build.gradle.kts
@@ -20,7 +20,6 @@ plugins {
 dependencies {
     api(project(":spi"))
 
-    testImplementation("com.github.javafaker:javafaker:1.0.2")
     testImplementation("org.assertj:assertj-core:3.21.0")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.8.1")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.8.1")

--- a/spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataRequest.java
+++ b/spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataRequest.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.dataspaceconnector.spi.types.domain.Polymorphic;
 import org.eclipse.dataspaceconnector.spi.types.domain.message.RemoteMessage;
 
+import java.util.Map;
+
 /**
  * Polymorphic data request.
  */
@@ -44,6 +46,8 @@ public class DataRequest implements RemoteMessage, Polymorphic {
     private DataAddress dataDestination;
 
     private boolean managedResources = true;
+
+    private Map<String, String> properties = Map.of();
 
     private TransferType transferType;
 
@@ -120,6 +124,13 @@ public class DataRequest implements RemoteMessage, Polymorphic {
         return dataDestination;
     }
 
+    /**
+     * Custom properties that are passed to the provider connector.
+     */
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
     public boolean isManagedResources() {
         return managedResources;
     }
@@ -136,6 +147,7 @@ public class DataRequest implements RemoteMessage, Polymorphic {
                 .dataAddress(dataDestination)
                 .transferType(transferType)
                 .managedResources(managedResources)
+                .properties(properties)
                 .build();
     }
 
@@ -212,6 +224,11 @@ public class DataRequest implements RemoteMessage, Polymorphic {
 
         public Builder managedResources(boolean value) {
             request.managedResources = value;
+            return this;
+        }
+
+        public Builder properties(Map<String, String> value) {
+            request.properties = value == null ? null : Map.copyOf(value);
             return this;
         }
 


### PR DESCRIPTION
This PR contains a proposal to solve issue #299  by extending the DataRequest object with a Map of custom properties.

- add properties Map field to DataRequest
- add the properties to the artifactMessage in DataRequestMessageSender so that they are passed to the provider
- read the properties in ArtifactRequestController
- add unit tests for verifying that the properties were passed from DataRequest to ArtifactRequestMessage in consumer and from ArtifactRequestMessage to DataRequest in provider

Closes #299 