### PR TITLE
Isolate TransferProcessStore usage into TransferProcessManager

### DIFF
--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
@@ -54,6 +54,7 @@ public class CoreTransferExtension implements ServiceExtension {
     private ProvisionManagerImpl provisionManager;
     private DelegatingTransferProcessManager processManager;
     private TransferProcessStore transferProcessStore;
+    private AsyncTransferProcessManager asyncMgr;
 
     @Override
     public String name() {
@@ -109,7 +110,7 @@ public class CoreTransferExtension implements ServiceExtension {
 
 
         transferProcessStore = context.getService(TransferProcessStore.class);
-        var asyncMgr = AsyncTransferProcessManager.Builder.newInstance()
+        asyncMgr = AsyncTransferProcessManager.Builder.newInstance()
                 .waitStrategy(waitStrategy)
                 .manifestGenerator(manifestGenerator)
                 .dataFlowManager(dataFlowManager)
@@ -137,7 +138,7 @@ public class CoreTransferExtension implements ServiceExtension {
     public void start() {
 
 
-        provisionManager.start(processManager.createProvisionContext());
+        provisionManager.start(asyncMgr.createProvisionContext());
         processManager.start(transferProcessStore);
     }
 

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
@@ -99,7 +99,7 @@ public class CoreTransferExtension implements ServiceExtension {
 
         var vault = context.getService(Vault.class);
 
-        provisionManager = new ProvisionManagerImpl(vault, typeManager, monitor);
+        provisionManager = new ProvisionManagerImpl();
         context.registerService(ProvisionManager.class, provisionManager);
 
         var waitStrategy = context.hasService(TransferWaitStrategy.class) ? context.getService(TransferWaitStrategy.class) : new ExponentialWaitStrategy(DEFAULT_ITERATION_WAIT);
@@ -117,6 +117,8 @@ public class CoreTransferExtension implements ServiceExtension {
                 .dispatcherRegistry(dispatcherRegistry)
                 .statusCheckerRegistry(statusCheckerRegistry)
                 .monitor(monitor)
+                .vault(vault)
+                .typeManager(typeManager)
                 .build();
 
         var proxyEntryHandlerRegistry = new DefaultProxyEntryHandlerRegistry();
@@ -135,7 +137,7 @@ public class CoreTransferExtension implements ServiceExtension {
     public void start() {
 
 
-        provisionManager.start(transferProcessStore);
+        provisionManager.start(processManager.createProvisionContext());
         processManager.start(transferProcessStore);
     }
 

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/provision/ProvisionContextImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/provision/ProvisionContextImpl.java
@@ -19,7 +19,6 @@ import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedDataDestinationResource;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedResource;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.SecretToken;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -31,13 +30,10 @@ public class ProvisionContextImpl implements ProvisionContext {
     private final Consumer<ProvisionedResource> resourceCallback;
     private final BiConsumer<ProvisionedDataDestinationResource, SecretToken> destinationCallback;
     private final BiConsumer<ProvisionedDataDestinationResource, Throwable> deprovisionCallback;
-    private final TransferProcessStore processStore;
 
-    public ProvisionContextImpl(TransferProcessStore processStore,
-                                Consumer<ProvisionedResource> resourceCallback,
+    public ProvisionContextImpl(Consumer<ProvisionedResource> resourceCallback,
                                 BiConsumer<ProvisionedDataDestinationResource, SecretToken> destinationCallback,
                                 BiConsumer<ProvisionedDataDestinationResource, Throwable> deprovisionCallback) {
-        this.processStore = processStore;
         this.resourceCallback = resourceCallback;
         this.destinationCallback = destinationCallback;
         this.deprovisionCallback = deprovisionCallback;
@@ -58,18 +54,4 @@ public class ProvisionContextImpl implements ProvisionContext {
         deprovisionCallback.accept(resource, error);
     }
 
-    @Override
-    public void create(String processId, String resourceDefinitionId, Object data) {
-        processStore.createData(processId, resourceDefinitionId, data);
-    }
-
-    @Override
-    public void update(String processId, String resourceDefinitionId, Object data) {
-        processStore.updateData(processId, resourceDefinitionId, data);
-    }
-
-    @Override
-    public <T> @Nullable T find(Class<T> type, String processId, String resourceDefinitionId) {
-        return processStore.findData(type, processId, resourceDefinitionId);
-    }
 }

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/provision/ProvisionManagerImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/provision/ProvisionManagerImpl.java
@@ -16,18 +16,14 @@ package org.eclipse.dataspaceconnector.transfer.core.provision;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.security.Vault;
+import org.eclipse.dataspaceconnector.spi.transfer.provision.ProvisionContext;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ProvisionManager;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.Provisioner;
 import org.eclipse.dataspaceconnector.spi.transfer.response.ResponseStatus;
-import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedDataDestinationResource;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedResource;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.SecretToken;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -37,25 +33,16 @@ import java.util.stream.Collectors;
 import static java.lang.String.format;
 
 /**
- * Default provision manager. Invoke {@link #start(TransferProcessStore)} to initialize an instance.
+ * Default provision manager.
  */
 public class ProvisionManagerImpl implements ProvisionManager {
-    private final Vault vault;
-    private final TypeManager typeManager;
-    private final Monitor monitor;
     private final List<Provisioner<?, ?>> provisioners = new ArrayList<>();
-    private TransferProcessStore processStore;
 
-    public ProvisionManagerImpl(Vault vault, TypeManager typeManager, Monitor monitor) {
-        this.vault = vault;
-        this.typeManager = typeManager;
-        this.monitor = monitor;
+    public ProvisionManagerImpl() {
     }
 
-    public void start(TransferProcessStore processStore) {
-        this.processStore = processStore;
-        var context = new ProvisionContextImpl(this.processStore, this::onResource, this::onDestinationResource, this::onDeprovisionComplete);
-        provisioners.forEach(provisioner -> provisioner.initialize(context));
+    public void start(ProvisionContext provisionContext) {
+        provisioners.forEach(provisioner -> provisioner.initialize(provisionContext));
     }
 
     @Override
@@ -79,81 +66,6 @@ public class ProvisionManagerImpl implements ProvisionManager {
                     return chosenProvisioner.deprovision(definition);
                 })
                 .collect(Collectors.toList());
-    }
-
-    void onDeprovisionComplete(ProvisionedDataDestinationResource resource, Throwable deprovisionError) {
-        if (deprovisionError != null) {
-            monitor.severe("Deprovisioning error: ", deprovisionError);
-        } else {
-            monitor.info("Deprovisioning successfully completed.");
-
-            TransferProcess transferProcess = processStore.find(resource.getTransferProcessId());
-            if (transferProcess != null) {
-                transferProcess.transitionDeprovisioned();
-                processStore.update(transferProcess);
-                monitor.debug("Process " + transferProcess.getId() + " is now " + TransferProcessStates.from(transferProcess.getState()));
-            } else {
-                monitor.severe("ProvisionManager: no TransferProcess found for deprovisioned resource");
-            }
-
-        }
-    }
-
-    void onDestinationResource(ProvisionedDataDestinationResource destinationResource, SecretToken secretToken) {
-        var processId = destinationResource.getTransferProcessId();
-        var transferProcess = processStore.find(processId);
-        if (transferProcess == null) {
-            processNotFound(destinationResource);
-            return;
-        }
-
-        if (!destinationResource.isError()) {
-            transferProcess.getDataRequest().updateDestination(destinationResource.createDataDestination());
-        }
-
-        if (secretToken != null) {
-            String keyName = destinationResource.getResourceName();
-            vault.storeSecret(keyName, typeManager.writeValueAsString(secretToken));
-            transferProcess.getDataRequest().getDataDestination().setKeyName(keyName);
-
-        }
-
-        updateProcessWithProvisionedResource(destinationResource, transferProcess);
-    }
-
-    void onResource(ProvisionedResource provisionedResource) {
-        var processId = provisionedResource.getTransferProcessId();
-        var transferProcess = processStore.find(processId);
-        if (transferProcess == null) {
-            processNotFound(provisionedResource);
-            return;
-        }
-
-        updateProcessWithProvisionedResource(provisionedResource, transferProcess);
-    }
-
-    private void updateProcessWithProvisionedResource(ProvisionedResource provisionedResource, TransferProcess transferProcess) {
-        transferProcess.addProvisionedResource(provisionedResource);
-
-        if (provisionedResource.isError()) {
-            var processId = transferProcess.getId();
-            var resourceId = provisionedResource.getResourceDefinitionId();
-            monitor.severe(format("Error provisioning resource %s for process %s: %s", resourceId, processId, provisionedResource.getErrorMessage()));
-            processStore.update(transferProcess);
-            return;
-        }
-
-        if (TransferProcessStates.ERROR.code() != transferProcess.getState() && transferProcess.provisioningComplete()) {
-            // TODO If all resources provisioned, delete scratch data
-            transferProcess.transitionProvisioned();
-        }
-        processStore.update(transferProcess);
-    }
-
-    private void processNotFound(ProvisionedResource provisionedResource) {
-        var resourceId = provisionedResource.getResourceDefinitionId();
-        var processId = provisionedResource.getTransferProcessId();
-        monitor.severe(format("Error received when provisioning resource %s Process id not found for: %s", resourceId, processId));
     }
 
     @NotNull

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/AsyncTransferProcessManager.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/AsyncTransferProcessManager.java
@@ -484,7 +484,7 @@ public class AsyncTransferProcessManager extends TransferProcessObservable imple
     }
 
     public ProvisionContext createProvisionContext() {
-        return new ProvisionContextImpl(this.transferProcessStore, this::onResource, this::onDestinationResource, this::onDeprovisionComplete);
+        return new ProvisionContextImpl(this::onResource, this::onDestinationResource, this::onDeprovisionComplete);
     }
 
     void onDeprovisionComplete(ProvisionedDataDestinationResource resource, Throwable deprovisionError) {

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/AsyncTransferProcessManager.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/AsyncTransferProcessManager.java
@@ -119,6 +119,26 @@ public class AsyncTransferProcessManager extends TransferProcessObservable imple
         return initiateRequest(PROVIDER, dataRequest);
     }
 
+    @Override
+    public void transitionRequestAck(String processId) {
+        TransferProcess transferProcess = transferProcessStore.find(processId);
+        transferProcess.transitionRequestAck();
+        transferProcessStore.update(transferProcess);
+    }
+
+    @Override
+    public void transitionProvisioned(String processId) {
+        TransferProcess transferProcess = transferProcessStore.find(processId);
+        transferProcess.transitionProvisioned();
+        transferProcessStore.update(transferProcess);
+    }
+
+    @Override
+    public void transitionError(String processId, String detail) {
+        TransferProcess transferProcess = transferProcessStore.find(processId);
+        transferProcess.transitionError(detail);
+        transferProcessStore.update(transferProcess);
+    }
 
     private TransferInitiateResult initiateRequest(TransferProcess.Type type, DataRequest dataRequest) {
         // make the request idempotent: if the process exists, return

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/DelegatingTransferProcessManager.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/DelegatingTransferProcessManager.java
@@ -1,9 +1,11 @@
 package org.eclipse.dataspaceconnector.transfer.core.transfer;
 
+import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferInitiateResult;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
 
 /**
  * This transfer process managers delegates {@link DataRequest} objects out to either the {@link SyncTransferProcessManager} or the
@@ -26,6 +28,26 @@ public class DelegatingTransferProcessManager implements TransferProcessManager 
     @Override
     public TransferInitiateResult initiateProviderRequest(DataRequest dataRequest) {
         return dataRequest.isSync() ? syncManager.initiateProviderRequest(dataRequest) : asyncManager.initiateProviderRequest(dataRequest);
+    }
+
+    @Override
+    public void transitionRequestAck(String processId) {
+
+    }
+
+    @Override
+    public void transitionProvisioned(String processId) {
+
+    }
+
+    @Override
+    public void transitionError(String processId, String detail) {
+
+    }
+
+    @Override
+    public Result<TransferProcessStates> deprovision(String processId) {
+        return null;
     }
 
     public void start(TransferProcessStore transferProcessStore) {

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/SyncTransferProcessManager.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/SyncTransferProcessManager.java
@@ -1,6 +1,7 @@
 package org.eclipse.dataspaceconnector.transfer.core.transfer;
 
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferInitiateResult;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
 import org.eclipse.dataspaceconnector.spi.transfer.response.ResponseStatus;
@@ -96,6 +97,26 @@ public class SyncTransferProcessManager implements TransferProcessManager {
             return TransferInitiateResult.success(process.getId(), proxyData);
         }
         return TransferInitiateResult.error(process.getId(), ResponseStatus.FATAL_ERROR);
+    }
+
+    @Override
+    public void transitionRequestAck(String processId) {
+
+    }
+
+    @Override
+    public void transitionProvisioned(String processId) {
+
+    }
+
+    @Override
+    public void transitionError(String processId, String detail) {
+
+    }
+
+    @Override
+    public Result<TransferProcessStates> deprovision(String processId) {
+        return null;
     }
 
     private ProxyEntry convert(Object result) {

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/TestResourceDefinition.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/TestResourceDefinition.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.transfer.core;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
+
+@JsonTypeName("dataspaceconnector:testresourcedefinition")
+@JsonDeserialize(builder = TestResourceDefinition.Builder.class)
+public
+class TestResourceDefinition extends ResourceDefinition {
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ResourceDefinition.Builder<TestResourceDefinition, Builder> {
+        private Builder() {
+            super(new TestResourceDefinition());
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+    }
+}

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/TestResourceDefinition.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/TestResourceDefinition.java
@@ -22,8 +22,7 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefiniti
 
 @JsonTypeName("dataspaceconnector:testresourcedefinition")
 @JsonDeserialize(builder = TestResourceDefinition.Builder.class)
-public
-class TestResourceDefinition extends ResourceDefinition {
+public class TestResourceDefinition extends ResourceDefinition {
 
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder extends ResourceDefinition.Builder<TestResourceDefinition, Builder> {

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/provision/ProvisionManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/provision/ProvisionManagerImplTest.java
@@ -2,6 +2,7 @@ package org.eclipse.dataspaceconnector.transfer.core.provision;
 
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
+import org.eclipse.dataspaceconnector.spi.transfer.provision.ProvisionContext;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.Provisioner;
 import org.eclipse.dataspaceconnector.spi.transfer.response.ResponseStatus;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
@@ -27,7 +28,7 @@ import static org.mockito.Mockito.when;
 
 class ProvisionManagerImplTest {
 
-    private ProvisionManagerImpl provisionManager = new ProvisionManagerImpl(mock(Vault.class), mock(TypeManager.class), mock(Monitor.class));
+    private final ProvisionManagerImpl provisionManager = new ProvisionManagerImpl();
 
     @BeforeEach
     void setUp() {
@@ -43,7 +44,7 @@ class ProvisionManagerImplTest {
                 .state(TransferProcessStates.REQUESTED.code())
                 .resourceManifest(ResourceManifest.Builder.newInstance().definitions(List.of(new TestResourceDefinition())).build())
                 .build();
-        provisionManager.start(mock(TransferProcessStore.class));
+        provisionManager.start(mock(ProvisionContext.class));
 
         provisionManager.provision(transferProcess);
 
@@ -61,7 +62,7 @@ class ProvisionManagerImplTest {
                 .state(TransferProcessStates.REQUESTED.code())
                 .provisionedResourceSet(ProvisionedResourceSet.Builder.newInstance().resources(List.of(new TestProvisionedResource())).build())
                 .build();
-        provisionManager.start(mock(TransferProcessStore.class));
+        provisionManager.start(mock(ProvisionContext.class));
 
         List<ResponseStatus> status = provisionManager.deprovision(transferProcess);
 

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/provision/ProvisionManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/provision/ProvisionManagerImplTest.java
@@ -1,0 +1,73 @@
+package org.eclipse.dataspaceconnector.transfer.core.provision;
+
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.security.Vault;
+import org.eclipse.dataspaceconnector.spi.transfer.provision.Provisioner;
+import org.eclipse.dataspaceconnector.spi.transfer.response.ResponseStatus;
+import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedResource;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedResourceSet;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceManifest;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
+import org.eclipse.dataspaceconnector.transfer.core.TestResourceDefinition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ProvisionManagerImplTest {
+
+    private ProvisionManagerImpl provisionManager = new ProvisionManagerImpl(mock(Vault.class), mock(TypeManager.class), mock(Monitor.class));
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Test
+    void provisionTransferProcess() {
+        var provisioner = mock(Provisioner.class);
+        when(provisioner.canProvision(isA(TestResourceDefinition.class))).thenReturn(true);
+        provisionManager.register(provisioner);
+        TransferProcess transferProcess = TransferProcess.Builder.newInstance()
+                .id("id")
+                .state(TransferProcessStates.REQUESTED.code())
+                .resourceManifest(ResourceManifest.Builder.newInstance().definitions(List.of(new TestResourceDefinition())).build())
+                .build();
+        provisionManager.start(mock(TransferProcessStore.class));
+
+        provisionManager.provision(transferProcess);
+
+        verify(provisioner).provision(any());
+    }
+
+    @Test
+    void deprovisionTransferProcessReturnsResponseList() {
+        var provisioner = mock(Provisioner.class);
+        when(provisioner.canDeprovision(isA(ProvisionedResource.class))).thenReturn(true);
+        when(provisioner.deprovision(isA(TestProvisionedResource.class))).thenReturn(ResponseStatus.OK);
+        provisionManager.register(provisioner);
+        TransferProcess transferProcess = TransferProcess.Builder.newInstance()
+                .id("id")
+                .state(TransferProcessStates.REQUESTED.code())
+                .provisionedResourceSet(ProvisionedResourceSet.Builder.newInstance().resources(List.of(new TestProvisionedResource())).build())
+                .build();
+        provisionManager.start(mock(TransferProcessStore.class));
+
+        List<ResponseStatus> status = provisionManager.deprovision(transferProcess);
+
+        assertThat(status).containsExactly(ResponseStatus.OK);
+        verify(provisioner).deprovision(any());
+    }
+
+    private static class TestProvisionedResource extends ProvisionedResource {}
+}

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/AsyncTransferProcessManagerImplConsumerTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/AsyncTransferProcessManagerImplConsumerTest.java
@@ -81,6 +81,7 @@ class AsyncTransferProcessManagerImplConsumerTest {
         when(manifestGenerator.generateConsumerManifest(any(TransferProcess.class))).thenReturn(re);
 
         statusCheckerRegistry = mock(StatusCheckerRegistry.class);
+
         var waitStrategyMock = mock(ExponentialWaitStrategy.class);
 
         transferProcessManager = AsyncTransferProcessManager.Builder.newInstance()

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/AsyncTransferProcessManagerImplConsumerTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/AsyncTransferProcessManagerImplConsumerTest.java
@@ -64,30 +64,21 @@ class AsyncTransferProcessManagerImplConsumerTest {
 
     private static final long TIMEOUT = 5;
     private static final int TRANSFER_MANAGER_BATCHSIZE = 10;
+    private final ProvisionManager provisionManager = mock(ProvisionManager.class);
+    private final RemoteMessageDispatcherRegistry dispatcherRegistry = mock(RemoteMessageDispatcherRegistry.class);
+    private final StatusCheckerRegistry statusCheckerRegistry = mock(StatusCheckerRegistry.class);
+    private final ResourceManifestGenerator manifestGenerator = mock(ResourceManifestGenerator.class);
     private AsyncTransferProcessManager transferProcessManager;
-    private ProvisionManager provisionManager;
-    private RemoteMessageDispatcherRegistry dispatcherRegistry;
-    private StatusCheckerRegistry statusCheckerRegistry;
-    private ExponentialWaitStrategy waitStrategyMock;
-    private ResourceManifestGenerator manifestGenerator;
 
     @BeforeEach
     void setup() {
-        provisionManager = mock(ProvisionManager.class);
-        DataFlowManager dataFlowManager = mock(DataFlowManager.class);
-        dispatcherRegistry = mock(RemoteMessageDispatcherRegistry.class);
-
-        ResourceManifest re = ResourceManifest.Builder.newInstance().definitions(List.of(new TestResourceDefinition())).build();
-        when(manifestGenerator.generateConsumerManifest(any(TransferProcess.class))).thenReturn(re);
-
-        statusCheckerRegistry = mock(StatusCheckerRegistry.class);
-
-        var waitStrategyMock = mock(ExponentialWaitStrategy.class);
+        var resourceManifest = ResourceManifest.Builder.newInstance().definitions(List.of(new TestResourceDefinition())).build();
+        when(manifestGenerator.generateConsumerManifest(any(TransferProcess.class))).thenReturn(resourceManifest);
 
         transferProcessManager = AsyncTransferProcessManager.Builder.newInstance()
                 .provisionManager(provisionManager)
-                .dataFlowManager(dataFlowManager)
-                .waitStrategy(waitStrategyMock)
+                .dataFlowManager(mock(DataFlowManager.class))
+                .waitStrategy(mock(ExponentialWaitStrategy.class))
                 .batchSize(TRANSFER_MANAGER_BATCHSIZE)
                 .dispatcherRegistry(dispatcherRegistry)
                 .manifestGenerator(manifestGenerator)

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/AsyncTransferProcessManagerImplConsumerTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/AsyncTransferProcessManagerImplConsumerTest.java
@@ -30,6 +30,7 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.StatusCheckerReg
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferType;
+import org.eclipse.dataspaceconnector.transfer.core.TestResourceDefinition;
 import org.eclipse.dataspaceconnector.transfer.store.memory.InMemoryTransferProcessStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -67,14 +68,17 @@ class AsyncTransferProcessManagerImplConsumerTest {
     private ProvisionManager provisionManager;
     private RemoteMessageDispatcherRegistry dispatcherRegistry;
     private StatusCheckerRegistry statusCheckerRegistry;
+    private ExponentialWaitStrategy waitStrategyMock;
+    private ResourceManifestGenerator manifestGenerator;
 
     @BeforeEach
     void setup() {
         provisionManager = mock(ProvisionManager.class);
         DataFlowManager dataFlowManager = mock(DataFlowManager.class);
         dispatcherRegistry = mock(RemoteMessageDispatcherRegistry.class);
-        ResourceManifestGenerator manifestGenerator = mock(ResourceManifestGenerator.class);
-        when(manifestGenerator.generateConsumerManifest(any(TransferProcess.class))).thenReturn(new ResourceManifest());
+
+        ResourceManifest re = ResourceManifest.Builder.newInstance().definitions(List.of(new TestResourceDefinition())).build();
+        when(manifestGenerator.generateConsumerManifest(any(TransferProcess.class))).thenReturn(re);
 
         statusCheckerRegistry = mock(StatusCheckerRegistry.class);
         var waitStrategyMock = mock(ExponentialWaitStrategy.class);
@@ -102,9 +106,9 @@ class AsyncTransferProcessManagerImplConsumerTest {
             return null;
         }).when(provisionManager).provision(any(TransferProcess.class));
 
-        //prepare process store
         TransferProcessStore processStoreMock = mock(TransferProcessStore.class);
         when(processStoreMock.nextForState(eq(INITIAL.code()), anyInt())).thenReturn(List.of(process));
+
         processStoreMock.update(process);
         doNothing().when(processStoreMock).update(process);
 

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/IdsCoreServiceExtension.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/IdsCoreServiceExtension.java
@@ -46,6 +46,7 @@ import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 
 import java.util.ArrayList;
@@ -143,7 +144,7 @@ public class IdsCoreServiceExtension implements ServiceExtension {
      * Assembles the IDS remote message dispatcher and its senders.
      */
     private void assembleIdsDispatcher(String connectorId, ServiceExtensionContext context, IdentityService identityService) {
-        var processStore = context.getService(TransferProcessStore.class);
+        var processManager = context.getService(TransferProcessManager.class);
         var vault = context.getService(Vault.class);
         var httpClient = context.getService(OkHttpClient.class);
 
@@ -153,7 +154,7 @@ public class IdsCoreServiceExtension implements ServiceExtension {
 
         var restDispatcher = new IdsRestRemoteMessageDispatcher();
         restDispatcher.register(new QueryMessageSender(connectorId, identityService, httpClient, mapper, monitor));
-        restDispatcher.register(new DataRequestMessageSender(connectorId, identityService, processStore, vault, httpClient, mapper, monitor));
+        restDispatcher.register(new DataRequestMessageSender(connectorId, identityService, vault, httpClient, mapper, monitor, processManager));
 
         var registry = context.getService(RemoteMessageDispatcherRegistry.class);
         registry.register(restDispatcher);

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/message/DataRequestMessageSender.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/message/DataRequestMessageSender.java
@@ -25,13 +25,14 @@ import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
 import org.eclipse.dataspaceconnector.spi.message.MessageContext;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
@@ -48,27 +49,27 @@ public class DataRequestMessageSender implements IdsMessageSender<DataRequest, O
     private static final String JSON = "application/json";
     private static final String VERSION = "1.0";
     private final Monitor monitor;
+    private final TransferProcessManager transferProcessManager;
     private final URI connectorId;
     private final IdentityService identityService;
-    private final TransferProcessStore transferProcessStore;
     private final Vault vault;
     private final OkHttpClient httpClient;
     private final ObjectMapper mapper;
 
     public DataRequestMessageSender(String connectorId,
                                     IdentityService identityService,
-                                    TransferProcessStore transferProcessStore,
                                     Vault vault,
                                     OkHttpClient httpClient,
                                     ObjectMapper mapper,
-                                    Monitor monitor) {
+                                    Monitor monitor,
+                                    TransferProcessManager transferProcessManager) {
         this.connectorId = URI.create(connectorId);
         this.identityService = identityService;
-        this.transferProcessStore = transferProcessStore;
         this.vault = vault;
         this.httpClient = httpClient;
         this.mapper = mapper;
         this.monitor = monitor;
+        this.transferProcessManager = transferProcessManager;
     }
 
     @Override
@@ -118,7 +119,8 @@ public class DataRequestMessageSender implements IdsMessageSender<DataRequest, O
         var connectorAddress = dataRequest.getConnectorAddress();
         HttpUrl baseUrl = HttpUrl.parse(connectorAddress);
         if (baseUrl == null) {
-            return transitionToErrorState("Invalid connector address: " + connectorAddress, context);
+            transferProcessManager.transitionError(context.getProcessId(), "Invalid connector address: " + connectorAddress);
+            return CompletableFuture.completedFuture(null);
         }
 
         HttpUrl connectorEndpoint = baseUrl.newBuilder().addPathSegment("api").addPathSegment("ids").addPathSegment("request").build();
@@ -129,15 +131,15 @@ public class DataRequestMessageSender implements IdsMessageSender<DataRequest, O
 
         httpClient.newCall(request).enqueue(new FutureCallback<>(future, r -> {
             try (r) {
-                TransferProcess transferProcess = transferProcessStore.find(processId);
+                // TODO: future is not always completed, this
                 if (r.isSuccessful()) {
                     monitor.debug("Request approved and acknowledged for process: " + processId);
-                    transferProcess.transitionRequestAck();
+                    transferProcessManager.transitionRequestAck(processId);
                     Object dataObject = extractArtifactResponse(r);
                     future.complete(dataObject);
-
                 } else if (r.code() == 500) {
-                    transferProcess.transitionProvisioned();  // force retry
+                    transferProcessManager.transitionProvisioned(processId);
+                    future.completeExceptionally(new EdcException("Received InternalServerError " + r.message()));
                 } else {
                     if (r.code() == 403) {
                         // forbidden
@@ -149,9 +151,10 @@ public class DataRequestMessageSender implements IdsMessageSender<DataRequest, O
                             String.format("IDS Rejection: '%s', code %s", rejectionMsg.getRejectionReason().name(), r.code()) :
                             "General error, HTTP response code: " + r.code();
                     monitor.info(message);
-                    transferProcess.transitionError(message);
+                    transferProcessManager.transitionError(processId, "General error, HTTP response code: " + r.code());
+                    future.completeExceptionally(new EdcException("Received Error " + r.code() + " " + message));
                 }
-                transferProcessStore.update(transferProcess);
+
                 return null;
             }
         }));
@@ -176,16 +179,6 @@ public class DataRequestMessageSender implements IdsMessageSender<DataRequest, O
             monitor.severe("Could not read body of response", e);
             return null;
         }
-    }
-
-    @NotNull
-    private CompletableFuture<Object> transitionToErrorState(String error, MessageContext context) {
-        TransferProcess transferProcess = transferProcessStore.find(context.getProcessId());
-        transferProcess.transitionError(error);
-        transferProcessStore.update(transferProcess);
-        CompletableFuture<Object> future = new CompletableFuture<>();
-        future.complete(null);
-        return future;
     }
 
 }

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/message/DataRequestMessageSenderTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/message/DataRequestMessageSenderTest.java
@@ -25,7 +25,7 @@ import org.eclipse.dataspaceconnector.spi.iam.TokenRepresentation;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
-import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,8 +65,9 @@ class DataRequestMessageSenderTest {
         IdentityService identityService = mock(IdentityService.class);
         var tokenRepresentation = TokenRepresentation.Builder.newInstance().token(faker.lorem().characters()).build();
         Result<TokenRepresentation> tokenResult = Result.success(tokenRepresentation);
+
         when(identityService.obtainClientCredentials(connectorId)).thenReturn(tokenResult);
-        sender = new DataRequestMessageSender(connectorId, identityService, mock(TransferProcessStore.class), mock(Vault.class), httpClient, mapper, mock(Monitor.class));
+        sender = new DataRequestMessageSender(connectorId, identityService, mock(Vault.class), httpClient, mapper, mock(Monitor.class), mock(TransferProcessManager.class));
     }
 
     @Test

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/crawler/CrawlerImplTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/crawler/CrawlerImplTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.catalog.cache.TestUtil.createWorkItem;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -136,9 +137,7 @@ class CrawlerImplTest {
     @Test
     @DisplayName("Should not insert when Queue is at capacity")
     void shouldLogError_whenQueueFull() throws InterruptedException {
-        queue.add(new UpdateResponse());
-        queue.add(new UpdateResponse());
-        queue.add(new UpdateResponse()); //queue is full now
+        range(0, QUEUE_CAPACITY).forEach(i -> queue.add(new UpdateResponse())); //queue is full now
 
         var l = new CountDownLatch(1);
         when(protocolAdapterMock.sendRequest(isA(UpdateRequest.class))).thenAnswer(i -> {
@@ -147,6 +146,7 @@ class CrawlerImplTest {
         });
 
         workQueue.put(createWorkItem());
+
         executorService.submit(crawler);
 
         assertThat(l.await(JOIN_WAIT_TIME, TimeUnit.MILLISECONDS)).isTrue();

--- a/samples/05-file-transfer-cloud/api/src/main/java/org/eclipse/dataspaceconnector/extensions/api/ConsumerApiController.java
+++ b/samples/05-file-transfer-cloud/api/src/main/java/org/eclipse/dataspaceconnector/extensions/api/ConsumerApiController.java
@@ -12,6 +12,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.eclipse.dataspaceconnector.common.collection.CollectionUtil;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
@@ -74,33 +75,18 @@ public class ConsumerApiController {
     @DELETE
     @Path("datarequest/{id}")
     public Response deprovisionRequest(@PathParam("id") String requestId) {
-
-        var process = processStore.find(requestId);
-        if (process == null) {
-            return Response.status(Response.Status.NOT_FOUND).build();
-        }
         try {
-            if (CollectionUtil.isAnyOf(process.getState(),
-                    TransferProcessStates.DEPROVISIONED.code(),
-                    TransferProcessStates.DEPROVISIONING_REQ.code(),
-                    TransferProcessStates.DEPROVISIONING.code(),
-                    TransferProcessStates.ENDED.code()
-            )) {
-                monitor.info("Request already deprovisioning or deprovisioned.");
+            Result<TransferProcessStates> result = processManager.deprovision(requestId);
+            if (result.succeeded()) {
+                return Response.ok(TransferProcessStates.from(result.getContent().code()).toString()).build();
             } else {
-                monitor.info("starting to deprovision data request " + requestId);
-                process.transitionCompleted();
-                process.transitionDeprovisionRequested();
-                processStore.update(process);
+                return Response.status(Response.Status.NOT_FOUND).build();
             }
-            return Response.ok(TransferProcessStates.from(process.getState()).toString()).build();
         } catch (IllegalStateException ex) {
             monitor.severe(ex.getMessage());
             return Response.status(400).entity("The process must be in one of these states: " +
                     String.join(", ", TransferProcessStates.IN_PROGRESS.name(), TransferProcessStates.REQUESTED_ACK.name(), TransferProcessStates.COMPLETED.name(), TransferProcessStates.STREAMING.name())).build();
         }
-
     }
-
 
 }

--- a/samples/other/public-rest-api/src/main/java/org/eclipse/dataspaceconnector/demo/api/rest/DemoApiController.java
+++ b/samples/other/public-rest-api/src/main/java/org/eclipse/dataspaceconnector/demo/api/rest/DemoApiController.java
@@ -13,6 +13,7 @@ import jakarta.ws.rs.core.Response;
 import org.eclipse.dataspaceconnector.common.collection.CollectionUtil;
 import org.eclipse.dataspaceconnector.metadata.catalog.CatalogService;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
@@ -94,26 +95,13 @@ public class DemoApiController {
     @DELETE
     @Path("datarequest/{id}")
     public Response deprovisionRequest(@PathParam("id") String requestId) {
-
-        var process = processStore.find(requestId);
-        if (process == null) {
-            return Response.status(Response.Status.NOT_FOUND).build();
-        }
         try {
-            if (CollectionUtil.isAnyOf(process.getState(),
-                    TransferProcessStates.DEPROVISIONED.code(),
-                    TransferProcessStates.DEPROVISIONING_REQ.code(),
-                    TransferProcessStates.DEPROVISIONING.code(),
-                    TransferProcessStates.ENDED.code()
-            )) {
-                monitor.info("Request already deprovisioning or deprovisioned.");
+            Result<TransferProcessStates> result = transferProcessManager.deprovision(requestId);
+            if (result.succeeded()) {
+                return Response.ok(TransferProcessStates.from(result.getContent().code()).toString()).build();
             } else {
-                monitor.info("starting to deprovision data request " + requestId);
-                process.transitionCompleted();
-                process.transitionDeprovisionRequested();
-                processStore.update(process);
+                return Response.status(Response.Status.NOT_FOUND).build();
             }
-            return Response.ok(formatAsJson(TransferProcessStates.from(process.getState()).toString())).build();
         } catch (IllegalStateException ex) {
             monitor.severe(ex.getMessage());
             return Response.status(400).entity("The process must be in one of these states: " + String.join(", ", TransferProcessStates.IN_PROGRESS.name(), TransferProcessStates.REQUESTED_ACK.name(), TransferProcessStates.STREAMING.name())).build();

--- a/spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/TransferProcessManager.java
+++ b/spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/TransferProcessManager.java
@@ -14,7 +14,9 @@
 
 package org.eclipse.dataspaceconnector.spi.transfer;
 
+import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
 
 /**
  * Manages data transfer processes. Currently synchronous and asynchronous data transfers are supported.
@@ -38,4 +40,6 @@ public interface TransferProcessManager {
     void transitionProvisioned(String processId);
 
     void transitionError(String processId, String detail);
+
+    Result<TransferProcessStates> deprovision(String processId);
 }

--- a/spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/TransferProcessManager.java
+++ b/spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/TransferProcessManager.java
@@ -35,11 +35,15 @@ public interface TransferProcessManager {
      */
     TransferInitiateResult initiateProviderRequest(DataRequest dataRequest);
 
+    // TODO: will be substituted by the upcoming command queue introduction
     void transitionRequestAck(String processId);
 
+    // TODO: will be substituted by the upcoming command queue introduction
     void transitionProvisioned(String processId);
 
+    // TODO: will be substituted by the upcoming command queue introduction
     void transitionError(String processId, String detail);
 
+    // TODO: will be substituted by the upcoming command queue introduction
     Result<TransferProcessStates> deprovision(String processId);
 }

--- a/spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/TransferProcessManager.java
+++ b/spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/TransferProcessManager.java
@@ -33,4 +33,9 @@ public interface TransferProcessManager {
      */
     TransferInitiateResult initiateProviderRequest(DataRequest dataRequest);
 
+    void transitionRequestAck(String processId);
+
+    void transitionProvisioned(String processId);
+
+    void transitionError(String processId, String detail);
 }

--- a/spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ProvisionContext.java
+++ b/spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ProvisionContext.java
@@ -42,25 +42,4 @@ public interface ProvisionContext {
      */
     void deprovisioned(ProvisionedDataDestinationResource resource, Throwable error);
 
-    /**
-     * Persists data related to a provision request.  Data will be removed after all resources have been provisioned for a transfer process.
-     * This is intended as a facility to use for recovery. For example, infrastructure request ids can be persisted and recovered to continue processing after runtime restart.
-     */
-    default void create(String processId, String resourceDefinitionId, Object data) {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Updates data related to a provision request.
-     */
-    default void update(String processId, String resourceDefinitionId, Object data) {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Returns data related to a provision request.
-     */
-    default @Nullable <T> T find(Class<T> type, String processId, String resourceDefinitionId) {
-        throw new UnsupportedOperationException();
-    }
 }

--- a/spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ProvisionManager.java
+++ b/spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ProvisionManager.java
@@ -14,9 +14,12 @@
 
 package org.eclipse.dataspaceconnector.spi.transfer.provision;
 
+import org.eclipse.dataspaceconnector.spi.transfer.response.ResponseStatus;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedResource;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+
+import java.util.List;
 
 /**
  * Manages resource provisioning for a data transfer.
@@ -36,5 +39,5 @@ public interface ProvisionManager {
     /**
      * Removes ephemeral resources associated with the data transfer. this operation is idempotent.
      */
-    void deprovision(TransferProcess process);
+    List<ResponseStatus> deprovision(TransferProcess process);
 }


### PR DESCRIPTION
Part of #330

This PR bring all the code that calls methods that change a transfer process (`create`, `update`, `delete`) inside `TransferProcessManager`, that will help introducing the command queue.

I have two questions, both for @jimmarino and @paullatzelsperger 
1. The process of handling post-provision/deprovision actions using `ProvisionContext` is pretty hard to understand (it took me a while), I would suggest to change that implementation, I have two proposal:
  * Make `Provisoner`'s `provision` and `deprovision` and `ProvisionManager`'s `provision` and `deprovision` return a `CompletableFuture` containing the result, doing so, the definition of what should be done after the provisioning/deprovisioning will be set right after the method call, more easy to read. (preferred solution for me)
  * Make `Provisoner`'s `provision` and `deprovision` and `ProvisionManager`'s `provision` and `deprovision` accept the callback  as parameter.
  
2. On `ProvisionContext` there are 3 methods unused: `create`, `update` and `find`, can they be removed or will be needed (I would remove them anyway since they are not used at the moment)