### PR TITLE
Ids-multipart: Replace usage of TransferProcessStore with -Manager

### DIFF
--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/build.gradle.kts
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     api(project(":data-protocols:ids:ids-spi"))
     api(project(":data-protocols:ids:ids-core"))
     api(project(":data-protocols:ids:ids-transform-v1"))
+    api(project(":core:transfer"))
 
     implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
     implementation("org.glassfish.jersey.media:jersey-media-multipart:${jerseyVersion}")

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsMultipartApiServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsMultipartApiServiceExtension.java
@@ -72,7 +72,7 @@ public final class IdsMultipartApiServiceExtension implements ServiceExtension {
     @Override
     public Set<String> requires() {
         return Set.of(IdentityService.FEATURE,
-                "dataspaceconnector:transferprocessstore",
+                "dataspaceconnector:transfer-process-manager",
                 "edc:ids:core",
                 "edc:ids:transform:v1");
     }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsMultipartApiServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsMultipartApiServiceExtension.java
@@ -46,6 +46,7 @@ import org.eclipse.dataspaceconnector.spi.protocol.web.WebService;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 import org.jetbrains.annotations.NotNull;
 
@@ -144,10 +145,10 @@ public final class IdsMultipartApiServiceExtension implements ServiceExtension {
         List<Handler> handlers = new LinkedList<>();
         handlers.add(descriptionHandler);
 
-        TransferProcessStore transferProcessStore = serviceExtensionContext.getService(TransferProcessStore.class);
+        TransferProcessManager transferProcessManager = serviceExtensionContext.getService(TransferProcessManager.class);
         ContractValidationService contractValidationService = serviceExtensionContext.getService(ContractValidationService.class);
         Vault vault = serviceExtensionContext.getService(Vault.class);
-        ArtifactRequestHandler artifactRequestHandler = new ArtifactRequestHandler(monitor, connectorId, objectMapper, contractDefinitionStore, contractValidationService, transferProcessStore, vault);
+        ArtifactRequestHandler artifactRequestHandler = new ArtifactRequestHandler(monitor, connectorId, objectMapper, contractDefinitionStore, contractValidationService, transferProcessManager, vault);
         handlers.add(artifactRequestHandler);
 
         // create & register controller


### PR DESCRIPTION
Replaces usage of TransferProcessStore with TransferProcessManager in ids-multipart.

Closes #301 

Brendan Cronin brendan.cronin@daimler.com, Daimler TSS GmbH, [legal info/Impressum](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)