### PR TITLE
integration-test: fix path

### DIFF
--- a/.github/workflows/integrationtests.yaml
+++ b/.github/workflows/integrationtests.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Object Storage StatusChecker Test
         env:
           RUN_INTEGRATION_TEST: true
-        run: ./gradlew extensions:azure:blobstorage:provision:check
+        run: ./gradlew extensions:azure:blobstorage:blob-provision:check
 
       - name: CosmosDB Transfer Process Store Test
         env:
@@ -86,7 +86,7 @@ jobs:
           RUN_INTEGRATION_TEST: true
           S3_ACCESS_KEY_ID: root
           S3_SECRET_ACCESS_KEY: password
-        run: ./gradlew extensions:aws:s3:provision:check
+        run: ./gradlew extensions:aws:s3:s3-provision:check
 
   Daps-Integration-Test:
     runs-on: ubuntu-latest

--- a/samples/other/file-transfer-s3-to-s3/build.gradle.kts
+++ b/samples/other/file-transfer-s3-to-s3/build.gradle.kts
@@ -24,8 +24,8 @@ plugins {
 dependencies {
     api(project(":core"))
     api(project(":spi"))
-    implementation(project(":extensions:aws:s3:provision"))
-    implementation(project(":extensions:aws:s3:s3-schema"))
+    implementation(project(":extensions:aws:s3:s3-provision"))
+    implementation(project(":extensions:aws:s3:s3-core"))
     implementation(project(":extensions:inline-data-transfer:inline-data-transfer-spi"))
     implementation(project(":extensions:inline-data-transfer:inline-data-transfer-core"))
 


### PR DESCRIPTION
Since blobstorage's `provision` module was renamed to `blob-provision`, integration tests started to fail, this will fix them.