### PR TITLE
samples: return json as specified in produces and update readme examples

### DIFF
--- a/samples/02-health-endpoint/README.md
+++ b/samples/02-health-endpoint/README.md
@@ -52,7 +52,7 @@ public class HealthApiController {
     @Path("health")
     public String checkHealth() {
         monitor.info("Received a health request");
-        return "I'm alive!";
+        return "{\"response\":\"I'm alive!\"}";
     }
 }
 ```

--- a/samples/02-health-endpoint/src/main/java/org/eclipse/dataspaceconnector/extensions/health/HealthApiController.java
+++ b/samples/02-health-endpoint/src/main/java/org/eclipse/dataspaceconnector/extensions/health/HealthApiController.java
@@ -23,6 +23,6 @@ public class HealthApiController {
     @Path("health")
     public String checkHealth() {
         monitor.info("Received a health request");
-        return "I'm alive!";
+        return "{\"response\":\"I'm alive!\"}";
     }
 }

--- a/samples/03-configuration/README.md
+++ b/samples/03-configuration/README.md
@@ -126,7 +126,7 @@ public class HealthApiController {
     @Path("health")
     public String checkHealth() {
         monitor.info(String.format("%s :: Received a health request", logPrefix));
-        return "I'm alive!";
+        return "{\"response\":\"I'm alive!\"}";
     }
 }
 ```

--- a/samples/03-configuration/src/main/java/org/eclipse/dataspaceconnector/extensions/health/HealthApiController.java
+++ b/samples/03-configuration/src/main/java/org/eclipse/dataspaceconnector/extensions/health/HealthApiController.java
@@ -27,6 +27,6 @@ public class HealthApiController {
     @Path("health")
     public String checkHealth() {
         monitor.info(format("%s :: Received a health request", logPrefix));
-        return "I'm alive!";
+        return "{\"response\":\"I'm alive!\"}";
     }
 }

--- a/samples/04-file-transfer/api/src/main/java/org/eclipse/dataspaceconnector/extensions/api/ConsumerApiController.java
+++ b/samples/04-file-transfer/api/src/main/java/org/eclipse/dataspaceconnector/extensions/api/ConsumerApiController.java
@@ -58,7 +58,7 @@ public class ConsumerApiController {
     @Path("health")
     public String checkHealth() {
         monitor.info("%s :: Received a health request");
-        return "I'm alive!";
+        return "{\"response\":\"I'm alive!\"}";
     }
 
     @POST

--- a/samples/05-file-transfer-cloud/api/src/main/java/org/eclipse/dataspaceconnector/extensions/api/ConsumerApiController.java
+++ b/samples/05-file-transfer-cloud/api/src/main/java/org/eclipse/dataspaceconnector/extensions/api/ConsumerApiController.java
@@ -39,7 +39,7 @@ public class ConsumerApiController {
     @Path("health")
     public String checkHealth() {
         monitor.info("%s :: Received a health request");
-        return "I'm alive!";
+        return "{\"response\":\"I'm alive!\"}";
     }
 
     @POST


### PR DESCRIPTION
Issue https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/405:
- [X] return json in samples as specified in Controller-produces
- [X] update sample-readme
