### PR TITLE
Feature/616 fetch entities async

### DIFF
--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
@@ -57,7 +57,6 @@ public class ContractServiceExtension implements ServiceExtension {
 
     private static final long DEFAULT_ITERATION_WAIT = 5000; // millis
     private Monitor monitor;
-    private ServiceExtensionContext context;
     private ConsumerContractNegotiationManagerImpl consumerNegotiationManager;
     private ProviderContractNegotiationManagerImpl providerNegotiationManager;
     @Inject
@@ -68,6 +67,8 @@ public class ContractServiceExtension implements ServiceExtension {
     private RemoteMessageDispatcherRegistry dispatcherRegistry;
     @Inject
     private CommandHandlerRegistry commandHandlerRegistry;
+    @Inject
+    private ContractNegotiationStore store;
 
     @Override
     public String name() {
@@ -77,7 +78,6 @@ public class ContractServiceExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         monitor = context.getMonitor();
-        this.context = context;
 
         registerTypes(context);
         registerServices(context);
@@ -85,10 +85,8 @@ public class ContractServiceExtension implements ServiceExtension {
 
     @Override
     public void start() {
-        // Start negotiation managers.
-        var negotiationStore = context.getService(ContractNegotiationStore.class);
-        consumerNegotiationManager.start(negotiationStore);
-        providerNegotiationManager.start(negotiationStore);
+        consumerNegotiationManager.start(store);
+        providerNegotiationManager.start(store);
     }
 
     @Override

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
@@ -59,6 +59,7 @@ public class ContractServiceExtension implements ServiceExtension {
     private Monitor monitor;
     private ConsumerContractNegotiationManagerImpl consumerNegotiationManager;
     private ProviderContractNegotiationManagerImpl providerNegotiationManager;
+
     @Inject
     private AssetIndex assetIndex;
     @Inject

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -55,6 +55,7 @@ import static java.lang.String.format;
 import static org.eclipse.dataspaceconnector.contract.common.ContractId.DEFINITION_PART;
 import static org.eclipse.dataspaceconnector.contract.common.ContractId.parseContractId;
 import static org.eclipse.dataspaceconnector.spi.contract.negotiation.response.NegotiationResult.Status.FATAL_ERROR;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation.Type.CONSUMER;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONFIRMED;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONSUMER_APPROVING;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONSUMER_OFFERING;
@@ -82,8 +83,7 @@ public class ConsumerContractNegotiationManagerImpl implements ConsumerContractN
     private Telemetry telemetry;
     private Monitor monitor;
 
-    public ConsumerContractNegotiationManagerImpl() {
-    }
+    private ConsumerContractNegotiationManagerImpl() { }
 
     public void start(ContractNegotiationStore store) {
         negotiationStore = store;
@@ -120,6 +120,7 @@ public class ConsumerContractNegotiationManagerImpl implements ConsumerContractN
                 .counterPartyId(contractOffer.getConnectorId())
                 .counterPartyAddress(contractOffer.getConnectorAddress())
                 .traceContext(telemetry.getCurrentTraceContext())
+                .type(CONSUMER)
                 .build();
 
         negotiation.addContractOffer(contractOffer.getContractOffer());
@@ -311,14 +312,31 @@ public class ConsumerContractNegotiationManagerImpl implements ConsumerContractN
         negotiationStore.save(negotiation);
 
         sendOffer(offer, negotiation, ContractOfferRequest.Type.INITIAL)
-                .whenComplete(onOfferSent(negotiation.getId(), offer));
+                .whenComplete(onInitialOfferSent(negotiation.getId(), offer.getId()));
+
         return true;
     }
 
+    /**
+     * Processes {@link ContractNegotiation} in state CONSUMER_OFFERING. Tries to send the current
+     * offer to the respective provider. If this succeeds, the ContractNegotiation is transitioned
+     * to state CONSUMER_OFFERED. Else, it is transitioned to CONSUMER_OFFERING for a retry.
+     *
+     * @return true if processed, false elsewhere
+     */
+    @WithSpan
+    private boolean processConsumerOffering(ContractNegotiation negotiation) {
+        var offer = negotiation.getLastContractOffer();
+        sendOffer(offer, negotiation, ContractOfferRequest.Type.COUNTER_OFFER)
+                .whenComplete(onCounterOfferSent(negotiation.getId(), offer.getId()));
+
+        return false;
+    }
+
     @NotNull
-    private BiConsumer<Object, Throwable> onOfferSent(String id, ContractOffer offer) {
+    private BiConsumer<Object, Throwable> onInitialOfferSent(String id, @NotNull String offerId) {
         return (response, throwable) -> {
-            ContractNegotiation negotiation = negotiationStore.find(id);
+            var negotiation = negotiationStore.find(id);
             if (negotiation == null) {
                 monitor.severe(String.format("[Consumer] ContractNegotiation %s not found.", id));
                 return;
@@ -335,40 +353,36 @@ public class ConsumerContractNegotiationManagerImpl implements ConsumerContractN
                 negotiationStore.save(negotiation);
                 observable.invokeForEach(l -> l.requesting(negotiation));
                 String message = format("[Consumer] Failed to send contract offer with id %s. ContractNegotiation %s stays in state %s.",
-                        offer.getId(), negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
+                        offerId, negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
                 monitor.debug(message, throwable);
             }
         };
     }
 
-    /**
-     * Processes {@link ContractNegotiation} in state CONSUMER_OFFERING. Tries to send the current
-     * offer to the respective provider. If this succeeds, the ContractNegotiation is transitioned
-     * to state CONSUMER_OFFERED. Else, it is transitioned to CONSUMER_OFFERING for a retry.
-     *
-     * @return true if processed, false elsewhere
-     */
-    @WithSpan
-    private boolean processConsumerOffering(ContractNegotiation negotiation) {
-        var offer = negotiation.getLastContractOffer();
-        sendOffer(offer, negotiation, ContractOfferRequest.Type.COUNTER_OFFER)
-                .whenComplete((response, throwable) -> {
-                    if (throwable == null) {
-                        negotiation.transitionOffered();
-                        negotiationStore.save(negotiation);
-                        observable.invokeForEach(l -> l.consumerOffered(negotiation));
-                        monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
-                                negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
-                    } else {
-                        negotiation.transitionOffering();
-                        negotiationStore.save(negotiation);
-                        observable.invokeForEach(l -> l.consumerOffering(negotiation));
-                        String message = format("[Consumer] Failed to send contract offer with id %s. ContractNegotiation %s stays in state %s.",
-                                offer.getId(), negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
-                        monitor.debug(message, throwable);
-                    }
-                });
-        return false;
+    @NotNull
+    private BiConsumer<Object, Throwable> onCounterOfferSent(String negotiationId, String offerId) {
+        return (response, throwable) -> {
+            var negotiation = negotiationStore.find(negotiationId);
+            if (negotiation == null) {
+                monitor.severe(String.format("[Consumer] ContractNegotiation %s not found.", negotiationId));
+                return;
+            }
+
+            if (throwable == null) {
+                negotiation.transitionOffered();
+                negotiationStore.save(negotiation);
+                observable.invokeForEach(l -> l.consumerOffered(negotiation));
+                monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
+                        negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
+            } else {
+                negotiation.transitionOffering();
+                negotiationStore.save(negotiation);
+                observable.invokeForEach(l -> l.consumerOffering(negotiation));
+                String message = format("[Consumer] Failed to send contract offer with id %s. ContractNegotiation %s stays in state %s.",
+                        offerId, negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
+                monitor.debug(message, throwable);
+            }
+        };
     }
 
     /**
@@ -412,23 +426,35 @@ public class ConsumerContractNegotiationManagerImpl implements ConsumerContractN
 
         // TODO protocol-independent response type?
         dispatcherRegistry.send(Object.class, request, negotiation::getId)
-                .whenComplete((response, throwable) -> {
-                    if (throwable == null) {
-                        negotiation.transitionApproved();
-                        negotiationStore.save(negotiation);
-                        observable.invokeForEach(l -> l.consumerApproved(negotiation));
-                        monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
-                                negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
-                    } else {
-                        negotiation.transitionApproving();
-                        negotiationStore.save(negotiation);
-                        observable.invokeForEach(l -> l.consumerApproving(negotiation));
-                        String message = format("[Consumer] Failed to send contract agreement with id %s. ContractNegotiation %s stays in state %s.",
-                                agreement.getId(), negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
-                        monitor.debug(message, throwable);
-                    }
-                });
+                .whenComplete(onAgreementSent(negotiation.getId(), agreement.getId()));
+
         return false;
+    }
+
+    @NotNull
+    private BiConsumer<Object, Throwable> onAgreementSent(String negotiationId, String agreementId) {
+        return (response, throwable) -> {
+            var negotiation = negotiationStore.find(negotiationId);
+            if (negotiation == null) {
+                monitor.severe(String.format("[Consumer] ContractNegotiation %s not found.", negotiationId));
+                return;
+            }
+
+            if (throwable == null) {
+                negotiation.transitionApproved();
+                negotiationStore.save(negotiation);
+                observable.invokeForEach(l -> l.consumerApproved(negotiation));
+                monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
+                        negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
+            } else {
+                negotiation.transitionApproving();
+                negotiationStore.save(negotiation);
+                observable.invokeForEach(l -> l.consumerApproving(negotiation));
+                String message = format("[Consumer] Failed to send contract agreement with id %s. ContractNegotiation %s stays in state %s.",
+                        agreementId, negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
+                monitor.debug(message, throwable);
+            }
+        };
     }
 
     /**
@@ -450,23 +476,34 @@ public class ConsumerContractNegotiationManagerImpl implements ConsumerContractN
 
         // TODO protocol-independent response type?
         dispatcherRegistry.send(Object.class, rejection, negotiation::getId)
-                .whenComplete((response, throwable) -> {
-                    if (throwable == null) {
-                        negotiation.transitionDeclined();
-                        negotiationStore.save(negotiation);
-                        observable.invokeForEach(l -> l.declined(negotiation));
-                        monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
-                                negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
-                    } else {
-                        negotiation.transitionDeclining();
-                        negotiationStore.save(negotiation);
-                        observable.invokeForEach(l -> l.declining(negotiation));
-                        String message = format("[Consumer] Failed to send contract rejection. ContractNegotiation %s stays in state %s.",
-                                negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
-                        monitor.debug(message, throwable);
-                    }
-                });
+                .whenComplete(onRejectionSent(negotiation.getId()));
         return false;
+    }
+
+    @NotNull
+    private BiConsumer<Object, Throwable> onRejectionSent(String negotiationId) {
+        return (response, throwable) -> {
+            var negotiation = negotiationStore.find(negotiationId);
+            if (negotiation == null) {
+                monitor.severe(String.format("[Consumer] ContractNegotiation %s not found.", negotiationId));
+                return;
+            }
+
+            if (throwable == null) {
+                negotiation.transitionDeclined();
+                negotiationStore.save(negotiation);
+                observable.invokeForEach(l -> l.declined(negotiation));
+                monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
+                        negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
+            } else {
+                negotiation.transitionDeclining();
+                negotiationStore.save(negotiation);
+                observable.invokeForEach(l -> l.declining(negotiation));
+                String message = format("[Consumer] Failed to send contract rejection. ContractNegotiation %s stays in state %s.",
+                        negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
+                monitor.debug(message, throwable);
+            }
+        };
     }
 
     /**

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -80,7 +80,7 @@ class ConsumerContractNegotiationManagerImplTest {
                 .observable(mock(ContractNegotiationObservable.class))
                 .build();
 
-        //TODO hand over store in start method, but run method should not be executed
+        //TODO hand over store in start method:, but run method should not be executed
         var negotiationStoreField = ConsumerContractNegotiationManagerImpl.class.getDeclaredField("negotiationStore");
         negotiationStoreField.setAccessible(true);
         negotiationStoreField.set(negotiationManager, store);

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
@@ -491,6 +491,11 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
 
     private void transitionToError(String id, Throwable throwable, String message) {
         var transferProcess = transferProcessStore.find(id);
+        if (transferProcess == null) {
+            monitor.severe(format("TransferProcessManager: no TransferProcess found with id %s", id));
+            return;
+        }
+
         monitor.severe(message, throwable);
         transferProcess.transitionError(format("%s: %s", message, throwable.getLocalizedMessage()));
         transferProcessStore.update(transferProcess);
@@ -542,7 +547,12 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
                 .whenComplete((o, throwable) -> {
                     if (o != null) {
                         monitor.info("Object received: " + o);
-                        transitionToInProgress(transferProcessStore.find(process.getId()));
+                        TransferProcess transferProcess = transferProcessStore.find(process.getId());
+                        if (transferProcess == null) {
+                            monitor.severe(format("TransferProcessManager: no TransferProcess found with id %s", process.getId()));
+                            return;
+                        }
+                        transitionToInProgress(transferProcess);
                     }
                 });
     }

--- a/extensions/http/jersey/build.gradle.kts
+++ b/extensions/http/jersey/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation("org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api:5.0.2")
 
     testImplementation("com.squareup.okhttp3:okhttp:${okHttpVersion}")
+    testImplementation(testFixtures(project(":common:util")))
 }
 
 publishing {

--- a/extensions/http/jetty/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyConfiguration.java
+++ b/extensions/http/jetty/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyConfiguration.java
@@ -60,7 +60,7 @@ public class JettyConfiguration {
 
 
         if (jettyConfig.getPortMappings().isEmpty()) {
-            jettyConfig.portMapping(new PortMapping());
+            jettyConfig.portMapping(PortMapping.getDefault());
         }
 
         return jettyConfig;

--- a/extensions/http/jetty/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/PortMapping.java
+++ b/extensions/http/jetty/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/PortMapping.java
@@ -25,8 +25,12 @@ public class PortMapping {
     private final int port;
     private final String path;
 
-    public PortMapping() {
-        this(JettyConfiguration.DEFAULT_CONTEXT_NAME, JettyConfiguration.DEFAULT_PORT, JettyConfiguration.DEFAULT_PATH);
+    public static PortMapping getDefault() {
+        return getDefault(JettyConfiguration.DEFAULT_PORT);
+    }
+
+    public static PortMapping getDefault(int port) {
+        return new PortMapping(JettyConfiguration.DEFAULT_CONTEXT_NAME, port, JettyConfiguration.DEFAULT_PATH);
     }
 
     public PortMapping(String name, int port, String path) {

--- a/extensions/http/jetty/src/test/java/org/eclipse/dataspaceconnector/extension/jetty/JettyConfigurationTest.java
+++ b/extensions/http/jetty/src/test/java/org/eclipse/dataspaceconnector/extension/jetty/JettyConfigurationTest.java
@@ -100,7 +100,7 @@ class JettyConfigurationTest {
         var result = JettyConfiguration.createFromConfig(null, null,
                 ConfigFactory.fromMap(Map.of("web.http.this.is.longer.port", "8888")));
 
-        assertThat(result.getPortMappings()).allSatisfy(p -> assertThat(p).usingRecursiveComparison().isEqualTo(new PortMapping()));
+        assertThat(result.getPortMappings()).allSatisfy(p -> assertThat(p).usingRecursiveComparison().isEqualTo(PortMapping.getDefault()));
 
     }
 

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcess.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcess.java
@@ -185,6 +185,15 @@ public class TransferProcess implements TraceCarrier {
         transition(TransferProcessStates.REQUESTED_ACK, TransferProcessStates.REQUESTED);
     }
 
+    public void transitionInProgressOrStreaming() {
+        var dataRequest = getDataRequest();
+        if (dataRequest.getTransferType().isFinite()) {
+            transitionInProgress();
+        } else {
+            transitionStreaming();
+        }
+    }
+
     public void transitionInProgress() {
         if (type == Type.CONSUMER) {
             // the consumer must first transition to the request/ack states before in progress


### PR DESCRIPTION
Fix #616 

### Context
At the moment, there's a not safe behaviour in `Transfer` and `ContractNegotiation` managers, to update and save, after the completion of an async operation, the entity that was fetched before the async operation. This could lead to states overrides and unexpected errors.

### What brings
The entity will be fetched again on the completion of every async operation.
