### PR TITLE
Add filtering for properties and making them hierarchical

### DIFF
--- a/common/util/src/main/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctions.java
+++ b/common/util/src/main/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctions.java
@@ -56,9 +56,6 @@ public class ConfigurationFunctions {
         return hierarchical(properties, autoRoot(properties.keySet()));
     }
 
-    private static String autoRoot(Set<String> keySet) {
-        return StringUtils.getCommonPrefix(new ArrayList<>(keySet));
-    }
 
     /**
      * Takes a list of flat properties and converts them into a hierarchical map of entries starting from a given root.
@@ -97,13 +94,11 @@ public class ConfigurationFunctions {
             if (k.contains(".")) {
                 var group = k.split("\\.")[0];
                 var key = k.replace(group + ".", "");
-                if (groupedList.containsKey(group)) {
-                    groupedList.get(group).put(key, v);
-                } else {
-                    var m = new HashMap<String, Object>();
-                    m.put(key, v);
-                    groupedList.put(group, m);
-                }
+
+                var m = groupedList.computeIfAbsent(group, s -> new HashMap<>());
+
+                groupedList.get(group).put(key, v);
+                m.put(key, v);
             } else {
                 var m = groupedList.computeIfAbsent(root, s -> new HashMap<>());
                 m.put(k, v);
@@ -111,5 +106,9 @@ public class ConfigurationFunctions {
         });
 
         return groupedList;
+    }
+
+    private static String autoRoot(Set<String> keySet) {
+        return StringUtils.getCommonPrefix(new ArrayList<>(keySet));
     }
 }

--- a/common/util/src/main/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctions.java
+++ b/common/util/src/main/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctions.java
@@ -14,6 +14,16 @@
 
 package org.eclipse.dataspaceconnector.common.configuration;
 
+import org.eclipse.dataspaceconnector.common.string.StringUtils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 /**
  * Common configuration functions used by extensions.
  */
@@ -31,5 +41,75 @@ public class ConfigurationFunctions {
         String upperKey = key.toUpperCase().replace('.', '_');
         value = System.getenv(upperKey);
         return value != null ? value : defaultValue;
+    }
+
+    /**
+     * Takes a list of flat properties and converts them into a hierarchical map of entries. The root node is determined automatically
+     * by computing the largest common prefix
+     *
+     * @param properties A flat map of properties
+     * @return A "map of maps", each of which containing the sub-properties of one node.
+     * @see ConfigurationFunctions#hierarchical(Map, String)
+     * @see StringUtils#getCommonPrefix(List)
+     */
+    public static Map<String, Map<String, Object>> hierarchical(Map<String, Object> properties) {
+        return hierarchical(properties, autoRoot(properties.keySet()));
+    }
+
+    private static String autoRoot(Set<String> keySet) {
+        return StringUtils.getCommonPrefix(new ArrayList<>(keySet));
+    }
+
+    /**
+     * Takes a list of flat properties and converts them into a hierarchical map of entries starting from a given root.
+     * Ideally, the root should be the common property key prefix. For example lets assume we have those properties:
+     * <pre>
+     * {@code
+     * edc.datasource.default.user=user1
+     * edc.datasource.default.password=user1
+     * edc.datasource.another.user=user2
+     * edc.datasource.another.password=password2
+     * }
+     * </pre>
+     * <p>
+     * This would give the following results:
+     * {@code
+     * hierarchical(props, "edc.datasource") returns "default" -> {"user" -> "user1", "password"->"password1"}
+     * "another" -> {"user" -> "user2", "password"->"password2"}
+     * }
+     * <p>
+     * This could be used to dynamically configure a multiple of something, e.g. datasources.
+     *
+     * @param properties a flat map of properties
+     * @param root       The common prefix that is used as starting point
+     * @return A "map of maps", each of which containing the sub-properties of one node.
+     */
+    public static Map<String, Map<String, Object>> hierarchical(Map<String, Object> properties, String root) {
+        Objects.requireNonNull(properties, "properties");
+        if (root != null) {
+            properties = properties.entrySet().stream()
+                    .filter(e -> e.getKey().startsWith(root))
+                    .collect(Collectors.toMap(s -> s.getKey().replace(root + ".", ""), Map.Entry::getValue));
+
+        }
+        Map<String, Map<String, Object>> groupedList = new HashMap<>();
+        properties.forEach((k, v) -> {
+            if (k.contains(".")) {
+                var group = k.split("\\.")[0];
+                var key = k.replace(group + ".", "");
+                if (groupedList.containsKey(group)) {
+                    groupedList.get(group).put(key, v);
+                } else {
+                    var m = new HashMap<String, Object>();
+                    m.put(key, v);
+                    groupedList.put(group, m);
+                }
+            } else {
+                var m = groupedList.computeIfAbsent(root, s -> new HashMap<>());
+                m.put(k, v);
+            }
+        });
+
+        return groupedList;
     }
 }

--- a/common/util/src/main/java/org/eclipse/dataspaceconnector/common/string/StringUtils.java
+++ b/common/util/src/main/java/org/eclipse/dataspaceconnector/common/string/StringUtils.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.common.string;
 
+import java.util.List;
 import java.util.Objects;
 
 public class StringUtils {
@@ -38,4 +39,32 @@ public class StringUtils {
         return nullable != null ? nullable.toString() : null;
     }
 
+    //algorithm taken from https://www.geeksforgeeks.org/longest-common-prefix-using-sorting/
+    public static String getCommonPrefix(List<String> strs) {
+        int size = strs.size();
+
+        /* if size is 0, return empty string */
+        if (size == 0) {
+            return "";
+        }
+
+        if (size == 1) {
+            return strs.get(0);
+        }
+
+        /* sort the array of strings */
+        strs.sort(String::compareTo);
+
+        /* find the minimum length from first and last string */
+        int end = Math.min(strs.get(0).length(), strs.get(size - 1).length());
+
+        /* find the common prefix between the first and
+           last string */
+        int i = 0;
+        while (i < end && strs.get(0).charAt(i) == strs.get(size - 1).charAt(i)) {
+            i++;
+        }
+
+        return strs.get(0).substring(0, i);
+    }
 }

--- a/common/util/src/test/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctionsTest.java
+++ b/common/util/src/test/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctionsTest.java
@@ -1,0 +1,61 @@
+package org.eclipse.dataspaceconnector.common.configuration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConfigurationFunctionsTest {
+
+    private Map<String, Object> allProperties;
+
+    @BeforeEach
+    void setUp() {
+        allProperties = Map.of(
+                "edc.datasource.default.user", "test-user",
+                "edc.datasource.default.password", "test-pwd",
+                "edc.datasource.default.driverClassName", "org.company.default.Driver",
+                "edc.datasource.another.user", "test-user2",
+                "edc.datasource.another.password", "test-pwd2",
+                "edc.datasource.another.driverClassName", "org.company.another.Driver",
+                "edc.datasource.another.sub.property2", "bar");
+    }
+
+    @Test
+    void hierarchical() {
+        var hierarchy = ConfigurationFunctions.hierarchical(allProperties);
+        assertThat(hierarchy).hasSize(1);
+        assertThat(hierarchy).containsKey("edc");
+    }
+
+    @Test
+    void hierarchical_withRoot() {
+        var hierarchy = ConfigurationFunctions.hierarchical(allProperties, "edc.datasource");
+
+        assertThat(hierarchy).hasSize(2);
+        assertThat(hierarchy.get("default")).containsExactlyInAnyOrderEntriesOf(Map.of(
+                "user", "test-user",
+                "password", "test-pwd",
+                "driverClassName", "org.company.default.Driver"));
+
+        assertThat(hierarchy.get("another")).containsExactlyInAnyOrderEntriesOf(Map.of(
+                "user", "test-user2",
+                "password", "test-pwd2",
+                "sub.property2", "bar",
+                "driverClassName", "org.company.another.Driver"));
+    }
+
+    @Test
+    void hierarchical_withRoot_deeperLevel() {
+
+        var hierarchy = ConfigurationFunctions.hierarchical(allProperties, "edc.datasource.default");
+
+        assertThat(hierarchy).hasSize(1);
+        assertThat(hierarchy.get("edc.datasource.default")).containsExactlyInAnyOrderEntriesOf(Map.of(
+                "user", "test-user",
+                "password", "test-pwd",
+                "driverClassName", "org.company.default.Driver"));
+    }
+}

--- a/common/util/src/test/java/org/eclipse/dataspaceconnector/common/string/StringUtilsTest.java
+++ b/common/util/src/test/java/org/eclipse/dataspaceconnector/common/string/StringUtilsTest.java
@@ -16,6 +16,10 @@ package org.eclipse.dataspaceconnector.common.string;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class StringUtilsTest {
@@ -68,5 +72,14 @@ class StringUtilsTest {
         assertThat(StringUtils.toString(23)).isEqualTo("23");
         assertThat(StringUtils.toString(null)).isEqualTo(null);
         assertThat(StringUtils.toString(new Object())).contains("java.lang.Object@");
+    }
+
+    @Test
+    void commonPrefix() {
+        assertThat(StringUtils.getCommonPrefix(new ArrayList<>(List.of("abc.def", "abc-def", "abd+cef")))).isEqualTo("ab");
+        assertThat(StringUtils.getCommonPrefix(new ArrayList<>(List.of("abc.def", "", "abd+cef")))).isEqualTo("");
+        assertThat(StringUtils.getCommonPrefix(new ArrayList<>(List.of("AB-de", "abc-def", "abd+cef")))).isEqualTo("");
+        assertThat(StringUtils.getCommonPrefix(new ArrayList<>(List.of("abcd")))).isEqualTo("abcd");
+        assertThat(StringUtils.getCommonPrefix(Collections.emptyList())).isEqualTo("");
     }
 }

--- a/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/DefaultServiceExtensionContextTest.java
+++ b/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/DefaultServiceExtensionContextTest.java
@@ -18,6 +18,7 @@ import org.eclipse.dataspaceconnector.boot.util.CyclicDependencyException;
 import org.eclipse.dataspaceconnector.core.BaseExtension;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.system.ConfigurationExtension;
 import org.eclipse.dataspaceconnector.spi.system.EdcInjectionException;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.InjectionContainer;
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -53,6 +55,61 @@ class DefaultServiceExtensionContextTest {
         Monitor monitor = mock(Monitor.class);
         serviceLocatorMock = mock(ServiceLocator.class);
         context = new DefaultServiceExtensionContext(typeManager, monitor, serviceLocatorMock);
+    }
+
+    @Test
+    void getSettingsWithPrefix_onlyFromConfig() {
+        var prefix = "edc.test";
+
+        var configExtMock = mock(ConfigurationExtension.class);
+        when(configExtMock.getSettingsWithPrefix(prefix)).thenReturn(Map.of("edc.test.entry1", "value1", "edc.test.entry2", "value2"));
+        when(serviceLocatorMock.loadImplementors(eq(ConfigurationExtension.class), anyBoolean())).thenReturn(List.of(configExtMock));
+        context.initialize();
+
+        var settings = context.getSettings(prefix);
+
+        assertThat(settings).containsExactlyInAnyOrderEntriesOf(Map.of("edc.test.entry1", "value1", "edc.test.entry2", "value2"));
+    }
+
+    @Test
+    void getSettingsWithPrefix_withOtherProperties() {
+        var prefix = "edc.test";
+
+        var configExtMock = mock(ConfigurationExtension.class);
+        when(configExtMock.getSettingsWithPrefix(prefix)).thenReturn(Map.of("edc.test.entry1", "value1", "edc.test.entry2", "value2"));
+        when(serviceLocatorMock.loadImplementors(eq(ConfigurationExtension.class), anyBoolean())).thenReturn(List.of(configExtMock));
+        context.initialize();
+
+        System.setProperty("edc.test.entry3", "foo");
+
+        var settings = context.getSettings(prefix);
+        try {
+            assertThat(settings).containsExactlyInAnyOrderEntriesOf(Map.of("edc.test.entry1", "value1",
+                    "edc.test.entry2", "value2",
+                    "edc.test.entry3", "foo"));
+        } finally {
+            System.clearProperty("edc.test.entry3");
+        }
+    }
+
+    @Test
+    void getSettingsWithPrefix_withOtherPropertiesOverlapping() {
+        var prefix = "edc.test";
+
+        var configExtMock = mock(ConfigurationExtension.class);
+        when(configExtMock.getSettingsWithPrefix(prefix)).thenReturn(Map.of("edc.test.entry1", "value1", "edc.test.entry2", "value2"));
+        when(serviceLocatorMock.loadImplementors(eq(ConfigurationExtension.class), anyBoolean())).thenReturn(List.of(configExtMock));
+        context.initialize();
+
+        System.setProperty("edc.test.entry2", "foo");
+
+        var settings = context.getSettings(prefix);
+        try {
+            assertThat(settings).containsExactlyInAnyOrderEntriesOf(Map.of("edc.test.entry1", "value1",
+                    "edc.test.entry2", "foo"));
+        } finally {
+            System.clearProperty("edc.test.entry2");
+        }
     }
 
     @Test

--- a/extensions/filesystem/configuration-fs/build.gradle.kts
+++ b/extensions/filesystem/configuration-fs/build.gradle.kts
@@ -20,7 +20,6 @@ plugins {
 dependencies {
     api(project(":spi"))
     implementation(project(":common:util"))
-
 }
 
 publishing {

--- a/extensions/filesystem/configuration-fs/src/main/java/org/eclipse/dataspaceconnector/configuration/fs/FsConfigurationExtension.java
+++ b/extensions/filesystem/configuration-fs/src/main/java/org/eclipse/dataspaceconnector/configuration/fs/FsConfigurationExtension.java
@@ -28,6 +28,7 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static org.eclipse.dataspaceconnector.common.configuration.ConfigurationFunctions.propOrEnv;
@@ -83,5 +84,12 @@ public class FsConfigurationExtension implements ConfigurationExtension {
     @Override
     public @Nullable String getSetting(String key) {
         return propertyCache.get(key);
+    }
+
+    @Override
+    public Map<String, String> getSettingsWithPrefix(String prefix) {
+        return propertyCache.entrySet().stream().filter(entry -> entry.getKey().startsWith(prefix))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
     }
 }

--- a/extensions/filesystem/configuration-fs/src/test/java/org/eclipse/dataspaceconnector/configuration/fs/FsConfigurationExtensionTest.java
+++ b/extensions/filesystem/configuration-fs/src/test/java/org/eclipse/dataspaceconnector/configuration/fs/FsConfigurationExtensionTest.java
@@ -22,7 +22,9 @@ import org.junit.jupiter.api.Test;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
@@ -31,24 +33,68 @@ import static org.mockito.Mockito.when;
 
 class FsConfigurationExtensionTest {
     private FsConfigurationExtension configurationExtension;
+    private ServiceExtensionContext context;
 
     @BeforeEach
     void setUp() throws URISyntaxException {
         Path location = Paths.get(getClass().getClassLoader().getResource("edc-configuration.properties").toURI());
 
         configurationExtension = new FsConfigurationExtension(location);
+
+        context = mock(ServiceExtensionContext.class);
+        when(context.getMonitor()).thenReturn(mock(Monitor.class));
+
+        configurationExtension.initialize(context.getMonitor());
     }
 
     @Test
     void verifyResolution() {
-        ServiceExtensionContext context = mock(ServiceExtensionContext.class);
-        when(context.getMonitor()).thenReturn(mock(Monitor.class));
-
-        configurationExtension.initialize(context.getMonitor());
 
         assertEquals("testvalue1", configurationExtension.getSetting("testkey1"));
         assertNull(configurationExtension.getSetting("notthere"));
         verify(context).getMonitor();
+    }
+
+    @Test
+    void getSettingWithPrefix_groupingLevel1() {
+        var all = configurationExtension.getSettingsWithPrefix("edc.datasource");
+        assertThat(all).hasSize(9);
+
+    }
+
+    @Test
+    void getSettingWithPrefix_groupingLevel2() {
+        var prefix = "edc.datasource.default";
+        var all = configurationExtension.getSettingsWithPrefix(prefix);
+
+
+        assertThat(all).hasSize(3)
+                .containsExactlyInAnyOrderEntriesOf(Map.of(
+                        prefix + ".user", "test-user",
+                        prefix + ".password", "test-pwd",
+                        prefix + ".driverClassName", "org.testcompany.testDriver.Driver"));
+
+        prefix = "edc.datasource.another";
+        all = configurationExtension.getSettingsWithPrefix(prefix);
+        assertThat(all).hasSize(6)
+                .containsExactlyInAnyOrderEntriesOf(Map.of(
+                        prefix + ".user", "test-user-2",
+                        prefix + ".password", "test-pwd-2",
+                        prefix + ".sub.property", "foo",
+                        prefix + ".sub.property2", "bar",
+                        prefix + ".driverClassName", "org.testcompany.another.Driver",
+                        prefix + ".specialProperty", "specialValue"));
+    }
+
+    @Test
+    void getSettingWithPrefix_groupingLevel3() {
+
+        var prefix = "edc.datasource.another.sub";
+        var all = configurationExtension.getSettingsWithPrefix(prefix);
+        assertThat(all).hasSize(2)
+                .containsExactlyInAnyOrderEntriesOf(Map.of(
+                        prefix + ".property", "foo",
+                        prefix + ".property2", "bar"));
     }
 
 }

--- a/extensions/filesystem/configuration-fs/src/test/resources/edc-configuration.properties
+++ b/extensions/filesystem/configuration-fs/src/test/resources/edc-configuration.properties
@@ -11,5 +11,14 @@
 #       Microsoft Corporation - initial API and implementation
 #
 #
-
 testkey1=testvalue1
+# used for tests of the prefixed properties
+edc.datasource.default.user=test-user
+edc.datasource.default.password=test-pwd
+edc.datasource.default.driverClassName=org.testcompany.testDriver.Driver
+edc.datasource.another.user=test-user-2
+edc.datasource.another.password=test-pwd-2
+edc.datasource.another.driverClassName=org.testcompany.another.Driver
+edc.datasource.another.specialProperty=specialValue
+edc.datasource.another.sub.property=foo
+edc.datasource.another.sub.property2=bar

--- a/extensions/iam/daps/src/test/java/org/eclipse/dataspaceconnector/iam/daps/DapsIntegrationTest.java
+++ b/extensions/iam/daps/src/test/java/org/eclipse/dataspaceconnector/iam/daps/DapsIntegrationTest.java
@@ -25,6 +25,7 @@ import org.eclipse.dataspaceconnector.spi.security.CertificateResolver;
 import org.eclipse.dataspaceconnector.spi.security.PrivateKeyResolver;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.system.ConfigurationExtension;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -83,7 +84,18 @@ class DapsIntegrationTest {
     @BeforeEach
     protected void before(EdcExtension extension) {
         KeyStore clientKeystore = readKeystoreFromResources("keystore.p12", "PKCS12", CLIENT_KEYSTORE_PASSWORD);
-        extension.registerSystemExtension(ConfigurationExtension.class, (ConfigurationExtension) configuration::get);
+        extension.registerSystemExtension(ConfigurationExtension.class, new ConfigurationExtension() {
+            @Override
+            public @Nullable String getSetting(String key) {
+                return configuration.get(key);
+            }
+
+            @Override
+            public Map<String, String> getSettingsWithPrefix(String prefix) {
+                throw new UnsupportedOperationException();
+            }
+
+        });
         extension.registerServiceMock(Vault.class, new MockVault());
         extension.registerServiceMock(PrivateKeyResolver.class, new FsPrivateKeyResolver(CLIENT_KEYSTORE_PASSWORD, clientKeystore));
         extension.registerServiceMock(CertificateResolver.class, new FsCertificateResolver(clientKeystore));

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ConfigurationExtension.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ConfigurationExtension.java
@@ -16,6 +16,8 @@ package org.eclipse.dataspaceconnector.spi.system;
 
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Map;
+
 /**
  * Contributes configuration to a runtime. Multiple configuration extensions may be loaded in a runtime.
  */
@@ -27,4 +29,11 @@ public interface ConfigurationExtension extends BootExtension {
     @Nullable
     String getSetting(String key);
 
+    /**
+     * Gets all configuration settings that start with a certain prefix (= filtering).
+     *
+     * @param prefix the prefix
+     * @return A map that contains all config entries that start with the prefix.
+     */
+    Map<String, String> getSettingsWithPrefix(String prefix);
 }

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ServiceExtensionContext.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ServiceExtensionContext.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Context provided to extensions when they are initialized.
@@ -46,6 +47,11 @@ public interface ServiceExtensionContext {
      * Returns the configuration value, or the default value if not found.
      */
     String getSetting(String setting, String defaultValue);
+
+    /**
+     * Gets all properties that start with a particular prefix and returns them as a map.
+     */
+    Map<String, Object> getSettings(String prefix);
 
     /**
      * Returns true if the service type is registered.


### PR DESCRIPTION
This PR extends the configuration feature and adds an option to filter by prefix. There also is a new helper method that will then interpret the resulting properties hierarchically.
Having this feature makes configuring multiple instances of a single thing (e.g. datasources) much easier.

Closes #546 