### PR TITLE
extensions: implement S3BucketReader

### DIFF
--- a/.github/workflows/integrationtests.yaml
+++ b/.github/workflows/integrationtests.yaml
@@ -96,6 +96,13 @@ jobs:
           S3_SECRET_ACCESS_KEY: password
         run: ./gradlew extensions:aws:s3:s3-provision:check
 
+      - name: AWS S3 StatusChecker Test
+        env:
+          RUN_INTEGRATION_TEST: true
+          S3_ACCESS_KEY_ID: root
+          S3_SECRET_ACCESS_KEY: password
+        run: ./gradlew extensions:aws:s3:s3-data-operator:check
+
   Daps-Integration-Test:
     runs-on: ubuntu-latest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ the detailed section referring to by linking pull requests or issues.
 * `ContractDefinitionStore` supports paging (#717)
 * Add okhttp client timeouts (#735)
 * Unit test framework for Dependency Injection (#843)
+* Implemented S3BucketReader (#675)
 
 #### Changed
 

--- a/extensions/aws/aws-test/README.md
+++ b/extensions/aws/aws-test/README.md
@@ -2,7 +2,7 @@
 
 To run AWS integration tests you will need a MinIO instance running:
 ```
-docker run -d -p 9000:9000 -e MINIO_ACCESS_KEY=root -e MINIO_SECRET_KEY=password bitnami/minio:latest
+docker run -d -p 9000:9000 -e MINIO_ROOT_USER=root -e MINIO_ROOT_PASSWORD=password bitnami/minio:latest
 ```
 
 Then set the two environment variables:

--- a/extensions/aws/aws-test/src/testFixtures/java/org/eclipse/dataspaceconnector/aws/testfixtures/AbstractS3Test.java
+++ b/extensions/aws/aws-test/src/testFixtures/java/org/eclipse/dataspaceconnector/aws/testfixtures/AbstractS3Test.java
@@ -39,7 +39,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.UUID;
@@ -94,14 +93,14 @@ public abstract class AbstractS3Test {
     }
 
     @BeforeEach
-    public void setupClient() throws URISyntaxException {
+    public void setupClient() {
         client = S3AsyncClient.builder()
                 .serviceConfiguration(S3Configuration.builder()
                         .pathStyleAccessEnabled(true)
                         .build())
                 .region(Region.of(REGION))
                 .credentialsProvider(this::getCredentials)
-                .endpointOverride(new URI(S3_ENDPOINT))
+                .endpointOverride(URI.create(S3_ENDPOINT))
                 .build();
 
         createBucket(bucketName);
@@ -152,7 +151,7 @@ public abstract class AbstractS3Test {
         return client.putObject(PutObjectRequest.builder().bucket(bucketName).key(key).build(), file.toPath());
     }
 
-    private @NotNull AwsCredentials getCredentials() {
+    protected @NotNull AwsCredentials getCredentials() {
         String profile = propOrEnv("AWS_PROFILE", null);
         if (profile != null) {
             return ProfileCredentialsProvider.create(profile).resolveCredentials();

--- a/extensions/aws/s3/s3-core/src/main/java/org/eclipse/dataspaceconnector/aws/s3/core/S3ClientProvider.java
+++ b/extensions/aws/s3/s3-core/src/main/java/org/eclipse/dataspaceconnector/aws/s3/core/S3ClientProvider.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2020, 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.aws.s3.core;
+
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.SecretToken;
+import software.amazon.awssdk.services.s3.S3Client;
+
+/**
+ * Provides S3Client
+ */
+public interface S3ClientProvider {
+
+    /**
+     * Returns the client for the specified region and secretToken
+     */
+    S3Client provide(String region, SecretToken secretToken);
+
+}

--- a/extensions/aws/s3/s3-core/src/main/java/org/eclipse/dataspaceconnector/aws/s3/core/S3ClientProviderImpl.java
+++ b/extensions/aws/s3/s3-core/src/main/java/org/eclipse/dataspaceconnector/aws/s3/core/S3ClientProviderImpl.java
@@ -1,0 +1,35 @@
+package org.eclipse.dataspaceconnector.aws.s3.core;
+
+import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.SecretToken;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+public class S3ClientProviderImpl implements S3ClientProvider {
+    @Override
+    public S3Client provide(String region, SecretToken token) {
+        if (token instanceof AwsTemporarySecretToken) {
+            var temporary = (AwsTemporarySecretToken) token;
+            var credentials = AwsSessionCredentials.create(temporary.getAccessKeyId(), temporary.getSecretAccessKey(), temporary.getSessionToken());
+            var credentialsProvider = StaticCredentialsProvider.create(credentials);
+            return S3Client.builder()
+                    .credentialsProvider(credentialsProvider)
+                    .region(Region.of(region))
+                    .build();
+        } else if (token instanceof AwsSecretToken) {
+            var secretToken = (AwsSecretToken) token;
+            var credentials = AwsBasicCredentials.create(secretToken.getAccessKeyId(), secretToken.getSecretAccessKey());
+            var credentialsProvider = StaticCredentialsProvider.create(credentials);
+            return S3Client.builder()
+                    .credentialsProvider(credentialsProvider)
+                    .region(Region.of(region))
+                    .build();
+
+        } else {
+            throw new EdcException(String.format("SecretToken %s is not supported", token.getClass()));
+        }
+    }
+}

--- a/extensions/aws/s3/s3-data-operator/build.gradle.kts
+++ b/extensions/aws/s3/s3-data-operator/build.gradle.kts
@@ -20,6 +20,9 @@ dependencies {
     api(project(":spi"))
     api(project(":core"))
     api(project(":extensions:aws:s3:s3-core"))
+
+    testImplementation(testFixtures(project(":common:util")))
+    testImplementation(testFixtures(project(":extensions:aws:aws-test")))
 }
 
 publishing {

--- a/extensions/aws/s3/s3-data-operator/src/main/java/org/eclipse/dataspaceconnector/aws/s3/operator/S3BucketReader.java
+++ b/extensions/aws/s3/s3-data-operator/src/main/java/org/eclipse/dataspaceconnector/aws/s3/operator/S3BucketReader.java
@@ -1,19 +1,53 @@
 package org.eclipse.dataspaceconnector.aws.s3.operator;
 
+import org.eclipse.dataspaceconnector.aws.s3.core.AwsSecretToken;
+import org.eclipse.dataspaceconnector.aws.s3.core.S3BucketSchema;
+import org.eclipse.dataspaceconnector.aws.s3.core.S3ClientProvider;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.transfer.inline.DataReader;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 
 import java.io.ByteArrayInputStream;
 
 public class S3BucketReader implements DataReader {
+
+    private final Monitor monitor;
+    private final Vault vault;
+    private final S3ClientProvider clientProvider;
+
+    public S3BucketReader(Monitor monitor, Vault vault, S3ClientProvider clientProvider) {
+        this.monitor = monitor;
+        this.vault = vault;
+        this.clientProvider = clientProvider;
+    }
+
     @Override
     public boolean canHandle(String type) {
-        return false;
+        return S3BucketSchema.TYPE.equals(type);
     }
 
     @Override
     public Result<ByteArrayInputStream> read(DataAddress source) {
-        return null;
+        var region = source.getProperty(S3BucketSchema.REGION);
+        var bucketName = source.getProperty(S3BucketSchema.BUCKET_NAME);
+        var accessKeyId = this.vault.resolveSecret("aws-access-key-id");
+        var secretAccessKey = this.vault.resolveSecret("aws-secret-access-key");
+        var token = new AwsSecretToken(accessKeyId, secretAccessKey);
+
+        try (var s3 = clientProvider.provide(region, token)) {
+            var request = GetObjectRequest.builder().bucket(bucketName).key(source.getKeyName()).build();
+            monitor.debug("Data request: begin transfer...");
+            var response = s3.getObject(request);
+            var inputStream = new ByteArrayInputStream(response.readAllBytes());
+            monitor.debug("Data request done.");
+            return Result.success(inputStream);
+        } catch (Exception ex) {
+            this.monitor.severe("Data request: transfer failed!", ex);
+            return Result.failure("Data request: transfer failed!");
+        }
     }
+
 }

--- a/extensions/aws/s3/s3-data-operator/src/test/java/org/eclipse/dataspaceconnector/aws/s3/operator/S3DataOperatorIntegrationTest.java
+++ b/extensions/aws/s3/s3-data-operator/src/test/java/org/eclipse/dataspaceconnector/aws/s3/operator/S3DataOperatorIntegrationTest.java
@@ -1,0 +1,84 @@
+package org.eclipse.dataspaceconnector.aws.s3.operator;
+
+import net.jodah.failsafe.RetryPolicy;
+import org.eclipse.dataspaceconnector.aws.s3.core.AwsTemporarySecretToken;
+import org.eclipse.dataspaceconnector.aws.s3.core.S3BucketSchema;
+import org.eclipse.dataspaceconnector.aws.s3.core.S3ClientProvider;
+import org.eclipse.dataspaceconnector.aws.testfixtures.AbstractS3Test;
+import org.eclipse.dataspaceconnector.common.annotations.IntegrationTest;
+import org.eclipse.dataspaceconnector.spi.monitor.ConsoleMonitor;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.security.Vault;
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.SecretToken;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.eclipse.dataspaceconnector.aws.s3.core.S3BucketSchema.TYPE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@IntegrationTest
+public class S3DataOperatorIntegrationTest extends AbstractS3Test {
+
+    private final TypeManager typeManager = new TypeManager();
+    private final S3ClientProvider clientProvider = new TestS3ClientProvider(getCredentials(), S3_ENDPOINT);
+    private final Monitor monitor = new ConsoleMonitor();
+    private final Vault vault = mock(Vault.class);
+
+    @Test
+    void shouldWriteAndReadFromS3Bucket() {
+        var reader = new S3BucketReader(monitor, vault, clientProvider);
+        var writer = new S3BucketWriter(monitor, typeManager, new RetryPolicy<>(), clientProvider);
+        var address = DataAddress.Builder.newInstance()
+                .type(TYPE)
+                .keyName("key")
+                .property(S3BucketSchema.REGION, "any")
+                .property(S3BucketSchema.BUCKET_NAME, bucketName)
+                .build();
+        var credentials = getCredentials();
+        var secret = typeManager.writeValueAsString(new AwsTemporarySecretToken(credentials.accessKeyId(), credentials.secretAccessKey(), "", 3600));
+        when(vault.resolveSecret("aws-credentials")).thenReturn(secret);
+        when(vault.resolveSecret("aws-access-key-id")).thenReturn(credentials.accessKeyId());
+        when(vault.resolveSecret("aws-secret-access-key")).thenReturn(credentials.secretAccessKey());
+
+        var writeResult = writer.write(address, "key", new ByteArrayInputStream("content".getBytes()), secret);
+        assertThat(writeResult.succeeded()).isEqualTo(true);
+
+        var result = reader.read(address);
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent()).hasBinaryContent("content".getBytes());
+    }
+
+    private static class TestS3ClientProvider implements S3ClientProvider {
+
+        private final AwsCredentials credentials;
+        private final String s3Endpoint;
+
+        public TestS3ClientProvider(AwsCredentials credentials, String s3Endpoint) {
+            this.credentials = credentials;
+            this.s3Endpoint = s3Endpoint;
+        }
+
+        @Override
+        public S3Client provide(String region, SecretToken secretToken) {
+            return S3Client.builder()
+                    .serviceConfiguration(S3Configuration.builder()
+                            .pathStyleAccessEnabled(true)
+                            .build())
+                    .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                    .region(Region.of("region"))
+                    .endpointOverride(URI.create(s3Endpoint))
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
## Context
In the process of deploying an EDC to transfer data from an S3 bucket to another we noticed that the data cannot be read because the `S3BucketReader` is a dummy implementation.

## What brings
An implementation of `S3BucketReader`. a `S3ClientProvider` was introduced upfront to permit testability.