### PR TITLE
Removed erroneous maven publication from FCC Node Directory Cosmos

### DIFF
--- a/extensions/azure/cosmos/fcc-node-directory-cosmos/build.gradle.kts
+++ b/extensions/azure/cosmos/fcc-node-directory-cosmos/build.gradle.kts
@@ -37,11 +37,3 @@ publishing {
         }
     }
 }
-publishing {
-    publications {
-        create<MavenPublication>("in-memory.asset-resolver") {
-            artifactId = "in-memory.asset-resolver"
-            from(components["java"])
-        }
-    }
-}


### PR DESCRIPTION
Removed a maven publication that probably slipped in after some merge/rebase