### PR TITLE
Automatic swagger generation

### DIFF
--- a/.github/workflows/generate_openapi_spec.yaml
+++ b/.github/workflows/generate_openapi_spec.yaml
@@ -1,0 +1,20 @@
+name: Generate OpenApi Spec
+
+on: [ push, pull_request ]
+
+jobs:
+  GenerateOAS:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+
+      - name: Generate YAML spec
+        env:
+          INTEGRATION_TEST: false
+        run: |
+          ./gradlew clean resolve
+          ./gradlew mergeOpenApiFiles

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ More information about the extension concept can be found here [TBW].
 
 More information about shadowJar can be found [here](https://github.com/johnrengelman/shadow).
 
+## Generate the OpenApi specification
+
+Please refer to [this document](./openapi.md).
+
 # Directory structure
 
 ### `spi`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -186,7 +186,6 @@ openApiMerger {
             }
         }
     }
-
 }
 
 val test by tasks.getting(Test::class) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,17 +16,20 @@ plugins {
     `java-library`
     `maven-publish`
     checkstyle
+    id("com.rameshkp.openapi-merger-gradle-plugin") version "1.0.4"
 }
 
 repositories {
     mavenCentral()
 }
 
+
 val jetBrainsAnnotationsVersion: String by project
 val jacksonVersion: String by project
 val javaVersion: String by project
 val jupiterVersion: String by project
 val mockitoVersion: String by project
+val rsApi: String by project
 
 val groupId: String = "org.eclipse.dataspaceconnector"
 var edcVersion: String = "0.0.1-SNAPSHOT"
@@ -49,6 +52,12 @@ subprojects {
     }
 
     tasks.register<DependencyReportTask>("allDependencies") {}
+}
+
+buildscript {
+    dependencies {
+        classpath("io.swagger.core.v3:swagger-gradle-plugin:2.1.12")
+    }
 }
 
 allprojects {
@@ -103,6 +112,32 @@ allprojects {
 
     }
 
+    pluginManager.withPlugin("io.swagger.core.v3.swagger-gradle-plugin") {
+
+        dependencies{
+            // this is used to scan the classpath and generate an openapi yaml file
+            implementation("io.swagger.core.v3:swagger-jaxrs2-jakarta:2.1.12")
+            implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
+        }
+// this is used to scan the classpath and generate an openapi yaml file
+        tasks.withType<io.swagger.v3.plugins.gradle.tasks.ResolveTask>{
+            outputFileName = project.name
+            outputFormat = io.swagger.v3.plugins.gradle.tasks.ResolveTask.Format.YAML
+            prettyPrint = true
+            classpath = java.sourceSets["main"].runtimeClasspath
+            buildClasspath = classpath
+            resourcePackages = setOf("org.eclipse.dataspaceconnector")
+            outputDir = file("${rootProject.projectDir.path}/resources/openapi/yaml")
+        }
+        configurations {
+            all {
+                exclude(group = "com.fasterxml.jackson.jaxrs", module = "jackson-jaxrs-json-provider")
+            }
+        }
+    }
+
+
+
     tasks.withType<Test> {
         useJUnitPlatform()
     }
@@ -127,6 +162,30 @@ allprojects {
             from("${rootProject.projectDir.path}/NOTICE.md")
         }
     }
+}
+
+openApiMerger {
+    val yamlDirectory = file("${rootProject.projectDir.path}/resources/openapi/yaml")
+
+    inputDirectory.set(yamlDirectory)
+    output {
+        directory.set(file("${rootProject.projectDir.path}/resources/openapi/"))
+        fileName.set("openapi")
+        fileExtension.set("yaml")
+    }
+    openApi {
+        openApiVersion.set("3.0.1")
+        info {
+            title.set("EDC REST API")
+            description.set("All files merged by open api merger")
+            version.set("1.0.0-SNAPSHOT")
+            license {
+                name.set("Apache License v2.0")
+                url.set("http://apache.org/v2")
+            }
+        }
+    }
+
 }
 
 val test by tasks.getting(Test::class) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ val javaVersion: String by project
 val jupiterVersion: String by project
 val mockitoVersion: String by project
 val rsApi: String by project
+val swaggerJaxrs2Version: String by project
 
 val groupId: String = "org.eclipse.dataspaceconnector"
 var edcVersion: String = "0.0.1-SNAPSHOT"
@@ -114,13 +115,13 @@ allprojects {
 
     pluginManager.withPlugin("io.swagger.core.v3.swagger-gradle-plugin") {
 
-        dependencies{
+        dependencies {
             // this is used to scan the classpath and generate an openapi yaml file
-            implementation("io.swagger.core.v3:swagger-jaxrs2-jakarta:2.1.12")
+            implementation("io.swagger.core.v3:swagger-jaxrs2-jakarta:${swaggerJaxrs2Version}")
             implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
         }
 // this is used to scan the classpath and generate an openapi yaml file
-        tasks.withType<io.swagger.v3.plugins.gradle.tasks.ResolveTask>{
+        tasks.withType<io.swagger.v3.plugins.gradle.tasks.ResolveTask> {
             outputFileName = project.name
             outputFormat = io.swagger.v3.plugins.gradle.tasks.ResolveTask.Format.YAML
             prettyPrint = true

--- a/extensions/api/control/build.gradle.kts
+++ b/extensions/api/control/build.gradle.kts
@@ -19,6 +19,7 @@ val jerseyVersion: String by project
 
 plugins {
     `java-library`
+    id("io.swagger.core.v3.swagger-gradle-plugin")
 }
 
 dependencies {

--- a/extensions/api/observability/build.gradle.kts
+++ b/extensions/api/observability/build.gradle.kts
@@ -19,6 +19,7 @@ val jerseyVersion: String by project
 
 plugins {
     `java-library`
+    id("io.swagger.core.v3.swagger-gradle-plugin")
 }
 
 dependencies {
@@ -29,8 +30,6 @@ dependencies {
 
     implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
     testImplementation(testFixtures(project(":launchers:junit")))
-
-
 }
 
 publishing {

--- a/extensions/catalog/federated-catalog-cache/build.gradle.kts
+++ b/extensions/catalog/federated-catalog-cache/build.gradle.kts
@@ -14,6 +14,7 @@
 
 plugins {
     `java-library`
+    id("io.swagger.core.v3.swagger-gradle-plugin")
 }
 
 val rsApi: String by project

--- a/extensions/iam/decentralized-identity/identity-did-core/build.gradle.kts
+++ b/extensions/iam/decentralized-identity/identity-did-core/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-library`
+    id("io.swagger.core.v3.swagger-gradle-plugin")
 }
 
 val rsApi: String by project

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,4 @@ mockitoVersion=4.1.0
 org.gradle.parallel=true
 org.gradle.workers.max=32
 nimbusVersion=8.22.1
+swaggerJaxrs2Version=2.1.11

--- a/openapi.md
+++ b/openapi.md
@@ -71,4 +71,11 @@ responsible for serving web content.
 Furthermore, **no** client code is auto-generated, as this will be highly dependent on the frameworks used 
 on the client side. 
 
-A pointer on how to expose the YAML file and the Swagger UI using Jetty can be found [here](https://anirtek.github.io/java/jetty/swagger/openapi/2021/06/12/Hooking-up-OpenAPI-with-Jetty.html)
+A pointer on how to expose the YAML file and the Swagger UI using Jetty can be found [here](https://anirtek.github.io/java/jetty/swagger/openapi/2021/06/12/Hooking-up-OpenAPI-with-Jetty.html).
+
+To just take a quick look at the generated API documentation with Swagger UI, you can run it in a Docker container:
+
+```shell
+docker run -p 80:8080 -e SWAGGER_JSON=/openapi.yaml -v $(pwd)resources/openapi/openapi.yaml:/openapi.yaml swaggerapi/swagger-ui
+```
+

--- a/openapi.md
+++ b/openapi.md
@@ -1,0 +1,74 @@
+# Generating the OpenApi Spec (*.yaml)
+
+It is possible to generate an OpenApi spec in the form of a `*.yaml` file by invoking two simple Gradle
+tasks.
+
+
+## Generate `*.yaml` files
+
+Every module (=subproject) that contains REST endpoints is scanned for Jakarta Annotations which are then
+used to generate a `*.yaml` specification for that particular module. 
+This means that there is one `*.yaml`file _per module_, resulting in several `*.yaml` files.
+
+Those files are named `MODULENAME.yaml`, e.g. `observability.yaml` or `control.yaml`. 
+
+To re-generate those files, simply invoke 
+```shell
+./gradlew clean resolve
+```
+This will generate all `*.yaml` files in the `resources/openapi/yaml` directory.
+
+### Merge the files
+Unfortunately those files are not yet usable, because they need to be **merged together**. For that we need
+another Gradle task:
+
+```shell
+./gradlew mergeOpenApiFiles
+```
+which takes all `*.yaml` files located in `resources/openapi/yaml`, combines them into a single
+file and puts that into `resources/openapi/openapi.yaml`
+
+
+The resulting `openapi.yaml` can then be used to generate client code, expose static web content,
+etc.
+
+> **IMPORTANT: these two Gradle tasks must be executed separately! `./gradlew resolve mergeOpenApiFiles` will NOT work!**
+
+## Gradle Plugins
+
+We use two different Gradle plugins:
+- `"io.swagger.core.v3.swagger-gradle-plugin"`: used to generate a `*.yaml` file per module
+- `"com.rameshkp.openapi-merger-gradle-plugin"`: used to merge all the `*.yaml` files together
+
+So in order for a module to be picked up by the Swagger Gradle plugin, simply add it to the `build.gradle.kts`:
+
+```kotlin
+// in yourModule/build.gradle.kts
+
+val rsApi: String by project
+
+plugins {
+    `java-library`
+    id("io.swagger.core.v3.swagger-gradle-plugin") //<-- add this
+}
+
+dependencies {
+    implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}") //<-- you'll probably already have this
+    // other dependencies
+}
+```
+
+If you developed a REST endpoint, you very likely already have the `jakarta.ws.rs:....` part in your build file.
+However, if you leave it out, the Swagger Gradle Plugin will report an error.
+
+## Note of omission
+
+This feature does **neither** expose the generated files through a REST endpoint, nor does it serve static
+web content with the ever-so-popular Swagger UI.
+The EDC is a framework rather than an application, and in our point of view it is the application that is 
+responsible for serving web content.
+
+Furthermore, **no** client code is auto-generated, as this will be highly dependent on the frameworks used 
+on the client side. 
+
+A pointer on how to expose the YAML file and the Swagger UI using Jetty can be found [here](https://anirtek.github.io/java/jetty/swagger/openapi/2021/06/12/Hooking-up-OpenAPI-with-Jetty.html)

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -1,0 +1,425 @@
+openapi: 3.0.1
+info:
+  title: EDC REST API
+  description: All files merged by open api merger
+  license:
+    name: Apache License v2.0
+    url: http://apache.org/v2
+  version: 1.0.0-SNAPSHOT
+servers:
+- url: /
+paths:
+  /identity-hub/query-commits:
+    post:
+      operationId: queryCommits
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
+  /identity-hub/query-objects:
+    post:
+      operationId: queryObjects
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
+  /identity-hub/collections:
+    post:
+      operationId: write
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
+  /identity-hub/collections-commit:
+    post:
+      operationId: writeCommit
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /control/catalog:
+    get:
+      operationId: getDescription
+      parameters:
+      - name: provider
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /control/transfer:
+    post:
+      operationId: addTransfer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /control/agreement/{id}:
+    get:
+      operationId: getAgreementById
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /control/negotiation/{id}:
+    get:
+      operationId: getNegotiationById
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /control/negotiation:
+    post:
+      operationId: initiateNegotiation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ContractOfferRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /check/health:
+    get:
+      operationId: checkHealth
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /check/liveness:
+    get:
+      operationId: getLiveness
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /check/readiness:
+    get:
+      operationId: getReadiness
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /check/startup:
+    get:
+      operationId: getStartup
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /catalog:
+    post:
+      operationId: getCatalog
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FederatedCatalogCacheQuery'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractOffer'
+components:
+  schemas:
+    Action:
+      type: object
+      properties:
+        type:
+          type: string
+        includedIn:
+          type: string
+        constraint:
+          $ref: '#/components/schemas/Constraint'
+    Asset:
+      type: object
+      properties:
+        properties:
+          type: object
+          additionalProperties:
+            type: object
+    Constraint:
+      required:
+      - edctype
+      type: object
+      properties:
+        edctype:
+          type: string
+      discriminator:
+        propertyName: edctype
+    ContractOffer:
+      type: object
+      properties:
+        id:
+          type: string
+        policy:
+          $ref: '#/components/schemas/Policy'
+        asset:
+          $ref: '#/components/schemas/Asset'
+        provider:
+          type: string
+          format: uri
+        consumer:
+          type: string
+          format: uri
+        offerStart:
+          type: string
+          format: date-time
+        offerEnd:
+          type: string
+          format: date-time
+        contractStart:
+          type: string
+          format: date-time
+        contractEnd:
+          type: string
+          format: date-time
+    ContractOfferRequest:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+          - INITIAL
+          - COUNTER_OFFER
+        protocol:
+          type: string
+        connectorId:
+          type: string
+        connectorAddress:
+          type: string
+        correlationId:
+          type: string
+        contractOffer:
+          $ref: '#/components/schemas/ContractOffer'
+    Criterion:
+      type: object
+      properties:
+        left:
+          type: object
+        op:
+          type: string
+        right:
+          type: object
+    DataAddress:
+      type: object
+      properties:
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+        keyName:
+          type: string
+        type:
+          type: string
+    DataRequest:
+      type: object
+      properties:
+        id:
+          type: string
+        processId:
+          type: string
+        connectorAddress:
+          type: string
+        protocol:
+          type: string
+        connectorId:
+          type: string
+        assetId:
+          type: string
+        contractId:
+          type: string
+        dataDestination:
+          $ref: '#/components/schemas/DataAddress'
+        managedResources:
+          type: boolean
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+        transferType:
+          $ref: '#/components/schemas/TransferType'
+        destinationType:
+          type: string
+        sync:
+          type: boolean
+    Duty:
+      type: object
+      properties:
+        uid:
+          type: string
+        target:
+          type: string
+        action:
+          $ref: '#/components/schemas/Action'
+        assignee:
+          type: string
+        assigner:
+          type: string
+        constraints:
+          type: array
+          items:
+            $ref: '#/components/schemas/Constraint'
+        parentPermission:
+          $ref: '#/components/schemas/Permission'
+        consequence:
+          $ref: '#/components/schemas/Duty'
+    FederatedCatalogCacheQuery:
+      type: object
+      properties:
+        criteria:
+          type: array
+          items:
+            $ref: '#/components/schemas/Criterion'
+    Permission:
+      type: object
+      properties:
+        uid:
+          type: string
+        target:
+          type: string
+        action:
+          $ref: '#/components/schemas/Action'
+        assignee:
+          type: string
+        assigner:
+          type: string
+        constraints:
+          type: array
+          items:
+            $ref: '#/components/schemas/Constraint'
+        duties:
+          type: array
+          items:
+            $ref: '#/components/schemas/Duty'
+    Policy:
+      type: object
+      properties:
+        uid:
+          type: string
+        permissions:
+          type: array
+          items:
+            $ref: '#/components/schemas/Permission'
+        prohibitions:
+          type: array
+          items:
+            $ref: '#/components/schemas/Prohibition'
+        obligations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Duty'
+        extensibleProperties:
+          type: object
+          additionalProperties:
+            type: object
+        inheritsFrom:
+          type: string
+        assigner:
+          type: string
+        assignee:
+          type: string
+        target:
+          type: string
+        '@type':
+          type: string
+          enum:
+          - SET
+          - OFFER
+          - CONTRACT
+    Prohibition:
+      type: object
+      properties:
+        uid:
+          type: string
+        target:
+          type: string
+        action:
+          $ref: '#/components/schemas/Action'
+        assignee:
+          type: string
+        assigner:
+          type: string
+        constraints:
+          type: array
+          items:
+            $ref: '#/components/schemas/Constraint'
+    TransferType:
+      type: object
+      properties:
+        contentType:
+          type: string
+        isFinite:
+          type: boolean

--- a/resources/openapi/yaml/control.yaml
+++ b/resources/openapi/yaml/control.yaml
@@ -1,0 +1,284 @@
+openapi: 3.0.1
+paths:
+  /control/catalog:
+    get:
+      operationId: getDescription
+      parameters:
+      - name: provider
+        in: query
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /control/transfer:
+    post:
+      operationId: addTransfer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /control/agreement/{id}:
+    get:
+      operationId: getAgreementById
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /control/negotiation/{id}:
+    get:
+      operationId: getNegotiationById
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /control/negotiation:
+    post:
+      operationId: initiateNegotiation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ContractOfferRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+components:
+  schemas:
+    DataAddress:
+      type: object
+      properties:
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+        keyName:
+          type: string
+        type:
+          type: string
+    DataRequest:
+      type: object
+      properties:
+        id:
+          type: string
+        processId:
+          type: string
+        connectorAddress:
+          type: string
+        protocol:
+          type: string
+        connectorId:
+          type: string
+        assetId:
+          type: string
+        contractId:
+          type: string
+        dataDestination:
+          $ref: '#/components/schemas/DataAddress'
+        managedResources:
+          type: boolean
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+        transferType:
+          $ref: '#/components/schemas/TransferType'
+        destinationType:
+          type: string
+        sync:
+          type: boolean
+    TransferType:
+      type: object
+      properties:
+        contentType:
+          type: string
+        isFinite:
+          type: boolean
+    Action:
+      type: object
+      properties:
+        type:
+          type: string
+        includedIn:
+          type: string
+        constraint:
+          $ref: '#/components/schemas/Constraint'
+    Asset:
+      type: object
+      properties:
+        properties:
+          type: object
+          additionalProperties:
+            type: object
+    Constraint:
+      required:
+      - edctype
+      type: object
+      properties:
+        edctype:
+          type: string
+      discriminator:
+        propertyName: edctype
+    ContractOffer:
+      type: object
+      properties:
+        id:
+          type: string
+        policy:
+          $ref: '#/components/schemas/Policy'
+        asset:
+          $ref: '#/components/schemas/Asset'
+        provider:
+          type: string
+          format: uri
+        consumer:
+          type: string
+          format: uri
+        offerStart:
+          type: string
+          format: date-time
+        offerEnd:
+          type: string
+          format: date-time
+        contractStart:
+          type: string
+          format: date-time
+        contractEnd:
+          type: string
+          format: date-time
+    ContractOfferRequest:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+          - INITIAL
+          - COUNTER_OFFER
+        protocol:
+          type: string
+        connectorId:
+          type: string
+        connectorAddress:
+          type: string
+        correlationId:
+          type: string
+        contractOffer:
+          $ref: '#/components/schemas/ContractOffer'
+    Duty:
+      type: object
+      properties:
+        uid:
+          type: string
+        target:
+          type: string
+        action:
+          $ref: '#/components/schemas/Action'
+        assignee:
+          type: string
+        assigner:
+          type: string
+        constraints:
+          type: array
+          items:
+            $ref: '#/components/schemas/Constraint'
+        parentPermission:
+          $ref: '#/components/schemas/Permission'
+        consequence:
+          $ref: '#/components/schemas/Duty'
+    Permission:
+      type: object
+      properties:
+        uid:
+          type: string
+        target:
+          type: string
+        action:
+          $ref: '#/components/schemas/Action'
+        assignee:
+          type: string
+        assigner:
+          type: string
+        constraints:
+          type: array
+          items:
+            $ref: '#/components/schemas/Constraint'
+        duties:
+          type: array
+          items:
+            $ref: '#/components/schemas/Duty'
+    Policy:
+      type: object
+      properties:
+        uid:
+          type: string
+        permissions:
+          type: array
+          items:
+            $ref: '#/components/schemas/Permission'
+        prohibitions:
+          type: array
+          items:
+            $ref: '#/components/schemas/Prohibition'
+        obligations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Duty'
+        extensibleProperties:
+          type: object
+          additionalProperties:
+            type: object
+        inheritsFrom:
+          type: string
+        assigner:
+          type: string
+        assignee:
+          type: string
+        target:
+          type: string
+        '@type':
+          type: string
+          enum:
+          - SET
+          - OFFER
+          - CONTRACT
+    Prohibition:
+      type: object
+      properties:
+        uid:
+          type: string
+        target:
+          type: string
+        action:
+          $ref: '#/components/schemas/Action'
+        assignee:
+          type: string
+        assigner:
+          type: string
+        constraints:
+          type: array
+          items:
+            $ref: '#/components/schemas/Constraint'

--- a/resources/openapi/yaml/federated-catalog-cache.yaml
+++ b/resources/openapi/yaml/federated-catalog-cache.yaml
@@ -1,0 +1,183 @@
+openapi: 3.0.1
+paths:
+  /catalog:
+    post:
+      operationId: getCatalog
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FederatedCatalogCacheQuery'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractOffer'
+components:
+  schemas:
+    Action:
+      type: object
+      properties:
+        type:
+          type: string
+        includedIn:
+          type: string
+        constraint:
+          $ref: '#/components/schemas/Constraint'
+    Asset:
+      type: object
+      properties:
+        properties:
+          type: object
+          additionalProperties:
+            type: object
+    Constraint:
+      required:
+      - edctype
+      type: object
+      properties:
+        edctype:
+          type: string
+      discriminator:
+        propertyName: edctype
+    ContractOffer:
+      type: object
+      properties:
+        id:
+          type: string
+        policy:
+          $ref: '#/components/schemas/Policy'
+        asset:
+          $ref: '#/components/schemas/Asset'
+        provider:
+          type: string
+          format: uri
+        consumer:
+          type: string
+          format: uri
+        offerStart:
+          type: string
+          format: date-time
+        offerEnd:
+          type: string
+          format: date-time
+        contractStart:
+          type: string
+          format: date-time
+        contractEnd:
+          type: string
+          format: date-time
+    Duty:
+      type: object
+      properties:
+        uid:
+          type: string
+        target:
+          type: string
+        action:
+          $ref: '#/components/schemas/Action'
+        assignee:
+          type: string
+        assigner:
+          type: string
+        constraints:
+          type: array
+          items:
+            $ref: '#/components/schemas/Constraint'
+        parentPermission:
+          $ref: '#/components/schemas/Permission'
+        consequence:
+          $ref: '#/components/schemas/Duty'
+    Permission:
+      type: object
+      properties:
+        uid:
+          type: string
+        target:
+          type: string
+        action:
+          $ref: '#/components/schemas/Action'
+        assignee:
+          type: string
+        assigner:
+          type: string
+        constraints:
+          type: array
+          items:
+            $ref: '#/components/schemas/Constraint'
+        duties:
+          type: array
+          items:
+            $ref: '#/components/schemas/Duty'
+    Policy:
+      type: object
+      properties:
+        uid:
+          type: string
+        permissions:
+          type: array
+          items:
+            $ref: '#/components/schemas/Permission'
+        prohibitions:
+          type: array
+          items:
+            $ref: '#/components/schemas/Prohibition'
+        obligations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Duty'
+        extensibleProperties:
+          type: object
+          additionalProperties:
+            type: object
+        inheritsFrom:
+          type: string
+        assigner:
+          type: string
+        assignee:
+          type: string
+        target:
+          type: string
+        '@type':
+          type: string
+          enum:
+          - SET
+          - OFFER
+          - CONTRACT
+    Prohibition:
+      type: object
+      properties:
+        uid:
+          type: string
+        target:
+          type: string
+        action:
+          $ref: '#/components/schemas/Action'
+        assignee:
+          type: string
+        assigner:
+          type: string
+        constraints:
+          type: array
+          items:
+            $ref: '#/components/schemas/Constraint'
+    Criterion:
+      type: object
+      properties:
+        left:
+          type: object
+        op:
+          type: string
+        right:
+          type: object
+    FederatedCatalogCacheQuery:
+      type: object
+      properties:
+        criteria:
+          type: array
+          items:
+            $ref: '#/components/schemas/Criterion'

--- a/resources/openapi/yaml/identity-did-core.yaml
+++ b/resources/openapi/yaml/identity-did-core.yaml
@@ -1,0 +1,62 @@
+openapi: 3.0.1
+paths:
+  /identity-hub/query-commits:
+    post:
+      operationId: queryCommits
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
+  /identity-hub/query-objects:
+    post:
+      operationId: queryObjects
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
+  /identity-hub/collections:
+    post:
+      operationId: write
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
+  /identity-hub/collections-commit:
+    post:
+      operationId: writeCommit
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}

--- a/resources/openapi/yaml/observability.yaml
+++ b/resources/openapi/yaml/observability.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.1
+paths:
+  /check/health:
+    get:
+      operationId: checkHealth
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /check/liveness:
+    get:
+      operationId: getLiveness
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /check/readiness:
+    get:
+      operationId: getReadiness
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /check/startup:
+    get:
+      operationId: getStartup
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -129,6 +129,8 @@ include(":spi:transfer-spi")
 include(":spi:contract-spi")
 include(":spi:catalog-spi")
 
+//include(":openapi")
+
 // numbered samples for the onboarding experience
 include(":samples:01-basic-connector")
 include(":samples:02-health-endpoint")


### PR DESCRIPTION
This PR adds two Gradle tasks to automatically scan the code base and generate a `*.yaml` specification: 

```shell
./gradlew clean resolve
./gradlew mergeOpenApiFiles
```

Unfortunately I'm not savvy enough in Gradle and Kotlin to have those two tasks somehow depend on each other, so we need to execute them separately. 
Also updated docs.
