### PR TITLE
core: health check service cache can be refreshed at boot completion

### DIFF
--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/CoreServicesExtension.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/CoreServicesExtension.java
@@ -83,6 +83,11 @@ public class CoreServicesExtension implements ServiceExtension {
     }
 
     @Override
+    public void start() {
+        healthCheckService.start();
+    }
+
+    @Override
     public void shutdown() {
         healthCheckService.stop();
         ServiceExtension.super.shutdown();

--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/runtime/BaseRuntime.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/runtime/BaseRuntime.java
@@ -67,13 +67,17 @@ public class BaseRuntime {
             var seList = serviceExtensions.stream().map(InjectionContainer::getInjectionTarget).collect(Collectors.toList());
             java.lang.Runtime.getRuntime().addShutdownHook(new Thread(() -> shutdown(seList, monitor)));
             bootExtensions(context, serviceExtensions);
-            var hc = context.getService(HealthCheckService.class);
-            hc.addStartupStatusProvider(this::getStartupStatus);
+
+            var healthCheckService = context.getService(HealthCheckService.class);
+            healthCheckService.addStartupStatusProvider(this::getStartupStatus);
+
+            startupStatus.set(HealthCheckResult.success());
+
+            healthCheckService.refresh();
         } catch (Exception e) {
             onError(e);
-
         }
-        startupStatus.set(HealthCheckResult.success());
+
         monitor.info(format("%s ready", name));
 
     }

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/health/HealthCheckService.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/health/HealthCheckService.java
@@ -25,4 +25,6 @@ public interface HealthCheckService {
     HealthStatus isReady();
 
     HealthStatus getStartupStatus();
+
+    void refresh();
 }


### PR DESCRIPTION
Fix #605 