### PR TITLE
Remove unused mulesoft repository

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,9 +46,6 @@ subprojects {
         maven {
             url = uri("https://maven.iais.fraunhofer.de/artifactory/eis-ids-public/")
         }
-        maven {
-            url = uri("https://repository.mulesoft.org/nexus/content/repositories/public/") //used for the multihash lib
-        }
     }
 
     tasks.register<DependencyReportTask>("allDependencies") {}


### PR DESCRIPTION
The comment reported that this dependency was "used for the multihash lib", but we don't use that dependency (there are some copy-and-pasted files from it).
This is currently breaking CI (e.g. https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/runs/4607127286?check_suite_focus=true) because the mulsesoft repository is responding 502 but, since it's not needed, we can get rid of it.