### PR TITLE
control-api: Adds api-key HTTP containerRequestFilter (closes #302)

### DIFF
--- a/extensions/api/control/README.md
+++ b/extensions/api/control/README.md
@@ -8,6 +8,13 @@ All content reflects the current state of discussion, not final decisions.
 
 # Client API Extension
 
+## Configuration
+
+| Key |  Description | Default |
+|:---|:---|:---|
+| edc.api.control.auth.apikey.key | The HTTP headers name carrying the API key |`X-API-KEY`|
+| edc.api.control.auth.apikey.value | The API-Key expected to be present on incoming HTTP requests | *random value generated during boot time*
+
 ## Initiate Data Transfer
 
 To initiate the data transfer send a data request to the API endpoint.

--- a/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/ControlApiServiceExtension.java
+++ b/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/ControlApiServiceExtension.java
@@ -1,18 +1,29 @@
 package org.eclipse.dataspaceconnector.api.control;
 
+import jakarta.ws.rs.container.ContainerRequestContext;
+import org.eclipse.dataspaceconnector.spi.EdcSetting;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.protocol.web.WebService;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
-import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
+import org.jetbrains.annotations.NotNull;
 
+import java.security.SecureRandom;
 import java.util.Set;
+import java.util.function.Predicate;
 
 public class ControlApiServiceExtension implements ServiceExtension {
 
     private static final String NAME = "EDC Control API extension";
+
+    @EdcSetting
+    public static final String EDC_API_CONTROL_AUTH_APIKEY_KEY = "edc.api.control.auth.apikey.key";
+    public static final String EDC_API_CONTROL_AUTH_APIKEY_KEY_DEFAULT = "X-Api-Key";
+
+    @EdcSetting
+    public static final String EDC_API_CONTROL_AUTH_APIKEY_VALUE = "edc.api.control.auth.apikey.value";
 
     private Monitor monitor;
 
@@ -32,6 +43,16 @@ public class ControlApiServiceExtension implements ServiceExtension {
         webService.registerController(new ClientController(transferProcessManager));
         webService.registerController(new ClientControlCatalogApiController(remoteMessageDispatcherRegistry));
 
+        /*
+         * Registers a API-Key authentication filter
+         */
+        HttpApiKeyAuthContainerRequestFilter httpApiKeyAuthContainerRequestFilter = new HttpApiKeyAuthContainerRequestFilter(
+                resolveApiKeyHeaderName(serviceExtensionContext),
+                resolveApiKeyHeaderValue(serviceExtensionContext),
+                AuthenticationContainerRequestContextPredicate.INSTANCE);
+
+        webService.registerController(httpApiKeyAuthContainerRequestFilter);
+
         monitor.info(String.format("Initialized %s", NAME));
     }
 
@@ -43,5 +64,51 @@ public class ControlApiServiceExtension implements ServiceExtension {
     @Override
     public void shutdown() {
         monitor.info(String.format("Shutdown %s", NAME));
+    }
+
+    private String resolveApiKeyHeaderName(@NotNull ServiceExtensionContext context) {
+        String key = context.getSetting(EDC_API_CONTROL_AUTH_APIKEY_KEY, null);
+        if (key == null) {
+            key = EDC_API_CONTROL_AUTH_APIKEY_KEY_DEFAULT;
+            monitor.warning(String.format("Settings: No setting found for key '%s'. Using default value '%s'", EDC_API_CONTROL_AUTH_APIKEY_KEY, EDC_API_CONTROL_AUTH_APIKEY_KEY_DEFAULT));
+        }
+        return key;
+    }
+
+    private String resolveApiKeyHeaderValue(@NotNull ServiceExtensionContext context) {
+        String value = context.getSetting(EDC_API_CONTROL_AUTH_APIKEY_VALUE, null);
+        if (value == null) {
+            value = generateRandomString();
+            monitor.warning(String.format("Settings: No setting found for key '%s'. Using random value '%s'", EDC_API_CONTROL_AUTH_APIKEY_VALUE, value));
+        }
+        return value;
+    }
+
+    /*
+     * Produces twelve characters long sequence in the ascii range of '!' (dec 33) to '~' (dec 126).
+     *
+     * @return sequence
+     */
+    private static String generateRandomString() {
+        StringBuilder stringBuilder = new SecureRandom().ints('!', ((int) '~' + 1))
+                .limit(12).collect(
+                        StringBuilder::new,
+                        StringBuilder::appendCodePoint,
+                        StringBuilder::append);
+        return stringBuilder.toString();
+    }
+
+    private enum AuthenticationContainerRequestContextPredicate implements Predicate<ContainerRequestContext> {
+        INSTANCE;
+
+        @Override
+        public boolean test(ContainerRequestContext containerRequestContext) {
+            String path = containerRequestContext.getUriInfo().getPath();
+            if (!path.startsWith("/")) {
+                path = "/" + path;
+            }
+
+            return path.startsWith("/control");
+        }
     }
 }

--- a/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/HttpApiKeyAuthContainerRequestFilter.java
+++ b/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/HttpApiKeyAuthContainerRequestFilter.java
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial API and Implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.control;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.PreMatching;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+@Deprecated
+@Provider
+@PreMatching
+class HttpApiKeyAuthContainerRequestFilter implements ContainerRequestFilter {
+    /**
+     * A predicate evaluating eligibility of the ContainerRequestFilter to handle the incoming request
+     */
+    private final Predicate<ContainerRequestContext> containerRequestContextPredicate;
+
+    /**
+     * The name/key of the HTTP header carrying the authentication key
+     */
+    private final String expectedHeaderName;
+
+    /**
+     * The expected API-Key to be present in the incoming request
+     */
+    private final String expectedHeaderValue;
+
+    public HttpApiKeyAuthContainerRequestFilter(
+            @NotNull String expectedHeaderName,
+            @NotNull String expectedHeaderValue,
+            @NotNull Predicate<ContainerRequestContext> containerRequestContextPredicate) {
+        this.expectedHeaderName = Objects.requireNonNull(expectedHeaderName);
+        this.expectedHeaderValue = Objects.requireNonNull(expectedHeaderValue);
+        this.containerRequestContextPredicate = Objects.requireNonNull(containerRequestContextPredicate);
+    }
+
+    @Override
+    public void filter(ContainerRequestContext containerRequestContext) throws IOException {
+        if (!containerRequestContextPredicate.test(containerRequestContext)) {
+            return;
+        }
+
+        MultivaluedMap<String, String> headers = containerRequestContext.getHeaders();
+
+        String apiKeyHeaderValue;
+        /*
+         * No apiKey has be provided, so abort the request with HTTP status 401 UNAUTHORIZED
+         */
+        if (!headers.containsKey(expectedHeaderName) || (apiKeyHeaderValue = headers.getFirst(expectedHeaderName)) == null) {
+            containerRequestContext.abortWith(unauthorized());
+            return;
+        }
+
+        /*
+         * If the apiKey does not match the configured value abort the request with HTTP status 403 FORBIDDEN
+         */
+        if (!expectedHeaderValue.equals(apiKeyHeaderValue)) {
+            containerRequestContext.abortWith(forbidden());
+        }
+    }
+
+    private static Response unauthorized() {
+        return Response.status(Response.Status.UNAUTHORIZED).build();
+    }
+
+    private static Response forbidden() {
+        return Response.status(Response.Status.FORBIDDEN).build();
+    }
+}


### PR DESCRIPTION
Adding a simple HTTP API-Key `ContainerRequestFilter` to the control-api. Closes #302.

<sub> Denis Neuling <denis.neuling@daimler.com>, Daimler TSS GmbH, [legal info/Impressum](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)