### PR TITLE
Implement Data Plane launcher; minor cosmetic fixes to launch output

### DIFF
--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/runtime/BaseRuntime.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/runtime/BaseRuntime.java
@@ -155,9 +155,9 @@ public class BaseRuntime {
         while (iter.hasPrevious()) {
             var extension = iter.previous();
             extension.shutdown();
-            monitor.info("Shutdown " + extension);
+            monitor.info("Shutdown " + extension.name());
         }
-        monitor.info("Connector shutdown complete");
+        monitor.info("Shutdown complete");
     }
 
     /**

--- a/launchers/data-plane-server/build.gradle.kts
+++ b/launchers/data-plane-server/build.gradle.kts
@@ -17,15 +17,31 @@ val jodahFailsafeVersion: String by project
 
 plugins {
     `java-library`
+    id("application")
+    id("com.github.johnrengelman.shadow") version "7.0.0"
 }
 
 dependencies {
     implementation(project(":spi:web-spi"))
+    implementation(project(":core:base"))
+    implementation(project(":core:boot"))
+    implementation(project(":extensions:http"))
     implementation(project(":extensions:data-plane:data-plane-spi"))
     implementation(project(":extensions:data-plane:data-plane-framework"))
     implementation(project(":extensions:data-plane:data-plane-http"))
     implementation(project(":extensions:data-plane:data-plane-api"))
 }
+
+application {
+    mainClass.set("org.eclipse.dataspaceconnector.boot.system.runtime.BaseRuntime")
+}
+
+tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
+    exclude("**/pom.properties", "**/pom.xm")
+    mergeServiceFiles()
+    archiveFileName.set("data-plane-server.jar")
+}
+
 
 publishing {
     publications {
@@ -35,3 +51,5 @@ publishing {
         }
     }
 }
+
+


### PR DESCRIPTION
This PR implements the basic DPF Server sans API and introduces a few minor cosmetic changes to the launch output.