### PR TITLE
integration-tests: reset permissions

### DIFF
--- a/.github/workflows/integrationtests.yaml
+++ b/.github/workflows/integrationtests.yaml
@@ -99,10 +99,13 @@ jobs:
         ports:
           - 4567:4567
         volumes:
-          - /home/runner/work/DataSpaceConnector/DataSpaceConnector/extensions/iam/daps/src/test/resources/config:/opt/config
-          - /home/runner/work/DataSpaceConnector/DataSpaceConnector/extensions/iam/daps/src/test/resources/keys:/opt/keys
+          - ${{ github.workspace }}/extensions/iam/daps/src/test/resources/config:/opt/config
+          - ${{ github.workspace }}/extensions/iam/daps/src/test/resources/keys:/opt/keys
 
     steps:
+      - name: reset permissions to permit checkout (because the omejdn volumes)
+        run: sudo chown -R $USER:$USER ${{ github.workspace }}
+
       - uses: actions/checkout@v2
       - name: Set up JDK 11
         uses: actions/setup-java@v1


### PR DESCRIPTION
As stated in #221 this should fix the daps integration test running.
The problem is that the docker volumes change the permissions in the workspace folder so there's the need to reset them before.