### PR TITLE
contract negotiation: add contract negotiation listener

### DIFF
--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -16,7 +16,6 @@ package org.eclipse.dataspaceconnector.contract.negotiation;
 
 import org.eclipse.dataspaceconnector.contract.common.ContractId;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.ConsumerContractNegotiationManager;
-import org.eclipse.dataspaceconnector.spi.contract.negotiation.ContractNegotiationListener;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.ContractNegotiationObservable;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.NegotiationWaitStrategy;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.response.NegotiationResult;
@@ -42,7 +41,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 
 import static java.lang.String.format;
 import static org.eclipse.dataspaceconnector.contract.common.ContractId.DEFINITION_PART;
@@ -486,15 +484,6 @@ public class ConsumerContractNegotiationManagerImpl extends ContractNegotiationO
                 }
             }
         }
-    }
-    
-    /**
-     * Invokes a given action on all registered {@link ContractNegotiationListener}s.
-     *
-     * @param action the action to invoke.
-     */
-    private void invokeForEach(Consumer<ContractNegotiationListener> action) {
-        getListeners().forEach(action);
     }
 
     /**

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -148,20 +148,11 @@ public class ConsumerContractNegotiationManagerImpl extends ContractNegotiationO
         Result<ContractOffer> result = validationService.validate(token, contractOffer, latestOffer);
         negotiation.addContractOffer(contractOffer); // TODO persist unchecked offer of provider?
         if (result.failed()) {
-            //if (result.isCounterOfferAvailable()) {
-            //    negotiation.addContractOffer(result.getCounterOffer());
-            //    monitor.debug("[Consumer] Contract offer received. A counter offer is available.");
-            //    negotiation.transitionOffering();
-            //    negotiationStore.save(negotiation);
-            //    invokeForEach(l -> l.consumerOffering(negotiation));
-            //} else {
-            // If no counter offer available + validation result invalid, decline negotiation.
             monitor.debug("[Consumer] Contract offer received. Will be rejected.");
             negotiation.setErrorDetail("Contract rejected."); //TODO set error detail
             negotiation.transitionDeclining();
             negotiationStore.save(negotiation);
             invokeForEach(l -> l.declining(negotiation));
-            //}
         } else {
             // Offer has been approved.
             monitor.debug("[Consumer] Contract offer received. Will be approved.");

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -16,6 +16,8 @@ package org.eclipse.dataspaceconnector.contract.negotiation;
 
 import org.eclipse.dataspaceconnector.contract.common.ContractId;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.ConsumerContractNegotiationManager;
+import org.eclipse.dataspaceconnector.spi.contract.negotiation.ContractNegotiationListener;
+import org.eclipse.dataspaceconnector.spi.contract.negotiation.ContractNegotiationObservable;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.NegotiationWaitStrategy;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.response.NegotiationResult;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
@@ -40,6 +42,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 import static java.lang.String.format;
 import static org.eclipse.dataspaceconnector.contract.common.ContractId.DEFINITION_PART;
@@ -59,7 +62,7 @@ import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiati
  * - ConsumerContractNegotiationManager & ProviderContractNegotiationManager: add start and stop methods, builder
  * - method call in CoreTransferExtension
  */
-public class ConsumerContractNegotiationManagerImpl implements ConsumerContractNegotiationManager {
+public class ConsumerContractNegotiationManagerImpl extends ContractNegotiationObservable implements ConsumerContractNegotiationManager {
     private final AtomicBoolean active = new AtomicBoolean();
     private ContractNegotiationStore negotiationStore;
     private ContractValidationService validationService;
@@ -109,6 +112,7 @@ public class ConsumerContractNegotiationManagerImpl implements ConsumerContractN
 
         negotiation.addContractOffer(contractOffer.getContractOffer());
         negotiationStore.save(negotiation);
+        invokeForEach(l -> l.requesting(negotiation));
 
         monitor.debug(String.format("[Consumer] ContractNegotiation initiated. %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
@@ -150,19 +154,24 @@ public class ConsumerContractNegotiationManagerImpl implements ConsumerContractN
             //    negotiation.addContractOffer(result.getCounterOffer());
             //    monitor.debug("[Consumer] Contract offer received. A counter offer is available.");
             //    negotiation.transitionOffering();
+            //    negotiationStore.save(negotiation);
+            //    invokeForEach(l -> l.consumerOffering(negotiation));
             //} else {
             // If no counter offer available + validation result invalid, decline negotiation.
             monitor.debug("[Consumer] Contract offer received. Will be rejected.");
             negotiation.setErrorDetail("Contract rejected."); //TODO set error detail
             negotiation.transitionDeclining();
+            negotiationStore.save(negotiation);
+            invokeForEach(l -> l.declining(negotiation));
             //}
         } else {
             // Offer has been approved.
             monitor.debug("[Consumer] Contract offer received. Will be approved.");
             negotiation.transitionApproving();
+            negotiationStore.save(negotiation);
+            invokeForEach(l -> l.consumerApproving(negotiation));
         }
-
-        negotiationStore.save(negotiation);
+        
         monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
 
@@ -203,6 +212,7 @@ public class ConsumerContractNegotiationManagerImpl implements ConsumerContractN
             negotiation.setErrorDetail("Contract rejected."); //TODO set error detail
             negotiation.transitionDeclining();
             negotiationStore.save(negotiation);
+            invokeForEach(l -> l.declining(negotiation));
             monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
                     negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
             return NegotiationResult.success(negotiation);
@@ -213,6 +223,7 @@ public class ConsumerContractNegotiationManagerImpl implements ConsumerContractN
         monitor.debug("[Consumer] Contract agreement received. Validation successful.");
         negotiation.transitionConfirmed();
         negotiationStore.save(negotiation);
+        invokeForEach(l -> l.confirmed(negotiation));
         monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
 
@@ -238,6 +249,7 @@ public class ConsumerContractNegotiationManagerImpl implements ConsumerContractN
         monitor.debug("[Consumer] Contract rejection received. Abort negotiation process");
         negotiation.transitionDeclined();
         negotiationStore.save(negotiation);
+        invokeForEach(l -> l.declined(negotiation));
         monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
         return NegotiationResult.success(negotiation);
@@ -282,11 +294,13 @@ public class ConsumerContractNegotiationManagerImpl implements ConsumerContractN
                         if (throwable == null) {
                             process.transitionRequested();
                             negotiationStore.save(process);
+                            invokeForEach(l -> l.requested(process));
                             monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
                                     process.getId(), ContractNegotiationStates.from(process.getState())));
                         } else {
                             process.transitionRequesting();
                             negotiationStore.save(process);
+                            invokeForEach(l -> l.requesting(process));
                             String message = format("[Consumer] Failed to send contract offer with id %s. ContractNegotiation %s stays in state %s.",
                                     offer.getId(), process.getId(), ContractNegotiationStates.from(process.getState()));
                             monitor.debug(message, throwable);
@@ -314,11 +328,13 @@ public class ConsumerContractNegotiationManagerImpl implements ConsumerContractN
                         if (throwable == null) {
                             process.transitionOffered();
                             negotiationStore.save(process);
+                            invokeForEach(l -> l.consumerOffered(process));
                             monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
                                     process.getId(), ContractNegotiationStates.from(process.getState())));
                         } else {
                             process.transitionOffering();
                             negotiationStore.save(process);
+                            invokeForEach(l -> l.consumerOffering(process));
                             String message = format("[Consumer] Failed to send contract offer with id %s. ContractNegotiation %s stays in state %s.",
                                     offer.getId(), process.getId(), ContractNegotiationStates.from(process.getState()));
                             monitor.debug(message, throwable);
@@ -376,11 +392,13 @@ public class ConsumerContractNegotiationManagerImpl implements ConsumerContractN
                         if (throwable == null) {
                             process.transitionApproved();
                             negotiationStore.save(process);
+                            invokeForEach(l -> l.consumerApproved(process));
                             monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
                                     process.getId(), ContractNegotiationStates.from(process.getState())));
                         } else {
                             process.transitionApproving();
                             negotiationStore.save(process);
+                            invokeForEach(l -> l.consumerApproving(process));
                             String message = format("[Consumer] Failed to send contract agreement with id %s. ContractNegotiation %s stays in state %s.",
                                     agreement.getId(), process.getId(), ContractNegotiationStates.from(process.getState()));
                             monitor.debug(message, throwable);
@@ -418,11 +436,13 @@ public class ConsumerContractNegotiationManagerImpl implements ConsumerContractN
                         if (throwable == null) {
                             process.transitionDeclined();
                             negotiationStore.save(process);
+                            invokeForEach(l -> l.declined(process));
                             monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
                                     process.getId(), ContractNegotiationStates.from(process.getState())));
                         } else {
                             process.transitionDeclining();
                             negotiationStore.save(process);
+                            invokeForEach(l -> l.declining(process));
                             String message = format("[Consumer] Failed to send contract rejection. ContractNegotiation %s stays in state %s.",
                                     process.getId(), ContractNegotiationStates.from(process.getState()));
                             monitor.debug(message, throwable);
@@ -466,6 +486,15 @@ public class ConsumerContractNegotiationManagerImpl implements ConsumerContractN
                 }
             }
         }
+    }
+    
+    /**
+     * Invokes a given action on all registered {@link ContractNegotiationListener}s.
+     *
+     * @param action the action to invoke.
+     */
+    private void invokeForEach(Consumer<ContractNegotiationListener> action) {
+        getListeners().forEach(action);
     }
 
     /**

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -15,6 +15,8 @@
 package org.eclipse.dataspaceconnector.contract.negotiation;
 
 import org.eclipse.dataspaceconnector.contract.common.ContractId;
+import org.eclipse.dataspaceconnector.spi.contract.negotiation.ContractNegotiationListener;
+import org.eclipse.dataspaceconnector.spi.contract.negotiation.ContractNegotiationObservable;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.NegotiationWaitStrategy;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.ProviderContractNegotiationManager;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.response.NegotiationResult;
@@ -38,6 +40,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 import static java.lang.String.format;
 import static org.eclipse.dataspaceconnector.contract.common.ContractId.DEFINITION_PART;
@@ -50,7 +53,7 @@ import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiati
 /**
  * Implementation of the {@link ProviderContractNegotiationManager}.
  */
-public class ProviderContractNegotiationManagerImpl implements ProviderContractNegotiationManager {
+public class ProviderContractNegotiationManagerImpl extends ContractNegotiationObservable implements ProviderContractNegotiationManager {
 
     private final AtomicBoolean active = new AtomicBoolean();
 
@@ -107,6 +110,7 @@ public class ProviderContractNegotiationManagerImpl implements ProviderContractN
         }
         negotiation.transitionDeclined();
         negotiationStore.save(negotiation);
+        invokeForEach(l -> l.declined(negotiation));
         monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
 
@@ -137,6 +141,8 @@ public class ProviderContractNegotiationManagerImpl implements ProviderContractN
                 .build();
 
         negotiationStore.save(negotiation);
+        invokeForEach(l -> l.requested(negotiation));
+        
         monitor.debug(String.format("[Provider] ContractNegotiation initiated. %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
 
@@ -190,13 +196,16 @@ public class ProviderContractNegotiationManagerImpl implements ProviderContractN
             //    negotiation.addContractOffer(result.getCounterOffer());
             //    monitor.debug("[Provider] Contract offer received. A counter offer is available.");
             //    negotiation.transitionOffering();
+            //    negotiationStore.save(negotiation);
+            //    invokeForEach(l -> l.providerOffering(negotiation));
             //} else {
             monitor.debug("[Provider] Contract offer received. Will be rejected.");
             negotiation.setErrorDetail("Contract rejected."); //TODO set error detail
             negotiation.transitionDeclining();
-            //}
-
             negotiationStore.save(negotiation);
+            invokeForEach(l -> l.declining(negotiation));
+            //}
+            
             monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                     negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
             return NegotiationResult.success(negotiation);
@@ -206,6 +215,7 @@ public class ProviderContractNegotiationManagerImpl implements ProviderContractN
         // negotiation.addContractOffer(result.getValidatedOffer()); TODO
         negotiation.transitionConfirming();
         negotiationStore.save(negotiation);
+        invokeForEach(l -> l.confirming(negotiation));
         monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
 
@@ -232,6 +242,7 @@ public class ProviderContractNegotiationManagerImpl implements ProviderContractN
         monitor.debug("[Provider] Contract offer has been approved by consumer.");
         negotiation.transitionConfirming();
         negotiationStore.save(negotiation);
+        invokeForEach(l -> l.confirming(negotiation));
         monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
         return NegotiationResult.success(negotiation);
@@ -300,11 +311,13 @@ public class ProviderContractNegotiationManagerImpl implements ProviderContractN
                         if (throwable == null) {
                             negotiation.transitionOffered();
                             negotiationStore.save(negotiation);
+                            invokeForEach(l -> l.providerOffered(negotiation));
                             monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                                     negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
                         } else {
                             negotiation.transitionOffering();
                             negotiationStore.save(negotiation);
+                            invokeForEach(l -> l.providerOffering(negotiation));
                             String message = format("[Provider] Failed to send contract offer with id %s. ContractNegotiation %s stays in state %s.",
                                     currentOffer.getId(), negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
                             monitor.debug(message, throwable);
@@ -340,11 +353,13 @@ public class ProviderContractNegotiationManagerImpl implements ProviderContractN
                         if (throwable == null) {
                             negotiation.transitionDeclined();
                             negotiationStore.save(negotiation);
+                            invokeForEach(l -> l.declined(negotiation));
                             monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                                     negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
                         } else {
                             negotiation.transitionDeclining();
                             negotiationStore.save(negotiation);
+                            invokeForEach(l -> l.declining(negotiation));
                             String message = format("[Provider] Failed to send contract rejection. ContractNegotiation %s stays in state %s.",
                                     negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
                             monitor.debug(message, throwable);
@@ -409,11 +424,13 @@ public class ProviderContractNegotiationManagerImpl implements ProviderContractN
                             negotiation.setContractAgreement(agreement);
                             negotiation.transitionConfirmed();
                             negotiationStore.save(negotiation);
+                            invokeForEach(l -> l.confirmed(negotiation));
                             monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                                     negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
                         } else {
                             negotiation.transitionConfirming();
                             negotiationStore.save(negotiation);
+                            invokeForEach(l -> l.confirming(negotiation));
                             String message = format("[Provider] Failed to send contract agreement with id %s. ContractNegotiation %s stays in state %s.",
                                     agreement.getId(), negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
                             monitor.debug(message, throwable);
@@ -422,6 +439,15 @@ public class ProviderContractNegotiationManagerImpl implements ProviderContractN
         }
 
         return confirmingNegotiations.size();
+    }
+    
+    /**
+     * Invokes a given action on all registered {@link ContractNegotiationListener}s.
+     *
+     * @param action the action to invoke.
+     */
+    private void invokeForEach(Consumer<ContractNegotiationListener> action) {
+        getListeners().forEach(action);
     }
 
     /**

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -190,19 +190,11 @@ public class ProviderContractNegotiationManagerImpl extends ContractNegotiationO
         negotiation.addContractOffer(offer); // TODO persist unchecked offer of consumer?
 
         if (result.failed()) {
-            //if (result.isCounterOfferAvailable()) {
-            //    negotiation.addContractOffer(result.getCounterOffer());
-            //    monitor.debug("[Provider] Contract offer received. A counter offer is available.");
-            //    negotiation.transitionOffering();
-            //    negotiationStore.save(negotiation);
-            //    invokeForEach(l -> l.providerOffering(negotiation));
-            //} else {
             monitor.debug("[Provider] Contract offer received. Will be rejected.");
             negotiation.setErrorDetail("Contract rejected."); //TODO set error detail
             negotiation.transitionDeclining();
             negotiationStore.save(negotiation);
             invokeForEach(l -> l.declining(negotiation));
-            //}
             
             monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                     negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.contract.negotiation;
 
 import org.eclipse.dataspaceconnector.contract.common.ContractId;
-import org.eclipse.dataspaceconnector.spi.contract.negotiation.ContractNegotiationListener;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.ContractNegotiationObservable;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.NegotiationWaitStrategy;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.ProviderContractNegotiationManager;
@@ -40,7 +39,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 
 import static java.lang.String.format;
 import static org.eclipse.dataspaceconnector.contract.common.ContractId.DEFINITION_PART;
@@ -439,15 +437,6 @@ public class ProviderContractNegotiationManagerImpl extends ContractNegotiationO
         }
 
         return confirmingNegotiations.size();
-    }
-    
-    /**
-     * Invokes a given action on all registered {@link ContractNegotiationListener}s.
-     *
-     * @param action the action to invoke.
-     */
-    private void invokeForEach(Consumer<ContractNegotiationListener> action) {
-        getListeners().forEach(action);
     }
 
     /**

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -15,7 +15,6 @@ package org.eclipse.dataspaceconnector.contract.negotiation;
 
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
-import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractOfferRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.junit.jupiter.api.Disabled;
@@ -38,10 +37,10 @@ class ContractNegotiationIntegrationTest extends AbstractContractNegotiationInte
         when(validationService.validate(token, offer)).thenReturn(Result.success(offer));
         when(validationService.validate(eq(token), any(ContractAgreement.class),
                 any(ContractOffer.class))).thenReturn(true);
-
-        // Create signaling stores for provider and consumer
-        providerStore = new SignalingInMemoryContractNegotiationStore(countDownLatch, ContractNegotiationStates.CONFIRMED);
-        consumerStore = new SignalingInMemoryContractNegotiationStore(countDownLatch, ContractNegotiationStates.CONFIRMED);
+        
+        // Create and register listeners for provider and consumer
+        providerManager.registerListener(new ConfirmedContractNegotiationListener(countDownLatch));
+        consumerManager.registerListener(new ConfirmedContractNegotiationListener(countDownLatch));
 
         // Start provider and consumer negotiation managers
         providerManager.start(providerStore);
@@ -84,10 +83,10 @@ class ContractNegotiationIntegrationTest extends AbstractContractNegotiationInte
         ContractOffer offer = getContractOffer();
 
         when(validationService.validate(token, offer)).thenReturn(Result.success(offer));
-
-        // Create signaling stores for provider and consumer
-        providerStore = new SignalingInMemoryContractNegotiationStore(countDownLatch, ContractNegotiationStates.DECLINED);
-        consumerStore = new SignalingInMemoryContractNegotiationStore(countDownLatch, ContractNegotiationStates.DECLINED);
+    
+        // Create and register listeners for provider and consumer
+        providerManager.registerListener(new DeclinedContractNegotiationListener(countDownLatch));
+        consumerManager.registerListener(new DeclinedContractNegotiationListener(countDownLatch));
 
         // Start provider and consumer negotiation managers
         providerManager.start(providerStore);
@@ -133,10 +132,10 @@ class ContractNegotiationIntegrationTest extends AbstractContractNegotiationInte
         when(validationService.validate(token, offer)).thenReturn(Result.success(offer));
         when(validationService.validate(eq(token), any(ContractAgreement.class),
                 any(ContractOffer.class))).thenReturn(false);
-
-        // Create signaling stores for provider and consumer
-        providerStore = new SignalingInMemoryContractNegotiationStore(countDownLatch, ContractNegotiationStates.DECLINED);
-        consumerStore = new SignalingInMemoryContractNegotiationStore(countDownLatch, ContractNegotiationStates.DECLINED);
+    
+        // Create and register listeners for provider and consumer
+        providerManager.registerListener(new DeclinedContractNegotiationListener(countDownLatch));
+        consumerManager.registerListener(new DeclinedContractNegotiationListener(countDownLatch));
 
         // Start provider and consumer negotiation managers
         providerManager.start(providerStore);
@@ -186,10 +185,10 @@ class ContractNegotiationIntegrationTest extends AbstractContractNegotiationInte
         when(validationService.validate(token, counterOffer, initialOffer)).thenReturn(Result.success(null));
         when(validationService.validate(eq(token), any(ContractAgreement.class),
                 eq(counterOffer))).thenReturn(true);
-
-        // Create signaling stores for provider and consumer
-        providerStore = new SignalingInMemoryContractNegotiationStore(countDownLatch, ContractNegotiationStates.CONFIRMED);
-        consumerStore = new SignalingInMemoryContractNegotiationStore(countDownLatch, ContractNegotiationStates.CONFIRMED);
+    
+        // Create and register listeners for provider and consumer
+        providerManager.registerListener(new ConfirmedContractNegotiationListener(countDownLatch));
+        consumerManager.registerListener(new ConfirmedContractNegotiationListener(countDownLatch));
 
         // Start provider and consumer negotiation managers
         providerManager.start(providerStore);
@@ -245,10 +244,10 @@ class ContractNegotiationIntegrationTest extends AbstractContractNegotiationInte
 
         when(validationService.validate(token, initialOffer)).thenReturn(Result.success(null));
         when(validationService.validate(token, counterOffer, initialOffer)).thenReturn(Result.success(null));
-
-        // Create signaling stores for provider and consumer
-        providerStore = new SignalingInMemoryContractNegotiationStore(countDownLatch, ContractNegotiationStates.DECLINED);
-        consumerStore = new SignalingInMemoryContractNegotiationStore(countDownLatch, ContractNegotiationStates.DECLINED);
+    
+        // Create and register listeners for provider and consumer
+        providerManager.registerListener(new DeclinedContractNegotiationListener(countDownLatch));
+        consumerManager.registerListener(new DeclinedContractNegotiationListener(countDownLatch));
 
         // Start provider and consumer negotiation managers
         providerManager.start(providerStore);
@@ -315,11 +314,10 @@ class ContractNegotiationIntegrationTest extends AbstractContractNegotiationInte
         // Mock validation of agreement on consumer side
         when(validationService.validate(eq(token), any(ContractAgreement.class),
                 eq(consumerCounterOffer))).thenReturn(true);
-
-
-        // Create signaling stores for provider and consumer
-        providerStore = new SignalingInMemoryContractNegotiationStore(countDownLatch, ContractNegotiationStates.CONFIRMED);
-        consumerStore = new SignalingInMemoryContractNegotiationStore(countDownLatch, ContractNegotiationStates.CONFIRMED);
+        
+        // Create and register listeners for provider and consumer
+        providerManager.registerListener(new ConfirmedContractNegotiationListener(countDownLatch));
+        consumerManager.registerListener(new ConfirmedContractNegotiationListener(countDownLatch));
 
         // Start provider and consumer negotiation managers
         providerManager.start(providerStore);
@@ -387,11 +385,10 @@ class ContractNegotiationIntegrationTest extends AbstractContractNegotiationInte
 
         //Mock validation of second counter offer on provider side => decline
         when(validationService.validate(token, consumerCounterOffer, counterOffer)).thenReturn(Result.success(null));
-
-
-        // Create signaling stores for provider and consumer
-        providerStore = new SignalingInMemoryContractNegotiationStore(countDownLatch, ContractNegotiationStates.DECLINED);
-        consumerStore = new SignalingInMemoryContractNegotiationStore(countDownLatch, ContractNegotiationStates.DECLINED);
+        
+        // Create and register listeners for provider and consumer
+        providerManager.registerListener(new DeclinedContractNegotiationListener(countDownLatch));
+        consumerManager.registerListener(new DeclinedContractNegotiationListener(countDownLatch));
 
         // Start provider and consumer negotiation managers
         providerManager.start(providerStore);

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/AsyncTransferProcessManager.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/AsyncTransferProcessManager.java
@@ -21,7 +21,6 @@ import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistr
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferInitiateResult;
-import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessListener;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessObservable;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferWaitStrategy;
@@ -46,7 +45,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
@@ -493,10 +491,6 @@ public class AsyncTransferProcessManager extends TransferProcessObservable imple
                         transferProcessStore.update(process);
                     }
                 });
-    }
-
-    private void invokeForEach(Consumer<TransferProcessListener> action) {
-        getListeners().forEach(action);
     }
 
     public static class Builder {

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/ContractNegotiationListener.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/ContractNegotiationListener.java
@@ -1,0 +1,146 @@
+/*
+ *  Copyright (c) 2022 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.spi.contract.negotiation;
+
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates;
+
+/**
+ * Interface implemented by listeners registered to observe contract negotiation state changes
+ * via {@link ContractNegotiationObservable#registerListener(ContractNegotiationListener)}.
+ * <p>
+ * Note that the listener is not guaranteed to be called after a state change, in case
+ * the application restarts. That is relevant when using a persistent contract negotiation
+ * store implementation.
+ */
+public interface ContractNegotiationListener {
+    
+    /**
+     * Called after a {@link ContractNegotiation} has moved to state
+     * {@link ContractNegotiationStates#REQUESTING}.
+     *
+     * @param negotiation the contract negotiation whose state has changed.
+     */
+    default void requesting(ContractNegotiation negotiation) {
+    }
+    
+    /**
+     * Called after a {@link ContractNegotiation} has moved to state
+     * {@link ContractNegotiationStates#REQUESTED}.
+     *
+     * @param negotiation the contract negotiation whose state has changed.
+     */
+    default void requested(ContractNegotiation negotiation) {
+    }
+    
+    /**
+     * Called after a {@link ContractNegotiation} has moved to state
+     * {@link ContractNegotiationStates#PROVIDER_OFFERING}.
+     *
+     * @param negotiation the contract negotiation whose state has changed.
+     */
+    default void providerOffering(ContractNegotiation negotiation) {
+    }
+    
+    /**
+     * Called after a {@link ContractNegotiation} has moved to state
+     * {@link ContractNegotiationStates#PROVIDER_OFFERED}.
+     *
+     * @param negotiation the contract negotiation whose state has changed.
+     */
+    default void providerOffered(ContractNegotiation negotiation) {
+    }
+    
+    /**
+     * Called after a {@link ContractNegotiation} has moved to state
+     * {@link ContractNegotiationStates#CONSUMER_OFFERING}.
+     *
+     * @param negotiation the contract negotiation whose state has changed.
+     */
+    default void consumerOffering(ContractNegotiation negotiation) {
+    }
+    
+    /**
+     * Called after a {@link ContractNegotiation} has moved to state
+     * {@link ContractNegotiationStates#CONSUMER_OFFERED}.
+     *
+     * @param negotiation the contract negotiation whose state has changed.
+     */
+    default void consumerOffered(ContractNegotiation negotiation) {
+    }
+    
+    /**
+     * Called after a {@link ContractNegotiation} has moved to state
+     * {@link ContractNegotiationStates#CONSUMER_APPROVING}.
+     *
+     * @param negotiation the contract negotiation whose state has changed.
+     */
+    default void consumerApproving(ContractNegotiation negotiation) {
+    }
+    
+    /**
+     * Called after a {@link ContractNegotiation} has moved to state
+     * {@link ContractNegotiationStates#CONSUMER_APPROVED}.
+     *
+     * @param negotiation the contract negotiation whose state has changed.
+     */
+    default void consumerApproved(ContractNegotiation negotiation) {
+    }
+    
+    /**
+     * Called after a {@link ContractNegotiation} has moved to state
+     * {@link ContractNegotiationStates#DECLINING}.
+     *
+     * @param negotiation the contract negotiation whose state has changed.
+     */
+    default void declining(ContractNegotiation negotiation) {
+    }
+    
+    /**
+     * Called after a {@link ContractNegotiation} has moved to state
+     * {@link ContractNegotiationStates#DECLINED}.
+     *
+     * @param negotiation the contract negotiation whose state has changed.
+     */
+    default void declined(ContractNegotiation negotiation) {
+    }
+    
+    /**
+     * Called after a {@link ContractNegotiation} has moved to state
+     * {@link ContractNegotiationStates#CONFIRMING}.
+     *
+     * @param negotiation the contract negotiation whose state has changed.
+     */
+    default void confirming(ContractNegotiation negotiation) {
+    }
+    
+    /**
+     * Called after a {@link ContractNegotiation} has moved to state
+     * {@link ContractNegotiationStates#CONFIRMED}.
+     *
+     * @param negotiation the contract negotiation whose state has changed.
+     */
+    default void confirmed(ContractNegotiation negotiation) {
+    }
+    
+    /**
+     * Called after a {@link ContractNegotiation} has moved to state
+     * {@link ContractNegotiationStates#ERROR}.
+     *
+     * @param negotiation the contract negotiation whose state has changed.
+     */
+    default void error(ContractNegotiation negotiation) {
+    }
+    
+}

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/ContractNegotiationObservable.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/ContractNegotiationObservable.java
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2022 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.spi.contract.negotiation;
+
+import org.eclipse.dataspaceconnector.spi.Observable;
+import org.eclipse.dataspaceconnector.spi.system.Feature;
+
+@Feature("edc:core:contract:contractnegotiation:observable")
+public abstract class ContractNegotiationObservable extends Observable<ContractNegotiationListener> {
+}

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/Observable.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/Observable.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - extended method implementation
  *
  */
 
@@ -17,6 +18,7 @@ package org.eclipse.dataspaceconnector.spi;
 
 import java.util.Collection;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Consumer;
 
 public abstract class Observable<T> {
 
@@ -39,5 +41,14 @@ public abstract class Observable<T> {
 
     public void unregisterListener(T listener) {
         listeners.remove(listener);
+    }
+    
+    /**
+     * Invokes a given action on all registered listeners.
+     *
+     * @param action the action to invoke.
+     */
+    protected void invokeForEach(Consumer<T> action) {
+        getListeners().forEach(action);
     }
 }


### PR DESCRIPTION
This PR makes the `Provider- and ConsumerContractNegotiationManagers` observable by providing the possibility to register listeners. The listeners will be notified about every state change on a `ContractNegotiation` instance. The PR also refactors the `ContractNegotiationIntegrationTest` to use listeners instead of signaling stores to determine when the desired end state has been reached.

Closes #352 