### PR TITLE
sample: update samples 04.1 and 04.2

### DIFF
--- a/samples/04.1-file-transfer-listener/README.md
+++ b/samples/04.1-file-transfer-listener/README.md
@@ -48,17 +48,22 @@ Let's rebuild and run them both:
 ./gradlew samples:04.1-file-transfer-listener:consumer:build
 java -Dedc.fs.config=samples/04.1-file-transfer-listener/consumer/config.properties -jar samples/04.1-file-transfer-listener/consumer/build/libs/consumer.jar
 # in another terminal window:
-./gradlew samples:04-file-transfer:provider:build
-java -Dedc.fs.config=samples/04-file-transfer/provider/config.properties -jar samples/04-file-transfer/provider/build/libs/provider.jar
+./gradlew samples:04.0-file-transfer:provider:build
+java -Dedc.fs.config=samples/04.0-file-transfer/provider/config.properties -jar samples/04.0-file-transfer/provider/build/libs/provider.jar
 ````
 
-Assuming you didn't change the config files, the consumer will listen on port `9191` and the provider will listen on port `8181`. Open another terminal window (or any REST client of your choice) and execute the following REST request:
+Assuming you didn't change the config files, the consumer will listen on port `9191` and the provider will listen on port `8181`.
+Open another terminal window (or any REST client of your choice) and execute the following REST requests like in the previous sample:
 
 ```bash
-curl -X POST "http://localhost:9191/api/file/test-document?connectorAddress=http://localhost:8181/&destination=/path/on/yourmachine"
+curl -X POST -H "Content-Type: application/json" -d @samples/04.0-file-transfer/contractoffer.json "http://localhost:9191/api/negotiation?connectorAddress=http://localhost:8181/api/ids/multipart"
+curl -X GET -H 'X-Api-Key: password' "http://localhost:9191/api/control/negotiation/{negotiation ID}"
+curl -X POST "http://localhost:9191/api/file/test-document?connectorAddress=http://localhost:8181/api/ids/multipart/&destination=/path/on/yourmachine&contractId={agreement ID}"
 ```
 
-> **Please adjust the `destination` to match your local dev machine!**
+> **Replace `{negotiation ID}` in the second request with the UUID received as the response to the first request!**
+>
+> **Copy the contract agreement's ID from the second response, substitute it for `{agreement ID}` in the last request and adjust the `destination` to match your local dev machine!**
 
 - the last path item, `test-document`, matches the ID of the `Asset` that we created earlier in
   `FileTransferExtension.java`, thus referencing the _data source_

--- a/samples/04.1-file-transfer-listener/consumer/build.gradle.kts
+++ b/samples/04.1-file-transfer-listener/consumer/build.gradle.kts
@@ -35,9 +35,11 @@ dependencies {
     implementation(project(":extensions:filesystem:configuration-fs"))
     implementation(project(":extensions:iam:iam-mock"))
 
+    implementation(project(":extensions:api:control"))
+
     implementation(project(":data-protocols:ids"))
 
-    implementation(project(":samples:04.1-file-transfer-listener:api"))
+    implementation(project(":samples:04.0-file-transfer:api"))
     implementation(project(":samples:04.1-file-transfer-listener:listener"))
 }
 

--- a/samples/04.1-file-transfer-listener/consumer/config.properties
+++ b/samples/04.1-file-transfer-listener/consumer/config.properties
@@ -1,1 +1,3 @@
 web.http.port=9191
+edc.api.control.auth.apikey.value=password
+ids.webhook.address=http://localhost:9191

--- a/samples/04.2-modify-transferprocess/README.md
+++ b/samples/04.2-modify-transferprocess/README.md
@@ -94,7 +94,7 @@ Exposing the `CommandQueue` would also expose its entire API including `peek()` 
 Also, most clients will already have a reference to the `TransferProcessManager`, so little change needs to be done. Instead simply
 do:
 ```java
-tpm.enqueueCommand(new CheckTimeoutCommand(3, TransferProcessStates.IN_PROGRESS, Duration.ofSeconds(10)));
+tpm.enqueueCommand(new CheckTransferProcessTimeoutCommand(3, TransferProcessStates.IN_PROGRESS, Duration.ofSeconds(10)));
 ```
 
 that will eventually get processed by the `TransferProcessManager`, resulting in log output similar to this: 
@@ -119,6 +119,6 @@ Modules:
 In order to run the sample, enter the following commands in a shell:
 
 ```bash
- ./gradlew samples:04.2-modify-transferprocess:provider:build
+./gradlew samples:04.2-modify-transferprocess:consumer:build
 java -Dedc.fs.config=samples/04.2-modify-transferprocess/consumer/config.properties -jar samples/04.2-modify-transferprocess/consumer/build/libs/consumer.jar
 ```


### PR DESCRIPTION
While running the samples 04.1 and 04.2, I noticed some inconsistencies in both READMEs as well as the configuration of the consumer for 04.1. Therefore, the samples could not be run by just copying the commands from the README. This should be fixed with this PR.