### PR TITLE
Re-added the @Requires annotation

### DIFF
--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/system/DefaultServiceExtensionContext.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/system/DefaultServiceExtensionContext.java
@@ -191,16 +191,14 @@ public class DefaultServiceExtensionContext implements ServiceExtensionContext {
         var unsatisfiedRequirements = new ArrayList<String>();
         loadedExtensions.forEach(ext -> {
             var features = getRequiredFeatures(ext.getClass());
-            if (features != null) {
-                features.forEach(feature -> {
-                    var dependencies = dependencyMap.get(feature);
-                    if (dependencies == null) {
-                        unsatisfiedRequirements.add(feature);
-                    } else {
-                        dependencies.forEach(dependency -> sort.addDependency(ext, dependency));
-                    }
-                });
-            }
+            features.forEach(feature -> {
+                var dependencies = dependencyMap.get(feature);
+                if (dependencies == null) {
+                    unsatisfiedRequirements.add(feature);
+                } else {
+                    dependencies.forEach(dependency -> sort.addDependency(ext, dependency));
+                }
+            });
         });
 
         if (!unsatisfiedRequirements.isEmpty()) {

--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/system/DefaultServiceExtensionContext.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/system/DefaultServiceExtensionContext.java
@@ -23,6 +23,7 @@ import org.eclipse.dataspaceconnector.spi.system.ConfigurationExtension;
 import org.eclipse.dataspaceconnector.spi.system.Feature;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.Provides;
+import org.eclipse.dataspaceconnector.spi.system.Requires;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
@@ -37,6 +38,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Base service extension context.
@@ -162,31 +164,22 @@ public class DefaultServiceExtensionContext implements ServiceExtensionContext {
 
     private List<InjectionContainer<ServiceExtension>> sortExtensions(List<ServiceExtension> loadedExtensions) {
         Map<String, List<ServiceExtension>> dependencyMap = new HashMap<>();
-        var allProvided = loadedExtensions.stream().flatMap(se -> getProvidedFeatures(se).stream()).collect(Collectors.toSet());
-
         addDefaultExtensions(loadedExtensions);
 
         // add all provided features to the dependency map
         loadedExtensions.forEach(ext -> getProvidedFeatures(ext).forEach(feature -> dependencyMap.computeIfAbsent(feature, k -> new ArrayList<>()).add(ext)));
-
         var sort = new TopologicalSort<ServiceExtension>();
 
+        // check if all injected fields are satisfied, collect missing ones and throw exception otherwise
         var unsatisfiedInjectionPoints = new ArrayList<InjectionPoint<ServiceExtension>>();
-
-        // check if all required dependencies are satisfied, collect missing ones and throw exception otherwise
-        var injectionPoints = loadedExtensions.stream().flatMap(ext -> {
-            var injectedFields = getRequiredFeatures(ext, allProvided);
-
-            injectedFields.forEach(injectionPoint -> {
-                List<ServiceExtension> dependencies = dependencyMap.get(injectionPoint.getFeatureName());
-                if (dependencies == null) {
-                    unsatisfiedInjectionPoints.add(injectionPoint);
-                } else {
-                    dependencies.forEach(dependency -> sort.addDependency(ext, dependency));
-                }
-            });
-            return injectedFields.stream();
-        }).collect(Collectors.toList());
+        var injectionPoints = loadedExtensions.stream().flatMap(ext -> getInjectedFields(ext).stream().peek(injectionPoint -> {
+            List<ServiceExtension> dependencies = dependencyMap.get(injectionPoint.getFeatureName());
+            if (dependencies == null) {
+                unsatisfiedInjectionPoints.add(injectionPoint);
+            } else {
+                dependencies.forEach(dependency -> sort.addDependency(ext, dependency));
+            }
+        })).collect(Collectors.toList());
 
         if (!unsatisfiedInjectionPoints.isEmpty()) {
             var string = "The following injected fields were not provided:\n";
@@ -194,11 +187,41 @@ public class DefaultServiceExtensionContext implements ServiceExtensionContext {
             throw new EdcInjectionException(string);
         }
 
+        //check that all the @Required features are there
+        var unsatisfiedRequirements = new ArrayList<String>();
+        loadedExtensions.forEach(ext -> {
+            var features = getRequiredFeatures(ext.getClass());
+            if (features != null) {
+                features.forEach(feature -> {
+                    var dependencies = dependencyMap.get(feature);
+                    if (dependencies == null) {
+                        unsatisfiedRequirements.add(feature);
+                    } else {
+                        dependencies.forEach(dependency -> sort.addDependency(ext, dependency));
+                    }
+                });
+            }
+        });
+
+        if (!unsatisfiedRequirements.isEmpty()) {
+            var string = String.format("The following @Require'd features were not provided: [%s]", String.join(", ", unsatisfiedRequirements));
+            throw new EdcException(string);
+        }
+
         sort.sort(loadedExtensions);
 
         // todo: should the list of InjectionContainers be generated directly by the flatmap?
         // convert the sorted list of extensions into an equally sorted list of InjectionContainers
         return loadedExtensions.stream().map(se -> new InjectionContainer<>(se, injectionPoints.stream().filter(ip -> ip.getInstance() == se).collect(Collectors.toSet()))).collect(Collectors.toList());
+    }
+
+    private Set<String> getRequiredFeatures(Class<?> clazz) {
+        var requiresAnnotation = clazz.getAnnotation(Requires.class);
+        if (requiresAnnotation != null) {
+            var features = requiresAnnotation.value();
+            return Stream.of(features).map(this::getFeatureValue).collect(Collectors.toSet());
+        }
+        return Collections.emptySet();
     }
 
     /**
@@ -222,7 +245,7 @@ public class DefaultServiceExtensionContext implements ServiceExtensionContext {
     /**
      * Obtains all features a specific extension provides as strings
      */
-    private Set<InjectionPoint<ServiceExtension>> getRequiredFeatures(ServiceExtension ext, Set<String> allFeatures) {
+    private Set<InjectionPoint<ServiceExtension>> getInjectedFields(ServiceExtension ext) {
         // initialize with legacy list
 
         var injectFields = Arrays.stream(ext.getClass().getDeclaredFields()).filter(f -> f.getAnnotation(Inject.class) != null).map(f -> new FieldInjectionPoint<>(ext, f, getFeatureValue(f.getType())));

--- a/core/base/src/test/java/org/eclipse/dataspaceconnector/core/system/DefaultServiceExtensionContextTest.java
+++ b/core/base/src/test/java/org/eclipse/dataspaceconnector/core/system/DefaultServiceExtensionContextTest.java
@@ -195,7 +195,7 @@ class DefaultServiceExtensionContextTest {
     @Test
     @DisplayName("Mixed requirement features work")
     void loadServiceExtensions_withMixedInjectAndAnnotation() {
-        var providingExtension = new ProvidingExtension();// provides SomeObject
+        var providingExtension = new ProvidingExtension(); // provides SomeObject
         var anotherProvidingExt = new AnotherProvidingExtension(); //provides AnotherObject
         var mixedAnnotation = new MixedAnnotation();
 

--- a/core/base/src/test/java/org/eclipse/dataspaceconnector/core/system/DefaultServiceExtensionContextTest.java
+++ b/core/base/src/test/java/org/eclipse/dataspaceconnector/core/system/DefaultServiceExtensionContextTest.java
@@ -20,6 +20,7 @@ import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.Provides;
+import org.eclipse.dataspaceconnector.spi.system.Requires;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
@@ -166,6 +167,57 @@ class DefaultServiceExtensionContextTest {
 
     }
 
+    @Test
+    @DisplayName("Requires annotation influences ordering")
+    void loadServiceExtensions_withAnnotation() {
+        var depending = new DependingExtension();
+        var providingExtension = new ProvidingExtension();
+        var annotatedExtension = new AnnotatedExtension();
+
+        when(serviceLocatorMock.loadImplementors(eq(ServiceExtension.class), anyBoolean())).thenReturn(mutableListOf(depending, annotatedExtension, providingExtension, coreExtension));
+
+        var services = context.loadServiceExtensions();
+        assertThat(services).extracting(InjectionContainer::getInjectionTarget).containsExactly(coreExtension, providingExtension, depending, annotatedExtension);
+        verify(serviceLocatorMock).loadImplementors(eq(ServiceExtension.class), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("Requires annotation not satisfied")
+    void loadServiceExtensions_withAnnotation_notSatisfied() {
+        var annotatedExtension = new AnnotatedExtension();
+
+        when(serviceLocatorMock.loadImplementors(eq(ServiceExtension.class), anyBoolean())).thenReturn(mutableListOf(annotatedExtension, coreExtension));
+
+        assertThatThrownBy(() -> context.loadServiceExtensions()).isNotInstanceOf(EdcInjectionException.class).isInstanceOf(EdcException.class);
+        verify(serviceLocatorMock).loadImplementors(eq(ServiceExtension.class), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("Mixed requirement features work")
+    void loadServiceExtensions_withMixedInjectAndAnnotation() {
+        var providingExtension = new ProvidingExtension();// provides SomeObject
+        var anotherProvidingExt = new AnotherProvidingExtension(); //provides AnotherObject
+        var mixedAnnotation = new MixedAnnotation();
+
+        when(serviceLocatorMock.loadImplementors(eq(ServiceExtension.class), anyBoolean())).thenReturn(mutableListOf(mixedAnnotation, providingExtension, coreExtension, anotherProvidingExt));
+
+        var services = context.loadServiceExtensions();
+        assertThat(services).extracting(InjectionContainer::getInjectionTarget).containsExactly(coreExtension, providingExtension, anotherProvidingExt, mixedAnnotation);
+        verify(serviceLocatorMock).loadImplementors(eq(ServiceExtension.class), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("Mixed requirement features introducing circular dependency")
+    void loadServiceExtensions_withMixedInjectAndAnnotation_withCircDependency() {
+        var s1 = new TestProvidingExtension3();
+        var s2 = new TestProvidingExtension();
+
+        when(serviceLocatorMock.loadImplementors(eq(ServiceExtension.class), anyBoolean())).thenReturn(mutableListOf(s1, s2, coreExtension));
+
+        assertThatThrownBy(() -> context.loadServiceExtensions()).isInstanceOf(CyclicDependencyException.class);
+        verify(serviceLocatorMock).loadImplementors(eq(ServiceExtension.class), anyBoolean());
+    }
+
     @SafeVarargs
     private <T> List<T> mutableListOf(T... elements) {
         return new ArrayList<>(List.of(elements));
@@ -183,6 +235,10 @@ class DefaultServiceExtensionContextTest {
     private static class ProvidingExtension implements ServiceExtension {
     }
 
+    @Provides(AnotherObject.class)
+    private static class AnotherProvidingExtension implements ServiceExtension {
+    }
+
     @Provides({ SomeObject.class })
     private static class TestProvidingExtension implements ServiceExtension {
         @Inject
@@ -195,6 +251,20 @@ class DefaultServiceExtensionContextTest {
         SomeObject obj;
     }
 
+    @Provides({ AnotherObject.class })
+    @Requires({ SomeObject.class })
+    private static class TestProvidingExtension3 implements ServiceExtension {
+    }
+
+    @Requires(SomeObject.class)
+    private static class AnnotatedExtension implements ServiceExtension {
+    }
+
+    @Requires(SomeObject.class)
+    private static class MixedAnnotation implements ServiceExtension {
+        @Inject
+        private AnotherObject obj;
+    }
 
     private static class SomeObject {
     }

--- a/spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/Requires.java
+++ b/spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/Requires.java
@@ -1,0 +1,21 @@
+package org.eclipse.dataspaceconnector.spi.system;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies which feature a certain class, package or modules provides.
+ * Feature must be namespaced in the form "edc:XXX:YYY:ZZZ".
+ * <p>
+ * If a referenced feature class is <em>not</em> annotated, the dependency injection mechanism will use the feature's fully
+ * qualified class name by default.
+ * <p>
+ * All fields that are marked with {@link Inject} must be @Provided by at least one extension.
+ */
+@Target({ ElementType.TYPE, ElementType.PACKAGE, ElementType.MODULE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Requires {
+    Class<?>[] value();
+}


### PR DESCRIPTION
As an after-task to the recent module loading PR (#475) I brought back the `@Requires` annotation to conform to the original issue (#469) and to enable programmatic/manual dependency resolution.