### PR TITLE
TransferProcessListener doc and sample

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -22,3 +22,14 @@ Before each data transfer a contract must be offered from the provider. A consum
 before its able to request data.
 
 These two processes (offering & negotation) are documented in the [contracts.md](contracts.md)
+
+### TransferProcessListener
+
+A consumer extension may register a listener to execute custom logic after a transfer changes state, for example, to notify an external application on the consumer side after data has been produced (i.e. the transfer moves to the completed state).
+
+```java
+transferProcessObservable = context.getService(TransferProcessObservable.class);
+transferProcessObservable.registerListener(myTransferProcessListener);
+```
+
+A sample is available at [04.1-file-transfer-listener](../../samples/04.1-file-transfer-listener).

--- a/samples/04.1-file-transfer-listener/README.md
+++ b/samples/04.1-file-transfer-listener/README.md
@@ -1,0 +1,80 @@
+# Implement a simple transfer listener
+
+In this sample, we build upon the [file transfer sample](../04-file-transfer) to add functionality to react to transfer completion on the consumer connector side.
+
+We will use the provider from the [file transfer sample](../04-file-transfer), and the consumer built on the consumer from that sample, with a transfer process listener added.
+
+Also, in order to keep things organized, the code in this example has been separated into several Java modules:
+
+- `consumer`: this is where the extension definition and dependencies reside for the consumer connector
+- `listener`: contains the `TransferProcessListener` implementation
+
+The consumer also uses the `api` module (REST API) from the [file transfer sample](../04-file-transfer).
+
+## Create the listener
+
+A TransferProcessListener may define methods that are invoked after a transfer changes state, for example, to notify an external application on the consumer side after data has been produced (i.e. the transfer moves to the completed state).
+
+```java
+// in TransferListenerExtension.java
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        // ...
+        var transferProcessObservable = context.getService(TransferProcessObservable.class);
+        transferProcessObservable.registerListener(new MarkerFileCreator(monitor));
+    }
+```
+
+```java
+public class MarkerFileCreator implements TransferProcessListener {
+
+    /**
+     * Callback invoked by the EDC framework when a transfer has completed.
+     *
+     * @param process
+     */
+    @Override
+    public void completed(final TransferProcess process) {
+        // ...
+    }
+}
+```
+
+## Perform a file transfer
+
+Let's rebuild and run them both:
+
+```bash
+./gradlew samples:04.1-file-transfer-listener:consumer:build
+java -Dedc.fs.config=samples/04.1-file-transfer-listener/consumer/config.properties -jar samples/04.1-file-transfer-listener/consumer/build/libs/consumer.jar
+# in another terminal window:
+./gradlew samples:04-file-transfer:provider:build
+java -Dedc.fs.config=samples/04-file-transfer/provider/config.properties -jar samples/04-file-transfer/provider/build/libs/provider.jar
+````
+
+Assuming you didn't change the config files, the consumer will listen on port `9191` and the provider will listen on port `8181`. Open another terminal window (or any REST client of your choice) and execute the following REST request:
+
+```bash
+curl -X POST "http://localhost:9191/api/file/test-document?connectorAddress=http://localhost:8181/&destination=/path/on/yourmachine"
+```
+
+> **Please adjust the `destination` to match your local dev machine!**
+
+- the last path item, `test-document`, matches the ID of the `Asset` that we created earlier in
+  `FileTransferExtension.java`, thus referencing the _data source_
+- the first query parameter (`connectorAddress`) is the address of the provider connector
+- the last query parameter (`destination`) indicates the desired _destination_ directory on you local machine.
+- `curl` will return the ID of the transfer process on the consumer connector.
+
+The consumer should spew out logs similar to:
+
+```bash
+INFO 2021-09-07T17:24:42.128363 Received request for file test-document against provider http://localhost:8181/
+DEBUG 2021-09-07T17:24:42.592422 Request approved and acknowledged for process: 2b0a9ab8-78db-4753-8b95-77678cdd9fc8
+DEBUG 2021-09-07T17:24:47.425729 Process 2b0a9ab8-78db-4753-8b95-77678cdd9fc8 is now IN_PROGRESS
+DEBUG 2021-09-07T17:24:47.426115 Process 2b0a9ab8-78db-4753-8b95-77678cdd9fc8 is now COMPLETED
+DEBUG 2021-09-07T17:24:47.426531 Transfer listener successfully wrote file /path/on/yourmachine/marker.txt
+
+```
+
+then check `/path/on/yourmachine`, which should now contain a file named `marker.txt` in addition to the file named `test-document.txt`.

--- a/samples/04.1-file-transfer-listener/consumer/build.gradle.kts
+++ b/samples/04.1-file-transfer-listener/consumer/build.gradle.kts
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2020, 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - added dependencies
+ *
+ */
+
+plugins {
+    `java-library`
+    id("application")
+    id("com.github.johnrengelman.shadow") version "7.0.0"
+}
+
+val jupiterVersion: String by project
+val rsApi: String by project
+
+dependencies {
+    implementation(project(":core"))
+
+    implementation(project(":extensions:in-memory:assetindex-memory"))
+    implementation(project(":extensions:in-memory:transfer-store-memory"))
+    implementation(project(":extensions:in-memory:policy-registry-memory"))
+    implementation(project(":extensions:in-memory:assetindex-memory"))
+    implementation(project(":extensions:in-memory:negotiation-store-memory"))
+    implementation(project(":extensions:in-memory:contractdefinition-store-memory"))
+
+    implementation(project(":extensions:filesystem:configuration-fs"))
+    implementation(project(":extensions:iam:iam-mock"))
+
+    implementation(project(":data-protocols:ids"))
+
+    implementation(project(":samples:04-file-transfer:api"))
+    implementation(project(":samples:04.1-file-transfer-listener:listener"))
+}
+
+application {
+    @Suppress("DEPRECATION")
+    mainClassName = "org.eclipse.dataspaceconnector.system.runtime.BaseRuntime"
+}
+
+tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
+    exclude("**/pom.properties", "**/pom.xml")
+    mergeServiceFiles()
+    archiveFileName.set("consumer.jar")
+}

--- a/samples/04.1-file-transfer-listener/consumer/config.properties
+++ b/samples/04.1-file-transfer-listener/consumer/config.properties
@@ -1,0 +1,1 @@
+web.http.port=9191

--- a/samples/04.1-file-transfer-listener/listener/build.gradle.kts
+++ b/samples/04.1-file-transfer-listener/listener/build.gradle.kts
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (c) 2020, 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    id("application")
+}
+
+dependencies {
+    api(project(":spi"))
+}

--- a/samples/04.1-file-transfer-listener/listener/src/main/java/org/eclipse/dataspaceconnector/extensions/listener/MarkerFileCreator.java
+++ b/samples/04.1-file-transfer-listener/listener/src/main/java/org/eclipse/dataspaceconnector/extensions/listener/MarkerFileCreator.java
@@ -1,0 +1,41 @@
+package org.eclipse.dataspaceconnector.extensions.listener;
+
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessListener;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.lang.String.format;
+
+public class MarkerFileCreator implements TransferProcessListener {
+
+    private final Monitor monitor;
+
+    public MarkerFileCreator(Monitor monitor) {
+        this.monitor = monitor;
+    }
+
+    /**
+     * Callback invoked by the EDC framework when a transfer has completed.
+     *
+     * @param process the transfer process that has completed.
+     */
+    @Override
+    public void completed(final TransferProcess process) {
+        Path path = Path.of(process.getDataRequest().getDataDestination().getProperty("path"));
+        if (!Files.isDirectory(path)) {
+            path = path.getParent();
+        }
+        path = path.resolve("marker.txt");
+
+        try {
+            Files.writeString(path, "Transfer complete");
+            monitor.info(format("Transfer Listener successfully wrote file %s", path));
+        } catch (IOException e) {
+            monitor.warning(format("Could not write file %s", path), e);
+        }
+    }
+}

--- a/samples/04.1-file-transfer-listener/listener/src/main/java/org/eclipse/dataspaceconnector/extensions/listener/TransferListenerExtension.java
+++ b/samples/04.1-file-transfer-listener/listener/src/main/java/org/eclipse/dataspaceconnector/extensions/listener/TransferListenerExtension.java
@@ -1,0 +1,16 @@
+package org.eclipse.dataspaceconnector.extensions.listener;
+
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessObservable;
+
+public class TransferListenerExtension implements ServiceExtension {
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var transferProcessObservable = context.getService(TransferProcessObservable.class);
+        var monitor = context.getMonitor();
+
+        transferProcessObservable.registerListener(new MarkerFileCreator(monitor));
+    }
+}

--- a/samples/04.1-file-transfer-listener/listener/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
+++ b/samples/04.1-file-transfer-listener/listener/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
@@ -1,0 +1,1 @@
+org.eclipse.dataspaceconnector.extensions.listener.TransferListenerExtension

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -143,3 +143,6 @@ include(":samples:05-file-transfer-cloud:provider")
 include(":samples:05-file-transfer-cloud:api")
 include(":samples:05-file-transfer-cloud:data-seeder")
 include(":samples:05-file-transfer-cloud:transfer-file")
+
+include(":samples:04.1-file-transfer-listener:consumer")
+include(":samples:04.1-file-transfer-listener:listener")

--- a/spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/TransferProcessListener.java
+++ b/spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/TransferProcessListener.java
@@ -15,35 +15,104 @@
 package org.eclipse.dataspaceconnector.spi.transfer;
 
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
 
+/**
+ * Interface implemented by listeners registered to observe transfer process
+ * state changes via {@link TransferProcessObservable#registerListener(TransferProcessListener)}.
+ * <p>
+ * Note that the listener is not guaranteed to be called after a state change, in case
+ * the application restarts. That is relevant when using a persistent transfer
+ * store implementation.
+ */
 public interface TransferProcessListener {
+    /**
+     * Called after a {@link TransferProcess} has moved to state
+     * {@link TransferProcessStates#INITIAL INITIAL}.
+     *
+     * @param process the transfer process whose state has changed.
+     */
     default void created(TransferProcess process) {
     }
 
+    /**
+     * Called after a {@link TransferProcess} has moved to state
+     * {@link TransferProcessStates#PROVISIONING PROVISIONING}.
+     *
+     * @param process the transfer process whose state has changed.
+     */
     default void provisioning(TransferProcess process) {
     }
 
+    /**
+     * Called after a {@link TransferProcess} has moved to state
+     * {@link TransferProcessStates#PROVISIONED PROVISIONED}.
+     *
+     * @param process the transfer process whose state has changed.
+     */
     default void provisioned(TransferProcess process) {
     }
 
+    /**
+     * Called after a {@link TransferProcess} has moved to state
+     * {@link TransferProcessStates#IN_PROGRESS IN_PROGRESS}.
+     *
+     * @param process the transfer process whose state has changed.
+     */
     default void inProgress(TransferProcess process) {
     }
 
+    /**
+     * Called after a {@link TransferProcess} has moved to state
+     * {@link TransferProcessStates#COMPLETED COMPLETED}.
+     *
+     * @param process the transfer process whose state has changed.
+     */
     default void completed(TransferProcess process) {
     }
 
+    /**
+     * Called after a {@link TransferProcess} has moved to state
+     * {@link TransferProcessStates#DEPROVISIONING DEPROVISIONING}.
+     *
+     * @param process the transfer process whose state has changed.
+     */
     default void deprovisioning(TransferProcess process) {
     }
 
+    /**
+     * Called after a {@link TransferProcess} has moved to state
+     * {@link TransferProcessStates#DEPROVISIONED DEPROVISIONED}.
+     *
+     * @param process the transfer process whose state has changed.
+     */
     default void deprovisioned(TransferProcess process) {
     }
 
+    /**
+     * Called after a {@link TransferProcess} has moved to state
+     * {@link TransferProcessStates#ENDED ENDED}.
+     *
+     * @param process the transfer process whose state has changed.
+     */
     default void ended(TransferProcess process) {
     }
 
+    /**
+     * Called after a {@link TransferProcess} has moved to state
+     * {@link TransferProcessStates#ERROR ERROR}.
+     *
+     * @param process the transfer process whose state has changed.
+     */
     default void error(TransferProcess process) {
     }
 
+    /**
+     * Called after a {@link TransferProcess} has moved to state
+     * {@link TransferProcessStates#REQUESTED REQUESTED}.
+     *
+     * @param process the transfer process whose state has changed.
+     */
     default void requested(TransferProcess process) {
     }
 }


### PR DESCRIPTION
Added Javadoc, Markdown documentation, and a sample on creating a `TransferProcessListener` to react to transfer state changes (in particular, transfer completion on the consumer side).

Closes #240