### PR TITLE
securityprofile: refactor exception-message and add test

### DIFF
--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/types/SecurityProfile.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/types/SecurityProfile.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
+ *       Fraunhofer Institute for Software and Systems Engineering
  *
  */
 
@@ -40,9 +41,9 @@ public enum SecurityProfile {
 
         throw new IllegalArgumentException(
                 String.format(
-                        "IDS Settings: Invalid security profile '%s'. Valid profiles: [%s]",
+                        "IDS Settings: Invalid security profile value '%s'. Valid security profile values: [%s]",
                         value,
-                        Arrays.stream(SecurityProfile.values()).map(Enum::toString).collect(Collectors.joining(", "))
+                        Arrays.stream(SecurityProfile.values()).map(it -> it.value).collect(Collectors.joining(", "))
                 )
         );
     }

--- a/data-protocols/ids/ids-spi/src/test/java/org/eclipse/dataspaceconnector/ids/spi/types/SecurityProfileTest.java
+++ b/data-protocols/ids/ids-spi/src/test/java/org/eclipse/dataspaceconnector/ids/spi/types/SecurityProfileTest.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2021 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *      Fraunhofer Institute for Software and Systems Engineering - Initial Implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.ids.spi.types;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SecurityProfileTest {
+
+    @Test
+    void fromValue() {
+        assertThrows(IllegalArgumentException.class, () -> SecurityProfile.fromValue("test"));
+        assertEquals(SecurityProfile.BASE_SECURITY_PROFILE, SecurityProfile.fromValue("base"));
+        assertEquals(SecurityProfile.TRUST_SECURITY_PROFILE, SecurityProfile.fromValue("trust"));
+        assertEquals(SecurityProfile.TRUST_PLUS_SECURITY_PROFILE, SecurityProfile.fromValue("trust-plus"));
+    }
+}

--- a/data-protocols/ids/ids-spi/src/test/java/org/eclipse/dataspaceconnector/ids/spi/types/SecurityProfileTest.java
+++ b/data-protocols/ids/ids-spi/src/test/java/org/eclipse/dataspaceconnector/ids/spi/types/SecurityProfileTest.java
@@ -16,8 +16,8 @@ package org.eclipse.dataspaceconnector.ids.spi.types;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class SecurityProfileTest {
 


### PR DESCRIPTION
Issue https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/397:
- [X] refactor SecurityProfile fromValue IllegalArgumentException-message
- [X] add test