### PR TITLE
extensions: fix duplicated artifact name

### DIFF
--- a/extensions/catalog/federated-catalog-spi/build.gradle.kts
+++ b/extensions/catalog/federated-catalog-spi/build.gradle.kts
@@ -22,8 +22,8 @@ dependencies {
 }
 publishing {
     publications {
-        create<MavenPublication>("catalog-spi") {
-            artifactId = "catalog-spi"
+        create<MavenPublication>("federated-catalog-spi") {
+            artifactId = "federated-catalog-spi"
             from(components["java"])
         }
     }


### PR DESCRIPTION
`catalog-spi` was already used