### PR TITLE
integration-tests: set absolute path on docker volumes

### DIFF
--- a/.github/workflows/integrationtests.yaml
+++ b/.github/workflows/integrationtests.yaml
@@ -99,8 +99,8 @@ jobs:
         ports:
           - 4567:4567
         volumes:
-          - $PWD/extensions/iam/daps/src/test/resources/config:/opt/config
-          - $PWD/extensions/iam/daps/src/test/resources/keys:/opt/keys
+          - /home/runner/work/DataSpaceConnector/DataSpaceConnector/extensions/iam/daps/src/test/resources/config:/opt/config
+          - /home/runner/work/DataSpaceConnector/DataSpaceConnector/extensions/iam/daps/src/test/resources/keys:/opt/keys
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Seems like the docker service didn't like the use of environment variables in the volume path.
Set these as absolute path.
Ref #440 