### PR TITLE
Added "IN" operator to all AssetIndex imlementations

### DIFF
--- a/extensions/azure/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndex.java
+++ b/extensions/azure/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndex.java
@@ -63,7 +63,7 @@ public class CosmosAssetIndex implements AssetIndex, DataAddressResolver, AssetL
 
         SqlQuerySpec query = queryBuilder.from(expression);
 
-        var response = with(retryPolicy).get(() -> assetDb.queryItems(query.getQueryText()));
+        var response = with(retryPolicy).get(() -> assetDb.queryItems(query));
         return response.map(this::convertObject)
                 .map(AssetDocument::getWrappedAsset);
     }

--- a/extensions/azure/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetQueryBuilder.java
+++ b/extensions/azure/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetQueryBuilder.java
@@ -11,7 +11,6 @@ import org.jetbrains.annotations.NotNull;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public class CosmosAssetQueryBuilder {
@@ -52,7 +51,7 @@ public class CosmosAssetQueryBuilder {
     }
 
     private static class WhereClause {
-        private static final List<String> SUPPORTED_OPERATOR = Collections.singletonList("=");
+        private static final List<String> SUPPORTED_OPERATOR = List.of("=", "IN");
         private final List<SqlParameter> parameters = new ArrayList<>();
         private String where = "";
 
@@ -62,9 +61,6 @@ public class CosmosAssetQueryBuilder {
             }
         }
 
-        private static String formatValue(String value) {
-            return "'" + value + "'";
-        }
 
         public String getWhere() {
             return where;
@@ -84,7 +80,7 @@ public class CosmosAssetQueryBuilder {
             parameters.add(new SqlParameter(param, criterion.getOperandRight().toString()));
             where += String.join(" " + criterion.getOperator() + " ",
                     " " + PATH_TO_PROPERTIES + "." + field,
-                    formatValue((String) criterion.getOperandRight()));
+                    (String) criterion.getOperandRight());
         }
     }
 }

--- a/extensions/azure/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetQueryBuilderTest.java
+++ b/extensions/azure/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetQueryBuilderTest.java
@@ -28,8 +28,8 @@ class CosmosAssetQueryBuilderTest {
     @Test
     void queryWithFilerOnProperty() {
         AssetSelectorExpression expression = AssetSelectorExpression.Builder.newInstance()
-                .whenEquals("id", "id-test")
-                .whenEquals("name", "name-test")
+                .whenEquals("id", "'id-test'")
+                .whenEquals("name", "'name-test'")
                 .build();
 
         SqlQuerySpec query = builder.from(expression);
@@ -40,8 +40,8 @@ class CosmosAssetQueryBuilderTest {
     @Test
     void queryWithFilerOnPropertyWithIllegalArgs() {
         AssetSelectorExpression expression = AssetSelectorExpression.Builder.newInstance()
-                .whenEquals("test:id", "id-test")
-                .whenEquals("test:name", "name-test")
+                .whenEquals("test:id", "'id-test'")
+                .whenEquals("test:name", "'name-test'")
                 .build();
 
         SqlQuerySpec query = builder.from(expression);

--- a/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/CriterionToPredicateConverterTest.java
+++ b/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/CriterionToPredicateConverterTest.java
@@ -57,10 +57,23 @@ class CriterionToPredicateConverterTest {
     }
 
     @Test
+    void convert_operatorIn() {
+        var asset = Asset.Builder.newInstance()
+                .name("bob")
+                .version("6.9")
+                .property("test-property", "somevalue")
+                .build();
+        var criterion = new Criterion(Asset.PROPERTY_NAME, "in", "(bob, alice)");
+        var pred = converter.convert(criterion);
+        assertThat(pred).isNotNull().accepts(asset);
+
+    }
+
+    @Test
     void convert_invalidOperator() {
-        var criterion = new Criterion("name", "in", "(bob, alice)");
+        var criterion = new Criterion("name", "GREATER_THAN", "(bob, alice)");
         assertThatThrownBy(() -> converter.convert(criterion)).isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Operator [in] is not supported by this converter!");
+                .hasMessage("Operator [GREATER_THAN] is not supported by this converter!");
 
     }
 

--- a/spi/src/main/java/org/eclipse/dataspaceconnector/spi/asset/Criterion.java
+++ b/spi/src/main/java/org/eclipse/dataspaceconnector/spi/asset/Criterion.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 
+import static java.lang.String.format;
+
 /**
  * This class can be used to form select expressions e.g. in SQL statements. It is a way to express
  * those statements in a generic way.
@@ -63,5 +65,10 @@ public class Criterion {
         }
         Criterion criterion = (Criterion) o;
         return Objects.equals(operandLeft, criterion.operandLeft) && Objects.equals(operator, criterion.operator) && Objects.equals(operandRight, criterion.operandRight);
+    }
+
+    @Override
+    public String toString() {
+        return format("%s %s %s", getOperandLeft(), getOperator(), getOperandRight());
     }
 }


### PR DESCRIPTION
Both the in-memory and the CosmosDB implementation of the `AssetIndex` can now handle the "IN" operator. Tests were added to verify that.

_Please be aware that the concrete syntax depends on the implementation! E.g. CosmosDB requires the list to be in brackets and - depending on the datatype - surrounded by single quotation marks, whereas the in-memory variant doesn't!_
 
Querying for a String property named `"someProperty"` would result in the following valid Criterion arguments:
|Impl | operandLeft | operator | operandRight |
| --------| :------------- |-------------:| :-----|
|In-mem | someProperty | "IN" | "(val1, val2, val3)" |
|cosmos | someProperty | "IN" | "('val1', 'val2', 'val3')"|

closes #307 

_Smaller changes to the `CosmosAssetIndex` and `CosmosAssetQueryBuilder` were necessary: the automatic addition of single-quotation marks was removed._
