### PR TITLE
data-protocols: evaluate ids.webhook.address at startup and not lazily

### DIFF
--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractAgreementSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractAgreementSender.java
@@ -73,10 +73,6 @@ public class MultipartContractAgreementSender extends IdsMultipartSender<Contrac
 
     @Override
     protected Message buildMessageHeader(ContractAgreementRequest request, DynamicAttributeToken token) throws Exception {
-        if (idsWebhookAddress == null || idsWebhookAddress.isBlank()) {
-            throw new EdcException("No valid value found for attribute ids.webhook.address");
-        }
-
         var id = request.getContractAgreement().getId();
         var idsId = IdsId.Builder.newInstance().type(IdsType.CONTRACT_AGREEMENT).value(id).build();
         var idUriResult = transformerRegistry.transform(idsId, URI.class);

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractOfferSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractOfferSender.java
@@ -72,10 +72,6 @@ public class MultipartContractOfferSender extends IdsMultipartSender<ContractOff
 
     @Override
     protected Message buildMessageHeader(ContractOfferRequest request, DynamicAttributeToken token) {
-        if (idsWebhookAddress == null || idsWebhookAddress.isBlank()) {
-            throw new EdcException("No valid value found for attribute ids.webhook.address");
-        }
-
         if (request.getType() == ContractOfferRequest.Type.INITIAL) {
             var message = new ContractRequestMessageBuilder()
                     ._modelVersion_(IdsProtocol.INFORMATION_MODEL_VERSION)

--- a/extensions/api/control/src/test/java/org/eclipse/dataspaceconnector/api/control/ClientControlCatalogApiControllerTest.java
+++ b/extensions/api/control/src/test/java/org/eclipse/dataspaceconnector/api/control/ClientControlCatalogApiControllerTest.java
@@ -23,6 +23,7 @@ class ClientControlCatalogApiControllerTest extends AbstractClientControlCatalog
             {
                 put("web.http.port", String.valueOf(getPort()));
                 put("edc.ids.id", "urn:connector:" + CONNECTOR_ID);
+                put("ids.webhook.address", "http://localhost:8181");
                 put(EDC_API_CONTROL_AUTH_APIKEY_KEY, API_KEY_HEADER);
                 put(EDC_API_CONTROL_AUTH_APIKEY_VALUE, API_KEY);
             }


### PR DESCRIPTION
The `ids.webhook.address` should be evaluated and verified on the initialization phase, this will avoid unexpected errors on execution.