### PR TITLE
Minor SPI package cleanup

### DIFF
--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/ReflectiveObjectFactory.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/ReflectiveObjectFactory.java
@@ -1,10 +1,10 @@
-package org.eclipse.dataspaceconnector.boot;
+package org.eclipse.dataspaceconnector.boot.system;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;
-import org.eclipse.dataspaceconnector.spi.ObjectFactory;
 import org.eclipse.dataspaceconnector.spi.system.InjectionContainer;
 import org.eclipse.dataspaceconnector.spi.system.InjectionPointScanner;
 import org.eclipse.dataspaceconnector.spi.system.Injector;
+import org.eclipse.dataspaceconnector.spi.system.ObjectFactory;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.jetbrains.annotations.NotNull;
 

--- a/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/ReflectiveObjectFactoryTest.java
+++ b/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/ReflectiveObjectFactoryTest.java
@@ -1,6 +1,5 @@
-package org.eclipse.dataspaceconnector.boot;
+package org.eclipse.dataspaceconnector.boot.system;
 
-import org.eclipse.dataspaceconnector.boot.system.InjectorImpl;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.InjectionPointScanner;

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/loader/LoaderManagerImpl.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/loader/LoaderManagerImpl.java
@@ -3,8 +3,8 @@ package org.eclipse.dataspaceconnector.catalog.cache.loader;
 import org.eclipse.dataspaceconnector.catalog.spi.Loader;
 import org.eclipse.dataspaceconnector.catalog.spi.LoaderManager;
 import org.eclipse.dataspaceconnector.catalog.spi.model.UpdateResponse;
-import org.eclipse.dataspaceconnector.spi.WaitStrategy;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.retry.WaitStrategy;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/loader/LoaderManagerImplTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/loader/LoaderManagerImplTest.java
@@ -2,8 +2,8 @@ package org.eclipse.dataspaceconnector.catalog.cache.loader;
 
 import org.eclipse.dataspaceconnector.catalog.spi.Loader;
 import org.eclipse.dataspaceconnector.catalog.spi.model.UpdateResponse;
-import org.eclipse.dataspaceconnector.spi.WaitStrategy;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.retry.WaitStrategy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/ContractNegotiationObservable.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/ContractNegotiationObservable.java
@@ -13,7 +13,7 @@
  */
 package org.eclipse.dataspaceconnector.spi.contract.negotiation;
 
-import org.eclipse.dataspaceconnector.spi.Observable;
+import org.eclipse.dataspaceconnector.spi.observe.Observable;
 import org.eclipse.dataspaceconnector.spi.system.Feature;
 
 @Feature("edc:core:contract:contractnegotiation:observable")

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/NegotiationWaitStrategy.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/NegotiationWaitStrategy.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.dataspaceconnector.spi.contract.negotiation;
 
-import org.eclipse.dataspaceconnector.spi.WaitStrategy;
+import org.eclipse.dataspaceconnector.spi.retry.WaitStrategy;
 
 /**
  * Implements a wait strategy for the {@link ContractNegotiationManager}.

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/observe/Observable.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/observe/Observable.java
@@ -13,7 +13,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.spi;
+package org.eclipse.dataspaceconnector.spi.observe;
 
 
 import java.util.Collection;
@@ -42,7 +42,7 @@ public abstract class Observable<T> {
     public void unregisterListener(T listener) {
         listeners.remove(listener);
     }
-    
+
     /**
      * Invokes a given action on all registered listeners.
      *

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/retry/WaitStrategy.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/retry/WaitStrategy.java
@@ -1,4 +1,4 @@
-package org.eclipse.dataspaceconnector.spi;
+package org.eclipse.dataspaceconnector.spi.retry;
 
 public interface WaitStrategy {
 

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ObjectFactory.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ObjectFactory.java
@@ -1,6 +1,5 @@
-package org.eclipse.dataspaceconnector.spi;
+package org.eclipse.dataspaceconnector.spi.system;
 
-import org.eclipse.dataspaceconnector.spi.system.Feature;
 import org.jetbrains.annotations.NotNull;
 
 /**

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/ObservableTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/ObservableTest.java
@@ -1,5 +1,6 @@
 package org.eclipse.dataspaceconnector.spi;
 
+import org.eclipse.dataspaceconnector.spi.observe.Observable;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/observe/ObservableTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/observe/ObservableTest.java
@@ -1,6 +1,5 @@
-package org.eclipse.dataspaceconnector.spi;
+package org.eclipse.dataspaceconnector.spi.observe;
 
-import org.eclipse.dataspaceconnector.spi.observe.Observable;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/TransferProcessObservable.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/TransferProcessObservable.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.dataspaceconnector.spi.transfer;
 
-import org.eclipse.dataspaceconnector.spi.Observable;
+import org.eclipse.dataspaceconnector.spi.observe.Observable;
 import org.eclipse.dataspaceconnector.spi.system.Feature;
 
 @Feature("edc:core:transfer:transferprocess-observable")

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/TransferWaitStrategy.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/TransferWaitStrategy.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.dataspaceconnector.spi.transfer;
 
-import org.eclipse.dataspaceconnector.spi.WaitStrategy;
+import org.eclipse.dataspaceconnector.spi.retry.WaitStrategy;
 
 /**
  * Implements a wait strategy for the {@link TransferProcessManager}.


### PR DESCRIPTION
This PR makes the following package adjustments in core-spi:

1. WaitStrategy moves from the top-level SPI package to the retry subpackage.
2. ObjectFactory and ReflectiveObjectFactory move from the top-level SPI package to the system subpackage. This removes package cycles.
3. Observable moves from the top-level SPI package to the observe subpackage.
