### PR TITLE
Fix Sample 5: AWS S3 Provision, closes #563

### DIFF
--- a/samples/05-file-transfer-cloud/consumer/build.gradle.kts
+++ b/samples/05-file-transfer-cloud/consumer/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
     implementation(project(":extensions:in-memory:negotiation-store-memory"))
     implementation(project(":extensions:http"))
 
+    implementation(project(":extensions:aws:s3:s3-provision"))
+
     implementation(project(":extensions:iam:iam-mock"))
     implementation(project(":extensions:azure:vault"))
 


### PR DESCRIPTION
Provisioning of an S3 Bucket, like described in the README.md, did not working because the provisioner was not registered in the consumer.

<sub>Dominik Pinsel <dominik.pinsel@daimler.com>, Daimler TSS GmbH, [legal info/Impressum](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md) </sub>