### PR TITLE
Documentation about onboarding new connectors (DistributedIdentity)

### DIFF
--- a/extensions/iam/distributed-identity/registration-service/README.md
+++ b/extensions/iam/distributed-identity/registration-service/README.md
@@ -1,1 +1,6 @@
-Periodically crawls the ION Network for a specific DID type ("Z3hp") and stores it in an internal cache.
+This service may act as the single source of trust for a DID-based dataspace if so desired. Its main tasks are:
+
+- onboarding new connectors by issuing verified claims
+- provide a "phonebook" for the entire dataspace by providing an overview of registered connectors
+- host a Web-DID that contains a public key for claims verification
+

--- a/extensions/iam/distributed-identity/registration-service/doc/onboarding_flow.md
+++ b/extensions/iam/distributed-identity/registration-service/doc/onboarding_flow.md
@@ -1,0 +1,32 @@
+## Preconditions, assumptions, terminology
+
+- It is assumed that a DID is already in place and publicly available. The generation or deployment of a DID is not part
+  of this flow.
+- The terms "connector" and "participant agent" are to be used interchangeably
+- `NewParticipant` in the diagram refers to the participant agent, which is to be onboarded in the dataspace
+- The flow presented here is _synchronous_, i.e. the verified claims are returned immediately
+- The registration service's public key is available through its DID
+- The registration service's DID key is public knowledge
+- Participant agent may be abbreviated by "PA"
+- Registration service may be abbreviated by "RS"
+
+## Onboarding flow
+
+- The new participant agent calls up the registration endpoint at `/register` and presents the following parameters:
+    - `participantAgentId`: a string uniquely identifying the PA in the dataspace
+    - `didKey`: the ID of the PA's DID, can be a Web-DID, ION-DID, etc. Must include the method, e.g. `did:web:...`
+    - `claims`: a list of key-value-pairs, each of which represents a claim, which shall be verified by the registration
+      service.
+- The registration service verifies the claims one by one and signs each with its private key
+- The RS returns the signed claims in the form of a signed JWT to the participant agent.
+- The PA stores the signed claims in its `IdentityHub`
+- If the claims **cannot be verified** the registration service returns HTTP 403
+
+## Future improvements
+
+- The registration service writes the verified claims directly in the participant agent's `IdentityHub`. This has been
+  intentionally left out for now for reasons of simplicity, modularity and testability.
+- Async flow: in case verifying the claims takes a long time, for example when human interaction is required, the
+  participant agent must supply a callback URL through which the registration service may announce that the verification
+  has completed (either successfully or with errors). This would be especially powerful if the RS writes directly to
+  the `IdentityHub`

--- a/extensions/iam/distributed-identity/registration-service/doc/onboarding_flow.md
+++ b/extensions/iam/distributed-identity/registration-service/doc/onboarding_flow.md
@@ -2,7 +2,9 @@
 
 - It is assumed that a DID is already in place and publicly available. The generation or deployment of a DID is not part
   of this flow.
-- The terms "connector" and "participant agent" are to be used interchangeably
+- The terms "connector" and "participant agent" are to be used interchangeably. Please note that both terms refer to a "
+  logical" connector - several replicas in a K8s cluster would share the same identity and thus count as one Participant
+  Agent.
 - `NewParticipant` in the diagram refers to the participant agent, which is to be onboarded in the dataspace
 - The flow presented here is _synchronous_, i.e. the verified claims are returned immediately
 - The registration service's public key is available through its DID

--- a/extensions/iam/distributed-identity/registration-service/doc/onboarding_flow.puml
+++ b/extensions/iam/distributed-identity/registration-service/doc/onboarding_flow.puml
@@ -1,0 +1,17 @@
+@startuml
+
+
+
+NewParticipantAgent -> RegistrationService : POST /register (NewParticipantAgentId, didKey, claims)
+RegistrationService -> RegistrationService : attempts verifies claims
+note right: this may potentially\ninvolve human interaction
+
+alt claims are verified
+    RegistrationService -> RegistrationService : sign claims w/ private key
+    RegistrationService ->  NewParticipantAgent: HTTP 200 signed JWT
+    NewParticipantAgent -> NewParticipantAgent: store claims in IdentityHub
+else claims not verified
+    RegistrationService -> NewParticipantAgent: HTTP 403 Not Authorized
+end
+
+@enduml

--- a/extensions/iam/distributed-identity/registration-service/doc/verification.md
+++ b/extensions/iam/distributed-identity/registration-service/doc/verification.md
@@ -1,0 +1,29 @@
+## Preconditions, assumptions, terminology
+
+The first two steps of the verification process must already be in place. Those are:
+
+1. Verify the JWT containing the DID Key
+2. Extract claims from the IdentityHub
+
+This flow adds one step to the flow, i.e. verifying the claims extracted from the `IdentityHub`. The DID key of
+the `RegistrationService` and its host URL are public knowledge, e.g. through configuration values. If Web-DIDs are
+used, one can be inferred from the other.
+
+In order for this flow to work, the RegistrationService need not provide an `IdentityHub`, and its DID need not contain
+an `IdentityHubUrl`.
+
+## Verification Flow
+
+_Detailing step 1 and 2 is not part of this document!_
+
+- ...
+- Provider fetches claims from Consumer's `IdentityHub`. They are stored in the form of a signed-JWT and were signed
+  with the RegistrationService's private key. See [the onboarding flow](onboarding_flow.puml) for details.
+- Provider obtains the RegistrationService's DID (or fetches it from an internal cache)
+- Provider extracts PublicKey from RS's DID
+- Provider verifies the signature of the Consumer's signed-JWT
+
+## Possible Improvements
+
+- instead of contacting the RegistrationService on every request, each connector caches the RS's DID in order to
+  increase resilience

--- a/extensions/iam/distributed-identity/registration-service/doc/verification.puml
+++ b/extensions/iam/distributed-identity/registration-service/doc/verification.puml
@@ -1,0 +1,25 @@
+@startuml
+
+group existing identity verification
+   Consumer -> Provider: request data w/ did key as JWT in header
+   Provider -> Consumer: GET /.well-known/did.json
+   Provider <-- Consumer: did.json
+   Provider -> Provider: extract PublicKey, verify JWT
+   Provider -> Provider: extract IdentityHubUrl
+   Consumer <- Provider: read IdentityHub
+   Consumer --> Provider: verifiable claims as JWS
+end
+
+Provider -> RegistrationService: GET /.well-known/did.json
+activate RegistrationService
+Provider <-- RegistrationService: did.json
+deactivate RegistrationService
+Provider -> Provider: verify verifiable claims' signature with PublicKey
+
+alt claims verified
+   Consumer <-- Provider: send TransferResponse.OK
+else claims not verified
+   Consumer <-- Provider: send authorization error
+end
+
+@enduml


### PR DESCRIPTION
This PR adds sequence diagrams and accompanying documentation about the following flows:
- onboarding new connectors, issuing verified credentials/claims
- verifying those claims 

Those flows are only valid in a distributed identity scenario, which uses DIDs and Identity Hubs[

Adapting the `registration-service` and `registration-service-api` will be done in a subsequent PR, this serves merely as basis for discussion. 