### PR TITLE
AssetIndex supports paging/querying/filtering

### DIFF
--- a/common/util/build.gradle.kts
+++ b/common/util/build.gradle.kts
@@ -19,8 +19,10 @@ plugins {
 }
 
 val jupiterVersion: String by project
+val mockitoVersion: String by project
 
 dependencies {
+    testFixturesImplementation("org.mockito:mockito-core:${mockitoVersion}")
     testFixturesImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
     testFixturesRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")
 }

--- a/common/util/src/testFixtures/java/org/eclipse/dataspaceconnector/common/matchers/PredicateMatcher.java
+++ b/common/util/src/testFixtures/java/org/eclipse/dataspaceconnector/common/matchers/PredicateMatcher.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.common.matchers;
+
+import org.mockito.ArgumentMatcher;
+
+import java.util.function.Predicate;
+
+public class PredicateMatcher<T> implements ArgumentMatcher<T> {
+
+    private final Predicate<T> predicate;
+
+    public PredicateMatcher(Predicate<T> predicate) {
+
+        this.predicate = predicate;
+    }
+
+    @Override
+    public boolean matches(T argument) {
+        return predicate.test(argument);
+    }
+}

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/NullAssetIndex.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/NullAssetIndex.java
@@ -15,12 +15,9 @@ package org.eclipse.dataspaceconnector.contract;
 
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
-import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.stream.Stream;
 
 /**
@@ -34,7 +31,7 @@ public class NullAssetIndex implements AssetIndex {
     }
 
     @Override
-    public Stream<Asset> queryAssets(List<Criterion> criteria) {
+    public Stream<Asset> queryAssets(QuerySpec querySpec) {
         return Stream.empty();
     }
 
@@ -43,8 +40,4 @@ public class NullAssetIndex implements AssetIndex {
         return null;
     }
 
-    @Override
-    public List<Asset> findAll(QuerySpec querySpec) {
-        return Collections.emptyList();
-    }
 }

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/NullAssetIndex.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/NullAssetIndex.java
@@ -16,8 +16,10 @@ package org.eclipse.dataspaceconnector.contract;
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -39,5 +41,10 @@ public class NullAssetIndex implements AssetIndex {
     @Override
     public Asset findById(String assetId) {
         return null;
+    }
+
+    @Override
+    public List<Asset> findAll(QuerySpec querySpec) {
+        return Collections.emptyList();
     }
 }

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImpl.java
@@ -19,6 +19,7 @@ import org.eclipse.dataspaceconnector.spi.contract.offer.ContractDefinitionServi
 import org.eclipse.dataspaceconnector.spi.contract.validation.ContractValidationService;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
@@ -66,7 +67,7 @@ public class ContractValidationServiceImpl implements ContractValidationService 
 
         // take asset from definition and index
         var criteria = createCriteria(offer, contractDefinition);
-        var targetAssets = assetIndex.queryAssets(criteria);
+        var targetAssets = assetIndex.queryAssets(QuerySpec.Builder.newInstance().filter(criteria).build());
         var targetAsset = targetAssets.findFirst().orElse(null);
         if (targetAsset == null) {
             return Result.failure("");

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImplTest.java
@@ -7,6 +7,7 @@ import org.eclipse.dataspaceconnector.spi.contract.agent.ParticipantAgent;
 import org.eclipse.dataspaceconnector.spi.contract.agent.ParticipantAgentService;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractDefinitionService;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
@@ -16,7 +17,6 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.time.LocalDate;
-import java.util.List;
 import java.util.stream.Stream;
 
 import static java.time.Instant.MAX;
@@ -49,7 +49,7 @@ class ContractValidationServiceImplTest {
 
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
         when(definitionService.definitionFor(isA(ParticipantAgent.class), eq("1"))).thenReturn(contractDefinition);
-        when(assetIndex.queryAssets(isA(List.class))).thenReturn(Stream.of(asset));
+        when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(Stream.of(asset));
 
         var claimToken = ClaimToken.Builder.newInstance().build();
         var offer = ContractOffer.Builder.newInstance().asset(asset).policy(originalPolicy).id("1:2").build();
@@ -60,7 +60,7 @@ class ContractValidationServiceImplTest {
         assertThat(result.getContent().getPolicy()).isNotSameAs(originalPolicy); // verify the returned policy is the sanitized one
         verify(agentService).createFor(isA(ClaimToken.class));
         verify(definitionService).definitionFor(isA(ParticipantAgent.class), eq("1"));
-        verify(assetIndex).queryAssets(isA(List.class));
+        verify(assetIndex).queryAssets(isA(QuerySpec.class));
     }
 
     @Test

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
@@ -34,7 +34,6 @@ import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
 import org.eclipse.dataspaceconnector.spi.message.MessageContext;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcher;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
-import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.system.Provides;
@@ -123,8 +122,8 @@ class IdsApiMultipartDispatcherV1IntegrationTestServiceExtension implements Serv
         }
 
         @Override
-        public Stream<Asset> queryAssets(List<Criterion> criteria) {
-            return null;
+        public Stream<Asset> queryAssets(QuerySpec querySpec) {
+            throw new UnsupportedOperationException("Filtering/Paging not supported");
         }
 
         @Override
@@ -132,10 +131,6 @@ class IdsApiMultipartDispatcherV1IntegrationTestServiceExtension implements Serv
             return assets.stream().filter(a -> a.getId().equals(assetId)).findFirst().orElse(null);
         }
 
-        @Override
-        public List<Asset> findAll(QuerySpec querySpec) {
-            throw new UnsupportedOperationException("Filtering/Paging not supported");
-        }
     }
 
     private static class FakeContractOfferService implements ContractOfferService {

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
@@ -35,6 +35,7 @@ import org.eclipse.dataspaceconnector.spi.message.MessageContext;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcher;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.system.Provides;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
@@ -129,6 +130,11 @@ class IdsApiMultipartDispatcherV1IntegrationTestServiceExtension implements Serv
         @Override
         public Asset findById(String assetId) {
             return assets.stream().filter(a -> a.getId().equals(assetId)).findFirst().orElse(null);
+        }
+
+        @Override
+        public List<Asset> findAll(QuerySpec querySpec) {
+            throw new UnsupportedOperationException("Filtering/Paging not supported");
         }
     }
 

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
@@ -36,7 +36,6 @@ import org.eclipse.dataspaceconnector.spi.iam.TokenRepresentation;
 import org.eclipse.dataspaceconnector.spi.message.MessageContext;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcher;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
-import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.system.Provides;
@@ -137,8 +136,8 @@ class IdsApiMultipartEndpointV1IntegrationTestServiceExtension implements Servic
         }
 
         @Override
-        public Stream<Asset> queryAssets(List<Criterion> criteria) {
-            return null;
+        public Stream<Asset> queryAssets(QuerySpec querySpec) {
+            throw new UnsupportedOperationException("Filtering/Paging not supported");
         }
 
         @Override
@@ -146,10 +145,6 @@ class IdsApiMultipartEndpointV1IntegrationTestServiceExtension implements Servic
             return assets.stream().filter(a -> a.getId().equals(assetId)).findFirst().orElse(null);
         }
 
-        @Override
-        public List<Asset> findAll(QuerySpec querySpec) {
-            throw new UnsupportedOperationException("Filtering/Paging not supported");
-        }
     }
 
     private static class FakeContractOfferService implements ContractOfferService {

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
@@ -37,6 +37,7 @@ import org.eclipse.dataspaceconnector.spi.message.MessageContext;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcher;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.system.Provides;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
@@ -143,6 +144,11 @@ class IdsApiMultipartEndpointV1IntegrationTestServiceExtension implements Servic
         @Override
         public Asset findById(String assetId) {
             return assets.stream().filter(a -> a.getId().equals(assetId)).findFirst().orElse(null);
+        }
+
+        @Override
+        public List<Asset> findAll(QuerySpec querySpec) {
+            throw new UnsupportedOperationException("Filtering/Paging not supported");
         }
     }
 

--- a/extensions/azure/cosmos/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndex.java
+++ b/extensions/azure/cosmos/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndex.java
@@ -24,6 +24,8 @@ import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
@@ -31,6 +33,7 @@ import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static net.jodah.failsafe.Failsafe.with;
@@ -63,7 +66,11 @@ public class CosmosAssetIndex implements AssetIndex, DataAddressResolver, AssetL
     public Stream<Asset> queryAssets(AssetSelectorExpression expression) {
         Objects.requireNonNull(expression, "AssetSelectorExpression can not be null!");
 
-        SqlQuerySpec query = queryBuilder.from(expression);
+        if (expression.equals(AssetSelectorExpression.SELECT_ALL)) {
+            return findAll(QuerySpec.none()).stream();
+        }
+
+        SqlQuerySpec query = queryBuilder.from(expression.getCriteria());
 
         var response = with(retryPolicy).get(() -> assetDb.queryItems(query));
         return response.map(this::convertObject)
@@ -83,6 +90,21 @@ public class CosmosAssetIndex implements AssetIndex, DataAddressResolver, AssetL
     public Asset findById(String assetId) {
         var result = queryByIdInternal(assetId);
         return result.map(AssetDocument::getWrappedAsset).orElse(null);
+    }
+
+    @Override
+    public List<Asset> findAll(QuerySpec querySpec) {
+        var expr = querySpec.getFilterExpression();
+
+        var sortField = querySpec.getSortField();
+        var limit = querySpec.getLimit();
+        var sortAsc = querySpec.getSortOrder() == SortOrder.ASC;
+
+        var sqlQuery = queryBuilder.from(expr, sortField, sortAsc, limit, querySpec.getOffset());
+        var response = with(retryPolicy).get(() -> assetDb.queryItems(sqlQuery));
+        return response.map(this::convertObject)
+                .map(AssetDocument::getWrappedAsset)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/extensions/azure/cosmos/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetQueryBuilder.java
+++ b/extensions/azure/cosmos/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetQueryBuilder.java
@@ -1,13 +1,10 @@
 package org.eclipse.dataspaceconnector.assetindex.azure;
 
-import com.azure.cosmos.models.SqlParameter;
 import com.azure.cosmos.models.SqlQuerySpec;
 import org.eclipse.dataspaceconnector.assetindex.azure.model.AssetDocument;
-import org.eclipse.dataspaceconnector.common.collection.CollectionUtil;
+import org.eclipse.dataspaceconnector.azure.cosmos.dialect.SqlStatement;
 import org.eclipse.dataspaceconnector.spi.EdcException;
-import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
-import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Field;
@@ -17,12 +14,9 @@ import java.util.List;
 
 public class CosmosAssetQueryBuilder {
 
-    private static final String PROPERTIES_FIELD = "wrappedInstance";
-    private static final String PATH_TO_PROPERTIES = String.join(".", AssetDocument.class.getSimpleName(), PROPERTIES_FIELD);
-
     public CosmosAssetQueryBuilder() {
         // pre-check fields of the AssetDocument class that will be used to build the queries
-        assertClassContainsField(AssetDocument.class, PROPERTIES_FIELD);
+        assertClassContainsField(AssetDocument.class, "wrappedInstance");
     }
 
     private static void assertClassContainsField(Class<?> clazz, String fieldName) {
@@ -47,71 +41,21 @@ public class CosmosAssetQueryBuilder {
         return fields;
     }
 
-    public SqlQuerySpec from(AssetSelectorExpression expression) {
-        WhereClause whereClause = new WhereClause(expression);
-        return new SqlQuerySpec("SELECT * FROM " + AssetDocument.class.getSimpleName() + whereClause.getWhere(), whereClause.getParameters());
-    }
-
     public SqlQuerySpec from(List<Criterion> criteria) {
-        WhereClause whereClause = new WhereClause(criteria);
-        return new SqlQuerySpec("SELECT * FROM " + AssetDocument.class.getSimpleName() + whereClause.getWhere(), whereClause.getParameters());
+        return new SqlStatement<>(AssetDocument.class)
+                .where(criteria)
+                .getQueryAsSqlQuerySpec();
     }
 
-    private static class WhereClause {
-        public static final String EQUALS_OPERATOR = "=";
-        public static final String IN_OPERATOR = "IN";
-        private static final List<String> SUPPORTED_OPERATOR = List.of(EQUALS_OPERATOR, IN_OPERATOR);
+    public SqlQuerySpec from(List<Criterion> criteria, String orderByField, boolean sortAscending, Integer limit, Integer offset) {
 
-        private final List<SqlParameter> parameters = new ArrayList<>();
-        private String where = "";
+        var stmt = new SqlStatement<>(AssetDocument.class)
+                .where(criteria)
+                .orderBy(orderByField, sortAscending)
+                .offset(offset)
+                .limit(limit);
 
-        public WhereClause(AssetSelectorExpression expression) {
-            if (expression != AssetSelectorExpression.SELECT_ALL) {
-                expression.getCriteria().forEach(this::criterion);
-            }
-        }
-
-        public WhereClause(List<Criterion> criteria) {
-            criteria.stream().distinct().forEach(this::criterion);
-        }
-
-        public String getWhere() {
-            return where;
-        }
-
-        public List<SqlParameter> getParameters() {
-            return parameters;
-        }
-
-        private void criterion(Criterion criterion) {
-            if (!SUPPORTED_OPERATOR.contains(criterion.getOperator())) {
-                throw new EdcException("Cannot build SqlParameter for operator: " + criterion.getOperator());
-            }
-            criterion = escape(criterion);
-            String field = AssetDocument.sanitize(criterion.getOperandLeft().toString());
-            String param = "@" + field;
-            where += parameters.isEmpty() ? " WHERE" : " AND";
-            parameters.add(new SqlParameter(param, criterion.getOperandRight().toString()));
-            where += String.join(" " + criterion.getOperator() + " ",
-                    " " + PATH_TO_PROPERTIES + "." + field,
-                    (String) criterion.getOperandRight());
-        }
-
-        private Criterion escape(Criterion criterion) {
-            var s = criterion.getOperandLeft().toString();
-            var isEqualsOperator = criterion.getOperator().equals(EQUALS_OPERATOR);
-            // need to add ticks if right-operand is a string type
-            if (isEqualsOperator &&
-                    CollectionUtil.isAnyOf(s,
-                            Asset.PROPERTY_ID, Asset.PROPERTY_CONTENT_TYPE,
-                            Asset.PROPERTY_NAME, Asset.PROPERTY_VERSION)) {
-                var or = criterion.getOperandRight().toString();
-                or = "'" + or + "'";
-                criterion = new Criterion(s, criterion.getOperator(), or);
-            }
-
-            return criterion;
-
-        }
+        return stmt.getQueryAsSqlQuerySpec();
     }
+
 }

--- a/extensions/azure/cosmos/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/model/AssetDocument.java
+++ b/extensions/azure/cosmos/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/model/AssetDocument.java
@@ -47,9 +47,6 @@ public class AssetDocument extends CosmosDocument<Map<String, Object>> {
         this.dataAddress = dataAddress;
     }
 
-    public static String sanitize(String key) {
-        return key.replace(':', '_');
-    }
 
     private static Map<String, Object> sanitizeProperties(Asset asset) {
         return asset.getProperties().entrySet().stream()

--- a/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexIntegrationTest.java
+++ b/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexIntegrationTest.java
@@ -23,6 +23,7 @@ import com.azure.cosmos.models.CosmosContainerResponse;
 import com.azure.cosmos.models.CosmosDatabaseResponse;
 import net.jodah.failsafe.RetryPolicy;
 import org.eclipse.dataspaceconnector.assetindex.azure.model.AssetDocument;
+import org.eclipse.dataspaceconnector.common.annotations.IntegrationTest;
 import org.eclipse.dataspaceconnector.cosmos.azure.CosmosDbApi;
 import org.eclipse.dataspaceconnector.cosmos.azure.CosmosDbApiImpl;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
@@ -48,7 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.dataspaceconnector.common.configuration.ConfigurationFunctions.propOrEnv;
 
-//@IntegrationTest
+@IntegrationTest
 class CosmosAssetIndexIntegrationTest {
     public static final String REGION = "westeurope";
     private static final String TEST_ID = UUID.randomUUID().toString();

--- a/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexIntegrationTest.java
+++ b/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexIntegrationTest.java
@@ -261,7 +261,7 @@ class CosmosAssetIndexIntegrationTest {
         Asset asset1 = createAsset("123", "test", "world");
         container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY, dataAddress));
 
-        var all = assetIndex.findAll(QuerySpec.none());
+        var all = assetIndex.queryAssets(QuerySpec.none());
         assertThat(all).hasSize(1).extracting(Asset::getId).containsExactly(asset1.getId());
 
     }
@@ -273,7 +273,7 @@ class CosmosAssetIndexIntegrationTest {
 
         var limitQuery = QuerySpec.Builder.newInstance().limit(5).offset(2).build();
 
-        var all = assetIndex.findAll(limitQuery);
+        var all = assetIndex.queryAssets(limitQuery);
         assertThat(all).hasSize(5).extracting(Asset::getId).containsExactly("id2", "id3", "id4", "id5", "id6");
     }
 
@@ -288,7 +288,7 @@ class CosmosAssetIndexIntegrationTest {
                 .sortOrder(SortOrder.DESC)
                 .build();
 
-        var all = assetIndex.findAll(limitQuery);
+        var all = assetIndex.queryAssets(limitQuery);
         assertThat(all).hasSize(5).extracting(Asset::getId).containsExactly("id7", "id6", "id5", "id4", "id3");
     }
 
@@ -303,7 +303,7 @@ class CosmosAssetIndexIntegrationTest {
                 .sortOrder(SortOrder.ASC)
                 .build();
 
-        var all = assetIndex.findAll(limitQuery);
+        var all = assetIndex.queryAssets(limitQuery);
         assertThat(all).hasSize(3).extracting(Asset::getId).containsExactly("id2", "id3", "id4");
     }
 
@@ -317,7 +317,7 @@ class CosmosAssetIndexIntegrationTest {
                 .filter("foo=bar4")
                 .build();
 
-        var all = assetIndex.findAll(filterQuery);
+        var all = assetIndex.queryAssets(filterQuery);
         assertThat(all).hasSize(1).extracting(a -> a.getProperty("foo")).containsOnly("bar4");
     }
 
@@ -331,7 +331,7 @@ class CosmosAssetIndexIntegrationTest {
                 .filter("foo STARTSWITH bar4")
                 .build();
 
-        assertThatThrownBy(() -> assetIndex.findAll(filterQuery)).isInstanceOf(IllegalArgumentException.class).hasMessage("Cannot build SqlParameter for operator: STARTSWITH");
+        assertThatThrownBy(() -> assetIndex.queryAssets(filterQuery)).isInstanceOf(IllegalArgumentException.class).hasMessage("Cannot build SqlParameter for operator: STARTSWITH");
     }
 
     @Test
@@ -345,7 +345,7 @@ class CosmosAssetIndexIntegrationTest {
                 .limit(10)
                 .build();
 
-        var all = assetIndex.findAll(filterQuery);
+        var all = assetIndex.queryAssets(filterQuery);
         assertThat(all).hasSize(4).extracting(Asset::getId).containsExactlyInAnyOrder("id4", "id3", "id2", "id1");
     }
 
@@ -359,7 +359,7 @@ class CosmosAssetIndexIntegrationTest {
                 .sortField("foo")
                 .build();
 
-        var all = assetIndex.findAll(sortQuery);
+        var all = assetIndex.queryAssets(sortQuery);
         assertThat(all).hasSize(5).extracting(Asset::getId).containsExactly("id9", "id8", "id7", "id6", "id5");
 
     }

--- a/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexIntegrationTest.java
+++ b/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexIntegrationTest.java
@@ -23,10 +23,11 @@ import com.azure.cosmos.models.CosmosContainerResponse;
 import com.azure.cosmos.models.CosmosDatabaseResponse;
 import net.jodah.failsafe.RetryPolicy;
 import org.eclipse.dataspaceconnector.assetindex.azure.model.AssetDocument;
-import org.eclipse.dataspaceconnector.common.annotations.IntegrationTest;
 import org.eclipse.dataspaceconnector.cosmos.azure.CosmosDbApi;
 import org.eclipse.dataspaceconnector.cosmos.azure.CosmosDbApiImpl;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
@@ -40,13 +41,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.dataspaceconnector.common.configuration.ConfigurationFunctions.propOrEnv;
 
-@IntegrationTest
+//@IntegrationTest
 class CosmosAssetIndexIntegrationTest {
     public static final String REGION = "westeurope";
     private static final String TEST_ID = UUID.randomUUID().toString();
@@ -96,15 +98,9 @@ class CosmosAssetIndexIntegrationTest {
 
     @Test
     void queryAssets_selectAll() {
-        Asset asset1 = Asset.Builder.newInstance()
-                .id("123")
-                .property("hello", "world")
-                .build();
+        Asset asset1 = createAsset("123", "hello", "world");
 
-        Asset asset2 = Asset.Builder.newInstance()
-                .id("456")
-                .property("foo", "bar")
-                .build();
+        Asset asset2 = createAsset("456", "foo", "bar");
 
         container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY, dataAddress));
         container.createItem(new AssetDocument(asset2, TEST_PARTITION_KEY, dataAddress));
@@ -118,15 +114,9 @@ class CosmosAssetIndexIntegrationTest {
 
     @Test
     void queryAssets_filterOnProperty() {
-        Asset asset1 = Asset.Builder.newInstance()
-                .id("123")
-                .property("test", "world")
-                .build();
+        Asset asset1 = createAsset("123", "test", "world");
 
-        Asset asset2 = Asset.Builder.newInstance()
-                .id("456")
-                .property("test", "bar")
-                .build();
+        Asset asset2 = createAsset("456", "test", "bar");
 
         container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY, dataAddress));
         container.createItem(new AssetDocument(asset2, TEST_PARTITION_KEY, dataAddress));
@@ -143,21 +133,15 @@ class CosmosAssetIndexIntegrationTest {
 
     @Test
     void queryAssets_filterOnPropertyContainingIllegalArgs() {
-        Asset asset1 = Asset.Builder.newInstance()
-                .id("123")
-                .property("test:value", "world")
-                .build();
+        Asset asset1 = createAsset("123", "test:value", "world");
 
-        Asset asset2 = Asset.Builder.newInstance()
-                .id("456")
-                .property("test:value", "bar")
-                .build();
+        Asset asset2 = createAsset("456", "test:value", "bar");
 
         container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY, dataAddress));
         container.createItem(new AssetDocument(asset2, TEST_PARTITION_KEY, dataAddress));
 
         AssetSelectorExpression expression = AssetSelectorExpression.Builder.newInstance()
-                .whenEquals("test:value", "'bar'")
+                .whenEquals("test:value", "bar")
                 .build();
 
         List<Asset> assets = assetIndex.queryAssets(expression).collect(Collectors.toList());
@@ -168,15 +152,9 @@ class CosmosAssetIndexIntegrationTest {
 
     @Test
     void findById() {
-        Asset asset1 = Asset.Builder.newInstance()
-                .id("123")
-                .property("test", "world")
-                .build();
+        Asset asset1 = createAsset("123", "test", "world");
 
-        Asset asset2 = Asset.Builder.newInstance()
-                .id("456")
-                .property("test", "bar")
-                .build();
+        Asset asset2 = createAsset("456", "test", "bar");
 
         container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY, dataAddress));
         container.createItem(new AssetDocument(asset2, TEST_PARTITION_KEY, dataAddress));
@@ -189,15 +167,9 @@ class CosmosAssetIndexIntegrationTest {
 
     @Test
     void queryAssets_operatorIn() {
-        Asset asset1 = Asset.Builder.newInstance()
-                .id("123")
-                .property("hello", "world")
-                .build();
+        Asset asset1 = createAsset("123", "hello", "world");
 
-        Asset asset2 = Asset.Builder.newInstance()
-                .id("456")
-                .property("foo", "bar")
-                .build();
+        Asset asset2 = createAsset("456", "foo", "bar");
 
         container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY, dataAddress));
         container.createItem(new AssetDocument(asset2, TEST_PARTITION_KEY, dataAddress));
@@ -216,15 +188,9 @@ class CosmosAssetIndexIntegrationTest {
 
     @Test
     void queryAssets_operatorIn_noUpTicks() {
-        Asset asset1 = Asset.Builder.newInstance()
-                .id("123")
-                .property("hello", "world")
-                .build();
+        Asset asset1 = createAsset("123", "hello", "world");
 
-        Asset asset2 = Asset.Builder.newInstance()
-                .id("456")
-                .property("foo", "bar")
-                .build();
+        Asset asset2 = createAsset("456", "foo", "bar");
 
         container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY, dataAddress));
         container.createItem(new AssetDocument(asset2, TEST_PARTITION_KEY, dataAddress));
@@ -241,15 +207,9 @@ class CosmosAssetIndexIntegrationTest {
 
     @Test
     void queryAssets_operatorIn_noBrackets_throwsException() {
-        Asset asset1 = Asset.Builder.newInstance()
-                .id("123")
-                .property("hello", "world")
-                .build();
+        Asset asset1 = createAsset("123", "hello", "world");
 
-        Asset asset2 = Asset.Builder.newInstance()
-                .id("456")
-                .property("foo", "bar")
-                .build();
+        Asset asset2 = createAsset("456", "foo", "bar");
 
         container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY, dataAddress));
         container.createItem(new AssetDocument(asset2, TEST_PARTITION_KEY, dataAddress));
@@ -266,15 +226,9 @@ class CosmosAssetIndexIntegrationTest {
 
     @Test
     void queryAssets_operatorIn_syntaxError_throwsException() {
-        Asset asset1 = Asset.Builder.newInstance()
-                .id("123")
-                .property("hello", "world")
-                .build();
+        Asset asset1 = createAsset("123", "hello", "world");
 
-        Asset asset2 = Asset.Builder.newInstance()
-                .id("456")
-                .property("foo", "bar")
-                .build();
+        Asset asset2 = createAsset("456", "foo", "bar");
 
         container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY, dataAddress));
         container.createItem(new AssetDocument(asset2, TEST_PARTITION_KEY, dataAddress));
@@ -301,9 +255,124 @@ class CosmosAssetIndexIntegrationTest {
         assertThat(assets).isEmpty();
     }
 
+    @Test
+    void findAll_noQuerySpec() {
+        Asset asset1 = createAsset("123", "test", "world");
+        container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY, dataAddress));
+
+        var all = assetIndex.findAll(QuerySpec.none());
+        assertThat(all).hasSize(1).extracting(Asset::getId).containsExactly(asset1.getId());
+
+    }
+
+    @Test
+    void findAll_withPaging() {
+        IntStream.range(0, 10).mapToObj(i -> createAsset("id" + i, "foo", "bar" + i))
+                .forEach(a -> container.createItem(new AssetDocument(a, TEST_PARTITION_KEY, dataAddress)));
+
+        var limitQuery = QuerySpec.Builder.newInstance().limit(5).offset(2).build();
+
+        var all = assetIndex.findAll(limitQuery);
+        assertThat(all).hasSize(5).extracting(Asset::getId).containsExactly("id2", "id3", "id4", "id5", "id6");
+    }
+
+    @Test
+    void findAll_withPaging_sortedDesc() {
+        IntStream.range(0, 10).mapToObj(i -> createAsset("id" + i, "foo", "bar" + i))
+                .forEach(a -> container.createItem(new AssetDocument(a, TEST_PARTITION_KEY, dataAddress)));
+
+        var limitQuery = QuerySpec.Builder.newInstance()
+                .limit(5).offset(2)
+                .sortField(AssetDocument.sanitize(Asset.PROPERTY_ID))
+                .sortOrder(SortOrder.DESC)
+                .build();
+
+        var all = assetIndex.findAll(limitQuery);
+        assertThat(all).hasSize(5).extracting(Asset::getId).containsExactly("id7", "id6", "id5", "id4", "id3");
+    }
+
+    @Test
+    void findAll_withPaging_sortedAsc() {
+        IntStream.range(0, 10).mapToObj(i -> createAsset("id" + i, "foo", "bar" + i))
+                .forEach(a -> container.createItem(new AssetDocument(a, TEST_PARTITION_KEY, dataAddress)));
+
+        var limitQuery = QuerySpec.Builder.newInstance()
+                .limit(3).offset(2)
+                .sortField(AssetDocument.sanitize(Asset.PROPERTY_ID))
+                .sortOrder(SortOrder.ASC)
+                .build();
+
+        var all = assetIndex.findAll(limitQuery);
+        assertThat(all).hasSize(3).extracting(Asset::getId).containsExactly("id2", "id3", "id4");
+    }
+
+    @Test
+    void findAll_withFiltering() {
+        IntStream.range(0, 5).mapToObj(i -> createAsset("id" + i, "foo", "bar" + i))
+                .forEach(a -> container.createItem(new AssetDocument(a, TEST_PARTITION_KEY, dataAddress)));
+
+        var filterQuery = QuerySpec.Builder.newInstance()
+                .equalsAsContains(false)
+                .filter("foo=bar4")
+                .build();
+
+        var all = assetIndex.findAll(filterQuery);
+        assertThat(all).hasSize(1).extracting(a -> a.getProperty("foo")).containsOnly("bar4");
+    }
+
+    @Test
+    void findAll_withInvalidFilter_throwsException() {
+        IntStream.range(0, 5).mapToObj(i -> createAsset("id" + i, "foo", "bar" + i))
+                .forEach(a -> container.createItem(new AssetDocument(a, TEST_PARTITION_KEY, dataAddress)));
+
+        var filterQuery = QuerySpec.Builder.newInstance()
+                .equalsAsContains(false)
+                .filter("foo STARTSWITH bar4")
+                .build();
+
+        assertThatThrownBy(() -> assetIndex.findAll(filterQuery)).isInstanceOf(IllegalArgumentException.class).hasMessage("Cannot build SqlParameter for operator: STARTSWITH");
+    }
+
+    @Test
+    void findAll_withFilteringOperatorIn_limitExceedsResultSize() {
+        IntStream.range(0, 5).mapToObj(i -> createAsset("id" + i, "foo", "bar" + i))
+                .forEach(a -> container.createItem(new AssetDocument(a, TEST_PARTITION_KEY, dataAddress)));
+
+        var filterQuery = QuerySpec.Builder.newInstance()
+                .equalsAsContains(false)
+                .filter("foo IN ('bar4', 'bar3', 'bar2', 'bar1')")
+                .limit(10)
+                .build();
+
+        var all = assetIndex.findAll(filterQuery);
+        assertThat(all).hasSize(4).extracting(Asset::getId).containsExactlyInAnyOrder("id4", "id3", "id2", "id1");
+    }
+
+    @Test
+    void findAll_withSorting() {
+        IntStream.range(5, 10).mapToObj(i -> createAsset("id" + i, "foo", "bar" + i))
+                .forEach(a -> container.createItem(new AssetDocument(a, TEST_PARTITION_KEY, dataAddress)));
+
+        var sortQuery = QuerySpec.Builder.newInstance()
+                .sortOrder(SortOrder.DESC)
+                .sortField("foo")
+                .build();
+
+        var all = assetIndex.findAll(sortQuery);
+        assertThat(all).hasSize(5).extracting(Asset::getId).containsExactly("id9", "id8", "id7", "id6", "id5");
+
+    }
+
     @AfterEach
     void teardown() {
         CosmosContainerResponse delete = container.delete();
         assertThat(delete.getStatusCode()).isGreaterThanOrEqualTo(200).isLessThan(300);
+    }
+
+    private Asset createAsset(String id, String somePropertyKey, String somePropertyValue) {
+        return Asset.Builder.newInstance()
+                .id(id)
+                .property(somePropertyKey, somePropertyValue)
+                .build();
     }
 }

--- a/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexTest.java
+++ b/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexTest.java
@@ -17,11 +17,15 @@ package org.eclipse.dataspaceconnector.assetindex.azure;
 import com.azure.cosmos.models.SqlQuerySpec;
 import net.jodah.failsafe.RetryPolicy;
 import org.eclipse.dataspaceconnector.assetindex.azure.model.AssetDocument;
+import org.eclipse.dataspaceconnector.common.matchers.PredicateMatcher;
 import org.eclipse.dataspaceconnector.cosmos.azure.CosmosDbApi;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -34,6 +38,7 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -165,8 +170,84 @@ class CosmosAssetIndexTest {
         assertThat(assets)
                 .anyMatch(asset -> asset.getId().equals(id1))
                 .anyMatch(asset -> asset.getId().equals(id2));
-        assertThat(queryCapture.getValue().getQueryText()).matches(".*WHERE AssetDocument.* = 'somename'");
+        assertThat(queryCapture.getValue().getQueryText()).matches(".*WHERE AssetDocument.* = @asset_prop_name");
         verify(api).queryItems(queryCapture.capture());
         verifyNoMoreInteractions(api);
     }
+
+    @Test
+    void findAll_noQuerySpec() {
+        String id = "id-test";
+        AssetDocument document = createDocument(id);
+        var expectedQuery = "SELECT * FROM AssetDocument OFFSET 0 LIMIT 50";
+        when(api.queryItems(argThat(queryMatches(expectedQuery)))).thenReturn(Stream.of(document));
+
+        List<Asset> assets = assetIndex.findAll(QuerySpec.none());
+
+        assertThat(assets).hasSize(1).extracting(Asset::getId).containsExactly(document.getWrappedAsset().getId());
+        assertThat(assets).extracting(Asset::getProperties).allSatisfy(m -> assertThat(m).containsAllEntriesOf(document.getWrappedAsset().getProperties()));
+        verify(api).queryItems(any(SqlQuerySpec.class));
+    }
+
+    @Test
+    void findAll_withPaging_SortingDesc() {
+        String id = "id-test";
+        AssetDocument document = createDocument(id);
+        var expectedQuery = "SELECT * FROM AssetDocument ORDER BY AssetDocument.wrappedInstance.anyField DESC OFFSET 5 LIMIT 100";
+        when(api.queryItems(argThat(queryMatches(expectedQuery)))).thenReturn(Stream.of(document));
+
+        List<Asset> assets = assetIndex.findAll(QuerySpec.Builder.newInstance()
+                .offset(5)
+                .limit(100)
+                .sortField("anyField")
+                .sortOrder(SortOrder.DESC)
+                .build());
+
+        assertThat(assets).hasSize(1).extracting(Asset::getId).containsExactly(document.getWrappedAsset().getId());
+        assertThat(assets).extracting(Asset::getProperties).allSatisfy(m -> assertThat(m).containsAllEntriesOf(document.getWrappedAsset().getProperties()));
+        verify(api).queryItems(any(SqlQuerySpec.class));
+    }
+
+    @Test
+    void findAll_withPaging_SortingAsc() {
+        String id = "id-test";
+        AssetDocument document = createDocument(id);
+        var expectedQuery = "SELECT * FROM AssetDocument ORDER BY AssetDocument.wrappedInstance.anyField ASC OFFSET 5 LIMIT 100";
+        when(api.queryItems(argThat(queryMatches(expectedQuery)))).thenReturn(Stream.of(document));
+
+        List<Asset> assets = assetIndex.findAll(QuerySpec.Builder.newInstance()
+                .offset(5)
+                .limit(100)
+                .sortField("anyField")
+                .sortOrder(SortOrder.ASC)
+                .build());
+
+        assertThat(assets).hasSize(1).extracting(Asset::getId).containsExactly(document.getWrappedAsset().getId());
+        assertThat(assets).extracting(Asset::getProperties).allSatisfy(m -> assertThat(m).containsAllEntriesOf(document.getWrappedAsset().getProperties()));
+        verify(api).queryItems(any(SqlQuerySpec.class));
+    }
+
+    @Test
+    void findAll_withFiltering() {
+        String id = "id-test";
+        AssetDocument document = createDocument(id);
+        var expectedQuery = "SELECT * FROM AssetDocument WHERE AssetDocument.wrappedInstance.someField = @someField OFFSET 5 LIMIT 100";
+        when(api.queryItems(argThat(queryMatches(expectedQuery)))).thenReturn(Stream.of(document));
+
+        List<Asset> assets = assetIndex.findAll(QuerySpec.Builder.newInstance()
+                .offset(5)
+                .limit(100)
+                .filter("someField=randomValue")
+                .build());
+
+        assertThat(assets).hasSize(1).extracting(Asset::getId).containsExactly(document.getWrappedAsset().getId());
+        assertThat(assets).extracting(Asset::getProperties).allSatisfy(m -> assertThat(m).containsAllEntriesOf(document.getWrappedAsset().getProperties()));
+        verify(api).queryItems(any(SqlQuerySpec.class));
+    }
+
+    @NotNull
+    private PredicateMatcher<SqlQuerySpec> queryMatches(String expectedQuery) {
+        return new PredicateMatcher<>(sqlQuerySpec -> sqlQuerySpec.getQueryText().equals(expectedQuery));
+    }
+
 }

--- a/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexTest.java
+++ b/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexTest.java
@@ -182,7 +182,7 @@ class CosmosAssetIndexTest {
         var expectedQuery = "SELECT * FROM AssetDocument OFFSET 0 LIMIT 50";
         when(api.queryItems(argThat(queryMatches(expectedQuery)))).thenReturn(Stream.of(document));
 
-        List<Asset> assets = assetIndex.findAll(QuerySpec.none());
+        List<Asset> assets = assetIndex.queryAssets(QuerySpec.none()).collect(Collectors.toList());
 
         assertThat(assets).hasSize(1).extracting(Asset::getId).containsExactly(document.getWrappedAsset().getId());
         assertThat(assets).extracting(Asset::getProperties).allSatisfy(m -> assertThat(m).containsAllEntriesOf(document.getWrappedAsset().getProperties()));
@@ -196,12 +196,13 @@ class CosmosAssetIndexTest {
         var expectedQuery = "SELECT * FROM AssetDocument ORDER BY AssetDocument.wrappedInstance.anyField DESC OFFSET 5 LIMIT 100";
         when(api.queryItems(argThat(queryMatches(expectedQuery)))).thenReturn(Stream.of(document));
 
-        List<Asset> assets = assetIndex.findAll(QuerySpec.Builder.newInstance()
-                .offset(5)
-                .limit(100)
-                .sortField("anyField")
-                .sortOrder(SortOrder.DESC)
-                .build());
+        List<Asset> assets = assetIndex.queryAssets(QuerySpec.Builder.newInstance()
+                        .offset(5)
+                        .limit(100)
+                        .sortField("anyField")
+                        .sortOrder(SortOrder.DESC)
+                        .build())
+                .collect(Collectors.toList());
 
         assertThat(assets).hasSize(1).extracting(Asset::getId).containsExactly(document.getWrappedAsset().getId());
         assertThat(assets).extracting(Asset::getProperties).allSatisfy(m -> assertThat(m).containsAllEntriesOf(document.getWrappedAsset().getProperties()));
@@ -215,12 +216,13 @@ class CosmosAssetIndexTest {
         var expectedQuery = "SELECT * FROM AssetDocument ORDER BY AssetDocument.wrappedInstance.anyField ASC OFFSET 5 LIMIT 100";
         when(api.queryItems(argThat(queryMatches(expectedQuery)))).thenReturn(Stream.of(document));
 
-        List<Asset> assets = assetIndex.findAll(QuerySpec.Builder.newInstance()
-                .offset(5)
-                .limit(100)
-                .sortField("anyField")
-                .sortOrder(SortOrder.ASC)
-                .build());
+        List<Asset> assets = assetIndex.queryAssets(QuerySpec.Builder.newInstance()
+                        .offset(5)
+                        .limit(100)
+                        .sortField("anyField")
+                        .sortOrder(SortOrder.ASC)
+                        .build())
+                .collect(Collectors.toList());
 
         assertThat(assets).hasSize(1).extracting(Asset::getId).containsExactly(document.getWrappedAsset().getId());
         assertThat(assets).extracting(Asset::getProperties).allSatisfy(m -> assertThat(m).containsAllEntriesOf(document.getWrappedAsset().getProperties()));
@@ -234,11 +236,12 @@ class CosmosAssetIndexTest {
         var expectedQuery = "SELECT * FROM AssetDocument WHERE AssetDocument.wrappedInstance.someField = @someField OFFSET 5 LIMIT 100";
         when(api.queryItems(argThat(queryMatches(expectedQuery)))).thenReturn(Stream.of(document));
 
-        List<Asset> assets = assetIndex.findAll(QuerySpec.Builder.newInstance()
-                .offset(5)
-                .limit(100)
-                .filter("someField=randomValue")
-                .build());
+        List<Asset> assets = assetIndex.queryAssets(QuerySpec.Builder.newInstance()
+                        .offset(5)
+                        .limit(100)
+                        .filter("someField=randomValue")
+                        .build())
+                .collect(Collectors.toList());
 
         assertThat(assets).hasSize(1).extracting(Asset::getId).containsExactly(document.getWrappedAsset().getId());
         assertThat(assets).extracting(Asset::getProperties).allSatisfy(m -> assertThat(m).containsAllEntriesOf(document.getWrappedAsset().getProperties()));

--- a/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/Clause.java
+++ b/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/Clause.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.azure.cosmos.dialect;
+
+import com.azure.cosmos.models.SqlParameter;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+interface Clause {
+    String asString();
+
+    @NotNull
+    default List<SqlParameter> getParameters() {
+        return List.of();
+    }
+}

--- a/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/Clause.java
+++ b/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/Clause.java
@@ -19,6 +19,9 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
+/**
+ * Interface for all SQL-like statements or parts thereof. Offers conversion to String plus an optional list of parameters.
+ */
 interface Clause {
     String asString();
 

--- a/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/LimitClause.java
+++ b/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/LimitClause.java
@@ -14,6 +14,10 @@
 
 package org.eclipse.dataspaceconnector.azure.cosmos.dialect;
 
+/**
+ * Represents in a structural way an LIMIT clause in an SQL statement.
+ * LIMIT clauses are optional in SQL statements, so if no LIMIT is required, simply pass {@code null} in the constructor.
+ */
 class LimitClause implements Clause {
 
     private final Integer limit;

--- a/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/LimitClause.java
+++ b/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/LimitClause.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.azure.cosmos.dialect;
+
+class LimitClause implements Clause {
+
+    private final Integer limit;
+
+    public LimitClause(Integer limit) {
+        this.limit = limit;
+    }
+
+    LimitClause() {
+        this(null);
+    }
+
+    @Override
+    public String asString() {
+        return limit != null ? "LIMIT " + limit : "";
+    }
+}

--- a/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/OffsetClause.java
+++ b/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/OffsetClause.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.azure.cosmos.dialect;
+
+import static java.lang.String.format;
+
+class OffsetClause implements Clause {
+
+    private final Integer offset;
+
+    public OffsetClause(Integer offset) {
+        this.offset = offset;
+    }
+
+    OffsetClause() {
+        this(null);
+    }
+
+    @Override
+    public String asString() {
+        return offset != null ? format("OFFSET %d", offset) : "";
+    }
+}

--- a/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/OffsetClause.java
+++ b/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/OffsetClause.java
@@ -16,6 +16,10 @@ package org.eclipse.dataspaceconnector.azure.cosmos.dialect;
 
 import static java.lang.String.format;
 
+/**
+ * Represents in a structural way an OFFSET clause in an SQL statement.
+ * OFFSET clauses are optional in SQL statements, so if no OFFSET is required, simply pass {@code null} in the constructor.
+ */
 class OffsetClause implements Clause {
 
     private final Integer offset;

--- a/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/OrderByClause.java
+++ b/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/OrderByClause.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.azure.cosmos.dialect;
+
+import org.jetbrains.annotations.NotNull;
+
+import static java.lang.String.format;
+
+class OrderByClause implements Clause {
+
+    private final String orderField;
+    private final boolean sortAsc;
+    private final String objectPrefix;
+
+    public OrderByClause(String orderField, boolean sortAsc, String objectPrefix) {
+
+        this.orderField = orderField;
+        this.sortAsc = sortAsc;
+        this.objectPrefix = objectPrefix;
+    }
+
+    OrderByClause() {
+        this(null, true, null);
+    }
+
+    @Override
+    public String asString() {
+        return orderField != null ? format("ORDER BY %s%s %s", getPrefix(), orderField, sortAsc ? "ASC" : "DESC") : "";
+    }
+
+    @NotNull
+    private String getPrefix() {
+        return objectPrefix != null ? objectPrefix + "." : "";
+    }
+
+}

--- a/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/OrderByClause.java
+++ b/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/OrderByClause.java
@@ -18,6 +18,17 @@ import org.jetbrains.annotations.NotNull;
 
 import static java.lang.String.format;
 
+/**
+ * Represents in a structural way an ORDER BY clause in an SQL statement.
+ * The sort criterion, i.e. the SQL column by which to sort, is needed.
+ * <p>
+ * Optionally an {@code orderPrefix} can be specified, which represents the "path" of the property. This is particularly
+ * relevant for CosmosDB queries, e.g:
+ * <pre>
+ *     SELECT * FROM YourDocument WHERE ... ORDER BY YourDocument.Header.Age
+ * </pre>
+ * In this case the {@code orderPrefix} would have to be {@code "YourDocument.Header"}.
+ */
 class OrderByClause implements Clause {
 
     private final String orderField;
@@ -29,6 +40,10 @@ class OrderByClause implements Clause {
         this.orderField = orderField;
         this.sortAsc = sortAsc;
         this.objectPrefix = objectPrefix;
+    }
+
+    public OrderByClause(String orderField, boolean sortAsc) {
+        this(orderField, sortAsc, null);
     }
 
     OrderByClause() {

--- a/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/SqlStatement.java
+++ b/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/SqlStatement.java
@@ -1,0 +1,133 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.azure.cosmos.dialect;
+
+import com.azure.cosmos.models.SqlParameter;
+import com.azure.cosmos.models.SqlQuerySpec;
+import org.eclipse.dataspaceconnector.cosmos.azure.CosmosDocument;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Serves as entry point to creating a type-safe SQL Statement for CosmosDB.
+ *
+ * @param <T> The kind of {@link CosmosDocument} that will be queried
+ */
+public class SqlStatement<T extends CosmosDocument<?>> {
+
+    private static final String PROPERTIES_FIELD = "wrappedInstance";
+    private final Class<T> objectType;
+    private final String wrapperPrefix;
+    private WhereClause whereClause = new WhereClause();
+    private OrderByClause orderClause = new OrderByClause();
+    private LimitClause limit = new LimitClause();
+    private boolean sortAscending = true;
+    private OffsetClause offset = new OffsetClause();
+
+    /**
+     * Creates a new statement for a specific object type.
+     *
+     * @param objectType The runtime type of the object for which the statement is to be created.
+     */
+    public SqlStatement(Class<T> objectType) {
+        this.objectType = objectType;
+        wrapperPrefix = PROPERTIES_FIELD;
+    }
+
+    /**
+     * Adds WHERE statements with the appropriate criteria
+     *
+     * @param criteria A list of criteria
+     */
+    public SqlStatement<T> where(List<Criterion> criteria) {
+        whereClause = new WhereClause(criteria, String.join(".", objectType.getSimpleName(), wrapperPrefix));
+        return this;
+    }
+
+    /**
+     * Adds an ORDER BY statement
+     *
+     * @param orderField The field to order by. This is just the field, so no prefix, no object type. Default sort order is DESC.
+     */
+    public SqlStatement<T> orderBy(String orderField) {
+        orderClause = new OrderByClause(orderField, sortAscending, String.join(".", objectType.getSimpleName(), wrapperPrefix));
+        return this;
+    }
+
+    /**
+     * Adds an ORDER BY statement
+     *
+     * @param orderField The field to order by. This is just the field, so no prefix, no object type.
+     * @param ascending  Whether the results should be sorted in ascending or descending order.
+     */
+    public SqlStatement<T> orderBy(String orderField, boolean ascending) {
+        sortAscending = ascending;
+        return orderBy(orderField);
+    }
+
+    /**
+     * Adds a LIMIT statement.
+     *
+     * @param limit The limit. Can be null, in which case the limit clause will be ignored. Negative limits may cause an error
+     *              in the SQL database.
+     */
+    public SqlStatement<T> limit(@Nullable Integer limit) {
+        this.limit = new LimitClause(limit);
+        return this;
+    }
+
+    /**
+     * Adds a OFFSET statement, effectively skipping entries.
+     *
+     * @param offset The offset. Can be null, in which case the offset clause will be ignored. Negative offsets
+     *               may cause an error in the SQL database.
+     */
+    public SqlStatement<T> offset(Integer offset) {
+        this.offset = new OffsetClause(offset);
+        return this;
+    }
+
+    /**
+     * Returns the query text. This does not expand parameterized statements.
+     */
+    public String getQueryAsString() {
+        return getQueryAsSqlQuerySpec().getQueryText();
+
+    }
+
+    /**
+     * Returns the parameters of the query.
+     */
+    public List<SqlParameter> getParameters() {
+        return Stream.concat(whereClause.getParameters().stream(), orderClause.getParameters().stream())
+                .collect(toList());
+    }
+
+    /**
+     * Returns the entire SQL statement, potentially parameterized.
+     */
+    public SqlQuerySpec getQueryAsSqlQuerySpec() {
+        var queryText = format("SELECT * FROM %s %s %s %s %s", objectType.getSimpleName(), whereClause.asString(), orderClause.asString(), offset.asString(), limit.asString());
+        queryText = queryText.strip().replaceAll(" +", " "); //remove all unnecessary whitespaces
+        var parameters = Stream.concat(whereClause.getParameters().stream(), orderClause.getParameters().stream()).collect(toList());
+        return new SqlQuerySpec(queryText, parameters);
+    }
+}

--- a/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/WhereClause.java
+++ b/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/WhereClause.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.azure.cosmos.dialect;
+
+import com.azure.cosmos.models.SqlParameter;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.eclipse.dataspaceconnector.cosmos.azure.CosmosDocument.sanitize;
+
+class WhereClause implements Clause {
+    public static final String EQUALS_OPERATOR = "=";
+    public static final String IN_OPERATOR = "IN";
+    private static final List<String> SUPPORTED_OPERATOR = List.of(EQUALS_OPERATOR, IN_OPERATOR);
+    private final String objectPrefix;
+    private final List<SqlParameter> parameters = new ArrayList<>();
+    private String where = "";
+
+    public WhereClause(List<Criterion> criteria, String objectPrefix) {
+        this.objectPrefix = objectPrefix;
+        if (criteria != null) {
+            criteria.stream().distinct().forEach(this::criterion);
+        }
+    }
+
+    WhereClause() {
+        objectPrefix = null;
+    }
+
+
+    public String getWhere() {
+        return where;
+    }
+
+    @Override
+    public String asString() {
+        return getWhere();
+    }
+
+    @Override
+    public @NotNull List<SqlParameter> getParameters() {
+        return parameters;
+    }
+
+    private void criterion(Criterion criterion) {
+        if (!SUPPORTED_OPERATOR.contains(criterion.getOperator())) {
+            throw new IllegalArgumentException("Cannot build SqlParameter for operator: " + criterion.getOperator());
+        }
+        //        criterion = operandEscapeFunction.apply(criterion);
+        var operandLeft = sanitize(criterion.getOperandLeft().toString());
+        var operandRight = criterion.getOperandRight().toString();
+        var queryParam = createQueryParam(operandLeft, criterion.getOperator(), operandRight);
+        String param = queryParam.isEmpty() ? operandRight : "@" + operandLeft;
+        where += parameters.isEmpty() ? "WHERE" : " AND";
+        parameters.addAll(queryParam);
+        where += String.format(" %s.%s %s %s", objectPrefix, operandLeft, criterion.getOperator(), param);
+    }
+
+    private List<SqlParameter> createQueryParam(String opLeft, String operator, String opRight) {
+        switch (operator) {
+            case EQUALS_OPERATOR:
+                return List.of(new SqlParameter("@" + opLeft, opRight));
+            case IN_OPERATOR:
+                return List.of();
+            default: //not actually needed, but it's good style to have a default case
+                throw new IllegalArgumentException("Cannot build SqlParameter for operator: " + operator);
+        }
+    }
+
+}

--- a/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/WhereClause.java
+++ b/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/WhereClause.java
@@ -23,6 +23,20 @@ import java.util.List;
 
 import static org.eclipse.dataspaceconnector.cosmos.azure.CosmosDocument.sanitize;
 
+/**
+ * Represents in a structural way a WHERE clause in an SQL statement. Attempts to use parameterized statements using
+ * {@link SqlParameter} if possible. Currently, this is only implemented for the equals-operator ("=").
+ * <p>
+ * For every {@link Criterion} that is passed in, another {@code WHERE}- or {@code AND}-clause is appended.
+ *
+ * <p>
+ * Optionally an {@code orderPrefix} can be specified, which represents the "path" of the property. This is particularly
+ * relevant for CosmosDB queries, e.g:
+ * <pre>
+ *     SELECT * FROM YourDocument WHERE YourDocument.Header.Author = 'Foo Bar'
+ * </pre>
+ * In this case the {@code orderPrefix} would have to be {@code "YourDocument.Header"}.
+ */
 class WhereClause implements Clause {
     public static final String EQUALS_OPERATOR = "=";
     public static final String IN_OPERATOR = "IN";
@@ -42,11 +56,6 @@ class WhereClause implements Clause {
         objectPrefix = null;
     }
 
-
-    public String getWhere() {
-        return where;
-    }
-
     @Override
     public String asString() {
         return getWhere();
@@ -55,6 +64,10 @@ class WhereClause implements Clause {
     @Override
     public @NotNull List<SqlParameter> getParameters() {
         return parameters;
+    }
+
+    String getWhere() {
+        return where;
     }
 
     private void criterion(Criterion criterion) {

--- a/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/cosmos/azure/CosmosDocument.java
+++ b/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/cosmos/azure/CosmosDocument.java
@@ -20,6 +20,10 @@ public abstract class CosmosDocument<T> {
         this.partitionKey = partitionKey;
     }
 
+    public static String sanitize(String key) {
+        return key.replace(':', '_');
+    }
+
     public String getPartitionKey() {
         return partitionKey;
     }

--- a/extensions/azure/cosmos/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/LimitClauseTest.java
+++ b/extensions/azure/cosmos/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/LimitClauseTest.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.azure.cosmos.dialect;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LimitClauseTest {
+
+    @Test
+    void asString() {
+        assertThat(new LimitClause(14).asString()).isEqualTo("LIMIT 14");
+        assertThat(new LimitClause(null).asString()).isEmpty();
+    }
+}

--- a/extensions/azure/cosmos/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/OffsetClauseTest.java
+++ b/extensions/azure/cosmos/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/OffsetClauseTest.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.azure.cosmos.dialect;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OffsetClauseTest {
+
+    @Test
+    void asString() {
+        assertThat(new OffsetClause(null).asString()).isNotNull().isEmpty();
+        assertThat(new OffsetClause(14).asString()).isEqualTo("OFFSET 14");
+    }
+}

--- a/extensions/azure/cosmos/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/OrderByClauseTest.java
+++ b/extensions/azure/cosmos/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/OrderByClauseTest.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.azure.cosmos.dialect;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OrderByClauseTest {
+
+    @Test
+    void asString() {
+        assertThat(new OrderByClause("description", true, "c.wrappedObject").asString()).isEqualTo("ORDER BY c.wrappedObject.description ASC");
+        assertThat(new OrderByClause("description", false, "c.wrappedObject").asString()).isEqualTo("ORDER BY c.wrappedObject.description DESC");
+        assertThat(new OrderByClause("description", false, "c").asString()).isEqualTo("ORDER BY c.description DESC");
+        assertThat(new OrderByClause(null, false, "c").asString()).isEmpty();
+        assertThat(new OrderByClause("description", false, null).asString()).isEqualTo("ORDER BY description DESC");
+    }
+
+}

--- a/extensions/azure/cosmos/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/SqlStatementTest.java
+++ b/extensions/azure/cosmos/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/SqlStatementTest.java
@@ -1,0 +1,91 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.azure.cosmos.dialect;
+
+import org.eclipse.dataspaceconnector.cosmos.azure.TestCosmosDocument;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SqlStatementTest {
+
+    @Test
+    void getQuerySpec() {
+        var stmt = new SqlStatement<>(TestCosmosDocument.class);
+        assertThat(stmt.getQueryAsString()).isEqualTo("SELECT * FROM TestCosmosDocument");
+    }
+
+    @Test
+    void getQuerySpec_withWhere() {
+        var stmt = new SqlStatement<>(TestCosmosDocument.class);
+        stmt.where(List.of(new Criterion("id", "=", "1")));
+        assertThat(stmt.getQueryAsString()).isEqualTo("SELECT * FROM TestCosmosDocument WHERE TestCosmosDocument.wrappedInstance.id = @id");
+        assertThat(stmt.getParameters()).hasSize(1).allSatisfy(p -> {
+            assertThat(p.getName()).isEqualTo("@id");
+            assertThat(p.getValue(String.class)).isEqualTo("1");
+        });
+    }
+
+    @Test
+    void getQuerySpec_withWhereOrderBy() {
+        var stmt = new SqlStatement<>(TestCosmosDocument.class)
+                .where(List.of(new Criterion("id", "=", "1")))
+                .orderBy("priority");
+        assertThat(stmt.getQueryAsString()).isEqualTo("SELECT * FROM TestCosmosDocument WHERE TestCosmosDocument.wrappedInstance.id = @id ORDER BY TestCosmosDocument.wrappedInstance.priority ASC");
+
+        stmt.orderBy("priority", false);
+        assertThat(stmt.getQueryAsString()).isEqualTo("SELECT * FROM TestCosmosDocument WHERE TestCosmosDocument.wrappedInstance.id = @id ORDER BY TestCosmosDocument.wrappedInstance.priority DESC");
+    }
+
+    @Test
+    void getQuerySpec_withWhereOrderByLimit() {
+        var stmt = new SqlStatement<>(TestCosmosDocument.class)
+                .where(List.of(new Criterion("id", "=", "1")))
+                .orderBy("priority")
+                .limit(15);
+        assertThat(stmt.getQueryAsString()).isEqualTo("SELECT * FROM TestCosmosDocument WHERE TestCosmosDocument.wrappedInstance.id = @id ORDER BY TestCosmosDocument.wrappedInstance.priority ASC LIMIT 15");
+
+        stmt.orderBy("priority", false);
+        assertThat(stmt.getQueryAsString()).isEqualTo("SELECT * FROM TestCosmosDocument WHERE TestCosmosDocument.wrappedInstance.id = @id ORDER BY TestCosmosDocument.wrappedInstance.priority DESC LIMIT 15");
+    }
+
+    @Test
+    void getQuerySpec_withWhereOrderByLimitOffset() {
+        var stmt = new SqlStatement<>(TestCosmosDocument.class)
+                .where(List.of(new Criterion("id", "=", "1")))
+                .orderBy("priority")
+                .offset(10)
+                .limit(15);
+        assertThat(stmt.getQueryAsString()).isEqualTo("SELECT * FROM TestCosmosDocument WHERE TestCosmosDocument.wrappedInstance.id = @id ORDER BY TestCosmosDocument.wrappedInstance.priority ASC OFFSET 10 LIMIT 15");
+
+        stmt.orderBy("priority", false);
+        assertThat(stmt.getQueryAsString()).isEqualTo("SELECT * FROM TestCosmosDocument WHERE TestCosmosDocument.wrappedInstance.id = @id ORDER BY TestCosmosDocument.wrappedInstance.priority DESC OFFSET 10 LIMIT 15");
+    }
+
+    @Test
+    void getQuerySpec_withLimitOffset() {
+        var stmt = new SqlStatement<>(TestCosmosDocument.class)
+                .orderBy("priority")
+                .offset(10)
+                .limit(15);
+        assertThat(stmt.getQueryAsString()).isEqualTo("SELECT * FROM TestCosmosDocument ORDER BY TestCosmosDocument.wrappedInstance.priority ASC OFFSET 10 LIMIT 15");
+
+        stmt.orderBy("priority", false);
+        assertThat(stmt.getQueryAsString()).isEqualTo("SELECT * FROM TestCosmosDocument ORDER BY TestCosmosDocument.wrappedInstance.priority DESC OFFSET 10 LIMIT 15");
+    }
+}

--- a/extensions/azure/cosmos/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/WhereClauseTest.java
+++ b/extensions/azure/cosmos/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/WhereClauseTest.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.azure.cosmos.dialect;
+
+import com.azure.cosmos.models.SqlParameter;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WhereClauseTest {
+
+
+    @Test
+    void whereClause_withEquals() {
+        var wc = new WhereClause(List.of(new Criterion("foo", "=", "bar")), "testobj");
+        assertThat(wc.getWhere()).isEqualTo("WHERE testobj.foo = @foo");
+        var listAssert = assertThat(wc.getParameters());
+        listAssert.extracting(SqlParameter::getName).containsOnly("@foo");
+    }
+
+    @Test
+    void whereClause_withIn() {
+        var wc = new WhereClause(List.of(new Criterion("foo", "IN", "('bar1', 'bar2')")), "testobj");
+        assertThat(wc.getWhere()).isEqualTo("WHERE testobj.foo IN ('bar1', 'bar2')");
+        assertThat(wc.getParameters()).isEmpty();
+    }
+
+    @Test
+    void whereClause_withInvalidOperator() {
+        assertThatThrownBy(() -> new WhereClause(List.of(new Criterion("foo", "BEGINSWITH", "bar3")), "testobj")).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FccTestExtension.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FccTestExtension.java
@@ -17,7 +17,6 @@ import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
 import org.eclipse.dataspaceconnector.spi.message.MessageContext;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcher;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
-import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.system.Provides;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
@@ -69,8 +68,8 @@ public class FccTestExtension implements ServiceExtension {
         }
 
         @Override
-        public Stream<Asset> queryAssets(List<Criterion> criteria) {
-            return null;
+        public Stream<Asset> queryAssets(QuerySpec querySpec) {
+            throw new UnsupportedOperationException("Filtering/Paging not supported");
         }
 
         @Override
@@ -78,10 +77,6 @@ public class FccTestExtension implements ServiceExtension {
             return assets.stream().filter(a -> a.getId().equals(assetId)).findFirst().orElse(null);
         }
 
-        @Override
-        public List<Asset> findAll(QuerySpec querySpec) {
-            throw new UnsupportedOperationException("Filtering/Paging not supported");
-        }
     }
 
     private static class FakeContractOfferService implements ContractOfferService {

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FccTestExtension.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FccTestExtension.java
@@ -18,6 +18,7 @@ import org.eclipse.dataspaceconnector.spi.message.MessageContext;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcher;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.system.Provides;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
@@ -75,6 +76,11 @@ public class FccTestExtension implements ServiceExtension {
         @Override
         public Asset findById(String assetId) {
             return assets.stream().filter(a -> a.getId().equals(assetId)).findFirst().orElse(null);
+        }
+
+        @Override
+        public List<Asset> findAll(QuerySpec querySpec) {
+            throw new UnsupportedOperationException("Filtering/Paging not supported");
         }
     }
 

--- a/extensions/in-memory/assetindex-memory/build.gradle.kts
+++ b/extensions/in-memory/assetindex-memory/build.gradle.kts
@@ -20,6 +20,8 @@ plugins {
 dependencies {
     api(project(":spi"))
     api(project(":extensions:dataloading"))
+
+    implementation(project(":common:util"))
 }
 publishing {
     publications {

--- a/extensions/in-memory/assetindex-memory/src/main/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetIndexExtension.java
+++ b/extensions/in-memory/assetindex-memory/src/main/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetIndexExtension.java
@@ -31,7 +31,7 @@ public class InMemoryAssetIndexExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var service = new InMemoryAssetLoader(new CriterionToPredicateConverter());
+        var service = new InMemoryAssetIndex(new CriterionToPredicateConverter());
         context.registerService(AssetIndex.class, service);
         context.registerService(AssetLoader.class, service);
         context.registerService(DataAddressResolver.class, service);

--- a/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetIndexTest.java
+++ b/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetIndexTest.java
@@ -19,11 +19,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression.SELECT_ALL;
 
 class InMemoryAssetIndexTest {
-    private InMemoryAssetLoader index;
+    private InMemoryAssetIndex index;
 
     @BeforeEach
     void setUp() {
-        index = new InMemoryAssetLoader(new CriterionToPredicateConverter());
+        index = new InMemoryAssetIndex(new CriterionToPredicateConverter());
     }
 
     @Test
@@ -193,7 +193,7 @@ class InMemoryAssetIndexTest {
     }
 
     @Test
-    void findAll_withPaging_desc() {
+    void findAll_withPaging_noSortOrderDesc() {
         IntStream.range(0, 10)
                 .mapToObj(i -> createAsset("test-asset", "id" + i))
                 .forEach(a -> index.accept(a, createDataAddress(a)));
@@ -201,12 +201,11 @@ class InMemoryAssetIndexTest {
         var spec = QuerySpec.Builder.newInstance().sortOrder(SortOrder.DESC).offset(5).limit(2).build();
 
         var all = index.findAll(spec);
-        //it gets sorted 9...0, then skip 5, take 2
-        assertThat(all).hasSize(2).extracting(Asset::getId).containsExactly("id4", "id3");
+        assertThat(all).hasSize(2);
     }
 
     @Test
-    void findAll_withPaging_asc() {
+    void findAll_withPaging_noSortOrderAsc() {
         IntStream.range(0, 10)
                 .mapToObj(i -> createAsset("test-asset", "id" + i))
                 .forEach(a -> index.accept(a, createDataAddress(a)));
@@ -214,8 +213,7 @@ class InMemoryAssetIndexTest {
         var spec = QuerySpec.Builder.newInstance().sortOrder(SortOrder.ASC).offset(3).limit(3).build();
 
         var all = index.findAll(spec);
-        assertThat(all).hasSize(3).extracting(Asset::getId).containsExactly("id3", "id4", "id5");
-
+        assertThat(all).hasSize(3);
     }
 
     @Test

--- a/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetIndexTest.java
+++ b/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetIndexTest.java
@@ -189,7 +189,7 @@ class InMemoryAssetIndexTest {
                 .peek(a -> index.accept(a, createDataAddress(a))).collect(Collectors.toList());
 
 
-        assertThat(index.findAll(QuerySpec.Builder.newInstance().build())).containsAll(assets);
+        assertThat(index.queryAssets(QuerySpec.Builder.newInstance().build())).containsAll(assets);
     }
 
     @Test
@@ -200,7 +200,7 @@ class InMemoryAssetIndexTest {
 
         var spec = QuerySpec.Builder.newInstance().sortOrder(SortOrder.DESC).offset(5).limit(2).build();
 
-        var all = index.findAll(spec);
+        var all = index.queryAssets(spec);
         assertThat(all).hasSize(2);
     }
 
@@ -212,7 +212,7 @@ class InMemoryAssetIndexTest {
 
         var spec = QuerySpec.Builder.newInstance().sortOrder(SortOrder.ASC).offset(3).limit(3).build();
 
-        var all = index.findAll(spec);
+        var all = index.queryAssets(spec);
         assertThat(all).hasSize(3);
     }
 
@@ -224,7 +224,7 @@ class InMemoryAssetIndexTest {
                 .collect(Collectors.toList());
 
         var spec = QuerySpec.Builder.newInstance().equalsAsContains(false).filter(Asset.PROPERTY_ID + " = id1").build();
-        assertThat(index.findAll(spec)).hasSize(1).containsExactly(assets.get(1));
+        assertThat(index.queryAssets(spec)).hasSize(1).containsExactly(assets.get(1));
     }
 
 
@@ -239,7 +239,7 @@ class InMemoryAssetIndexTest {
                 .offset(15)
                 .limit(10)
                 .build();
-        assertThat(index.findAll(spec)).isEmpty();
+        assertThat(index.queryAssets(spec)).isEmpty();
     }
 
     @Test
@@ -250,7 +250,7 @@ class InMemoryAssetIndexTest {
                 .collect(Collectors.toList());
 
         var spec = QuerySpec.Builder.newInstance().sortField(Asset.PROPERTY_ID).sortOrder(SortOrder.ASC).build();
-        assertThat(index.findAll(spec)).containsAll(assets);
+        assertThat(index.queryAssets(spec)).containsAll(assets);
     }
 
     @NotNull

--- a/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetLoaderIndexTest.java
+++ b/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetLoaderIndexTest.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class InMemoryAssetLoaderLoaderTest {
+public class InMemoryAssetLoaderIndexTest {
 
     private AssetLoader assetLoader;
 
@@ -23,8 +23,8 @@ public class InMemoryAssetLoaderLoaderTest {
         var dataAddress = createDataAddress(asset);
         assetLoader.accept(asset, dataAddress);
 
-        assertThat(((InMemoryAssetLoader) assetLoader).getAssets()).hasSize(1);
-        assertThat(((InMemoryAssetLoader) assetLoader).getDataAddresses()).hasSize(1);
+        assertThat(((InMemoryAssetIndex) assetLoader).getAssets()).hasSize(1);
+        assertThat(((InMemoryAssetIndex) assetLoader).getDataAddresses()).hasSize(1);
     }
 
     @Test
@@ -43,8 +43,8 @@ public class InMemoryAssetLoaderLoaderTest {
         assetLoader.accept(asset, dataAddress1);
 
         //assert that this replaces the previous data address
-        assertThat(((InMemoryAssetLoader) assetLoader).getAssets()).hasSize(1).containsValue(asset);
-        assertThat(((InMemoryAssetLoader) assetLoader).getDataAddresses()).hasSize(1).containsValue(dataAddress1);
+        assertThat(((InMemoryAssetIndex) assetLoader).getAssets()).hasSize(1).containsValue(asset);
+        assertThat(((InMemoryAssetIndex) assetLoader).getDataAddresses()).hasSize(1).containsValue(dataAddress1);
 
     }
 
@@ -59,8 +59,8 @@ public class InMemoryAssetLoaderLoaderTest {
         List.of(new AssetEntry(asset1, address1), new AssetEntry(asset2, address2))
                 .forEach(entry -> assetLoader.accept(entry));
 
-        assertThat(((InMemoryAssetLoader) assetLoader).getAssets()).hasSize(2);
-        assertThat(((InMemoryAssetLoader) assetLoader).getDataAddresses()).hasSize(2);
+        assertThat(((InMemoryAssetIndex) assetLoader).getAssets()).hasSize(2);
+        assertThat(((InMemoryAssetIndex) assetLoader).getDataAddresses()).hasSize(2);
 
     }
 
@@ -75,14 +75,14 @@ public class InMemoryAssetLoaderLoaderTest {
                 .forEach(entry -> assetLoader.accept(entry));
 
         // only one address/asset combo should exist
-        assertThat(((InMemoryAssetLoader) assetLoader).getAssets()).hasSize(1);
-        assertThat(((InMemoryAssetLoader) assetLoader).getDataAddresses()).hasSize(1).containsValue(address2).containsKeys(asset1.getId());
+        assertThat(((InMemoryAssetIndex) assetLoader).getAssets()).hasSize(1);
+        assertThat(((InMemoryAssetIndex) assetLoader).getDataAddresses()).hasSize(1).containsValue(address2).containsKeys(asset1.getId());
 
     }
 
     @BeforeEach
     void setup() {
-        assetLoader = new InMemoryAssetLoader(new CriterionToPredicateConverter());
+        assetLoader = new InMemoryAssetIndex(new CriterionToPredicateConverter());
     }
 
     private Asset createAsset(String name, String id) {

--- a/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetLoaderLoaderTest.java
+++ b/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetLoaderLoaderTest.java
@@ -1,8 +1,5 @@
 package org.eclipse.dataspaceconnector.metadata.memory;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.dataspaceconnector.dataloading.AssetEntry;
 import org.eclipse.dataspaceconnector.dataloading.AssetLoader;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
@@ -11,7 +8,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryDataAddressResolverTest.java
+++ b/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryDataAddressResolverTest.java
@@ -1,26 +1,22 @@
 package org.eclipse.dataspaceconnector.metadata.memory;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.assertj.core.api.Assertions;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class InMemoryDataAddressResolverTest {
-    private InMemoryAssetLoader resolver;
+    private InMemoryAssetIndex resolver;
 
 
     @BeforeEach
     void setUp() {
-        resolver = new InMemoryAssetLoader(new CriterionToPredicateConverter());
+        resolver = new InMemoryAssetIndex(new CriterionToPredicateConverter());
     }
 
     @Test

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/asset/AssetIndex.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/asset/AssetIndex.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.spi.asset;
 
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.system.Feature;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.jetbrains.annotations.Nullable;
@@ -59,5 +60,21 @@ public interface AssetIndex {
      */
     @Nullable
     Asset findById(String assetId);
+
+
+    /**
+     * Finds all assets that are covered by a specific {@link QuerySpec}. Results are always sorted. If no {@link QuerySpec#getSortField()}
+     * is specified, results are not explicitly sorted.
+     * <p>
+     * The general order of precedence of the query parameters is:
+     * <pre>
+     * filter > sort > limit
+     * </pre>
+     * <p>
+     *
+     * @param querySpec The query spec, e.g. paging, filtering, etc.
+     * @return A potentially empty collection of {@link Asset}, never null.
+     */
+    List<Asset> findAll(QuerySpec querySpec);
 
 }

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/asset/AssetIndex.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/asset/AssetIndex.java
@@ -14,13 +14,11 @@
 
 package org.eclipse.dataspaceconnector.spi.asset;
 
-import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.system.Feature;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.List;
 import java.util.stream.Stream;
 
 /**
@@ -47,22 +45,6 @@ public interface AssetIndex {
     Stream<Asset> queryAssets(AssetSelectorExpression expression);
 
     /**
-     * Returns true if the set of asset are in the group of assets defined by criteria.
-     */
-    Stream<Asset> queryAssets(List<Criterion> criteria);
-
-    /**
-     * Fetches the {@link Asset} with the given ID from the metadata backend.
-     *
-     * @param assetId A String that represents the Asset ID, in most cases this will be a UUID.
-     * @return The {@link Asset} if one was found, or null otherwise.
-     * @throws NullPointerException If {@code assetId} was null or empty.
-     */
-    @Nullable
-    Asset findById(String assetId);
-
-
-    /**
      * Finds all assets that are covered by a specific {@link QuerySpec}. Results are always sorted. If no {@link QuerySpec#getSortField()}
      * is specified, results are not explicitly sorted.
      * <p>
@@ -75,6 +57,17 @@ public interface AssetIndex {
      * @param querySpec The query spec, e.g. paging, filtering, etc.
      * @return A potentially empty collection of {@link Asset}, never null.
      */
-    List<Asset> findAll(QuerySpec querySpec);
+    Stream<Asset> queryAssets(QuerySpec querySpec);
+
+    /**
+     * Fetches the {@link Asset} with the given ID from the metadata backend.
+     *
+     * @param assetId A String that represents the Asset ID, in most cases this will be a UUID.
+     * @return The {@link Asset} if one was found, or null otherwise.
+     * @throws NullPointerException If {@code assetId} was null or empty.
+     */
+    @Nullable
+    Asset findById(String assetId);
+
 
 }

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/QuerySpec.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/QuerySpec.java
@@ -126,8 +126,7 @@ public class QuerySpec {
                     var tokens = filterExpression.split("=");
                     querySpec.filterExpression = List.of(new Criterion(tokens[0], equalsAsContains ? "contains" : "=", tokens[1]));
                 } else {
-                    var sanitized = filterExpression.replaceAll(" +", " ");
-                    var s = sanitized.split(" ");
+                    var s = filterExpression.split(" +");
 
                     //generic LEFT OPERAND RIGHT expression
                     if (s.length >= 3) {

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/QuerySpec.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/QuerySpec.java
@@ -14,8 +14,10 @@
 
 package org.eclipse.dataspaceconnector.spi.query;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Specifies various query parameters for collection-like queries.
@@ -25,8 +27,12 @@ public class QuerySpec {
     private int offset = 0;
     private int limit = 50;
     private List<Criterion> filterExpression;
-    private SortOrder sortOrder = SortOrder.DESC;
+    private SortOrder sortOrder = SortOrder.ASC;
     private String sortField;
+
+    public static QuerySpec none() {
+        return new QuerySpec();
+    }
 
     public String getSortField() {
         return sortField;
@@ -61,6 +67,7 @@ public class QuerySpec {
 
     public static final class Builder {
         private final QuerySpec querySpec;
+        private boolean equalsAsContains = false;
 
         private Builder() {
             querySpec = new QuerySpec();
@@ -94,6 +101,11 @@ public class QuerySpec {
             return this;
         }
 
+        public Builder equalsAsContains(boolean equalsAsContains) {
+            this.equalsAsContains = equalsAsContains;
+            return this;
+        }
+
         public QuerySpec build() {
             if (querySpec.offset < 0) {
                 throw new IllegalArgumentException("offset");
@@ -112,14 +124,15 @@ public class QuerySpec {
                     filterExpression = filterExpression.replace(" ", "");
                     // we'll interpret the "=" as "contains"
                     var tokens = filterExpression.split("=");
-                    querySpec.filterExpression = List.of(new Criterion(tokens[0], "contains", tokens[1]));
+                    querySpec.filterExpression = List.of(new Criterion(tokens[0], equalsAsContains ? "contains" : "=", tokens[1]));
                 } else {
                     var sanitized = filterExpression.replaceAll(" +", " ");
                     var s = sanitized.split(" ");
 
                     //generic LEFT OPERAND RIGHT expression
-                    if (s.length == 3) {
-                        querySpec.filterExpression = List.of(new Criterion(s[0], s[1], s[2]));
+                    if (s.length >= 3) {
+                        var rh = Arrays.stream(s, 2, s.length).collect(Collectors.joining(" "));
+                        querySpec.filterExpression = List.of(new Criterion(s[0], s[1], rh));
                     } else {
                         // unsupported filter expression
                         throw new IllegalArgumentException("Cannot convert " + filterExpression + " into a Criterion");

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/QuerySpec.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/QuerySpec.java
@@ -116,6 +116,11 @@ public class QuerySpec {
             return querySpec;
         }
 
+        public Builder filter(List<Criterion> criteria) {
+            querySpec.filterExpression = criteria;
+            return this;
+        }
+
         public Builder filter(String filterExpression) {
 
             if (filterExpression != null) {
@@ -141,5 +146,7 @@ public class QuerySpec {
 
             return this;
         }
+
+
     }
 }

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/query/QuerySpecTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/query/QuerySpecTest.java
@@ -38,15 +38,22 @@ class QuerySpecTest {
         assertion.extracting(QuerySpec::getFilterExpression).isNull();
         assertion.extracting(QuerySpec::getLimit).isEqualTo(50);
         assertion.extracting(QuerySpec::getOffset).isEqualTo(0);
-        assertion.extracting(QuerySpec::getSortOrder).isEqualTo(SortOrder.DESC);
+        assertion.extracting(QuerySpec::getSortOrder).isEqualTo(SortOrder.ASC);
         assertion.extracting(QuerySpec::getSortField).isNull();
     }
 
     @ParameterizedTest
     @ValueSource(strings = { "name=foo", "name = foo", "name =      foo", "name contains foo" })
-    void verifyEqualsFilterExpressions(String equalityExp) {
-        var spec = QuerySpec.Builder.newInstance().filter(equalityExp).build();
+    void verifyEquals_whenEqualsAsContainsFilterExpressions(String equalityExp) {
+        var spec = QuerySpec.Builder.newInstance().equalsAsContains(true).filter(equalityExp).build();
         assertThat(spec.getFilterExpression()).hasSize(1).containsOnly(new Criterion("name", "contains", "foo"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "name=foo", "name = foo", "name =      foo" })
+    void verifyEquals_whenEqualsFilterExpressions(String equalityExp) {
+        var spec = QuerySpec.Builder.newInstance().equalsAsContains(false).filter(equalityExp).build();
+        assertThat(spec.getFilterExpression()).hasSize(1).containsOnly(new Criterion("name", "=", "foo"));
     }
 
     @Test


### PR DESCRIPTION
This PR adds functionality to the AssetIndex, which allows for pagination, filtering, sorting.

In the course of this a few adjustments to the `QuerySpec` and overall improvements have been made, for example a `PredicateMatcher`.

Closes #632 
