### PR TITLE
ecdsa: support ecdsa private keys

### DIFF
--- a/extensions/filesystem/vault-fs/src/main/java/org/eclipse/dataspaceconnector/core/security/fs/FsPrivateKeyResolver.java
+++ b/extensions/filesystem/vault-fs/src/main/java/org/eclipse/dataspaceconnector/core/security/fs/FsPrivateKeyResolver.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering
  *
  */
 
@@ -21,16 +22,18 @@ import org.jetbrains.annotations.Nullable;
 import java.security.GeneralSecurityException;
 import java.security.Key;
 import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Resolves an RSA private key from a JKS keystore.
+ * Resolves a RSA or EC private key from a JKS keystore.
  */
 public class FsPrivateKeyResolver implements PrivateKeyResolver {
-    private final Map<String, RSAPrivateKey> privateKeyCache = new HashMap<>();
+    private final Map<String, PrivateKey> privateKeyCache = new HashMap<>();
 
     /**
      * Constructor.
@@ -49,8 +52,8 @@ public class FsPrivateKeyResolver implements PrivateKeyResolver {
                     continue;
                 }
                 Key key = keyStore.getKey(alias, encodedPassword);
-                if ((key instanceof RSAPrivateKey)) {
-                    privateKeyCache.put(alias, (RSAPrivateKey) key);
+                if ((key instanceof RSAPrivateKey || key instanceof ECPrivateKey)) {
+                    privateKeyCache.put(alias, (PrivateKey) key);
                 }
             }
 

--- a/extensions/filesystem/vault-fs/src/main/java/org/eclipse/dataspaceconnector/core/security/fs/FsPrivateKeyResolver.java
+++ b/extensions/filesystem/vault-fs/src/main/java/org/eclipse/dataspaceconnector/core/security/fs/FsPrivateKeyResolver.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Resolves a RSA or EC private key from a JKS keystore.
+ * Resolves an RSA or EC private key from a JKS keystore.
  */
 public class FsPrivateKeyResolver implements PrivateKeyResolver {
     private final Map<String, PrivateKey> privateKeyCache = new HashMap<>();

--- a/extensions/filesystem/vault-fs/src/test/java/org/eclipse/dataspaceconnector/core/security/fs/FsRsaPrivateKeyResolverTest.java
+++ b/extensions/filesystem/vault-fs/src/test/java/org/eclipse/dataspaceconnector/core/security/fs/FsRsaPrivateKeyResolverTest.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering
  *
  */
 
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 import java.security.KeyStore;
+import java.security.PrivateKey;
 import java.security.interfaces.RSAPrivateKey;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -31,6 +33,11 @@ class FsRsaPrivateKeyResolverTest {
 
     @Test
     public void verifyResolution() {
+        assertNotNull(keyResolver.resolvePrivateKey("testkey", PrivateKey.class));
+    }
+
+    @Test
+    public void verifyResolution_Rsa() {
         assertNotNull(keyResolver.resolvePrivateKey("testkey", RSAPrivateKey.class));
     }
 

--- a/extensions/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/impl/Oauth2ServiceImpl.java
+++ b/extensions/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/impl/Oauth2ServiceImpl.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering
  *
  */
 
@@ -19,6 +20,7 @@ import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jose.crypto.factories.DefaultJWSVerifierFactory;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
@@ -192,7 +194,15 @@ public class Oauth2ServiceImpl implements IdentityService {
 
     private String buildJwt() {
         try {
-            JWSHeader.Builder headerBuilder = new JWSHeader.Builder(JWSAlgorithm.RS256);
+            JWSHeader.Builder headerBuilder;
+            if (tokenSigner instanceof ECDSASigner) {
+                //supports ECDSA private key
+                headerBuilder = new JWSHeader.Builder(JWSAlgorithm.ES256);
+            } else {
+                //default: RSA private key
+                headerBuilder = new JWSHeader.Builder(JWSAlgorithm.RS256);
+            }
+
             var claimsSet = new JWTClaimsSet.Builder();
             jwtDecoratorRegistry.getAll().forEach(d -> d.decorate(headerBuilder, claimsSet));
             var jwt = new SignedJWT(headerBuilder.build(), claimsSet.build());

--- a/extensions/iam/oauth2/oauth2-core/src/test/java/org/eclipse/dataspaceconnector/iam/oauth2/core/impl/Oauth2ServiceImplTest.java
+++ b/extensions/iam/oauth2/oauth2-core/src/test/java/org/eclipse/dataspaceconnector/iam/oauth2/core/impl/Oauth2ServiceImplTest.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering
  *
  */
 
@@ -36,7 +37,6 @@ import java.security.interfaces.RSAPublicKey;
 import java.time.Instant;
 import java.util.Date;
 import java.util.UUID;
-import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -52,7 +52,7 @@ class Oauth2ServiceImplTest {
     private static final String PROVIDER_AUDIENCE = "audience-test";
 
     private Oauth2ServiceImpl authService;
-    private Supplier<JWSSigner> jwsSignerSupplier;
+    private JWSSigner jwsSigner;
 
     @Test
     void verifyNoAudienceToken() {
@@ -112,7 +112,7 @@ class Oauth2ServiceImplTest {
                 .generate();
 
         var pk = testKey.toPrivateKey();
-        jwsSignerSupplier = () -> new RSASSASigner(pk);
+        jwsSigner = new RSASSASigner(pk);
         PublicKeyResolver publicKeyResolverMock = mock(PublicKeyResolver.class);
         PrivateKeyResolver privateKeyResolverMock = mock(PrivateKeyResolver.class);
         CertificateResolver certificateResolverMock = mock(CertificateResolver.class);
@@ -128,7 +128,7 @@ class Oauth2ServiceImplTest {
                 .identityProviderKeyResolver(publicKeyResolverMock)
                 .build();
 
-        authService = new Oauth2ServiceImpl(configuration, jwsSignerSupplier, new OkHttpClient.Builder().build(), new JwtDecoratorRegistryImpl(), new TypeManager());
+        authService = new Oauth2ServiceImpl(configuration, jwsSigner, new OkHttpClient.Builder().build(), new JwtDecoratorRegistryImpl(), new TypeManager());
     }
 
     private SignedJWT createJwt(String aud, Date nbf, Date exp) {
@@ -140,7 +140,7 @@ class Oauth2ServiceImplTest {
 
         try {
             SignedJWT jwt = new SignedJWT(header, claimsSet);
-            jwt.sign(jwsSignerSupplier.get());
+            jwt.sign(jwsSigner);
             return jwt;
         } catch (JOSEException e) {
             throw new AssertionError(e);


### PR DESCRIPTION
Issue #382 

Adjustments to support EC private keys. The oauth2-core (Oauth2Extension, Oauth2ServiceImpl) and the filesystem-vault (FsPrivateKeyResolver and -Test) were changed. I hope I didn't miss anything (VaultPrivateKeyResolver parser ?).