### PR TITLE
Feature/538 avoid negotiation loop

### DIFF
--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -47,6 +47,7 @@ import static java.lang.String.format;
 import static org.eclipse.dataspaceconnector.contract.common.ContractId.DEFINITION_PART;
 import static org.eclipse.dataspaceconnector.contract.common.ContractId.parseContractId;
 import static org.eclipse.dataspaceconnector.spi.contract.negotiation.response.NegotiationResult.Status.FATAL_ERROR;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONFIRMED;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONSUMER_APPROVING;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONSUMER_OFFERING;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.DECLINING;
@@ -209,7 +210,10 @@ public class ConsumerContractNegotiationManagerImpl extends ContractNegotiationO
         // Agreement has been approved.
         negotiation.setContractAgreement(agreement); // TODO persist unchecked agreement of provider?
         monitor.debug("[Consumer] Contract agreement received. Validation successful.");
-        negotiation.transitionConfirmed();
+        if (negotiation.getState() != CONFIRMED.code()) {
+            // TODO: otherwise will fail. But should do it, since it's already confirmed? A duplicated message received shouldn't be an issue
+            negotiation.transitionConfirmed();
+        }
         negotiationStore.save(negotiation);
         invokeForEach(l -> l.confirmed(negotiation));
         monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -409,6 +409,8 @@ public class ProviderContractNegotiationManagerImpl extends ContractNegotiationO
                     .build();
 
             //TODO protocol-independent response type?
+            negotiation.transitionConfirmingSent();
+            negotiationStore.save(negotiation);
             dispatcherRegistry.send(Object.class, request, () -> null)
                     .whenComplete(onAgreementSent(negotiation.getId(), agreement));
         }

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONFIRMED;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -37,7 +38,7 @@ class ContractNegotiationIntegrationTest extends AbstractContractNegotiationInte
         when(validationService.validate(token, offer)).thenReturn(Result.success(offer));
         when(validationService.validate(eq(token), any(ContractAgreement.class),
                 any(ContractOffer.class))).thenReturn(true);
-        
+
         // Create and register listeners for provider and consumer
         providerManager.registerListener(new ConfirmedContractNegotiationListener(countDownLatch));
         consumerManager.registerListener(new ConfirmedContractNegotiationListener(countDownLatch));
@@ -64,6 +65,8 @@ class ContractNegotiationIntegrationTest extends AbstractContractNegotiationInte
         var providerNegotiation = providerStore.findForCorrelationId(consumerNegotiationId);
 
         // Assert that provider and consumer have the same offers and agreement stored
+        assertThat(consumerNegotiation).isNotNull();
+        assertThat(consumerNegotiation.getState()).isEqualTo(CONFIRMED.code());
         assertThat(consumerNegotiation.getContractOffers()).hasSize(1);
         assertThat(consumerNegotiation.getContractOffers().size()).isEqualTo(providerNegotiation.getContractOffers().size());
         assertThat(consumerNegotiation.getLastContractOffer()).isEqualTo(providerNegotiation.getLastContractOffer());
@@ -185,7 +188,7 @@ class ContractNegotiationIntegrationTest extends AbstractContractNegotiationInte
         when(validationService.validate(token, counterOffer, initialOffer)).thenReturn(Result.success(null));
         when(validationService.validate(eq(token), any(ContractAgreement.class),
                 eq(counterOffer))).thenReturn(true);
-    
+
         // Create and register listeners for provider and consumer
         providerManager.registerListener(new ConfirmedContractNegotiationListener(countDownLatch));
         consumerManager.registerListener(new ConfirmedContractNegotiationListener(countDownLatch));
@@ -314,7 +317,6 @@ class ContractNegotiationIntegrationTest extends AbstractContractNegotiationInte
         // Mock validation of agreement on consumer side
         when(validationService.validate(eq(token), any(ContractAgreement.class),
                 eq(consumerCounterOffer))).thenReturn(true);
-        
         // Create and register listeners for provider and consumer
         providerManager.registerListener(new ConfirmedContractNegotiationListener(countDownLatch));
         consumerManager.registerListener(new ConfirmedContractNegotiationListener(countDownLatch));

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -62,9 +62,6 @@ class ProviderContractNegotiationManagerImplTest {
 
         doAnswer(invocation -> {
             var negotiation = invocation.getArgument(0, ContractNegotiation.class);
-            if (ContractNegotiationStates.UNSAVED.code() == negotiation.getState()) {
-                negotiation.transitionRequested();
-            }
             negotiations.put(negotiation.getId(), negotiation);
             return null;
         }).when(negotiationStore).save(any(ContractNegotiation.class));

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/IdsMultipartSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/IdsMultipartSender.java
@@ -189,8 +189,8 @@ abstract class IdsMultipartSender<M extends RemoteMessage, R> implements IdsMess
 
         httpClient.newCall(httpRequest).enqueue(new FutureCallback<>(future, r -> {
             try (r) {
+                monitor.debug("Response received from connector. Status " + r.code());
                 if (r.isSuccessful()) {
-                    monitor.debug("Response received from connector");
                     try (var body = r.body()) {
                         if (body == null) {
                             future.completeExceptionally(new EdcException("Received an empty body response from connector"));

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStore.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStore.java
@@ -70,13 +70,6 @@ public class CosmosContractNegotiationStore implements ContractNegotiationStore 
 
     @Override
     public void save(ContractNegotiation negotiation) {
-        if (ContractNegotiationStates.UNSAVED.code() == negotiation.getState()) {
-            if (ContractNegotiation.Type.CONSUMER.equals(negotiation.getType())) {
-                negotiation.transitionRequesting();
-            } else {
-                negotiation.transitionRequested();
-            }
-        }
         cosmosDbApi.saveItem(new ContractNegotiationDocument(negotiation, partitionKey));
     }
 

--- a/extensions/in-memory/negotiation-store-memory/src/main/java/org/eclipse/dataspaceconnector/negotiation/store/memory/InMemoryContractNegotiationStore.java
+++ b/extensions/in-memory/negotiation-store-memory/src/main/java/org/eclipse/dataspaceconnector/negotiation/store/memory/InMemoryContractNegotiationStore.java
@@ -68,14 +68,6 @@ public class InMemoryContractNegotiationStore implements ContractNegotiationStor
     @Override
     public void save(ContractNegotiation negotiation) {
         writeLock(() -> {
-            if (ContractNegotiationStates.UNSAVED.code() == negotiation.getState()) {
-                if (ContractNegotiation.Type.CONSUMER.equals(negotiation.getType())) {
-                    negotiation.transitionRequesting();
-                } else {
-                    negotiation.transitionRequested();
-                }
-            }
-
             negotiation.updateStateTimestamp();
             delete(negotiation.getId());
             ContractNegotiation internalCopy = negotiation.copy();

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/negotiation/ContractNegotiation.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/negotiation/ContractNegotiation.java
@@ -31,6 +31,10 @@ import java.util.Objects;
 
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONFIRMED;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.INITIAL;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.REQUESTING;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.UNSAVED;
 
 /**
  * Represents a contract negotiation.
@@ -52,7 +56,7 @@ public class ContractNegotiation {
     private String counterPartyAddress;
     private String protocol;
     private Type type = Type.CONSUMER;
-    private int state;
+    private int state = UNSAVED.code();
     private int stateCount;
     private long stateTimestamp;
     private String errorDetail;
@@ -183,13 +187,20 @@ public class ContractNegotiation {
     }
 
     /**
+     * Transition to state INITIAL.
+     */
+    public void transitionInitial() {
+        transition(INITIAL, REQUESTING, UNSAVED);
+    }
+
+    /**
      * Transition to state REQUESTING (type consumer only).
      */
     public void transitionRequesting() {
         if (Type.PROVIDER == type) {
             throw new IllegalStateException("Provider processes have no REQUESTING state");
         }
-        transition(ContractNegotiationStates.REQUESTING, ContractNegotiationStates.REQUESTING, ContractNegotiationStates.UNSAVED);
+        transition(ContractNegotiationStates.REQUESTING, ContractNegotiationStates.REQUESTING, INITIAL);
     }
 
     /**
@@ -197,7 +208,7 @@ public class ContractNegotiation {
      */
     public void transitionRequested() {
         if (Type.PROVIDER == type) {
-            transition(ContractNegotiationStates.REQUESTED, ContractNegotiationStates.UNSAVED);
+            transition(ContractNegotiationStates.REQUESTED, UNSAVED);
         } else {
             transition(ContractNegotiationStates.REQUESTED, ContractNegotiationStates.REQUESTED, ContractNegotiationStates.REQUESTING);
         }
@@ -284,7 +295,7 @@ public class ContractNegotiation {
      */
     public void transitionConfirmed() {
         if (Type.CONSUMER == type) {
-            transition(ContractNegotiationStates.CONFIRMED, ContractNegotiationStates.CONSUMER_APPROVED, ContractNegotiationStates.REQUESTED, ContractNegotiationStates.CONSUMER_OFFERED);
+            transition(ContractNegotiationStates.CONFIRMED, ContractNegotiationStates.CONSUMER_APPROVED, ContractNegotiationStates.REQUESTED, ContractNegotiationStates.CONSUMER_OFFERED, CONFIRMED);
         } else {
             transition(ContractNegotiationStates.CONFIRMED, ContractNegotiationStates.CONFIRMING);
         }

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/negotiation/ContractNegotiation.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/negotiation/ContractNegotiation.java
@@ -32,7 +32,13 @@ import java.util.Objects;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONFIRMED;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONFIRMING;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONFIRMING_SENT;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONSUMER_APPROVED;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONSUMER_OFFERED;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.INITIAL;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.PROVIDER_OFFERED;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.REQUESTED;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.REQUESTING;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.UNSAVED;
 
@@ -208,9 +214,9 @@ public class ContractNegotiation {
      */
     public void transitionRequested() {
         if (Type.PROVIDER == type) {
-            transition(ContractNegotiationStates.REQUESTED, UNSAVED);
+            transition(REQUESTED, UNSAVED);
         } else {
-            transition(ContractNegotiationStates.REQUESTED, ContractNegotiationStates.REQUESTED, ContractNegotiationStates.REQUESTING);
+            transition(REQUESTED, REQUESTED, ContractNegotiationStates.REQUESTING);
         }
     }
 
@@ -219,9 +225,9 @@ public class ContractNegotiation {
      */
     public void transitionOffering() {
         if (Type.CONSUMER == type) {
-            transition(ContractNegotiationStates.CONSUMER_OFFERING, ContractNegotiationStates.REQUESTED);
+            transition(ContractNegotiationStates.CONSUMER_OFFERING, REQUESTED);
         } else {
-            transition(ContractNegotiationStates.PROVIDER_OFFERING, ContractNegotiationStates.PROVIDER_OFFERING, ContractNegotiationStates.PROVIDER_OFFERED, ContractNegotiationStates.REQUESTED);
+            transition(ContractNegotiationStates.PROVIDER_OFFERING, ContractNegotiationStates.PROVIDER_OFFERING, PROVIDER_OFFERED, REQUESTED);
         }
     }
 
@@ -231,9 +237,9 @@ public class ContractNegotiation {
      */
     public void transitionOffered() {
         if (Type.CONSUMER == type) {
-            transition(ContractNegotiationStates.CONSUMER_OFFERED, ContractNegotiationStates.PROVIDER_OFFERED, ContractNegotiationStates.CONSUMER_OFFERING);
+            transition(CONSUMER_OFFERED, PROVIDER_OFFERED, ContractNegotiationStates.CONSUMER_OFFERING);
         } else {
-            transition(ContractNegotiationStates.PROVIDER_OFFERED, ContractNegotiationStates.PROVIDER_OFFERED, ContractNegotiationStates.PROVIDER_OFFERING);
+            transition(PROVIDER_OFFERED, PROVIDER_OFFERED, ContractNegotiationStates.PROVIDER_OFFERING);
         }
     }
 
@@ -244,7 +250,7 @@ public class ContractNegotiation {
         if (Type.PROVIDER == type) {
             throw new IllegalStateException("Provider processes have no CONSUMER_APPROVING state");
         }
-        transition(ContractNegotiationStates.CONSUMER_APPROVING, ContractNegotiationStates.CONSUMER_APPROVING, ContractNegotiationStates.CONSUMER_OFFERED, ContractNegotiationStates.REQUESTED);
+        transition(ContractNegotiationStates.CONSUMER_APPROVING, ContractNegotiationStates.CONSUMER_APPROVING, CONSUMER_OFFERED, REQUESTED);
     }
 
     /**
@@ -254,7 +260,7 @@ public class ContractNegotiation {
         if (Type.PROVIDER == type) {
             throw new IllegalStateException("Provider processes have no CONSUMER_APPROVED state");
         }
-        transition(ContractNegotiationStates.CONSUMER_APPROVED, ContractNegotiationStates.CONSUMER_APPROVED, ContractNegotiationStates.CONSUMER_APPROVING, ContractNegotiationStates.PROVIDER_OFFERED);
+        transition(CONSUMER_APPROVED, CONSUMER_APPROVED, ContractNegotiationStates.CONSUMER_APPROVING, PROVIDER_OFFERED);
     }
 
     /**
@@ -262,9 +268,9 @@ public class ContractNegotiation {
      */
     public void transitionDeclining() {
         if (Type.CONSUMER == type) {
-            transition(ContractNegotiationStates.DECLINING, ContractNegotiationStates.DECLINING, ContractNegotiationStates.REQUESTED, ContractNegotiationStates.CONSUMER_OFFERED, ContractNegotiationStates.CONSUMER_APPROVED);
+            transition(ContractNegotiationStates.DECLINING, ContractNegotiationStates.DECLINING, REQUESTED, CONSUMER_OFFERED, CONSUMER_APPROVED);
         } else {
-            transition(ContractNegotiationStates.DECLINING, ContractNegotiationStates.DECLINING, ContractNegotiationStates.REQUESTED, ContractNegotiationStates.PROVIDER_OFFERED, ContractNegotiationStates.CONSUMER_APPROVED);
+            transition(ContractNegotiationStates.DECLINING, ContractNegotiationStates.DECLINING, REQUESTED, PROVIDER_OFFERED, CONSUMER_APPROVED);
         }
     }
 
@@ -273,9 +279,9 @@ public class ContractNegotiation {
      */
     public void transitionDeclined() {
         if (Type.CONSUMER == type) {
-            transition(ContractNegotiationStates.DECLINED, ContractNegotiationStates.DECLINING, ContractNegotiationStates.CONSUMER_OFFERED, ContractNegotiationStates.REQUESTED);
+            transition(ContractNegotiationStates.DECLINED, ContractNegotiationStates.DECLINING, CONSUMER_OFFERED, REQUESTED);
         } else {
-            transition(ContractNegotiationStates.DECLINED, ContractNegotiationStates.DECLINING, ContractNegotiationStates.PROVIDER_OFFERED, ContractNegotiationStates.CONFIRMED, ContractNegotiationStates.REQUESTED);
+            transition(ContractNegotiationStates.DECLINED, ContractNegotiationStates.DECLINING, PROVIDER_OFFERED, ContractNegotiationStates.CONFIRMED, REQUESTED);
         }
 
     }
@@ -287,7 +293,11 @@ public class ContractNegotiation {
         if (Type.CONSUMER == type) {
             throw new IllegalStateException("Consumer processes have no CONFIRMING state");
         }
-        transition(ContractNegotiationStates.CONFIRMING, ContractNegotiationStates.CONFIRMING, ContractNegotiationStates.REQUESTED, ContractNegotiationStates.PROVIDER_OFFERED);
+        transition(CONFIRMING, CONFIRMING, REQUESTED, PROVIDER_OFFERED, CONFIRMING_SENT);
+    }
+
+    public void transitionConfirmingSent() {
+        transition(CONFIRMING_SENT, CONFIRMING);
     }
 
     /**
@@ -295,9 +305,9 @@ public class ContractNegotiation {
      */
     public void transitionConfirmed() {
         if (Type.CONSUMER == type) {
-            transition(ContractNegotiationStates.CONFIRMED, ContractNegotiationStates.CONSUMER_APPROVED, ContractNegotiationStates.REQUESTED, ContractNegotiationStates.CONSUMER_OFFERED, CONFIRMED);
+            transition(ContractNegotiationStates.CONFIRMED, CONSUMER_APPROVED, REQUESTED, CONSUMER_OFFERED, CONFIRMED);
         } else {
-            transition(ContractNegotiationStates.CONFIRMED, ContractNegotiationStates.CONFIRMING);
+            transition(ContractNegotiationStates.CONFIRMED, CONFIRMING, CONFIRMING_SENT);
         }
 
     }

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/negotiation/ContractNegotiationStates.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/negotiation/ContractNegotiationStates.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 public enum ContractNegotiationStates {
 
     UNSAVED(0),
+    INITIAL(50),
     REQUESTING(100),
     REQUESTED(200),
     PROVIDER_OFFERING(300),

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/negotiation/ContractNegotiationStates.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/negotiation/ContractNegotiationStates.java
@@ -34,6 +34,7 @@ public enum ContractNegotiationStates {
     DECLINING(900),
     DECLINED(1000),
     CONFIRMING(1100),
+    CONFIRMING_SENT(1150),
     CONFIRMED(1200),
     ERROR(-1);
 


### PR DESCRIPTION
Ref #538 

This fix the referred issue introducing an `INITIAL` state that goes between `UNSAVED` and `REQUESTING`.
However, there are still some problems, probably introduced (or, better, unearthed) by the correct evaluation of the futures.

Before, for every state there was a single intermediate state: 
 * `REQUESTED` -> `REQUESTING`
 * `PROVIDER_OFFERED` -> `PROVIDER_OFFERING`
 * ...

But now we would need another intermediate states, like:
`INITIAL`: the negotiation is initialized, and it's retrievable by the state machine loop for being processed
`REQUESTING`: the negotiation has been retrieved from the store and sent to the provider, it should be not retrieved anymore by the state machine loop, otherwise it would be sent multiple times
`REQUESTED`: the request has been successfully sent to the provider.

To better describe these async transitions there could be 3 states for every "real state":
* `TO_BE_xxxED`
* `xxxING`
* `xxxED`
(replace xxx with, e.g. "REQUEST", "PROVIDER_OFFER", etc...)

This 3-state pattern need to be implemented for every state transition, otherwise there will be multiple and uncontrollable state changes.

I ask thoughts to those who worked on the state machines @jimmarino @paullatzelsperger @juliapampus @ronjaquensel , somebody else?