### PR TITLE
control-api: endpoint for negotiation state

### DIFF
--- a/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/ClientController.java
+++ b/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/ClientController.java
@@ -24,6 +24,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.eclipse.dataspaceconnector.api.control.response.NegotiationStatusResponse;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.ConsumerContractNegotiationManager;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferInitiateResult;
@@ -90,6 +91,18 @@ public class ClientController {
         }
 
         return Response.ok(negotiation).build();
+    }
+    
+    @GET
+    @Path("negotiation/{id}/state")
+    public Response getNegotiationStateById(@PathParam("id") String id) {
+        var negotiation = contractNegotiationStore.find(id);
+    
+        if (negotiation == null) {
+            return Response.status(404).build();
+        }
+        
+        return Response.ok(new NegotiationStatusResponse(negotiation)).build();
     }
 
     @GET

--- a/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/response/NegotiationStatusResponse.java
+++ b/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/response/NegotiationStatusResponse.java
@@ -43,6 +43,7 @@ public class NegotiationStatusResponse {
     
     /**
      * Constructs a NegotiationStatusResponse for a given ContractNegotiation.
+     *
      * @param negotiation the ContractNegotiation.
      */
     public NegotiationStatusResponse(ContractNegotiation negotiation) {

--- a/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/response/NegotiationStatusResponse.java
+++ b/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/response/NegotiationStatusResponse.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2022 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.control.response;
+
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates;
+
+/**
+ * Response for requesting the status of a {@link ContractNegotiation}.
+ */
+public class NegotiationStatusResponse {
+    
+    /**
+     * Status of the {@link ContractNegotiation}.
+     */
+    private ContractNegotiationStates status;
+    
+    /**
+     * Id of the ContractAgreement associated with the ContractNegotiation. Null, if the
+     * negotiation has not yet been completed successfully.
+     */
+    private String contractAgreementId;
+    
+    public ContractNegotiationStates getStatus() {
+        return status;
+    }
+    
+    public String getContractAgreementId() {
+        return contractAgreementId;
+    }
+    
+    /**
+     * Constructs a NegotiationStatusResponse for a given ContractNegotiation.
+     * @param negotiation the ContractNegotiation.
+     */
+    public NegotiationStatusResponse(ContractNegotiation negotiation) {
+        this.status = ContractNegotiationStates.from(negotiation.getState());
+        if (negotiation.getContractAgreement() != null) {
+            this.contractAgreementId = negotiation.getContractAgreement().getId();
+        }
+    }
+    
+}

--- a/samples/04.0-file-transfer/README.md
+++ b/samples/04.0-file-transfer/README.md
@@ -209,82 +209,35 @@ In the response we'll get a UUID that we can use to get the contract agreement n
 After calling the endpoint for initiating a contract negotiation, we get a UUID as the response. This UUID is the ID of
 the ongoing contract negotiation between consumer and provider. The negotiation sequence between provider and consumer
 is executed asynchronously in the background by a state machine. Once both provider and consumer either reach
-the `confirmed` or the  `declined`
-state, the negotiation is finished. We can now use the UUID to check the current status of the negotiation using an
-endpoint on the consumer side. As this end point is not part of this sample's API but of the actual control API, we need
-to authenticate ourselves to use this endpoint. For this, we use the `X-Api-Key` header with the same value that's set
-in our consumer's `config.properties`.
+the `confirmed` or the  `declined` state, the negotiation is finished. We can now use the UUID to check the
+current status of the negotiation using an endpoint on the consumer side. As this endpoint is not part of this
+sample's API but of the actual control API, we need to authenticate ourselves to use this endpoint. For this,
+we use the `X-Api-Key` header with the same value that's set in our consumer's `config.properties`.
 
 ```bash
-curl -X GET -H 'X-Api-Key: password' "http://localhost:9191/api/control/negotiation/{UUID}"
+curl -X GET -H 'X-Api-Key: password' "http://localhost:9191/api/control/negotiation/{UUID}/state"
 ```
 
-This will return a full description of the negotiation (see sample output below). When the state reads `1200` (=
-confirmed), this description will also contain a contract agreement. We can now use this agreement to request the file.
-So we copy and store the agreement's ID for the next step.
+This will return the current status of the negotiation and, if the negotiation has been completed successfully,
+the ID of a contract agreement. We can now use this agreement to request the file. So we copy and store the
+agreement ID for the next step.
 
 Sample output:
 
 ```json
 {
-  "id": <NEGOTIATION_UUID>,
-  "correlationId": null,
-  "counterPartyId": "consumer",
-  "counterPartyAddress": "http://localhost:8181/api/ids/multipart",
-  "protocol": "ids-multipart",
-  "type": "CONSUMER",
-  "state": 1200,
-  "stateCount": 1,
-  "stateTimestamp": 1639131245365,
-  "errorDetail": null,
-  "contractAgreement": {
-    "id": <AGREEMENT_ID>,
-    "providerAgentId": "null",
-    "consumerAgentId": "null",
-    "contractSigningDate": 0,
-    "contractStartDate": 0,
-    "contractEndDate": 0,
-    "asset": {
-      "properties": {
-        "asset:prop:id": "urn:artifact:test-document"
-      }
-    },
-    "policy": {
-      "uid": "be03b061-d9dc-4b85-a2a2-697ea6e7ca60",
-      "permissions": [
-        {
-          "edctype": "dataspaceconnector:permission",
-          "uid": null,
-          "target": "test-document",
-          "action": {
-            "type": "USE",
-            "includedIn": null,
-            "constraint": null
-          },
-          "assignee": null,
-          "assigner": null,
-          "constraints": [],
-          "duties": []
-        }
-      ],
-      "prohibitions": [],
-      "obligations": [],
-      "extensibleProperties": {},
-      "inheritsFrom": null,
-      "assigner": null,
-      "assignee": null,
-      "target": null,
-      "@type": {
-        "@policytype": "set"
-      }
-    }
-  },
-  "contractOffers": [
-    ...
-  ],
-  "lastContractOffer": {
-    ...
-  }
+  "status": "CONFIRMED",
+  "contractAgreementId": "<AGREEMENT_ID>"
+}
+```
+
+If you see an output similar to the following, the negotiation has not yet been completed. In this case,
+just wait for a moment and call the endpoint again.
+
+```json
+{
+    "status": "REQUESTED",
+    "contractAgreementId": null
 }
 ```
 

--- a/samples/04.1-file-transfer-listener/README.md
+++ b/samples/04.1-file-transfer-listener/README.md
@@ -57,7 +57,7 @@ Open another terminal window (or any REST client of your choice) and execute the
 
 ```bash
 curl -X POST -H "Content-Type: application/json" -d @samples/04.0-file-transfer/contractoffer.json "http://localhost:9191/api/negotiation?connectorAddress=http://localhost:8181/api/ids/multipart"
-curl -X GET -H 'X-Api-Key: password' "http://localhost:9191/api/control/negotiation/{negotiation ID}"
+curl -X GET -H 'X-Api-Key: password' "http://localhost:9191/api/control/negotiation/{negotiation ID}/state"
 curl -X POST "http://localhost:9191/api/file/test-document?connectorAddress=http://localhost:8181/api/ids/multipart/&destination=/path/on/yourmachine&contractId={agreement ID}"
 ```
 


### PR DESCRIPTION
This PR adds a new endpoint to the control API, that returns the current status for a negotiation as well as the contract agreement ID, if the negotiation has been confirmed. The READMEs of sample 04.0 and 04.1 have been updated to use the new endpoint for obtaining the agreement ID.

Closes #390 