### PR TITLE
Provide library to support postgresql as data retention site (closes #438)

### DIFF
--- a/common/libraries/clients/postgresql/README.md
+++ b/common/libraries/clients/postgresql/README.md
@@ -1,0 +1,23 @@
+# PostgreSQL Clients
+
+This library provides a connection pooling client to perform SQL queries towards PostgreSQL databases. The
+implementation prevents from SQL injection due to exclusive usage of `java.sql.PreparedStatement`s. It yields an
+interface for transactional SQL queries and automatic transaction rollback while treating exceptions.
+
+## Usage
+
+```java
+    ConnectionFactoryConfig connectionFactoryConfig = ConnectionFactoryConfig.Builder.newInstance()
+        .uri(URI.create("jdbc://localhost:5432/mydb"))
+        .userName("username")
+        .password("password")
+        .build();
+    ConnectionFactory connectionFactory = new ConnectionFactoryImpl(connectionFactoryConfig);
+    CommonsConnectionPoolConfig commonsConnectionPoolConfig = CommonsConnectionPoolConfig.Builder.newInstance().build();
+    ConnectionPool connectionPool = new CommonsConnectionPool(connectionFactory, commonsConnectionPoolConfig);
+    PostgresqlClient postgresqlClient = new PostgresqlClientImpl(connectionPool);
+
+    List<Integer> i = postgresqlClient.execute((r) -> r.getInt(1), "SELECT 1;");
+
+    postgresqlClient.close(); // closes all connections managed by the underlying pool
+```

--- a/common/libraries/clients/postgresql/build.gradle.kts
+++ b/common/libraries/clients/postgresql/build.gradle.kts
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - initial build file
+ *
+ */
+
+plugins {
+    `java-library`
+    `java-test-fixtures`
+    `maven-publish`
+}
+
+val jupiterVersion: String by project
+val postgresqlVersion: String by project
+val apacheCommonsPool2Version: String by project
+val testContainersVersion: String by project
+
+dependencies {
+    implementation("org.postgresql:postgresql:${postgresqlVersion}")
+    implementation("org.apache.commons:commons-pool2:${apacheCommonsPool2Version}")
+
+    testImplementation("ch.qos.logback:logback-classic:1.2.6")
+    testImplementation("org.testcontainers:postgresql:${testContainersVersion}")
+    testImplementation("org.testcontainers:junit-jupiter:${testContainersVersion}")
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("common-clients-postgresql") {
+            artifactId = "common-clients-postgresql"
+            from(components["java"])
+        }
+    }
+}

--- a/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/PostgresqlClient.java
+++ b/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/PostgresqlClient.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial API and Implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.clients.postgresql;
+
+import org.eclipse.dataspaceconnector.clients.postgresql.row.RowMapper;
+
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Client capable of issuing SQL queries against postgresql databases
+ */
+public interface PostgresqlClient extends AutoCloseable {
+
+    /**
+     * Intended for mutating queries.
+     *
+     * @param sql       the parametrized sql query
+     * @param arguments the parameteres to interpolate with the parametrized sql query
+     * @return rowsChanged
+     * @throws SQLException if execution of the query was failing
+     */
+    int execute(String sql, Object... arguments) throws SQLException;
+
+    /**
+     * Intended for reading queries.
+     *
+     * @param rowMapper able to map a row to an object e.g. pojo.
+     * @param sql       the parametrized sql query
+     * @param arguments the parameteres to interpolate with the parametrized sql query
+     * @param <T>       generic type returned after mapping from the executed query
+     * @return results
+     * @throws SQLException if execution of the query or mapping was failing
+     */
+    <T> List<T> execute(RowMapper<T> rowMapper, String sql, Object... arguments) throws SQLException;
+
+    /**
+     * Spans a transaction around the passed callback.
+     *
+     * @param callback transaction scoped callback
+     * @throws SQLException if the transaction was failing
+     */
+    void doInTransaction(TransactionCallback callback) throws SQLException;
+
+    /**
+     * Closes the postgres client and frees all underlying resources.
+     *
+     * @throws Exception in case an error was encountered while closing the postgres client
+     */
+    default void close() throws Exception {
+    }
+
+    /**
+     * A transaction scoped callback
+     */
+    @FunctionalInterface
+    interface TransactionCallback {
+
+        /**
+         * Callback.
+         *
+         * @param postgresqlClient the transaction scoped postgres client
+         * @throws SQLException if execution of any operations encountered an error
+         */
+        void accept(PostgresqlClient postgresqlClient) throws SQLException;
+    }
+}

--- a/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/PostgresqlClientImpl.java
+++ b/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/PostgresqlClientImpl.java
@@ -1,0 +1,212 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial API and Implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.clients.postgresql;
+
+import org.eclipse.dataspaceconnector.clients.postgresql.connection.pool.ConnectionPool;
+import org.eclipse.dataspaceconnector.clients.postgresql.row.RowMapper;
+import org.eclipse.dataspaceconnector.clients.postgresql.statement.ArgumentHandler;
+import org.eclipse.dataspaceconnector.clients.postgresql.statement.ArgumentHandlers;
+import org.jetbrains.annotations.NotNull;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * An implementation of a {@link org.eclipse.dataspaceconnector.clients.postgresql.PostgresqlClient}
+ * backed by an {@link org.eclipse.dataspaceconnector.clients.postgresql.connection.pool.ConnectionPool}
+ */
+public class PostgresqlClientImpl implements PostgresqlClient {
+    private final ConnectionPool connectionPool;
+
+    /**
+     * Constructor for instantiating the PostgresqlClientImpl
+     *
+     * @param connectionPool mandatory for obtaining connections
+     */
+    public PostgresqlClientImpl(ConnectionPool connectionPool) {
+        Objects.requireNonNull(connectionPool, "connectionFactory");
+
+        this.connectionPool = connectionPool;
+    }
+
+    @Override
+    public int execute(String sql, Object... arguments) throws SQLException {
+        Objects.requireNonNull(sql, "sql");
+        Objects.requireNonNull(arguments, "arguments");
+
+        return connectionPool.doWithConnection(
+                connection -> new SingleConnectionScopedPostgresqlClient(connection).execute(sql, arguments));
+    }
+
+    @Override
+    public <T> List<T> execute(RowMapper<T> rowMapper, String sql, Object... arguments) throws SQLException {
+        Objects.requireNonNull(sql, "rowMapper");
+        Objects.requireNonNull(sql, "sql");
+        Objects.requireNonNull(arguments, "arguments");
+
+        return connectionPool.doWithConnection(
+                connection -> new SingleConnectionScopedPostgresqlClient(connection).execute(rowMapper, sql, arguments));
+    }
+
+    @Override
+    public void doInTransaction(TransactionCallback callback) throws SQLException {
+        Objects.requireNonNull(callback, "callback");
+
+        connectionPool.doWithConnection(connection -> {
+            doInTransaction(connection, callback);
+            return null;
+        });
+    }
+
+    public void close() throws Exception {
+        connectionPool.close();
+    }
+
+    private static void doInTransaction(Connection connection, TransactionCallback transactionCallback) throws SQLException {
+        new Transaction(connection, transactionCallback).execute();
+    }
+
+    private static class SingleConnectionScopedPostgresqlClient implements PostgresqlClient {
+        private final Connection connection;
+
+        public SingleConnectionScopedPostgresqlClient(@NotNull Connection connection) {
+            this.connection = Objects.requireNonNull(connection, "connection");
+        }
+
+        @Override
+        public int execute(String sql, Object... arguments) throws SQLException {
+            Objects.requireNonNull(sql, "sql");
+            Objects.requireNonNull(arguments, "arguments");
+
+            try (PreparedStatement statement = connection.prepareStatement(sql, PreparedStatement.RETURN_GENERATED_KEYS)) {
+
+                setArguments(statement, arguments);
+
+                return statement.execute() ? 0 : statement.getUpdateCount();
+            }
+        }
+
+        @Override
+        public <T> List<T> execute(RowMapper<T> rowMapper, String sql, Object... arguments) throws SQLException {
+            Objects.requireNonNull(rowMapper, "rowMapper");
+            Objects.requireNonNull(sql, "sql");
+            Objects.requireNonNull(arguments, "arguments");
+
+            try (PreparedStatement statement = connection.prepareStatement(sql, PreparedStatement.RETURN_GENERATED_KEYS)) {
+
+                setArguments(statement, arguments);
+
+                return statement.execute() ? mapRows(statement.getResultSet(), rowMapper) : Collections.emptyList();
+            }
+        }
+
+        @Override
+        public void doInTransaction(@NotNull TransactionCallback callback) throws SQLException {
+            throw new SQLException("Transaction already open");
+        }
+
+        private void setArguments(PreparedStatement statement, Object[] arguments) throws SQLException {
+            for (int index = 0; index < arguments.length; index++) {
+                int position = index + 1;
+
+                setArgument(statement, position, arguments[index]);
+            }
+        }
+
+        private void setArgument(PreparedStatement statement, int position, Object argument) throws SQLException {
+            ArgumentHandler argumentHandler = null;
+            for (ArgumentHandler handler : ArgumentHandlers.values()) {
+                if (handler.accepts(argument)) {
+                    argumentHandler = handler;
+                    break;
+                }
+            }
+
+            // fallback: set as object
+            if (argumentHandler == null) {
+                argumentHandler = new ArgumentHandler() {
+                    @Override
+                    public boolean accepts(Object value) {
+                        return true;
+                    }
+
+                    @Override
+                    public void handle(PreparedStatement statement, int position, Object argument) throws SQLException {
+                        statement.setObject(position, argument);
+                    }
+                };
+            }
+
+            argumentHandler.handle(statement, position, argument);
+        }
+
+        private <T> List<T> mapRows(ResultSet resultSet, RowMapper<T> rowMapper) throws SQLException {
+            List<T> results = new LinkedList<>();
+
+            if (resultSet != null) {
+                while (resultSet.next()) {
+                    results.add(rowMapper.mapRow(resultSet));
+                }
+            }
+
+            return results;
+        }
+    }
+
+    private static class Transaction {
+        private final Connection connection;
+        private final TransactionCallback transactionCallback;
+
+        public Transaction(Connection connection, TransactionCallback transactionCallback) {
+            this.connection = connection;
+            this.transactionCallback = transactionCallback;
+        }
+
+        public void execute() throws SQLException {
+            try {
+                try (Statement statement = connection.createStatement()) {
+                    statement.execute("BEGIN");
+                }
+
+                transactionCallback.accept(new SingleConnectionScopedPostgresqlClient(connection));
+
+                connection.commit();
+            } catch (Exception exception) {
+                SQLException sqlException;
+                if (exception instanceof SQLException) {
+                    sqlException = (SQLException) exception;
+                } else {
+                    sqlException = new SQLException(exception);
+                }
+
+                try {
+                    connection.rollback();
+                } catch (SQLException txSqlException) {
+                    txSqlException.addSuppressed(sqlException);
+                    sqlException = txSqlException;
+                }
+
+                throw sqlException;
+            }
+        }
+    }
+}

--- a/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/connection/ConnectionFactory.java
+++ b/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/connection/ConnectionFactory.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial API and Implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.clients.postgresql.connection;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * A ConnectionFactory combines a set of connection configuration
+ * parameters that has been defined prior to connection creation.
+ */
+public interface ConnectionFactory {
+
+    /**
+     * Creates a fresh connection.
+     *
+     * @return connection created from a defined set of connection configuration parameters.
+     * @throws SQLException if the connection was not able to be obtained
+     */
+    Connection create() throws SQLException;
+}

--- a/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/connection/ConnectionFactoryConfig.java
+++ b/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/connection/ConnectionFactoryConfig.java
@@ -1,0 +1,329 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial API and Implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.clients.postgresql.connection;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * A ConnectionFactoryConfig is a container object containing a set of connection configuration
+ * parameters that can be used by a ConnectionFactory for connection creation.
+ */
+public class ConnectionFactoryConfig {
+    /**
+     * The jdbc url to connect to
+     */
+    private final URI uri;
+    private final String userName;
+    private final String password;
+    private final Boolean ssl;
+    private final SslMode sslMode;
+    private final Path sslCert;
+    private final Path sslKey;
+    private final Path sslRootCert;
+    private final String sslHostNameVerifier;
+    private final LoggerLevel loggerLevel;
+    private final Path loggerFile;
+    private final Boolean logUnclosedConnection;
+    private final long socketTimeout;
+    private final long connectTimeout;
+    private final long loginTimeout;
+    private final String applicationName;
+    private final boolean readOnly;
+    private final boolean autoCommit;
+
+    public ConnectionFactoryConfig(
+            @NotNull URI uri,
+            @NotNull String userName,
+            String password,
+            Boolean ssl,
+            SslMode sslMode,
+            Path sslCert,
+            Path sslKey,
+            Path sslRootCert,
+            String sslHostNameVerifier,
+            LoggerLevel loggerLevel,
+            Path loggerFile,
+            Boolean logUnclosedConnection,
+            long socketTimeout,
+            long connectTimeout,
+            long loginTimeout,
+            String applicationName,
+            boolean readOnly,
+            boolean autoCommit) {
+        this.uri = Objects.requireNonNull(uri);
+        this.userName = Objects.requireNonNull(userName);
+        this.password = password;
+        this.ssl = ssl;
+        this.sslMode = sslMode;
+        this.sslCert = sslCert;
+        this.sslKey = sslKey;
+        this.sslRootCert = sslRootCert;
+        this.sslHostNameVerifier = sslHostNameVerifier;
+        this.loggerLevel = loggerLevel;
+        this.loggerFile = loggerFile;
+        this.logUnclosedConnection = logUnclosedConnection;
+        this.socketTimeout = socketTimeout;
+        this.connectTimeout = connectTimeout;
+        this.loginTimeout = loginTimeout;
+        this.applicationName = applicationName;
+        this.readOnly = readOnly;
+        this.autoCommit = autoCommit;
+    }
+
+    public URI getUri() {
+        return uri;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public Path getSslRootCert() {
+        return sslRootCert;
+    }
+
+    public String getSslHostNameVerifier() {
+        return sslHostNameVerifier;
+    }
+
+    public LoggerLevel getLoggerLevel() {
+        return loggerLevel;
+    }
+
+    public Path getLoggerFile() {
+        return loggerFile;
+    }
+
+    public long getSocketTimeout() {
+        return socketTimeout;
+    }
+
+    public long getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public long getLoginTimeout() {
+        return loginTimeout;
+    }
+
+    public String getApplicationName() {
+        return applicationName;
+    }
+
+    public Boolean getReadOnly() {
+        return readOnly;
+    }
+
+    public Boolean getSsl() {
+        return ssl;
+    }
+
+    public SslMode getSslMode() {
+        return sslMode;
+    }
+
+    public Path getSslCert() {
+        return sslCert;
+    }
+
+    public Path getSslKey() {
+        return sslKey;
+    }
+
+    public Boolean getLogUnclosedConnection() {
+        return logUnclosedConnection;
+    }
+
+    public boolean getAutoCommit() {
+        return autoCommit;
+    }
+
+    /**
+     * Consult https://www.postgresql.org/docs/current/libpq-ssl.html
+     */
+    public enum SslMode {
+        DISABLE("disable"),
+        ALLOW("allow"),
+        PREFER("prefer"),
+        REQUIRE("require"),
+        VERIFY_CA("verify-ca"),
+        VERIFY_FULL("verify-full");
+        private final String value;
+
+        SslMode(String value) {
+            this.value = value;
+        }
+
+        public String toString() {
+            return value;
+        }
+    }
+
+    public enum LoggerLevel {
+        OFF,
+        DEBUG,
+        TRACE
+    }
+
+    public static class Builder {
+        private URI uri;
+        private String userName;
+        private String password;
+        private Boolean ssl;
+        private SslMode sslMode = SslMode.PREFER;
+        private Path sslCert;
+        private Path sslKey;
+        private Path sslRootCert;
+        private String sslHostNameVerifier;
+        private LoggerLevel loggerLevel;
+        private Path loggerFile;
+        private Boolean logUnclosedConnection;
+        private long socketTimeout = Duration.ofMillis(5000).toSeconds();
+        private long connectTimeout = Duration.ofMillis(5000).toSeconds();
+        private long loginTimeout = Duration.ofMillis(5000).toSeconds();
+        private String applicationName;
+        private boolean readOnly = false;
+        private boolean autoCommit = false;
+
+        private Builder() {
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder uri(URI value) {
+            this.uri = value;
+            return this;
+        }
+
+        public Builder userName(String value) {
+            this.userName = value;
+            return this;
+        }
+
+        public Builder password(String value) {
+            this.password = value;
+            return this;
+        }
+
+        public Builder sslRootCert(Path value) {
+            this.sslRootCert = value;
+            return this;
+        }
+
+        public Builder sslHostNameVerifier(String value) {
+            this.sslHostNameVerifier = value;
+            return this;
+        }
+
+        public Builder loggerLevel(LoggerLevel value) {
+            this.loggerLevel = value;
+            return this;
+        }
+
+        public Builder loggerFile(Path value) {
+            this.loggerFile = value;
+            return this;
+        }
+
+        public Builder socketTimeout(Long value) {
+            this.socketTimeout = value;
+            return this;
+        }
+
+        public Builder connectTimeout(Long value) {
+            this.connectTimeout = value;
+            return this;
+        }
+
+        public Builder loginTimeout(Long value) {
+            this.loginTimeout = value;
+            return this;
+        }
+
+        public Builder applicationName(String value) {
+            this.applicationName = value;
+            return this;
+        }
+
+        public Builder readOnly(Boolean value) {
+            this.readOnly = value;
+            return this;
+        }
+
+        public Builder ssl(Boolean value) {
+            this.ssl = value;
+            return this;
+        }
+
+        public Builder sslMode(SslMode value) {
+            this.sslMode = value;
+            return this;
+        }
+
+        public Builder sslCert(Path value) {
+            this.sslCert = value;
+            return this;
+        }
+
+        public Builder sslKey(Path value) {
+            this.sslKey = value;
+            return this;
+        }
+
+        public Builder logUnclosedConnections(Boolean value) {
+            this.logUnclosedConnection = value;
+            return this;
+        }
+
+        public Builder autoCommit(Boolean value) {
+            this.autoCommit = value;
+            return this;
+        }
+
+        public ConnectionFactoryConfig build() {
+            return new ConnectionFactoryConfig(
+                    uri,
+                    userName,
+                    password,
+                    ssl,
+                    sslMode,
+                    sslCert,
+                    sslKey,
+                    sslRootCert,
+                    sslHostNameVerifier,
+                    loggerLevel,
+                    loggerFile,
+                    logUnclosedConnection,
+                    socketTimeout,
+                    connectTimeout,
+                    loginTimeout,
+                    applicationName,
+                    readOnly,
+                    autoCommit
+            );
+        }
+    }
+}

--- a/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/connection/ConnectionFactoryImpl.java
+++ b/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/connection/ConnectionFactoryImpl.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial API and Implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.clients.postgresql.connection;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Objects;
+import java.util.Properties;
+
+/**
+ * A ConnectionFactory implementation that utilizes the ConnectionFactoryConfig for connection creation.
+ */
+public class ConnectionFactoryImpl implements ConnectionFactory {
+    private final String jdbcUrl;
+    private final Properties properties;
+    private final boolean autoCommit;
+
+    public ConnectionFactoryImpl(@NotNull ConnectionFactoryConfig connectionFactoryConfig) {
+        Objects.requireNonNull(connectionFactoryConfig, "connectionFactoryConfig");
+
+        this.jdbcUrl = Objects.requireNonNull(connectionFactoryConfig.getUri()).toString();
+        this.properties = getProperties(connectionFactoryConfig);
+        this.autoCommit = connectionFactoryConfig.getAutoCommit();
+    }
+
+    /**
+     * Constructs a map containing postgreSQL jdbc connection parameters to obtain a connection.
+     *
+     * @param connectionFactoryConfig container object containing set of connection configuration parameters
+     * @return properties to be used by the {@link java.sql.DriverManager}
+     * @see <a href="https://jdbc.postgresql.org/documentation/head/connect.html">PostgreSQL JDBC Driver - Connecting to the Database</a>
+     */
+    private Properties getProperties(ConnectionFactoryConfig connectionFactoryConfig) {
+        Properties properties = new Properties();
+        addProperty(properties, "user", connectionFactoryConfig.getUserName());
+        addProperty(properties, "password", connectionFactoryConfig.getPassword());
+        addProperty(properties, "ssl", connectionFactoryConfig.getSsl());
+        addProperty(properties, "sslmode", connectionFactoryConfig.getSslMode());
+        addProperty(properties, "sslcert", connectionFactoryConfig.getSslCert());
+        addProperty(properties, "sslkey", connectionFactoryConfig.getSslKey());
+        addProperty(properties, "sslrootcert", connectionFactoryConfig.getSslRootCert());
+        addProperty(properties, "sslhostnameverifier", connectionFactoryConfig.getSslHostNameVerifier());
+        addProperty(properties, "loggerLevel", connectionFactoryConfig.getLoggerLevel());
+        addProperty(properties, "loggerFile", connectionFactoryConfig.getLoggerFile());
+        addProperty(properties, "logUnclosedConnections", connectionFactoryConfig.getLogUnclosedConnection());
+        addProperty(properties, "connectTimeout", connectionFactoryConfig.getConnectTimeout());
+        addProperty(properties, "socketTimeout", connectionFactoryConfig.getSocketTimeout());
+        addProperty(properties, "loginTimeout", connectionFactoryConfig.getLoginTimeout());
+        addProperty(properties, "readOnly", connectionFactoryConfig.getReadOnly());
+        addProperty(properties, "ApplicationName", connectionFactoryConfig.getApplicationName());
+        return properties;
+    }
+
+    private void addProperty(Properties properties, String key, Object value) {
+        if (properties != null && key != null && value != null) {
+            properties.put(key, String.valueOf(value));
+        }
+    }
+
+    @Override
+    public Connection create() throws SQLException {
+        Connection connection = DriverManager.getConnection(jdbcUrl, properties);
+
+        connection.setAutoCommit(autoCommit);
+        // TODO transaction isolation made configurable
+        connection.setTransactionIsolation(Connection.TRANSACTION_READ_UNCOMMITTED);
+
+        return connection;
+    }
+}

--- a/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/connection/pool/ConnectionCallback.java
+++ b/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/connection/pool/ConnectionCallback.java
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial API and Implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.clients.postgresql.connection.pool;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface ConnectionCallback<T> {
+
+    T apply(Connection connection) throws SQLException;
+}

--- a/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/connection/pool/ConnectionPool.java
+++ b/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/connection/pool/ConnectionPool.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial API and Implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.clients.postgresql.connection.pool;
+
+import java.sql.SQLException;
+
+/**
+ * The connection pool maintains a cache of database connections,
+ * which can be reused when future requests to a database are needed.
+ */
+public interface ConnectionPool extends AutoCloseable {
+
+    /**
+     * Connection is guarded by the providing connection pool.
+     * Once the callback method returns the provided connection
+     * is returned and made available to be used by others.
+     *
+     * @param callback to be acting on the provided connection
+     * @param <T>      generic result argument
+     * @return result
+     * @throws SQLException if something went wrong
+     */
+    <T> T doWithConnection(ConnectionCallback<T> callback) throws SQLException;
+}

--- a/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/connection/pool/commons/CommonsConnectionPool.java
+++ b/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/connection/pool/commons/CommonsConnectionPool.java
@@ -1,0 +1,182 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial API and Implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.clients.postgresql.connection.pool.commons;
+
+import org.apache.commons.pool2.BasePooledObjectFactory;
+import org.apache.commons.pool2.DestroyMode;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.eclipse.dataspaceconnector.clients.postgresql.connection.ConnectionFactory;
+import org.eclipse.dataspaceconnector.clients.postgresql.connection.pool.ConnectionCallback;
+import org.eclipse.dataspaceconnector.clients.postgresql.connection.pool.ConnectionPool;
+import org.jetbrains.annotations.NotNull;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Objects;
+
+public final class CommonsConnectionPool implements ConnectionPool, AutoCloseable {
+    private final GenericObjectPool<Connection> connectionObjectPool;
+
+    public CommonsConnectionPool(ConnectionFactory connectionFactory, CommonsConnectionPoolConfig commonsConnectionPoolConfig) {
+        Objects.requireNonNull(connectionFactory, "connectionFactory");
+        Objects.requireNonNull(commonsConnectionPoolConfig, "commonsConnectionPoolConfig");
+
+        this.connectionObjectPool = new GenericObjectPool<>(
+                new PooledConnectionObjectFactory(connectionFactory, commonsConnectionPoolConfig.getTestQuery()),
+                getGenericObjectPoolConfig(commonsConnectionPoolConfig));
+    }
+
+    private static GenericObjectPoolConfig<Connection> getGenericObjectPoolConfig(CommonsConnectionPoolConfig commonsConnectionPoolConfig) {
+        GenericObjectPoolConfig<Connection> genericObjectPoolConfig = new GenericObjectPoolConfig<>();
+
+        // no need for JMX
+        genericObjectPoolConfig.setJmxEnabled(false);
+
+        genericObjectPoolConfig.setMaxIdle(commonsConnectionPoolConfig.getMaxIdleConnections());
+        genericObjectPoolConfig.setMaxTotal(commonsConnectionPoolConfig.getMaxTotalConnections());
+        genericObjectPoolConfig.setMinIdle(commonsConnectionPoolConfig.getMinIdleConnections());
+
+        genericObjectPoolConfig.setTestOnBorrow(commonsConnectionPoolConfig.getTestConnectionOnBorrow());
+        genericObjectPoolConfig.setTestOnCreate(commonsConnectionPoolConfig.getTestConnectionOnCreate());
+        genericObjectPoolConfig.setTestOnReturn(commonsConnectionPoolConfig.getTestConnectionOnReturn());
+        genericObjectPoolConfig.setTestWhileIdle(commonsConnectionPoolConfig.getTestConnectionWhileIdle());
+
+        return genericObjectPoolConfig;
+    }
+
+    public CommonsConnectionPoolStats getStats() {
+        return CommonsConnectionPoolStats.Builder.newInstance()
+                .active(connectionObjectPool.getNumActive())
+                .idle(connectionObjectPool.getNumIdle())
+                .waiters(connectionObjectPool.getNumWaiters())
+                .build();
+    }
+
+    @Override
+    public <T> T doWithConnection(ConnectionCallback<T> callback) throws SQLException {
+        Objects.requireNonNull(callback, "callback");
+
+        Connection connection;
+        try {
+            connection = connectionObjectPool.borrowObject();
+        } catch (SQLException sqlException) {
+            throw sqlException;
+        } catch (Exception e) {
+            throw new SQLException(e);
+        }
+
+        T result = null;
+        SQLException sqlException = null;
+        try {
+            result = callback.apply(connection);
+
+            connectionObjectPool.returnObject(connection);
+        } catch (Exception exception) {
+            try {
+                connectionObjectPool.invalidateObject(connection);
+            } catch (Exception e) {
+                // ignore
+            }
+
+            if (exception instanceof RuntimeException) {
+                throw (RuntimeException) exception;
+            } else if (exception instanceof SQLException) {
+                sqlException = (SQLException) exception;
+            } else {
+                sqlException = new SQLException(exception);
+            }
+        }
+
+        if (sqlException != null) {
+            throw sqlException;
+        }
+
+        return result;
+    }
+
+    @Override
+    public void close() {
+        connectionObjectPool.close();
+    }
+
+    private static class PooledConnectionObjectFactory extends BasePooledObjectFactory<Connection> {
+        private final String testQuery;
+        private final ConnectionFactory connectionFactory;
+
+        public PooledConnectionObjectFactory(@NotNull ConnectionFactory connectionFactory, @NotNull String testQuery) {
+            this.connectionFactory = Objects.requireNonNull(connectionFactory);
+            this.testQuery = Objects.requireNonNull(testQuery);
+        }
+
+        @Override
+        public Connection create() throws SQLException {
+            return connectionFactory.create();
+        }
+
+        @Override
+        public void destroyObject(PooledObject<Connection> pooledObject, DestroyMode destroyMode) throws Exception {
+            if (pooledObject == null) {
+                return;
+            }
+
+            Connection connection = pooledObject.getObject();
+
+            if (connection != null && !connection.isClosed()) {
+                connection.close();
+            }
+
+            pooledObject.invalidate();
+        }
+
+        @Override
+        public boolean validateObject(PooledObject<Connection> pooledObject) {
+            if (pooledObject == null) {
+                return false;
+            }
+
+            Connection connection = pooledObject.getObject();
+            if (connection == null) {
+                return false;
+            }
+
+            return isConnectionValid(connection);
+        }
+
+        private boolean isConnectionValid(Connection connection) {
+            try {
+                if (connection.isClosed()) {
+                    return false;
+                }
+
+                try (PreparedStatement preparedStatement = connection.prepareStatement(testQuery)) {
+                    return preparedStatement.execute();
+                } catch (SQLException e) {
+                    return false;
+                }
+            } catch (SQLException sqlException) {
+                return false;
+            }
+        }
+
+        @Override
+        public PooledObject<Connection> wrap(Connection connection) {
+            return new DefaultPooledObject<>(connection);
+        }
+    }
+}

--- a/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/connection/pool/commons/CommonsConnectionPoolConfig.java
+++ b/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/connection/pool/commons/CommonsConnectionPoolConfig.java
@@ -1,0 +1,153 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial API and Implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.clients.postgresql.connection.pool.commons;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public class CommonsConnectionPoolConfig {
+
+    private final int maxIdleConnections;
+    private final int maxTotalConnections;
+    private final int minIdleConnections;
+    private final boolean testConnectionOnBorrow;
+    private final boolean testConnectionOnCreate;
+    private final boolean testConnectionOnReturn;
+    private final boolean testConnectionWhileIdle;
+    private final String testQuery;
+
+    private CommonsConnectionPoolConfig(
+            int maxIdleConnections,
+            int maxTotalConnections,
+            int minIdleConnections,
+            boolean testConnectionOnBorrow,
+            boolean testConnectionOnCreate,
+            boolean testConnectionOnReturn,
+            boolean testConnectionWhileIdle,
+            @NotNull String testQuery) {
+        this.maxIdleConnections = maxIdleConnections;
+        this.maxTotalConnections = maxTotalConnections;
+        this.minIdleConnections = minIdleConnections;
+        this.testConnectionOnBorrow = testConnectionOnBorrow;
+        this.testConnectionOnCreate = testConnectionOnCreate;
+        this.testConnectionOnReturn = testConnectionOnReturn;
+        this.testConnectionWhileIdle = testConnectionWhileIdle;
+        this.testQuery = Objects.requireNonNull(testQuery);
+    }
+
+    public int getMaxIdleConnections() {
+        return maxIdleConnections;
+    }
+
+    public int getMaxTotalConnections() {
+        return maxTotalConnections;
+    }
+
+    public int getMinIdleConnections() {
+        return minIdleConnections;
+    }
+
+    public boolean getTestConnectionOnBorrow() {
+        return testConnectionOnBorrow;
+    }
+
+    public boolean getTestConnectionOnCreate() {
+        return testConnectionOnCreate;
+    }
+
+    public boolean getTestConnectionOnReturn() {
+        return testConnectionOnReturn;
+    }
+
+    public boolean getTestConnectionWhileIdle() {
+        return testConnectionWhileIdle;
+    }
+
+    public String getTestQuery() {
+        return testQuery;
+    }
+
+    public static final class Builder {
+        private int maxIdleConnections = 4;
+        private int maxTotalConnections = 8;
+        private int minIdleConnections = 1;
+        private boolean testConnectionOnBorrow = true;
+        private boolean testConnectionOnCreate = true;
+        private boolean testConnectionOnReturn = true;
+        private boolean testConnectionWhileIdle = false;
+        private String testQuery = "SELECT 1;";
+
+        private Builder() {
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder maxIdleConnections(int maxIdleConnections) {
+            this.maxIdleConnections = maxIdleConnections;
+            return this;
+        }
+
+        public Builder maxTotalConnections(int maxTotalConnections) {
+            this.maxTotalConnections = maxTotalConnections;
+            return this;
+        }
+
+        public Builder minIdleConnections(int minIdleConnections) {
+            this.minIdleConnections = minIdleConnections;
+            return this;
+        }
+
+        public Builder testConnectionOnBorrow(boolean testConnectionOnBorrow) {
+            this.testConnectionOnBorrow = testConnectionOnBorrow;
+            return this;
+        }
+
+        public Builder testConnectionOnCreate(boolean testConnectionOnCreate) {
+            this.testConnectionOnCreate = testConnectionOnCreate;
+            return this;
+        }
+
+        public Builder testConnectionOnReturn(boolean testConnectionOnReturn) {
+            this.testConnectionOnReturn = testConnectionOnReturn;
+            return this;
+        }
+
+        public Builder testConnectionWhileIdle(boolean testConnectionWhileIdle) {
+            this.testConnectionWhileIdle = testConnectionWhileIdle;
+            return this;
+        }
+
+        public Builder testQuery(String testQuery) {
+            this.testQuery = testQuery;
+            return this;
+        }
+
+        public CommonsConnectionPoolConfig build() {
+            return new CommonsConnectionPoolConfig(
+                    maxIdleConnections,
+                    maxTotalConnections,
+                    minIdleConnections,
+                    testConnectionOnBorrow,
+                    testConnectionOnCreate,
+                    testConnectionOnReturn,
+                    testConnectionWhileIdle,
+                    testQuery
+            );
+        }
+    }
+}

--- a/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/connection/pool/commons/CommonsConnectionPoolStats.java
+++ b/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/connection/pool/commons/CommonsConnectionPoolStats.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial API and Implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.clients.postgresql.connection.pool.commons;
+
+public final class CommonsConnectionPoolStats {
+
+    private final int active;
+    private final int idle;
+    private final int waiters;
+
+    private CommonsConnectionPoolStats(int active, int idle, int waiters) {
+        this.active = active;
+        this.idle = idle;
+        this.waiters = waiters;
+    }
+
+    public int getActive() {
+        return active;
+    }
+
+    public int getIdle() {
+        return idle;
+    }
+
+    public int getWaiters() {
+        return waiters;
+    }
+
+    @Override
+    public String toString() {
+        return "CommonsConnectionPoolStats{" +
+                "active=" + active +
+                ", idle=" + idle +
+                ", waiters=" + waiters +
+                '}';
+    }
+
+    public static class Builder {
+        private int active;
+        private int idle;
+        private int waiters;
+
+        private Builder() {
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder active(int active) {
+            this.active = active;
+            return this;
+        }
+
+        public Builder idle(int idle) {
+            this.idle = idle;
+            return this;
+        }
+
+        public Builder waiters(int waiters) {
+            this.waiters = waiters;
+            return this;
+        }
+
+        public CommonsConnectionPoolStats build() {
+            return new CommonsConnectionPoolStats(active, idle, waiters);
+        }
+    }
+}

--- a/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/row/RowMapper.java
+++ b/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/row/RowMapper.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial API and Implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.clients.postgresql.row;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Component capable of mapping {@link java.sql.ResultSet} to e.g. POJO.
+ *
+ * @param <T> generic type param of the resulting type
+ */
+public interface RowMapper<T> {
+
+    /**
+     * Maps a sql result set into a object.
+     *
+     * @param resultSet containing columns of a row
+     * @return result
+     * @throws SQLException if something went wrong
+     */
+    T mapRow(ResultSet resultSet) throws SQLException;
+}

--- a/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/statement/ArgumentHandler.java
+++ b/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/statement/ArgumentHandler.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial API and Implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.clients.postgresql.statement;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/**
+ * Component capable of setting a certain parameter type to it's
+ * corresponding position within a {@link java.sql.PreparedStatement}
+ */
+public interface ArgumentHandler {
+
+    /**
+     * Tests whether a argument can used by the current handler
+     *
+     * @param value to be associated with the prepared statement
+     * @return true if the current argument handler can act on the given argument
+     */
+    boolean accepts(Object value);
+
+    /**
+     * Associates an argument with a given sql statement at its specific position
+     *
+     * @param statement to be carrying the argument
+     * @param position  to be used for carrying the argument
+     * @param argument  to be used together with the statement
+     * @throws SQLException if something went wrong
+     */
+    void handle(PreparedStatement statement, int position, Object argument) throws SQLException;
+}

--- a/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/statement/ArgumentHandlers.java
+++ b/common/libraries/clients/postgresql/src/main/java/org/eclipse/dataspaceconnector/clients/postgresql/statement/ArgumentHandlers.java
@@ -1,0 +1,210 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial API and Implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.clients.postgresql.statement;
+
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.Date;
+
+/**
+ * ArgumentHandlers capable handling certain argument types
+ */
+public enum ArgumentHandlers implements ArgumentHandler {
+    /**
+     * Set's an @{code int} argument into its corresponding position of a statement
+     */
+    INT {
+        @Override
+        public boolean accepts(Object value) {
+            return value instanceof Integer;
+        }
+
+        @Override
+        public void handle(PreparedStatement statement, int position, Object argument) throws SQLException {
+            statement.setInt(position, (int) argument);
+        }
+    },
+    /**
+     * Set's an @{code long} argument into its corresponding position of a statement
+     */
+    LONG {
+        @Override
+        public boolean accepts(Object value) {
+            return value instanceof Long;
+        }
+
+        @Override
+        public void handle(PreparedStatement statement, int position, Object argument) throws SQLException {
+            statement.setLong(position, (long) argument);
+        }
+    },
+    /**
+     * Set's an @{code double} argument into its corresponding position of a statement
+     */
+    DOUBLE {
+        @Override
+        public boolean accepts(Object value) {
+            return value instanceof Double;
+        }
+
+        @Override
+        public void handle(PreparedStatement statement, int position, Object argument) throws SQLException {
+            statement.setDouble(position, (double) argument);
+        }
+    },
+    /**
+     * Set's an @{code float} argument into its corresponding position of a statement
+     */
+    FLOAT {
+        @Override
+        public boolean accepts(Object value) {
+            return value instanceof Float;
+        }
+
+        @Override
+        public void handle(PreparedStatement statement, int position, Object argument) throws SQLException {
+            statement.setFloat(position, (float) argument);
+        }
+    },
+    /**
+     * Set's an @{code short} argument into its corresponding position of a statement
+     */
+    SHORT {
+        @Override
+        public boolean accepts(Object value) {
+            return value instanceof Short;
+        }
+
+        @Override
+        public void handle(PreparedStatement statement, int position, Object argument) throws SQLException {
+            statement.setShort(position, (short) argument);
+        }
+    },
+    /**
+     * Set's an @{code java.math.BigDecimal} argument into its corresponding position of a statement
+     */
+    BIG_DECIMAL {
+        @Override
+        public boolean accepts(Object value) {
+            return value instanceof BigDecimal;
+        }
+
+        @Override
+        public void handle(PreparedStatement statement, int position, Object argument) throws SQLException {
+            statement.setBigDecimal(position, (BigDecimal) argument);
+        }
+    },
+    /**
+     * Set's an @{code java.lang.String} argument into its corresponding position of a statement
+     */
+    STRING {
+        @Override
+        public boolean accepts(Object value) {
+            return value instanceof String;
+        }
+
+        @Override
+        public void handle(PreparedStatement statement, int position, Object argument) throws SQLException {
+            statement.setString(position, (String) argument);
+        }
+    },
+    /**
+     * Set's an @{code boolean} argument into its corresponding position of a statement
+     */
+    BOOLEAN {
+        @Override
+        public boolean accepts(Object value) {
+            return value instanceof Boolean;
+        }
+
+        @Override
+        public void handle(PreparedStatement statement, int position, Object argument) throws SQLException {
+            statement.setBoolean(position, (Boolean) argument);
+        }
+    },
+    /**
+     * Set's an @{code java.util.Date} argument into its corresponding position of a statement
+     */
+    DATE {
+        @Override
+        public boolean accepts(Object value) {
+            return value instanceof Date;
+        }
+
+        @Override
+        public void handle(PreparedStatement statement, int position, Object argument) throws SQLException {
+            statement.setTimestamp(position, new Timestamp(((Date) argument).getTime()));
+        }
+    },
+    /**
+     * Set's an @{code byte} argument into its corresponding position of a statement
+     */
+    BYTE {
+        @Override
+        public boolean accepts(Object value) {
+            return value instanceof Byte;
+        }
+
+        @Override
+        public void handle(PreparedStatement statement, int position, Object argument) throws SQLException {
+            statement.setByte(position, (Byte) argument);
+        }
+    },
+    /**
+     * Set's an @{code byte[]} array argument into its corresponding position of a statement
+     */
+    BYTES {
+        @Override
+        public boolean accepts(Object value) {
+            return value instanceof byte[];
+        }
+
+        @Override
+        public void handle(PreparedStatement statement, int position, Object argument) throws SQLException {
+            statement.setBytes(position, (byte[]) argument);
+        }
+    },
+    /**
+     * Set's an @{code java.io.InputStream} argument into its corresponding position of a statement
+     */
+    INPUT_STREAM {
+        @Override
+        public boolean accepts(Object value) {
+            return value instanceof InputStream;
+        }
+
+        @Override
+        public void handle(PreparedStatement statement, int position, Object argument) throws SQLException {
+            statement.setBlob(position, (InputStream) argument);
+        }
+    },
+    /**
+     * Set's an @{code null} argument into its corresponding position of a statement
+     */
+    NULL {
+        @Override
+        public boolean accepts(Object value) {
+            return value == null;
+        }
+
+        @Override
+        public void handle(PreparedStatement statement, int position, Object argument) throws SQLException {
+            statement.setNull(position, java.sql.Types.NULL);
+        }
+    }
+}

--- a/common/libraries/clients/postgresql/src/test/java/org/eclipse/dataspaceconnector/clients/postgresql/PostgresqlClientImplTest.java
+++ b/common/libraries/clients/postgresql/src/test/java/org/eclipse/dataspaceconnector/clients/postgresql/PostgresqlClientImplTest.java
@@ -1,0 +1,260 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial API and Implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.clients.postgresql;
+
+import org.eclipse.dataspaceconnector.clients.postgresql.connection.ConnectionFactory;
+import org.eclipse.dataspaceconnector.clients.postgresql.connection.ConnectionFactoryConfig;
+import org.eclipse.dataspaceconnector.clients.postgresql.connection.ConnectionFactoryImpl;
+import org.eclipse.dataspaceconnector.clients.postgresql.connection.pool.ConnectionPool;
+import org.eclipse.dataspaceconnector.clients.postgresql.connection.pool.commons.CommonsConnectionPool;
+import org.eclipse.dataspaceconnector.clients.postgresql.connection.pool.commons.CommonsConnectionPoolConfig;
+import org.eclipse.dataspaceconnector.clients.postgresql.row.RowMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.net.URI;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+@Testcontainers
+class PostgresqlClientImplTest {
+    private PostgresqlClient postgresqlClient;
+
+    @Container
+    @SuppressWarnings("rawtypes")
+    private static final PostgreSQLContainer POSTGRES_CONTAINER = new PostgreSQLContainer("postgres:9.6.12");
+
+    @BeforeEach
+    public void setUp() {
+        ConnectionFactoryConfig connectionFactoryConfig = ConnectionFactoryConfig.Builder.newInstance()
+                .uri(URI.create(POSTGRES_CONTAINER.getJdbcUrl()))
+                .userName(POSTGRES_CONTAINER.getUsername())
+                .password(POSTGRES_CONTAINER.getPassword())
+                .build();
+
+        ConnectionFactory connectionFactory = new ConnectionFactoryImpl(connectionFactoryConfig);
+
+        CommonsConnectionPoolConfig commonsConnectionPoolConfig = CommonsConnectionPoolConfig.Builder.newInstance()
+                .build();
+
+        ConnectionPool connectionPool = new CommonsConnectionPool(connectionFactory, commonsConnectionPoolConfig);
+
+        postgresqlClient = new PostgresqlClientImpl(connectionPool);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        postgresqlClient.close();
+    }
+
+    private String getTableSchema(String tableName) {
+        return String.format("" +
+                "CREATE TABLE %s (\n" +
+                "    k VARCHAR(80) PRIMARY KEY NOT NULL,\n" +
+                "    v VARCHAR(80) NOT NULL\n" +
+                ");", Objects.requireNonNull(tableName));
+    }
+
+    @Test
+    void testExecute() throws SQLException {
+        postgresqlClient.execute("SELECT 1;");
+    }
+
+    @Test
+    void testExecuteWithRowMapping() throws SQLException {
+        List<Long> result = postgresqlClient.execute(CountRowMapper.INSTANCE, "SELECT 1;");
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals(1, result.iterator().next());
+    }
+
+    @Test
+    void testTransaction() throws SQLException {
+        postgresqlClient.doInTransaction(client -> client.execute("SELECT COUNT(c), COUNT(*) FROM (VALUES (1), (NULL)) t(c);"));
+    }
+
+    @Test
+    void testNestedTransactionUnsupported() throws SQLException {
+        String table = "kv_testNestedTransactionUnsupported";
+        String schema = getTableSchema(table);
+
+        postgresqlClient.doInTransaction(client -> client.execute(schema));
+
+        Assertions.assertThrows(SQLException.class, () -> postgresqlClient.doInTransaction(client -> {
+            client.doInTransaction(c -> c.execute(String.format("INSERT INTO %s (k, v) values (?, ?)", table), UUID.randomUUID().toString(), UUID.randomUUID().toString()));
+        }));
+
+        List<Long> countResult = postgresqlClient.execute(CountRowMapper.INSTANCE, String.format("SELECT COUNT(*) FROM %s", table));
+        Assertions.assertNotNull(countResult);
+        Assertions.assertEquals(1, countResult.size());
+        Assertions.assertEquals(0, countResult.iterator().next());
+    }
+
+    @Test
+    void testTransactionRollbackOnRuntimeException() throws SQLException {
+        String table = "kv_testTransactionRollbackOnRuntimeException";
+        String schema = getTableSchema(table);
+
+        postgresqlClient.doInTransaction(client -> client.execute(schema));
+
+        Assertions.assertThrows(SQLException.class, () -> postgresqlClient.doInTransaction(
+                client -> {
+                    client.execute(String.format("INSERT INTO %s (k, v) values (?, ?)", table), UUID.randomUUID().toString(), UUID.randomUUID().toString());
+
+                    throw new RuntimeException("Intended");
+                }));
+
+        List<Long> countResult = postgresqlClient.execute(CountRowMapper.INSTANCE, String.format("SELECT COUNT(*) FROM %s", table));
+        Assertions.assertNotNull(countResult);
+        Assertions.assertEquals(1, countResult.size());
+        Assertions.assertEquals(0, countResult.iterator().next());
+    }
+
+    @Test
+    void testTransactionRollbackOnSqlException() throws SQLException {
+        String table = "kv_testTransactionRollbackOnSqlException";
+        String schema = getTableSchema(table);
+
+        postgresqlClient.doInTransaction(client -> client.execute(schema));
+
+        Assertions.assertThrows(SQLException.class, () -> postgresqlClient.doInTransaction(
+                client -> {
+                    client.execute(String.format("INSERT INTO %s (k, v) values (?, ?)", table), UUID.randomUUID().toString(), UUID.randomUUID().toString());
+
+                    throw new SQLException("Intended");
+                }));
+
+        List<Long> countResult = postgresqlClient.execute(CountRowMapper.INSTANCE, String.format("SELECT COUNT(*) FROM %s", table));
+        Assertions.assertNotNull(countResult);
+        Assertions.assertEquals(1, countResult.size());
+        Assertions.assertEquals(0, countResult.iterator().next());
+    }
+
+    @Test
+    void testTransactionRollbackOnFailingQuery() throws SQLException {
+        String table = "kv_testTransactionRollbackOnFailingQuery";
+        String schema = getTableSchema(table);
+
+        postgresqlClient.doInTransaction(client -> client.execute(schema));
+
+        Assertions.assertThrows(SQLException.class, () -> postgresqlClient.doInTransaction(
+                client -> {
+                    client.execute(String.format("INSERT INTO %s (k, v) values (?, ?)", table), UUID.randomUUID().toString(), UUID.randomUUID().toString());
+
+                    client.doInTransaction(c2 -> c2.execute("BREAK TX"));
+                }));
+
+        List<Long> countResult = postgresqlClient.execute(CountRowMapper.INSTANCE, String.format("SELECT COUNT(*) FROM %s", table));
+        Assertions.assertNotNull(countResult);
+        Assertions.assertEquals(1, countResult.size());
+        Assertions.assertEquals(0, countResult.iterator().next());
+    }
+
+    @Test
+    void testRowMapper() throws SQLException {
+        String table = "kv_testRowMapper";
+        String schema = getTableSchema(table);
+
+        postgresqlClient.doInTransaction(client -> client.execute(schema));
+
+        Tuple tuple = new Tuple(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+
+        postgresqlClient.doInTransaction(client -> client.execute(
+                String.format("INSERT INTO %s (k, v) values (?, ?)", table), tuple.key, tuple.value));
+
+        RowMapper<Tuple> rowMapper = (resultSet) -> new Tuple(resultSet.getString("k"), resultSet.getString("v"));
+        List<Tuple> tuples = postgresqlClient.execute(rowMapper, String.format("SELECT * FROM %s", table));
+
+        Assertions.assertNotNull(tuples);
+        Assertions.assertEquals(1, tuples.size());
+        Assertions.assertEquals(tuple, tuples.iterator().next());
+    }
+
+    @Test
+    void testInvalidSql() {
+        Assertions.assertThrows(SQLException.class, () -> postgresqlClient.execute("Lorem ipsum dolor sit amet"));
+    }
+
+    @Test
+    void testIn() throws SQLException {
+        String table = "kv_testIn";
+        String schema = getTableSchema(table);
+
+        List<String> ks = new LinkedList<>();
+        postgresqlClient.doInTransaction(client -> {
+            client.execute(schema);
+            String k1 = UUID.randomUUID().toString();
+            ks.add(k1);
+            String k2 = UUID.randomUUID().toString();
+            ks.add(k2);
+            String k3 = UUID.randomUUID().toString();
+            ks.add(k3);
+            client.execute(String.format("INSERT INTO %s (k, v) values (?, ?)", table), k1, UUID.randomUUID().toString());
+            client.execute(String.format("INSERT INTO %s (k, v) values (?, ?)", table), k2, UUID.randomUUID().toString());
+            client.execute(String.format("INSERT INTO %s (k, v) values (?, ?)", table), k3, UUID.randomUUID().toString());
+        });
+
+        List<Long> countResult = postgresqlClient.execute(
+                CountRowMapper.INSTANCE,
+                String.format("SELECT COUNT(*) FROM %s WHERE k in (%s)", table, String.join(",", Collections.nCopies(ks.size(), "?"))),
+                ks.toArray());
+        Assertions.assertNotNull(countResult);
+        Assertions.assertEquals(1, countResult.size());
+        Assertions.assertEquals(3, countResult.iterator().next());
+    }
+
+    private enum CountRowMapper implements RowMapper<Long> {
+        INSTANCE;
+
+        @Override
+        public Long mapRow(ResultSet resultSet) throws SQLException {
+            return resultSet.getLong(1);
+        }
+    }
+
+    private static class Tuple {
+        final String key;
+        final String value;
+
+        public Tuple(String key, String value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Tuple tuple = (Tuple) o;
+            return key.equals(tuple.key) && Objects.equals(value, tuple.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(key, value);
+        }
+    }
+}

--- a/common/libraries/clients/postgresql/src/test/resources/logback.xml
+++ b/common/libraries/clients/postgresql/src/test/resources/logback.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2021 Daimler TSS GmbH
+
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0
+
+  SPDX-License-Identifier: Apache-2.0
+
+  Contributors:
+       Daimler TSS GmbH - Initial configuration
+
+-->
+<configuration>
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+        </layout>
+    </appender>
+    <root level="ERROR">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,6 @@ mockitoVersion=4.1.0
 org.gradle.parallel=true
 org.gradle.workers.max=32
 nimbusVersion=8.22.1
+postgresqlVersion=42.3.1
+apacheCommonsPool2Version=2.11.1
+testContainersVersion=1.16.2

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,7 @@ rootProject.name = "dataspaceconnector"
 // modules for common/util code
 
 include(":common:util")
+include(":common:libraries:clients:postgresql")
 
 // EDC core modules
 include(":core")


### PR DESCRIPTION
This PR ships a postgresql client library able to be used for creating e.g. a postgresql backed asset-index.

<sub> Denis Neuling <denis.neuling@daimler.com>, Daimler TSS GmbH, [legal info/Impressum](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)