### PR TITLE
Fixes a faulty test setup for the S3 StatusChecker Integration test

### DIFF
--- a/extensions/aws/s3/provision/src/test/java/org/eclipse/dataspaceconnector/provision/aws/s3/S3StatusCheckerIntegrationTest.java
+++ b/extensions/aws/s3/provision/src/test/java/org/eclipse/dataspaceconnector/provision/aws/s3/S3StatusCheckerIntegrationTest.java
@@ -38,6 +38,7 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.easymock.EasyMock.anyString;
+import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
@@ -52,11 +53,12 @@ class S3StatusCheckerIntegrationTest extends AbstractS3Test {
     void setup() {
         RetryPolicy<Object> retryPolicy = new RetryPolicy<>().withMaxRetries(3).withBackoff(200, 1000, ChronoUnit.MILLIS);
         ClientProvider providerMock = mock(ClientProvider.class);
-        expect(providerMock.clientFor(S3AsyncClient.class, anyString()))
-                .anyTimes()
+        expect(providerMock.clientFor(eq(S3AsyncClient.class), anyString()))
+
                 .andReturn(S3AsyncClient.builder()
                         .region(Region.of(REGION))
-                        .credentialsProvider(() -> AwsBasicCredentials.create(credentials.getAWSAccessKeyId(), credentials.getAWSSecretKey())).build());
+                        .credentialsProvider(() -> AwsBasicCredentials.create(credentials.getAWSAccessKeyId(), credentials.getAWSSecretKey())).build())
+                .anyTimes();
         replay(providerMock);
         checker = new S3StatusChecker(providerMock, retryPolicy);
     }


### PR DESCRIPTION
unfortunately, again, we need to merge this into `main` before we see the effects due to the workflow configuration.