### PR TITLE
fix: Repair InMemoryFederatedCacheStore as non-unique ContractOffer is used as key in the store

### DIFF
--- a/extensions/in-memory/fcc-store-memory/src/main/java/org/eclipse/dataspaceconnector/catalog/store/InMemoryFederatedCacheStore.java
+++ b/extensions/in-memory/fcc-store-memory/src/main/java/org/eclipse/dataspaceconnector/catalog/store/InMemoryFederatedCacheStore.java
@@ -25,8 +25,8 @@ public class InMemoryFederatedCacheStore implements FederatedCacheStore {
     }
 
     @Override
-    public void save(ContractOffer asset) {
-        cache.put(asset.getId(), asset);
+    public void save(ContractOffer contractOffer) {
+        cache.put(contractOffer.getAsset().getId(), contractOffer);
     }
 
     @Override
@@ -35,5 +35,4 @@ public class InMemoryFederatedCacheStore implements FederatedCacheStore {
         var rootPredicate = query.stream().map(converter::convert).reduce(x -> true, Predicate::and);
         return cache.values().stream().filter(rootPredicate).collect(Collectors.toList());
     }
-
 }

--- a/extensions/in-memory/fcc-store-memory/src/test/java/org/eclipse/dataspaceconnector/catalog/store/InMemoryFederatedCacheStoreTest.java
+++ b/extensions/in-memory/fcc-store-memory/src/test/java/org/eclipse/dataspaceconnector/catalog/store/InMemoryFederatedCacheStoreTest.java
@@ -1,0 +1,97 @@
+package org.eclipse.dataspaceconnector.catalog.store;
+
+import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheStore;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.asset.CriterionConverter;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.UUID;
+import java.util.function.Predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InMemoryFederatedCacheStoreTest {
+
+    private FederatedCacheStore store;
+
+    @BeforeEach
+    public void setUp() {
+        CriterionConverter<Predicate<ContractOffer>> converter = criterion -> offer -> true;
+        store = new InMemoryFederatedCacheStore(converter);
+    }
+
+    @Test
+    void queryCacheContainingOneElementWithNoCriterion_shouldReturnUniqueElement() {
+        String contractOfferId = UUID.randomUUID().toString();
+        String assetId = UUID.randomUUID().toString();
+        ContractOffer contractOffer = createContractOffer(contractOfferId, createAsset(assetId));
+
+        store.save(contractOffer);
+
+        Collection<ContractOffer> result = store.query(Collections.emptyList());
+
+        assertThat(result)
+                .hasSize(1)
+                .allSatisfy(co -> assertThat(co.getAsset().getId()).isEqualTo(assetId));
+    }
+
+    @Test
+    void queryCacheAfterInsertingSameAssetTwice_shouldReturnLastInsertedContractOfferOnly() {
+        String contractOfferId1 = UUID.randomUUID().toString();
+        String contractOfferId2 = UUID.randomUUID().toString();
+        String assetId = UUID.randomUUID().toString();
+        ContractOffer contractOffer1 = createContractOffer(contractOfferId1, createAsset(assetId));
+        ContractOffer contractOffer2 = createContractOffer(contractOfferId2, createAsset(assetId));
+
+        store.save(contractOffer1);
+        store.save(contractOffer2);
+
+        Collection<ContractOffer> result = store.query(Collections.emptyList());
+
+        assertThat(result)
+                .hasSize(1)
+                .allSatisfy(co -> {
+                    assertThat(co.getId()).isEqualTo(contractOfferId2);
+                    assertThat(co.getAsset().getId()).isEqualTo(assetId);
+                });
+    }
+
+    @Test
+    void queryCacheContainingTwoDistinctAssets_shouldReturnBothContractOffers() {
+        String contractOfferId1 = UUID.randomUUID().toString();
+        String contractOfferId2 = UUID.randomUUID().toString();
+        String assetId1 = UUID.randomUUID().toString();
+        String assetId2 = UUID.randomUUID().toString();
+        ContractOffer contractOffer1 = createContractOffer(contractOfferId1, createAsset(assetId1));
+        ContractOffer contractOffer2 = createContractOffer(contractOfferId2, createAsset(assetId2));
+
+        store.save(contractOffer1);
+        store.save(contractOffer2);
+
+        Collection<ContractOffer> result = store.query(Collections.emptyList());
+
+        assertThat(result)
+                .hasSize(2)
+                .anySatisfy(co -> assertThat(co.getAsset().getId()).isEqualTo(assetId1))
+                .anySatisfy(co -> assertThat(co.getAsset().getId()).isEqualTo(assetId2));
+    }
+
+    private static Asset createAsset(String id) {
+        return Asset.Builder.newInstance()
+                .id(id)
+                .build();
+    }
+
+    private static ContractOffer createContractOffer(String id, Asset asset) {
+        return ContractOffer.Builder.newInstance()
+                .id(id)
+                .asset(asset)
+                .policy(Policy.Builder.newInstance().build())
+                .build();
+    }
+}


### PR DESCRIPTION
Current implementation uses the id of the inserted `ContractOffer` as key in the underlying map of the in-memory store. 

However this id is not contains a random string (see `ContractOfferServiceImpl`), thus leading the store to contain duplicate versions of the same asset and to grow indefinitely.