### PR TITLE
Migrates the Federated Catalog subsystem over to use IDS Multipart

### DIFF
--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/AsyncTransferProcessManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/AsyncTransferProcessManagerImplTest.java
@@ -27,14 +27,12 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 
 class AsyncTransferProcessManagerImplTest {
@@ -62,9 +60,8 @@ class AsyncTransferProcessManagerImplTest {
      */
     @Test
     void verifyIdempotency() {
-        when(store.processIdForTransferId("1"))
-                .thenReturn(null) // first invoke returns no as there is no store process
-                .thenReturn("2");
+        doReturn(null, "2")
+                .when(store).processIdForTransferId("1");
 
         DataRequest dataRequest = DataRequest.Builder.newInstance().id("1").destinationType("test").build();
         manager.initiateProviderRequest(dataRequest);

--- a/extensions/catalog/federated-catalog-cache/build.gradle.kts
+++ b/extensions/catalog/federated-catalog-cache/build.gradle.kts
@@ -21,7 +21,7 @@ val rsApi: String by project
 dependencies {
     api(project(":spi"))
 
-    implementation(project(":extensions:catalog:federated-catalog-spi"))
+    api(project(":extensions:catalog:federated-catalog-spi"))
     implementation(project(":common:util"))
 
     implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")

--- a/extensions/catalog/federated-catalog-cache/build.gradle.kts
+++ b/extensions/catalog/federated-catalog-cache/build.gradle.kts
@@ -26,16 +26,10 @@ dependencies {
 
     implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
 
-    // generates random names
-    implementation("info.schnatterer.moby-names-generator:moby-names-generator:20.10.0-r0")
-
-    testImplementation(project(":core:bootstrap")) //for the console monitor
-
     // required for integration test
     testImplementation(testFixtures(project(":launchers:junit")))
     testImplementation(project(":core:protocol:web"))
     testImplementation(project(":extensions:in-memory:fcc-node-directory-memory"))
-    testImplementation(project(":extensions:in-memory:transfer-store-memory"))
     testImplementation(project(":extensions:in-memory:fcc-store-memory"))
 }
 

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/DefaultLoader.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/DefaultLoader.java
@@ -18,17 +18,7 @@ public class DefaultLoader implements Loader {
 
         for (var response : responses) {
             var catalog = response.getCatalog();
-            var originator = response.getSource();
-
-            catalog.getContractOffers().forEach(contractOffer -> {
-//                var asset = CachedAsset.Builder.newInstance()
-//                        .copyFrom(receivedAsset)
-//                        .originator(originator)
-//                        //.policy(somePolicy) //not yet implemented
-//                        .build();
-                store.save(contractOffer);
-            });
-
+            catalog.getContractOffers().forEach(store::save);
         }
     }
 }

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/DefaultLoader.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/DefaultLoader.java
@@ -1,6 +1,5 @@
 package org.eclipse.dataspaceconnector.catalog.cache;
 
-import org.eclipse.dataspaceconnector.catalog.spi.CachedAsset;
 import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheStore;
 import org.eclipse.dataspaceconnector.catalog.spi.Loader;
 import org.eclipse.dataspaceconnector.catalog.spi.model.UpdateResponse;
@@ -18,16 +17,16 @@ public class DefaultLoader implements Loader {
     public void load(Collection<UpdateResponse> responses) {
 
         for (var response : responses) {
-            var assets = response.getAssetNames();
+            var catalog = response.getCatalog();
             var originator = response.getSource();
 
-            assets.forEach(receivedAsset -> {
-                var asset = CachedAsset.Builder.newInstance()
-                        .copyFrom(receivedAsset)
-                        .originator(originator)
-                        //.policy(somePolicy) //not yet implemented
-                        .build();
-                store.save(asset);
+            catalog.getContractOffers().forEach(contractOffer -> {
+//                var asset = CachedAsset.Builder.newInstance()
+//                        .copyFrom(receivedAsset)
+//                        .originator(originator)
+//                        //.policy(somePolicy) //not yet implemented
+//                        .build();
+                store.save(contractOffer);
             });
 
         }

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheExtension.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheExtension.java
@@ -8,6 +8,7 @@ import org.eclipse.dataspaceconnector.catalog.cache.loader.LoaderManagerImpl;
 import org.eclipse.dataspaceconnector.catalog.cache.management.PartitionManagerImpl;
 import org.eclipse.dataspaceconnector.catalog.cache.query.CacheQueryAdapterRegistryImpl;
 import org.eclipse.dataspaceconnector.catalog.cache.query.DefaultCacheQueryAdapter;
+import org.eclipse.dataspaceconnector.catalog.cache.query.IdsMultipartNodeQueryAdapter;
 import org.eclipse.dataspaceconnector.catalog.cache.query.QueryEngineImpl;
 import org.eclipse.dataspaceconnector.catalog.spi.CacheQueryAdapterRegistry;
 import org.eclipse.dataspaceconnector.catalog.spi.Crawler;
@@ -22,6 +23,7 @@ import org.eclipse.dataspaceconnector.catalog.spi.QueryEngine;
 import org.eclipse.dataspaceconnector.catalog.spi.WorkItem;
 import org.eclipse.dataspaceconnector.catalog.spi.WorkItemQueue;
 import org.eclipse.dataspaceconnector.catalog.spi.model.UpdateResponse;
+import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.protocol.web.WebService;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
@@ -80,7 +82,12 @@ public class FederatedCatalogCacheExtension implements ServiceExtension {
 
 
         // CRAWLER SUBSYSTEM
-        context.registerService(NodeQueryAdapterRegistry.class, new NodeQueryAdapterRegistryImpl());
+        var nodeQueryAdapterRegistry = new NodeQueryAdapterRegistryImpl();
+        var dispatcherRegistry = context.getService(RemoteMessageDispatcherRegistry.class);
+
+        // catalog queries via IDS multipart are supported by default
+        nodeQueryAdapterRegistry.register("ids-multipart", new IdsMultipartNodeQueryAdapter(context.getConnectorId(), dispatcherRegistry));
+        context.registerService(NodeQueryAdapterRegistry.class, nodeQueryAdapterRegistry);
 
         updateResponseQueue = new ArrayBlockingQueue<>(DEFAULT_QUEUE_LENGTH);
 

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/controller/CatalogController.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/controller/CatalogController.java
@@ -11,7 +11,7 @@ import org.eclipse.dataspaceconnector.catalog.spi.QueryEngine;
 import org.eclipse.dataspaceconnector.catalog.spi.QueryResponse;
 import org.eclipse.dataspaceconnector.catalog.spi.model.FederatedCatalogCacheQuery;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 
 import java.util.Collection;
 
@@ -30,7 +30,7 @@ public class CatalogController {
 
     @POST
     @Path("catalog")
-    public Collection<Asset> getCatalog(FederatedCatalogCacheQuery federatedCatalogCacheQuery) {
+    public Collection<ContractOffer> getCatalog(FederatedCatalogCacheQuery federatedCatalogCacheQuery) {
         monitor.info("Received a catalog request");
         var queryResponse = queryEngine.getCatalog(federatedCatalogCacheQuery);
         // query not possible
@@ -41,6 +41,6 @@ public class CatalogController {
             throw new QueryException(queryResponse.getErrors());
         }
 
-        return queryResponse.getAssets();
+        return queryResponse.getOffers();
     }
 }

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/CacheQueryAdapterRegistryImpl.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/CacheQueryAdapterRegistryImpl.java
@@ -5,7 +5,7 @@ import org.eclipse.dataspaceconnector.catalog.spi.CacheQueryAdapterRegistry;
 import org.eclipse.dataspaceconnector.catalog.spi.QueryResponse;
 import org.eclipse.dataspaceconnector.catalog.spi.model.FederatedCatalogCacheQuery;
 import org.eclipse.dataspaceconnector.spi.EdcException;
-import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -42,17 +42,17 @@ public class CacheQueryAdapterRegistryImpl implements CacheQueryAdapterRegistry 
 
         var responseBuilder = QueryResponse.Builder.newInstance()
                 .status(QueryResponse.Status.ACCEPTED);
-        Stream<Asset> assets = Stream.empty();
+        Stream<ContractOffer> offers = Stream.empty();
 
         // add the results of all query adapters to the union stream
         for (var adapter : adapters) {
             try {
-                assets = Stream.concat(assets, adapter.executeQuery(query));
+                offers = Stream.concat(offers, adapter.executeQuery(query));
             } catch (EdcException ex) {
                 responseBuilder.error("Adapter failed: " + ex.getMessage());
             }
         }
 
-        return responseBuilder.assets(assets.collect(Collectors.toList())).build();
+        return responseBuilder.offers(offers.collect(Collectors.toList())).build();
     }
 }

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/DefaultCacheQueryAdapter.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/DefaultCacheQueryAdapter.java
@@ -16,9 +16,9 @@
 package org.eclipse.dataspaceconnector.catalog.cache.query;
 
 import org.eclipse.dataspaceconnector.catalog.spi.CacheQueryAdapter;
-import org.eclipse.dataspaceconnector.catalog.spi.CachedAsset;
 import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheStore;
 import org.eclipse.dataspaceconnector.catalog.spi.model.FederatedCatalogCacheQuery;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.stream.Stream;
@@ -32,7 +32,7 @@ public class DefaultCacheQueryAdapter implements CacheQueryAdapter {
     }
 
     @Override
-    public @NotNull Stream<CachedAsset> executeQuery(FederatedCatalogCacheQuery query) {
+    public @NotNull Stream<ContractOffer> executeQuery(FederatedCatalogCacheQuery query) {
         //todo: translate the generic CacheQuery into a list of criteria and
         return store.query(query.getCriteria()).stream();
     }

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/IdsMultipartNodeQueryAdapter.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/IdsMultipartNodeQueryAdapter.java
@@ -1,0 +1,59 @@
+package org.eclipse.dataspaceconnector.catalog.cache.query;
+
+import org.eclipse.dataspaceconnector.catalog.spi.NodeQueryAdapter;
+import org.eclipse.dataspaceconnector.catalog.spi.model.UpdateRequest;
+import org.eclipse.dataspaceconnector.catalog.spi.model.UpdateResponse;
+import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
+import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
+import org.eclipse.dataspaceconnector.spi.types.domain.catalog.CatalogRequest;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.eclipse.dataspaceconnector.common.types.Cast.cast;
+
+public class IdsMultipartNodeQueryAdapter implements NodeQueryAdapter {
+    public static final String IDS_MULTIPART_PROTOCOL = "ids-multipart";
+    private final String connectorId;
+    private final RemoteMessageDispatcherRegistry dispatcherRegistry;
+    private final TypeManager typeManager;
+
+    public IdsMultipartNodeQueryAdapter(String connectorId, RemoteMessageDispatcherRegistry dispatcherRegistry, TypeManager typeManager) {
+        this.connectorId = connectorId;
+        this.dispatcherRegistry = dispatcherRegistry;
+        this.typeManager = typeManager;
+    }
+
+    @Override
+    public CompletableFuture<UpdateResponse> sendRequest(UpdateRequest updateRequest) {
+        CatalogRequest catalogRequest = CatalogRequest.Builder.newInstance()
+                .protocol(IDS_MULTIPART_PROTOCOL)
+                .connectorAddress(getNodeUrl(updateRequest))
+                .connectorId(connectorId)
+                .build();
+
+        CompletableFuture<Catalog> future = cast(dispatcherRegistry.send(Object.class, catalogRequest, () -> null));
+
+        return future.thenApply(catalog -> {
+            // This is a dirty hack which is necessary because "assetNames" will get deserialized to
+            // a list of LinkedHashMaps, instead of Assets.
+            // so we need to serialize and manually deserialize again...
+//            var assetNames = Collections.emptyList();
+//            var assets = assetNames.stream()
+//                    .map(asset -> typeManager.readValue(typeManager.writeValueAsString(asset), Asset.class))
+//                    .collect(Collectors.toList());
+
+            return new UpdateResponse(getNodeUrl(updateRequest), catalog);
+        });
+    }
+
+    // adds /api/ids/multipart if not already there
+    private String getNodeUrl(UpdateRequest updateRequest) {
+        var url = updateRequest.getNodeUrl();
+        if (!url.endsWith("/api/ids/multipart")) {
+            url += "/api/ids/multipart";
+        }
+
+        return url;
+    }
+}

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/IdsMultipartNodeQueryAdapter.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/IdsMultipartNodeQueryAdapter.java
@@ -4,7 +4,6 @@ import org.eclipse.dataspaceconnector.catalog.spi.NodeQueryAdapter;
 import org.eclipse.dataspaceconnector.catalog.spi.model.UpdateRequest;
 import org.eclipse.dataspaceconnector.catalog.spi.model.UpdateResponse;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
-import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.CatalogRequest;
 
@@ -16,12 +15,10 @@ public class IdsMultipartNodeQueryAdapter implements NodeQueryAdapter {
     public static final String IDS_MULTIPART_PROTOCOL = "ids-multipart";
     private final String connectorId;
     private final RemoteMessageDispatcherRegistry dispatcherRegistry;
-    private final TypeManager typeManager;
 
-    public IdsMultipartNodeQueryAdapter(String connectorId, RemoteMessageDispatcherRegistry dispatcherRegistry, TypeManager typeManager) {
+    public IdsMultipartNodeQueryAdapter(String connectorId, RemoteMessageDispatcherRegistry dispatcherRegistry) {
         this.connectorId = connectorId;
         this.dispatcherRegistry = dispatcherRegistry;
-        this.typeManager = typeManager;
     }
 
     @Override
@@ -34,17 +31,7 @@ public class IdsMultipartNodeQueryAdapter implements NodeQueryAdapter {
 
         CompletableFuture<Catalog> future = cast(dispatcherRegistry.send(Object.class, catalogRequest, () -> null));
 
-        return future.thenApply(catalog -> {
-            // This is a dirty hack which is necessary because "assetNames" will get deserialized to
-            // a list of LinkedHashMaps, instead of Assets.
-            // so we need to serialize and manually deserialize again...
-//            var assetNames = Collections.emptyList();
-//            var assets = assetNames.stream()
-//                    .map(asset -> typeManager.readValue(typeManager.writeValueAsString(asset), Asset.class))
-//                    .collect(Collectors.toList());
-
-            return new UpdateResponse(getNodeUrl(updateRequest), catalog);
-        });
+        return future.thenApply(catalog -> new UpdateResponse(getNodeUrl(updateRequest), catalog));
     }
 
     // adds /api/ids/multipart if not already there

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FccTestExtension.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FccTestExtension.java
@@ -1,0 +1,297 @@
+package org.eclipse.dataspaceconnector.catalog.cache;
+
+import kotlin.NotImplementedError;
+import org.eclipse.dataspaceconnector.policy.model.Action;
+import org.eclipse.dataspaceconnector.policy.model.Permission;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyType;
+import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
+import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
+import org.eclipse.dataspaceconnector.spi.asset.Criterion;
+import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
+import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferQuery;
+import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
+import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
+import org.eclipse.dataspaceconnector.spi.contract.validation.ContractValidationService;
+import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
+import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
+import org.eclipse.dataspaceconnector.spi.iam.TokenRepresentation;
+import org.eclipse.dataspaceconnector.spi.message.MessageContext;
+import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcher;
+import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
+import org.eclipse.dataspaceconnector.spi.types.domain.message.RemoteMessage;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyList;
+
+public class FccTestExtension implements ServiceExtension {
+
+    @Override
+    public Set<String> provides() {
+        return Set.of("edc:iam", "edc:core:contract", "dataspaceconnector:transferprocessstore", AssetIndex.FEATURE, ContractDefinitionStore.FEATURE, "dataspaceconnector:dispatcher", "edc:ids:transform:v1");
+    }
+
+    @Override
+    public LoadPhase phase() {
+        //this is necessary because the CoreServicesExtension requires the TransferProcessStore and it is loaded in the PRIMORDIAL phase
+        return LoadPhase.PRIMORDIAL;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        List<Asset> assets = Collections.emptyList();
+        context.registerService(IdentityService.class, new FakeIdentityService());
+        context.registerService(TransferProcessStore.class, new FakeTransferProcessStore());
+        context.registerService(RemoteMessageDispatcherRegistry.class, new FakeRemoteMessageDispatcherRegistry());
+        context.registerService(AssetIndex.class, new FakeAssetIndex(assets));
+        context.registerService(ContractOfferService.class, new FakeContractOfferService(assets));
+        context.registerService(ContractDefinitionStore.class, new FakeContractDefinitionStore());
+        context.registerService(ContractValidationService.class, new FakeContractValidationService());
+        context.registerService(ContractNegotiationStore.class, new FakeContractNegotiationStore());
+    }
+
+    private static class FakeIdentityService implements IdentityService {
+        @Override
+        public Result<TokenRepresentation> obtainClientCredentials(String scope) {
+            return Result.success(TokenRepresentation.Builder.newInstance().build());
+        }
+
+        @Override
+        public Result<ClaimToken> verifyJwtToken(String token, String audience) {
+            return Result.success(ClaimToken.Builder.newInstance().build());
+        }
+    }
+
+    private static class FakeAssetIndex implements AssetIndex {
+        private final List<Asset> assets;
+
+        private FakeAssetIndex(List<Asset> assets) {
+            this.assets = Objects.requireNonNull(assets);
+        }
+
+        @Override
+        public Stream<Asset> queryAssets(AssetSelectorExpression expression) {
+            return assets.stream();
+        }
+
+        @Override
+        public Stream<Asset> queryAssets(List<Criterion> criteria) {
+            return null;
+        }
+
+        @Override
+        public Asset findById(String assetId) {
+            return assets.stream().filter(a -> a.getId().equals(assetId)).findFirst().orElse(null);
+        }
+    }
+
+    private static class FakeContractOfferService implements ContractOfferService {
+        private final List<Asset> assets;
+
+        private FakeContractOfferService(List<Asset> assets) {
+            this.assets = assets;
+        }
+
+        @Override
+        @NotNull
+        public Stream<ContractOffer> queryContractOffers(ContractOfferQuery query) {
+            return assets.stream().map(asset ->
+                    ContractOffer.Builder.newInstance()
+                            .id("1")
+                            .policy(createEverythingAllowedPolicy())
+                            .asset(asset)
+                            .build()
+            );
+        }
+
+        private Policy createEverythingAllowedPolicy() {
+            var policyBuilder = Policy.Builder.newInstance();
+            var permissionBuilder = Permission.Builder.newInstance();
+            var actionBuilder = Action.Builder.newInstance();
+
+            policyBuilder.type(PolicyType.CONTRACT);
+            actionBuilder.type("USE");
+            permissionBuilder.target("1");
+
+            permissionBuilder.action(actionBuilder.build());
+            policyBuilder.permission(permissionBuilder.build());
+
+            policyBuilder.target("1");
+            return policyBuilder.build();
+        }
+    }
+
+    private static class FakeTransferProcessStore implements TransferProcessStore {
+        @Override
+        public TransferProcess find(String id) {
+            return null;
+        }
+
+        @Override
+        public @Nullable String processIdForTransferId(String id) {
+            return null;
+        }
+
+        @Override
+        public @NotNull List<TransferProcess> nextForState(int state, int max) {
+            return emptyList();
+        }
+
+        @Override
+        public void create(TransferProcess process) {
+        }
+
+        @Override
+        public void update(TransferProcess process) {
+        }
+
+        @Override
+        public void delete(String processId) {
+        }
+
+        @Override
+        public void createData(String processId, String key, Object data) {
+        }
+
+        @Override
+        public void updateData(String processId, String key, Object data) {
+        }
+
+        @Override
+        public void deleteData(String processId, String key) {
+        }
+
+        @Override
+        public void deleteData(String processId, Set<String> keys) {
+        }
+
+        @Override
+        public <T> T findData(Class<T> type, String processId, String resourceDefinitionId) {
+            return null;
+        }
+    }
+
+    private static class FakeRemoteMessageDispatcherRegistry implements RemoteMessageDispatcherRegistry {
+
+        @Override
+        public void register(RemoteMessageDispatcher dispatcher) {
+        }
+
+        @Override
+        public <T> CompletableFuture<T> send(Class<T> responseType, RemoteMessage message, MessageContext context) {
+            return null;
+        }
+    }
+
+    private static class FakeContractDefinitionStore implements ContractDefinitionStore {
+
+        private final List<ContractDefinition> contractDefinitions = new ArrayList<>();
+
+        @Override
+        public @NotNull Collection<ContractDefinition> findAll() {
+            return contractDefinitions;
+        }
+
+        @Override
+        public void save(Collection<ContractDefinition> definitions) {
+            contractDefinitions.addAll(definitions);
+        }
+
+        @Override
+        public void save(ContractDefinition definition) {
+            contractDefinitions.add(definition);
+        }
+
+        @Override
+        public void update(ContractDefinition definition) {
+            throw new NotImplementedError();
+        }
+
+        @Override
+        public void delete(String id) {
+            throw new NotImplementedError();
+        }
+
+        @Override
+        public void reload() {
+            throw new NotImplementedError();
+        }
+    }
+
+    private static class FakeContractValidationService implements ContractValidationService {
+
+        @Override
+        public @NotNull Result<ContractOffer> validate(ClaimToken token, ContractOffer offer) {
+            return Result.success(ContractOffer.Builder.newInstance().build());
+        }
+
+        @Override
+        public @NotNull Result<ContractOffer> validate(ClaimToken token, ContractOffer offer, ContractOffer latestOffer) {
+            return Result.success(offer);
+        }
+
+        @Override
+        public boolean validate(ClaimToken token, ContractAgreement agreement) {
+            return true;
+        }
+
+        @Override
+        public boolean validate(ClaimToken token, ContractAgreement agreement, ContractOffer latestOffer) {
+            return false;
+        }
+    }
+
+    private static class FakeContractNegotiationStore implements ContractNegotiationStore {
+
+        @Override
+        public @Nullable ContractNegotiation find(String negotiationId) {
+            return null;
+        }
+
+        @Override
+        public @Nullable ContractNegotiation findForCorrelationId(String correlationId) {
+            return null;
+        }
+
+        @Override
+        public @Nullable ContractAgreement findContractAgreement(String contractId) {
+            return null;
+        }
+
+        @Override
+        public void save(ContractNegotiation negotiation) {
+
+        }
+
+        @Override
+        public void delete(String negotiationId) {
+
+        }
+
+        @Override
+        public @NotNull List<ContractNegotiation> nextForState(int state, int max) {
+            return null;
+        }
+    }
+
+}

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FccTestExtension.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FccTestExtension.java
@@ -8,24 +8,16 @@ import org.eclipse.dataspaceconnector.policy.model.PolicyType;
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 import org.eclipse.dataspaceconnector.spi.asset.Criterion;
-import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferQuery;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
-import org.eclipse.dataspaceconnector.spi.contract.validation.ContractValidationService;
-import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
-import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
-import org.eclipse.dataspaceconnector.spi.iam.TokenRepresentation;
 import org.eclipse.dataspaceconnector.spi.message.MessageContext;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcher;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
-import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
-import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
-import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.eclipse.dataspaceconnector.spi.types.domain.message.RemoteMessage;
@@ -60,26 +52,11 @@ public class FccTestExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         List<Asset> assets = Collections.emptyList();
-        context.registerService(IdentityService.class, new FakeIdentityService());
         context.registerService(TransferProcessStore.class, new FakeTransferProcessStore());
         context.registerService(RemoteMessageDispatcherRegistry.class, new FakeRemoteMessageDispatcherRegistry());
         context.registerService(AssetIndex.class, new FakeAssetIndex(assets));
         context.registerService(ContractOfferService.class, new FakeContractOfferService(assets));
         context.registerService(ContractDefinitionStore.class, new FakeContractDefinitionStore());
-        context.registerService(ContractValidationService.class, new FakeContractValidationService());
-        context.registerService(ContractNegotiationStore.class, new FakeContractNegotiationStore());
-    }
-
-    private static class FakeIdentityService implements IdentityService {
-        @Override
-        public Result<TokenRepresentation> obtainClientCredentials(String scope) {
-            return Result.success(TokenRepresentation.Builder.newInstance().build());
-        }
-
-        @Override
-        public Result<ClaimToken> verifyJwtToken(String token, String audience) {
-            return Result.success(ClaimToken.Builder.newInstance().build());
-        }
     }
 
     private static class FakeAssetIndex implements AssetIndex {
@@ -238,60 +215,5 @@ public class FccTestExtension implements ServiceExtension {
         }
     }
 
-    private static class FakeContractValidationService implements ContractValidationService {
-
-        @Override
-        public @NotNull Result<ContractOffer> validate(ClaimToken token, ContractOffer offer) {
-            return Result.success(ContractOffer.Builder.newInstance().build());
-        }
-
-        @Override
-        public @NotNull Result<ContractOffer> validate(ClaimToken token, ContractOffer offer, ContractOffer latestOffer) {
-            return Result.success(offer);
-        }
-
-        @Override
-        public boolean validate(ClaimToken token, ContractAgreement agreement) {
-            return true;
-        }
-
-        @Override
-        public boolean validate(ClaimToken token, ContractAgreement agreement, ContractOffer latestOffer) {
-            return false;
-        }
-    }
-
-    private static class FakeContractNegotiationStore implements ContractNegotiationStore {
-
-        @Override
-        public @Nullable ContractNegotiation find(String negotiationId) {
-            return null;
-        }
-
-        @Override
-        public @Nullable ContractNegotiation findForCorrelationId(String correlationId) {
-            return null;
-        }
-
-        @Override
-        public @Nullable ContractAgreement findContractAgreement(String contractId) {
-            return null;
-        }
-
-        @Override
-        public void save(ContractNegotiation negotiation) {
-
-        }
-
-        @Override
-        public void delete(String negotiationId) {
-
-        }
-
-        @Override
-        public @NotNull List<ContractNegotiation> nextForState(int state, int max) {
-            return null;
-        }
-    }
 
 }

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheEndToEndTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheEndToEndTest.java
@@ -7,10 +7,11 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import org.eclipse.dataspaceconnector.catalog.spi.CachedAsset;
 import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheStore;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -49,7 +50,7 @@ class FederatedCatalogCacheEndToEndTest {
         int nbAssets = 3;
 
         // generate assets and populate the store
-        List<CachedAsset> assets = new ArrayList<>();
+        List<ContractOffer> assets = new ArrayList<>();
         for (int i = 0; i < nbAssets; i++) {
             assets.add(buildAsset());
         }
@@ -67,20 +68,20 @@ class FederatedCatalogCacheEndToEndTest {
 
         // test
         assertThat(response.code()).isEqualTo(200);
-        List<Asset> actualAssets = Arrays.asList(MAPPER.readValue(Objects.requireNonNull(response.body()).string(), Asset[].class));
+        List<ContractOffer> actualAssets = Arrays.asList(MAPPER.readValue(Objects.requireNonNull(response.body()).string(), ContractOffer[].class));
         compareAssetsById(actualAssets, assets);
     }
 
-    private CachedAsset buildAsset() {
-        return CachedAsset.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
-                .name("demo-test")
+    private ContractOffer buildAsset() {
+        return ContractOffer.Builder.newInstance()
+                .asset(Asset.Builder.newInstance().id(UUID.randomUUID().toString()).build())
+                .policy(Policy.Builder.newInstance().build())
                 .build();
     }
 
-    private void compareAssetsById(List<Asset> actual, List<CachedAsset> expected) {
-        List<String> actualAssetIds = actual.stream().map(Asset::getId).sorted().collect(Collectors.toList());
-        List<String> expectedAssetIds = expected.stream().map(CachedAsset::getId).sorted().collect(Collectors.toList());
+    private void compareAssetsById(List<ContractOffer> actual, List<ContractOffer> expected) {
+        List<String> actualAssetIds = actual.stream().map(co -> co.getAsset().getId()).sorted().collect(Collectors.toList());
+        List<String> expectedAssetIds = expected.stream().map(co -> co.getAsset().getId()).sorted().collect(Collectors.toList());
         assertThat(actualAssetIds).isEqualTo(expectedAssetIds);
     }
 }

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/TestUtil.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/TestUtil.java
@@ -1,10 +1,24 @@
 package org.eclipse.dataspaceconnector.catalog.cache;
 
 import org.eclipse.dataspaceconnector.catalog.spi.WorkItem;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
+import org.jetbrains.annotations.NotNull;
 
 public class TestUtil {
 
     public static WorkItem createWorkItem() {
         return new WorkItem("test-url", "test-protocol");
     }
+
+    @NotNull
+    public static ContractOffer createOffer(String id) {
+        return ContractOffer.Builder.newInstance()
+                .id(id)
+                .asset(Asset.Builder.newInstance().id(id).build())
+                .policy(Policy.Builder.newInstance().build())
+                .build();
+    }
+
 }

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/query/InMemoryFccQueryAdapterRegistryTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/query/InMemoryFccQueryAdapterRegistryTest.java
@@ -14,11 +14,9 @@
 package org.eclipse.dataspaceconnector.catalog.cache.query;
 
 import org.eclipse.dataspaceconnector.catalog.spi.CacheQueryAdapter;
-import org.eclipse.dataspaceconnector.catalog.spi.CachedAsset;
 import org.eclipse.dataspaceconnector.catalog.spi.QueryResponse;
 import org.eclipse.dataspaceconnector.catalog.spi.model.FederatedCatalogCacheQuery;
 import org.eclipse.dataspaceconnector.spi.EdcException;
-import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,12 +31,11 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.catalog.cache.TestUtil.createOffer;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import static org.eclipse.dataspaceconnector.catalog.cache.TestUtil.createOffer;
 
 class InMemoryFccQueryAdapterRegistryTest {
     private static final ContractOffer ASSET_ABC = createOffer("ABC");

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/query/InMemoryFccQueryAdapterRegistryTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/query/InMemoryFccQueryAdapterRegistryTest.java
@@ -19,6 +19,7 @@ import org.eclipse.dataspaceconnector.catalog.spi.QueryResponse;
 import org.eclipse.dataspaceconnector.catalog.spi.model.FederatedCatalogCacheQuery;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -78,7 +79,7 @@ class InMemoryFccQueryAdapterRegistryTest {
         var result = registry.executeQuery(mock(FederatedCatalogCacheQuery.class));
 
         assertThat(result).isNotNull();
-        assertThat(result.getAssets()).isEmpty();
+        assertThat(result.getOffers()).isEmpty();
         assertThat(result.getErrors()).isEmpty();
         assertThat(result.getStatus()).isEqualTo(QueryResponse.Status.NO_ADAPTER_FOUND);
     }
@@ -94,8 +95,7 @@ class InMemoryFccQueryAdapterRegistryTest {
         registry.register(adapter3);
 
         var result = registry.executeQuery(mock(FederatedCatalogCacheQuery.class));
-
-        assertThat(result.getAssets()).hasSize(6);
+        assertThat(result.getOffers()).hasSize(6);
         assertThat(result.getErrors()).isEmpty();
         assertThat(result.getStatus()).isEqualTo(QueryResponse.Status.ACCEPTED);
     }
@@ -109,8 +109,7 @@ class InMemoryFccQueryAdapterRegistryTest {
         registry.register(adapter2);
 
         var result = registry.executeQuery(mock(FederatedCatalogCacheQuery.class));
-
-        assertThat(result.getAssets()).hasSize(6);
+        assertThat(result.getOffers()).hasSize(6);
         assertThat(result.getErrors()).isEmpty();
         assertThat(result.getStatus()).isEqualTo(QueryResponse.Status.ACCEPTED);
     }
@@ -126,8 +125,7 @@ class InMemoryFccQueryAdapterRegistryTest {
         registry.register(adapter3);
 
         var result = registry.executeQuery(mock(FederatedCatalogCacheQuery.class));
-
-        assertThat(result.getAssets()).hasSize(6);
+        assertThat(result.getOffers()).hasSize(6);
         assertThat(result.getErrors()).isNotEmpty().hasSize(1);
         assertThat(result.getStatus()).isEqualTo(QueryResponse.Status.ACCEPTED);
     }
@@ -143,8 +141,7 @@ class InMemoryFccQueryAdapterRegistryTest {
         registry.register(adapter3);
 
         var result = registry.executeQuery(mock(FederatedCatalogCacheQuery.class));
-
-        assertThat(result.getAssets()).hasSize(0);
+        assertThat(result.getOffers()).hasSize(0);
         assertThat(result.getErrors()).isNotEmpty().hasSize(3);
         assertThat(result.getStatus()).isEqualTo(QueryResponse.Status.ACCEPTED);
     }
@@ -160,7 +157,7 @@ class InMemoryFccQueryAdapterRegistryTest {
     private CacheQueryAdapter matchingAdapter() {
         CacheQueryAdapter adapter1 = mock(CacheQueryAdapter.class);
         when(adapter1.canExecute(any())).thenReturn(true);
-        Supplier<CachedAsset> as = () -> CachedAsset.Builder.newInstance().build();
+        Supplier<ContractOffer> as = () -> ContractOffer.Builder.newInstance().build();
         when(adapter1.executeQuery(any())).thenReturn(Stream.of(as.get(), as.get(), as.get()));
         return adapter1;
     }
@@ -172,8 +169,8 @@ class InMemoryFccQueryAdapterRegistryTest {
         return adapter1;
     }
 
-    private List<Asset> collectAssetsFromAdapters(Collection<CacheQueryAdapter> adapters) {
-        List<Asset> assets = new ArrayList<>();
+    private List<ContractOffer> collectAssetsFromAdapters(Collection<CacheQueryAdapter> adapters) {
+        List<ContractOffer> assets = new ArrayList<>();
         adapters.forEach(cacheQueryAdapter -> assets.addAll(cacheQueryAdapter.executeQuery(null).collect(Collectors.toList())));
         return assets;
     }

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/query/InMemoryFccQueryAdapterRegistryTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/query/InMemoryFccQueryAdapterRegistryTest.java
@@ -38,13 +38,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import static org.eclipse.dataspaceconnector.catalog.cache.TestUtil.createOffer;
 
 class InMemoryFccQueryAdapterRegistryTest {
-    private static final CachedAsset ASSET_ABC = CachedAsset.Builder.newInstance().id("ABC").build();
-    private static final CachedAsset ASSET_DEF = CachedAsset.Builder.newInstance().id("DEF").build();
-    private static final CachedAsset ASSET_XYZ = CachedAsset.Builder.newInstance().id("XYZ").build();
-
+    private static final ContractOffer ASSET_ABC = createOffer("ABC");
+    private static final ContractOffer ASSET_DEF = createOffer("DEF");
+    private static final ContractOffer ASSET_XYZ = createOffer("XYZ");
     private CacheQueryAdapterRegistryImpl registry;
+
 
     @Test
     void getAllAdapters() {
@@ -157,7 +158,7 @@ class InMemoryFccQueryAdapterRegistryTest {
     private CacheQueryAdapter matchingAdapter() {
         CacheQueryAdapter adapter1 = mock(CacheQueryAdapter.class);
         when(adapter1.canExecute(any())).thenReturn(true);
-        Supplier<ContractOffer> as = () -> ContractOffer.Builder.newInstance().build();
+        Supplier<ContractOffer> as = () -> createOffer("test-offer");
         when(adapter1.executeQuery(any())).thenReturn(Stream.of(as.get(), as.get(), as.get()));
         return adapter1;
     }

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/query/QueryEngineImplTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/query/QueryEngineImplTest.java
@@ -4,7 +4,6 @@ import org.eclipse.dataspaceconnector.catalog.spi.CacheQueryAdapterRegistry;
 import org.eclipse.dataspaceconnector.catalog.spi.QueryEngine;
 import org.eclipse.dataspaceconnector.catalog.spi.QueryResponse;
 import org.eclipse.dataspaceconnector.catalog.spi.model.FederatedCatalogCacheQuery;
-import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.junit.jupiter.api.Test;
 
@@ -18,9 +17,9 @@ import static org.mockito.Mockito.when;
 
 class QueryEngineImplTest {
 
-    private static final ContractOffer ASSET_ABC = ContractOffer.Builder.newInstance().id("ABC").build();
-    private static final ContractOffer ASSET_DEF = ContractOffer.Builder.newInstance().id("DEF").build();
-    private static final ContractOffer ASSET_XYZ = ContractOffer.Builder.newInstance().id("XYZ").build();
+    private static final ContractOffer ASSET_ABC = createOffer("ABC");
+    private static final ContractOffer ASSET_DEF = createOffer("DEF");
+    private static final ContractOffer ASSET_XYZ = createOffer("XYZ");
 
     @Test
     void getCatalog() {

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/query/QueryEngineImplTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/query/QueryEngineImplTest.java
@@ -5,6 +5,7 @@ import org.eclipse.dataspaceconnector.catalog.spi.QueryEngine;
 import org.eclipse.dataspaceconnector.catalog.spi.QueryResponse;
 import org.eclipse.dataspaceconnector.catalog.spi.model.FederatedCatalogCacheQuery;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -17,9 +18,9 @@ import static org.mockito.Mockito.when;
 
 class QueryEngineImplTest {
 
-    private static final Asset ASSET_ABC = Asset.Builder.newInstance().id("ABC").build();
-    private static final Asset ASSET_DEF = Asset.Builder.newInstance().id("DEF").build();
-    private static final Asset ASSET_XYZ = Asset.Builder.newInstance().id("XYZ").build();
+    private static final ContractOffer ASSET_ABC = ContractOffer.Builder.newInstance().id("ABC").build();
+    private static final ContractOffer ASSET_DEF = ContractOffer.Builder.newInstance().id("DEF").build();
+    private static final ContractOffer ASSET_XYZ = ContractOffer.Builder.newInstance().id("XYZ").build();
 
     @Test
     void getCatalog() {
@@ -32,7 +33,8 @@ class QueryEngineImplTest {
         QueryResponse catalog = queryEngine.getCatalog(FederatedCatalogCacheQuery.Builder.newInstance().build());
         assertThat(catalog.getStatus()).isEqualTo(QueryResponse.Status.ACCEPTED);
         assertThat(catalog.getErrors()).isEmpty();
-        assertThat(catalog.getAssets()).containsExactlyInAnyOrder(ASSET_ABC, ASSET_DEF, ASSET_XYZ);
+        assertThat(catalog.getOffers()).containsExactlyInAnyOrder(ASSET_ABC, ASSET_DEF, ASSET_XYZ);
+
         verify(registry).executeQuery(any());
     }
 
@@ -41,7 +43,7 @@ class QueryEngineImplTest {
         CacheQueryAdapterRegistry registry = mock(CacheQueryAdapterRegistry.class);
 
         when(registry.executeQuery(any())).thenReturn(QueryResponse.Builder.newInstance()
-                .assets(List.of(ASSET_ABC, ASSET_DEF, ASSET_XYZ))
+                .offers(List.of(ASSET_ABC, ASSET_DEF, ASSET_XYZ))
                 .error("some error")
                 .build());
 
@@ -50,7 +52,7 @@ class QueryEngineImplTest {
         QueryResponse catalog = queryEngine.getCatalog(FederatedCatalogCacheQuery.Builder.newInstance().build());
         assertThat(catalog.getStatus()).isEqualTo(QueryResponse.Status.ACCEPTED);
         assertThat(catalog.getErrors()).hasSize(1).containsExactly("some error");
-        assertThat(catalog.getAssets()).containsExactlyInAnyOrder(ASSET_ABC, ASSET_DEF, ASSET_XYZ);
+        assertThat(catalog.getOffers()).containsExactlyInAnyOrder(ASSET_ABC, ASSET_DEF, ASSET_XYZ);
         verify(registry).executeQuery(any());
     }
 
@@ -68,7 +70,7 @@ class QueryEngineImplTest {
         QueryResponse catalog = queryEngine.getCatalog(FederatedCatalogCacheQuery.Builder.newInstance().build());
         assertThat(catalog.getStatus()).isEqualTo(QueryResponse.Status.NO_ADAPTER_FOUND);
         assertThat(catalog.getErrors()).hasSize(1);
-        assertThat(catalog.getAssets()).isEmpty();
+        assertThat(catalog.getOffers()).isEmpty();
         verify(registry).executeQuery(any());
     }
 }

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/query/QueryEngineImplTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/query/QueryEngineImplTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.catalog.cache.TestUtil.createOffer;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/CacheQueryAdapter.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/CacheQueryAdapter.java
@@ -2,6 +2,7 @@ package org.eclipse.dataspaceconnector.catalog.spi;
 
 import org.eclipse.dataspaceconnector.catalog.spi.model.FederatedCatalogCacheQuery;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.stream.Stream;
@@ -21,7 +22,7 @@ public interface CacheQueryAdapter {
      * @return A stream of {@link Asset} objects. Can be empty, can never be null.
      * @throws IllegalArgumentException may be thrown if the implementor cannot translate the query.
      */
-    @NotNull Stream<CachedAsset> executeQuery(FederatedCatalogCacheQuery query);
+    @NotNull Stream<ContractOffer> executeQuery(FederatedCatalogCacheQuery query);
 
     /**
      * Checks whether a given query can be run by the implementor. This does not limit itself to whether the query

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/CacheQueryAdapterRegistry.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/CacheQueryAdapterRegistry.java
@@ -27,7 +27,7 @@ public interface CacheQueryAdapterRegistry {
      * Attempts to execute a query by forwarding it to all suitable {@link CacheQueryAdapter}s. It returns a query response with a status equal to
      * {@link QueryResponse.Status#ACCEPTED} if there was at least one adapter that could accept the query. If no suitable adapter was found, the status will be
      * {@link QueryResponse.Status#NO_ADAPTER_FOUND}. The actual result of the query, which could be mixed as some adapters might succeed, others might fail, can be
-     * obtained from {@link QueryResponse#getAssets()} and {@link QueryResponse#getErrors()}. The earlier list returns an aggregated stream of
+     * obtained from {@link QueryResponse#getOffers()} and {@link QueryResponse#getErrors()}. The earlier list returns an aggregated stream of
      * {@link org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset}, the latter contains a list of errors.
      * <p>
      * For example, when 1 of 5 adapters that receive the query times out, there will be results from 4, errors from 1.

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/FederatedCacheStore.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/FederatedCacheStore.java
@@ -1,6 +1,7 @@
 package org.eclipse.dataspaceconnector.catalog.spi;
 
 import org.eclipse.dataspaceconnector.spi.asset.Criterion;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 
 import java.util.Collection;
 import java.util.List;
@@ -12,17 +13,16 @@ public interface FederatedCacheStore {
     String FEATURE = "edc:catalog:cache:store";
 
     /**
-     * todo: rename _this_ asset to something else, and add the originator as property
-     * Adds an {@link CachedAsset} to the store
+     * Adds an {@link ContractOffer} to the store
      */
-    void save(CachedAsset asset);
+    void save(ContractOffer asset);
 
     /**
-     * Queries the store for {@link CachedAsset}s
+     * Queries the store for {@link ContractOffer}s
      *
      * @param query A list of criteria the asset must fulfill
      * @return A collection of assets that are already in the store and that satisfy a given list of criteria.
      */
-    Collection<CachedAsset> query(List<Criterion> query);
+    Collection<ContractOffer> query(List<Criterion> query);
 
 }

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/QueryResponse.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/QueryResponse.java
@@ -15,7 +15,7 @@
 
 package org.eclipse.dataspaceconnector.catalog.spi;
 
-import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +23,7 @@ import java.util.List;
 public class QueryResponse {
     private Status status;
     private List<String> errors = new ArrayList<>();
-    private List<Asset> assets = new ArrayList<>();
+    private List<ContractOffer> offers = new ArrayList<>();
 
     private QueryResponse(Status status) {
         this.status = status;
@@ -34,15 +34,15 @@ public class QueryResponse {
 
     }
 
-    public static QueryResponse ok(List<Asset> result) {
+    public static QueryResponse ok(List<ContractOffer> result) {
         return Builder.newInstance()
                 .status(Status.ACCEPTED)
-                .assets(result)
+                .offers(result)
                 .build();
     }
 
-    public List<Asset> getAssets() {
-        return assets;
+    public List<ContractOffer> getOffers() {
+        return offers;
     }
 
     public Status getStatus() {
@@ -71,8 +71,8 @@ public class QueryResponse {
             return new Builder();
         }
 
-        public Builder assets(List<Asset> assets) {
-            response.assets = assets;
+        public Builder offers(List<ContractOffer> assets) {
+            response.offers = assets;
             return this;
         }
 

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/model/UpdateResponse.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/model/UpdateResponse.java
@@ -4,9 +4,7 @@ package org.eclipse.dataspaceconnector.catalog.spi.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.eclipse.dataspaceconnector.catalog.spi.NodeQueryAdapter;
-import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
-
-import java.util.Collection;
+import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 
 /**
  * {@link NodeQueryAdapter}s return {@code UpdateResponse} objects after a
@@ -18,20 +16,20 @@ import java.util.Collection;
  */
 public class UpdateResponse {
     private String source;
-    private Collection<Asset> assetNames;
+    private Catalog catalog;
 
     @JsonCreator
-    public UpdateResponse(@JsonProperty("source") String source, @JsonProperty("assets") Collection<Asset> assetNames) {
+    public UpdateResponse(@JsonProperty("source") String source, @JsonProperty("catalog") Catalog assetNames) {
         this.source = source;
-        this.assetNames = assetNames;
+        catalog = assetNames;
     }
 
     public UpdateResponse() {
 
     }
 
-    public Collection<Asset> getAssetNames() {
-        return assetNames;
+    public Catalog getCatalog() {
+        return catalog;
     }
 
     public String getSource() {

--- a/extensions/in-memory/fcc-store-memory/src/main/java/org/eclipse/dataspaceconnector/catalog/store/InMemoryFederatedCacheStore.java
+++ b/extensions/in-memory/fcc-store-memory/src/main/java/org/eclipse/dataspaceconnector/catalog/store/InMemoryFederatedCacheStore.java
@@ -1,9 +1,9 @@
 package org.eclipse.dataspaceconnector.catalog.store;
 
-import org.eclipse.dataspaceconnector.catalog.spi.CachedAsset;
 import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheStore;
 import org.eclipse.dataspaceconnector.spi.asset.Criterion;
 import org.eclipse.dataspaceconnector.spi.asset.CriterionConverter;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 
 import java.util.Collection;
 import java.util.List;
@@ -17,20 +17,20 @@ import java.util.stream.Collectors;
  */
 public class InMemoryFederatedCacheStore implements FederatedCacheStore {
 
-    private final Map<String, CachedAsset> cache = new ConcurrentHashMap<>();
-    private final CriterionConverter<Predicate<CachedAsset>> converter;
+    private final Map<String, ContractOffer> cache = new ConcurrentHashMap<>();
+    private final CriterionConverter<Predicate<ContractOffer>> converter;
 
-    public InMemoryFederatedCacheStore(CriterionConverter<Predicate<CachedAsset>> converter) {
+    public InMemoryFederatedCacheStore(CriterionConverter<Predicate<ContractOffer>> converter) {
         this.converter = converter;
     }
 
     @Override
-    public void save(CachedAsset asset) {
+    public void save(ContractOffer asset) {
         cache.put(asset.getId(), asset);
     }
 
     @Override
-    public Collection<CachedAsset> query(List<Criterion> query) {
+    public Collection<ContractOffer> query(List<Criterion> query) {
         //AND all predicates
         var rootPredicate = query.stream().map(converter::convert).reduce(x -> true, Predicate::and);
         return cache.values().stream().filter(rootPredicate).collect(Collectors.toList());

--- a/extensions/in-memory/fcc-store-memory/src/main/java/org/eclipse/dataspaceconnector/catalog/store/InMemoryFederatedCacheStoreExtension.java
+++ b/extensions/in-memory/fcc-store-memory/src/main/java/org/eclipse/dataspaceconnector/catalog/store/InMemoryFederatedCacheStoreExtension.java
@@ -1,10 +1,10 @@
 package org.eclipse.dataspaceconnector.catalog.store;
 
-import org.eclipse.dataspaceconnector.catalog.spi.CachedAsset;
 import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheStore;
 import org.eclipse.dataspaceconnector.spi.asset.CriterionConverter;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 
 import java.util.Set;
 import java.util.function.Predicate;
@@ -25,7 +25,7 @@ public class InMemoryFederatedCacheStoreExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
 
         //todo: converts every criterion into a predicate that is always true. must be changed later!
-        CriterionConverter<Predicate<CachedAsset>> predicateCriterionConverter = criterion -> asset -> true;
+        CriterionConverter<Predicate<ContractOffer>> predicateCriterionConverter = criterion -> offer -> true;
         context.registerService(FederatedCacheStore.class, new InMemoryFederatedCacheStore(predicateCriterionConverter));
     }
 }

--- a/samples/other/streaming/src/test/java/org/eclipse/dataspaceconnector/transfer/demo/protocols/stream/DemoPushStreamTransferTest.java
+++ b/samples/other/streaming/src/test/java/org/eclipse/dataspaceconnector/transfer/demo/protocols/stream/DemoPushStreamTransferTest.java
@@ -24,7 +24,7 @@ import org.eclipse.dataspaceconnector.transfer.demo.protocols.spi.stream.StreamC
 import org.eclipse.dataspaceconnector.transfer.demo.protocols.spi.stream.StreamPublisher;
 import org.eclipse.dataspaceconnector.transfer.demo.protocols.spi.stream.StreamPublisherRegistry;
 import org.eclipse.dataspaceconnector.transfer.demo.protocols.spi.stream.TopicManager;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.Random;
@@ -43,8 +43,9 @@ import static org.eclipse.dataspaceconnector.transfer.demo.protocols.spi.DemoPro
  */
 class DemoPushStreamTransferTest extends AbstractDemoTransferTest {
 
-    @BeforeEach
-    void setup() {
+    @BeforeAll
+    static void setup() {
+        //let's randomize the port
         var port = 2000 + new Random().nextInt(8000);
         System.setProperty("web.http.port", String.valueOf(port));
         System.setProperty("edc.demo.protocol.ws.pubsub", "ws://localhost:" + port + "/pubsub/");

--- a/samples/other/streaming/src/test/java/org/eclipse/dataspaceconnector/transfer/demo/protocols/stream/DemoPushStreamTransferTest.java
+++ b/samples/other/streaming/src/test/java/org/eclipse/dataspaceconnector/transfer/demo/protocols/stream/DemoPushStreamTransferTest.java
@@ -24,12 +24,15 @@ import org.eclipse.dataspaceconnector.transfer.demo.protocols.spi.stream.StreamC
 import org.eclipse.dataspaceconnector.transfer.demo.protocols.spi.stream.StreamPublisher;
 import org.eclipse.dataspaceconnector.transfer.demo.protocols.spi.stream.StreamPublisherRegistry;
 import org.eclipse.dataspaceconnector.transfer.demo.protocols.spi.stream.TopicManager;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.transfer.demo.protocols.spi.DemoProtocols.DESTINATION_NAME;
 import static org.eclipse.dataspaceconnector.transfer.demo.protocols.spi.DemoProtocols.ENDPOINT_ADDRESS;
 import static org.eclipse.dataspaceconnector.transfer.demo.protocols.spi.DemoProtocols.PUSH_STREAM_HTTP;
@@ -39,6 +42,15 @@ import static org.eclipse.dataspaceconnector.transfer.demo.protocols.spi.DemoPro
  * Demonstrates an-end-to-end push stream transfer.
  */
 class DemoPushStreamTransferTest extends AbstractDemoTransferTest {
+
+    @BeforeEach
+    void setup() {
+        var port = 2000 + new Random().nextInt(8000);
+        System.setProperty("web.http.port", String.valueOf(port));
+        System.setProperty("edc.demo.protocol.ws.pubsub", "ws://localhost:" + port + "/pubsub/");
+        System.setProperty("edc.demo.protocol.http.pubsub", "http://localhost:" + port + "/api/demo/pubsub/");
+
+    }
 
     /**
      * Perform a push stream flow over Web Sockets using the loopback protocol.
@@ -73,8 +85,8 @@ class DemoPushStreamTransferTest extends AbstractDemoTransferTest {
 
         processManager.initiateConsumerRequest(dataRequestWs);
 
-        requestLatch.await(1, MINUTES);
-        receiveLatch.await(1, MINUTES);
+        assertThat(requestLatch.await(1, MINUTES)).isTrue();
+        assertThat(receiveLatch.await(1, MINUTES)).isTrue();
     }
 
     /**
@@ -110,8 +122,8 @@ class DemoPushStreamTransferTest extends AbstractDemoTransferTest {
 
         processManager.initiateConsumerRequest(dataRequestHttp);
 
-        requestLatch.await(1, MINUTES);
-        receiveLatch.await(1, MINUTES);
+        assertThat(requestLatch.await(1, MINUTES)).isTrue();
+        assertThat(receiveLatch.await(1, MINUTES)).isTrue();
     }
 
     private static class TestStreamPublisher implements StreamPublisher {


### PR DESCRIPTION
The Federated Catalog Cache now uses IDS Multipart Catalog queries, and instead of Assets it also only deals with `ContractOffer` objects.

Furthermore, the FCC now ships with an IDS-Multipart-based `NodeQueryAdapter` implementation and registers it for the `"ids-multipart"` protocol.

Closes #402 

_Unrelated: a potential NPE in the Async-TPM was fixed too_