### PR TITLE
build system: avoid deprecated gradle.kts features to specify main class

### DIFF
--- a/launchers/basic/build.gradle.kts
+++ b/launchers/basic/build.gradle.kts
@@ -36,8 +36,7 @@ dependencies {
 }
 
 application {
-    @Suppress("DEPRECATION")
-    mainClassName = "org.eclipse.dataspaceconnector.core.system.runtime.BaseRuntime"
+    mainClass.set("org.eclipse.dataspaceconnector.core.system.runtime.BaseRuntime")
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {

--- a/launchers/data-loader-cli/build.gradle.kts
+++ b/launchers/data-loader-cli/build.gradle.kts
@@ -45,8 +45,7 @@ dependencies {
 }
 
 application {
-    @Suppress("DEPRECATION")
-    mainClassName = "org.eclipse.dataspaceconnector.dataloader.cli.DataLoaderRuntime"
+    mainClass.set("org.eclipse.dataspaceconnector.dataloader.cli.DataLoaderRuntime")
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {

--- a/launchers/ids-connector/build.gradle.kts
+++ b/launchers/ids-connector/build.gradle.kts
@@ -40,8 +40,7 @@ dependencies {
 }
 
 application {
-    @Suppress("DEPRECATION")
-    mainClassName = "org.eclipse.dataspaceconnector.core.system.runtime.BaseRuntime"
+    mainClass.set("org.eclipse.dataspaceconnector.core.system.runtime.BaseRuntime")
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {

--- a/launchers/registration-service-app/build.gradle.kts
+++ b/launchers/registration-service-app/build.gradle.kts
@@ -33,8 +33,7 @@ dependencies {
 }
 
 application {
-    @Suppress("DEPRECATION")
-    mainClassName = "org.eclipse.dataspaceconnector.did.RegistrationServiceRuntime"
+    mainClass.set("org.eclipse.dataspaceconnector.did.RegistrationServiceRuntime")
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {

--- a/samples/01-basic-connector/build.gradle.kts
+++ b/samples/01-basic-connector/build.gradle.kts
@@ -28,8 +28,7 @@ dependencies {
 }
 
 application {
-    @Suppress("DEPRECATION")
-    mainClassName = "org.eclipse.dataspaceconnector.core.system.runtime.BaseRuntime"
+    mainClass.set("org.eclipse.dataspaceconnector.core.system.runtime.BaseRuntime")
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {

--- a/samples/02-health-endpoint/build.gradle.kts
+++ b/samples/02-health-endpoint/build.gradle.kts
@@ -32,8 +32,7 @@ dependencies {
 }
 
 application {
-    @Suppress("DEPRECATION")
-    mainClassName = "org.eclipse.dataspaceconnector.core.system.runtime.BaseRuntime"
+    mainClass.set("org.eclipse.dataspaceconnector.core.system.runtime.BaseRuntime")
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {

--- a/samples/03-configuration/build.gradle.kts
+++ b/samples/03-configuration/build.gradle.kts
@@ -35,8 +35,7 @@ dependencies {
 }
 
 application {
-    @Suppress("DEPRECATION")
-    mainClassName = "org.eclipse.dataspaceconnector.core.system.runtime.BaseRuntime"
+    mainClass.set("org.eclipse.dataspaceconnector.core.system.runtime.BaseRuntime")
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {

--- a/samples/04-file-transfer/consumer/build.gradle.kts
+++ b/samples/04-file-transfer/consumer/build.gradle.kts
@@ -42,8 +42,7 @@ dependencies {
 }
 
 application {
-    @Suppress("DEPRECATION")
-    mainClassName = "org.eclipse.dataspaceconnector.core.system.runtime.BaseRuntime"
+    mainClass.set("org.eclipse.dataspaceconnector.core.system.runtime.BaseRuntime")
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {

--- a/samples/04-file-transfer/provider/build.gradle.kts
+++ b/samples/04-file-transfer/provider/build.gradle.kts
@@ -39,8 +39,7 @@ dependencies {
 }
 
 application {
-    @Suppress("DEPRECATION")
-    mainClassName = "org.eclipse.dataspaceconnector.core.system.runtime.BaseRuntime"
+    mainClass.set("org.eclipse.dataspaceconnector.core.system.runtime.BaseRuntime")
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {

--- a/samples/04.1-file-transfer-listener/consumer/build.gradle.kts
+++ b/samples/04.1-file-transfer-listener/consumer/build.gradle.kts
@@ -41,8 +41,7 @@ dependencies {
 }
 
 application {
-    @Suppress("DEPRECATION")
-    mainClassName = "org.eclipse.dataspaceconnector.core.system.runtime.BaseRuntime"
+    mainClass.set("org.eclipse.dataspaceconnector.core.system.runtime.BaseRuntime")
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {

--- a/samples/05-file-transfer-cloud/consumer/build.gradle.kts
+++ b/samples/05-file-transfer-cloud/consumer/build.gradle.kts
@@ -48,8 +48,7 @@ dependencies {
 }
 
 application {
-    @Suppress("DEPRECATION")
-    mainClassName = "org.eclipse.dataspaceconnector.core.system.runtime.BaseRuntime"
+    mainClass.set("org.eclipse.dataspaceconnector.core.system.runtime.BaseRuntime")
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {

--- a/samples/05-file-transfer-cloud/provider/build.gradle.kts
+++ b/samples/05-file-transfer-cloud/provider/build.gradle.kts
@@ -43,8 +43,7 @@ dependencies {
 }
 
 application {
-    @Suppress("DEPRECATION")
-    mainClassName = "org.eclipse.dataspaceconnector.core.system.runtime.BaseRuntime"
+    mainClass.set("org.eclipse.dataspaceconnector.core.system.runtime.BaseRuntime")
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {

--- a/samples/other/commandline/consumer/build.gradle.kts
+++ b/samples/other/commandline/consumer/build.gradle.kts
@@ -39,8 +39,7 @@ dependencies {
 
 // workaround for this issue: https://github.com/johnrengelman/shadow/issues/609
 application {
-    @Suppress("DEPRECATION")
-    mainClassName = "org.eclipse.dataspaceconnector.client.Main"
+    mainClass.set("org.eclipse.dataspaceconnector.client.Main")
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {

--- a/samples/other/custom-runtime/build.gradle.kts
+++ b/samples/other/custom-runtime/build.gradle.kts
@@ -35,8 +35,7 @@ dependencies {
 }
 
 application {
-    @Suppress("DEPRECATION")
-    mainClassName = "org.eclipse.dataspaceconnector.demo.runtime.CustomRuntime"
+    mainClass.set("org.eclipse.dataspaceconnector.demo.runtime.CustomRuntime")
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {

--- a/samples/other/file-transfer-s3-to-s3/build.gradle.kts
+++ b/samples/other/file-transfer-s3-to-s3/build.gradle.kts
@@ -47,8 +47,7 @@ dependencies {
 }
 
 application {
-    @Suppress("DEPRECATION")
-    mainClassName = "org.eclipse.dataspaceconnector.core.system.runtime.BaseRuntime"
+    mainClass.set("org.eclipse.dataspaceconnector.core.system.runtime.BaseRuntime")
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {


### PR DESCRIPTION
This is my first and not very significant contribution :)

Here is a warning-free way of specifying the main class: [JavaApplication].(https://docs.gradle.org/current/javadoc/org/gradle/api/plugins/JavaApplication.html)