### PR TITLE
sample 5: generate service principal certificate with Terraform

### DIFF
--- a/samples/05-file-transfer-cloud/terraform/output.tf
+++ b/samples/05-file-transfer-cloud/terraform/output.tf
@@ -6,11 +6,16 @@ output "tenant-id" {
   value = data.azurerm_client_config.current.tenant_id
 }
 
+output "certificate" {
+  value     = data.azurerm_key_vault_secret.certificate.value
+  sensitive = true
+}
+
 output "vault-name" {
   value = azurerm_key_vault.main-vault.name
 }
 
-output "storage-account-name"{
+output "storage-account-name" {
   value = azurerm_storage_account.main-blobstore.name
 }
 

--- a/samples/05-file-transfer-cloud/terraform/variables.tf
+++ b/samples/05-file-transfer-cloud/terraform/variables.tf
@@ -13,8 +13,3 @@ variable "aws_region" {
 variable "environment" {
   description = "identifying string that is used in all azure resources"
 }
-
-variable "CERTIFICATE" {
-  type        = string
-  description = "private key file for the primary azure app SP"
-}


### PR DESCRIPTION
Generate X.509 certificate in Terraform, rather than on local machine.

Benefits:
- not requiring OpenSSL tools to be installed locally to deploy.
- not requiring the user to manually enter certificate information.
- useful Terraform code that can be adapted by end users for development environments.

Deployment fails against upstream main because of #381, but I tested it against an older head with minor modifications.

Other improvements:
- Locked terraform provider versions for maximum stability.
- Applied `terraform fmt` to format terraform files.