### PR TITLE
rename registerController->registerResource, remove deprecated method

### DIFF
--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsMultipartApiServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsMultipartApiServiceExtension.java
@@ -173,7 +173,7 @@ public final class IdsMultipartApiServiceExtension implements ServiceExtension {
 
         // create & register controller
         var multipartController = new MultipartController(connectorId, objectMapper, identityService, handlers);
-        webService.registerController(multipartController);
+        webService.registerResource(multipartController);
     }
 
     private String resolveConnectorId(@NotNull ServiceExtensionContext context) {

--- a/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/ControlApiServiceExtension.java
+++ b/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/ControlApiServiceExtension.java
@@ -59,8 +59,8 @@ public class ControlApiServiceExtension implements ServiceExtension {
         monitor = serviceExtensionContext.getMonitor();
 
 
-        webService.registerController(new ClientController(transferProcessManager, consumerNegotiationManager, contractNegotiationStore));
-        webService.registerController(new ClientControlCatalogApiController(remoteMessageDispatcherRegistry));
+        webService.registerResource(new ClientController(transferProcessManager, consumerNegotiationManager, contractNegotiationStore));
+        webService.registerResource(new ClientControlCatalogApiController(remoteMessageDispatcherRegistry));
 
         /*
          * Registers a API-Key authentication filter
@@ -68,7 +68,7 @@ public class ControlApiServiceExtension implements ServiceExtension {
         HttpApiKeyAuthContainerRequestFilter httpApiKeyAuthContainerRequestFilter = new HttpApiKeyAuthContainerRequestFilter(resolveApiKeyHeaderName(serviceExtensionContext), resolveApiKeyHeaderValue(serviceExtensionContext),
                 AuthenticationContainerRequestContextPredicate.INSTANCE);
 
-        webService.registerController(httpApiKeyAuthContainerRequestFilter);
+        webService.registerResource(httpApiKeyAuthContainerRequestFilter);
 
         // contribute to the liveness probe
         var hcs = serviceExtensionContext.getService(HealthCheckService.class, true);

--- a/extensions/api/observability/src/main/java/org/eclipse/dataspaceconnector/api/observability/ObservabilityApiExtension.java
+++ b/extensions/api/observability/src/main/java/org/eclipse/dataspaceconnector/api/observability/ObservabilityApiExtension.java
@@ -31,7 +31,7 @@ public class ObservabilityApiExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext serviceExtensionContext) {
 
 
-        webService.registerController(new ObservabilityApiController(healthCheckService));
+        webService.registerResource(new ObservabilityApiController(healthCheckService));
 
         // contribute to the liveness probe
         healthCheckService.addReadinessProvider(() -> HealthCheckResult.Builder.newInstance().component("Observability API").build());

--- a/extensions/api/observability/src/test/java/org/eclipse/dataspaceconnector/api/observability/ObservabilityApiExtensionTest.java
+++ b/extensions/api/observability/src/test/java/org/eclipse/dataspaceconnector/api/observability/ObservabilityApiExtensionTest.java
@@ -32,7 +32,7 @@ class ObservabilityApiExtensionTest {
 
         extension.initialize(contextMock);
 
-        verify(webServiceMock).registerController(isA(ObservabilityApiController.class));
+        verify(webServiceMock).registerResource(isA(ObservabilityApiController.class));
         verify(healthServiceMock).addReadinessProvider(isA(ReadinessProvider.class));
         verify(healthServiceMock).addLivenessProvider(isA(LivenessProvider.class));
         verifyNoMoreInteractions(webServiceMock);

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheExtension.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheExtension.java
@@ -82,7 +82,7 @@ public class FederatedCatalogCacheExtension implements ServiceExtension {
         context.registerService(QueryEngine.class, queryEngine);
         monitor = context.getMonitor();
         var catalogController = new CatalogController(monitor, queryEngine);
-        webService.registerController(catalogController);
+        webService.registerResource(catalogController);
 
         // contribute to the liveness probe
         if (healthCheckService != null) {

--- a/extensions/http/jersey/src/main/java/org/eclipse/dataspaceconnector/extension/jersey/JerseyRestService.java
+++ b/extensions/http/jersey/src/main/java/org/eclipse/dataspaceconnector/extension/jersey/JerseyRestService.java
@@ -50,11 +50,6 @@ public class JerseyRestService implements WebService {
     }
 
     @Override
-    public void registerController(Object controller) {
-        registerResource(controller);
-    }
-
-    @Override
     public void registerResource(Object resource) {
         controllers.computeIfAbsent(DEFAULT_CONTEXT_ALIAS, s -> new ArrayList<>())
                 .add(resource);

--- a/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtension.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtension.java
@@ -82,7 +82,7 @@ public class IdentityDidCoreExtension implements ServiceExtension {
         context.registerService(IdentityHub.class, hub);
 
         var controller = new IdentityHubController(hub);
-        webService.registerController(controller);
+        webService.registerResource(controller);
 
         // contribute to the liveness probe
         var hcs = context.getService(HealthCheckService.class, true);

--- a/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtensionTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtensionTest.java
@@ -55,6 +55,6 @@ class IdentityDidCoreExtensionTest {
         verify(contextMock).registerService(eq(DidPublicKeyResolver.class), isA(DidPublicKeyResolverImpl.class));
         verify(contextMock).registerService(eq(IdentityHub.class), isA(IdentityHubImpl.class));
         verify(contextMock).registerService(eq(IdentityHubClient.class), isA(IdentityHubClientImpl.class));
-        verify(webserviceMock).registerController(isA(IdentityHubController.class));
+        verify(webserviceMock).registerResource(isA(IdentityHubController.class));
     }
 }

--- a/extensions/iam/decentralized-identity/registration-service-api/src/main/java/org/eclipse/dataspaceconnector/samples/identity/registrationservice/api/RegistrationServiceApiExtension.java
+++ b/extensions/iam/decentralized-identity/registration-service-api/src/main/java/org/eclipse/dataspaceconnector/samples/identity/registrationservice/api/RegistrationServiceApiExtension.java
@@ -21,7 +21,7 @@ public class RegistrationServiceApiExtension implements ServiceExtension {
 
         // register the service as REST controller
         var webService = context.getService(WebService.class);
-        webService.registerController(regSrv);
+        webService.registerResource(regSrv);
 
         context.getMonitor().info("Registration Service REST API initialized");
     }

--- a/samples/02-health-endpoint/src/main/java/org/eclipse/dataspaceconnector/extensions/health/HealthEndpointExtension.java
+++ b/samples/02-health-endpoint/src/main/java/org/eclipse/dataspaceconnector/extensions/health/HealthEndpointExtension.java
@@ -11,6 +11,6 @@ public class HealthEndpointExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var webService = context.getService(WebService.class);
-        webService.registerController(new HealthApiController(context.getMonitor()));
+        webService.registerResource(new HealthApiController(context.getMonitor()));
     }
 }

--- a/samples/03-configuration/src/main/java/org/eclipse/dataspaceconnector/extensions/health/HealthEndpointExtension.java
+++ b/samples/03-configuration/src/main/java/org/eclipse/dataspaceconnector/extensions/health/HealthEndpointExtension.java
@@ -13,6 +13,6 @@ public class HealthEndpointExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         var logPrefix = context.getSetting(LOG_PREFIX_SETTING, "health");
         var webService = context.getService(WebService.class);
-        webService.registerController(new HealthApiController(context.getMonitor(), logPrefix));
+        webService.registerResource(new HealthApiController(context.getMonitor(), logPrefix));
     }
 }

--- a/samples/04.0-file-transfer/api/src/main/java/org/eclipse/dataspaceconnector/extensions/api/ApiEndpointExtension.java
+++ b/samples/04.0-file-transfer/api/src/main/java/org/eclipse/dataspaceconnector/extensions/api/ApiEndpointExtension.java
@@ -34,6 +34,6 @@ public class ApiEndpointExtension implements ServiceExtension {
         var processManager = context.getService(TransferProcessManager.class);
         var negotiationManager = context.getService(ConsumerContractNegotiationManager.class);
         var transferProcessStore = context.getService(TransferProcessStore.class);
-        webService.registerController(new ConsumerApiController(context.getMonitor(), processManager, negotiationManager, transferProcessStore));
+        webService.registerResource(new ConsumerApiController(context.getMonitor(), processManager, negotiationManager, transferProcessStore));
     }
 }

--- a/samples/04.0-file-transfer/provider/build.gradle.kts
+++ b/samples/04.0-file-transfer/provider/build.gradle.kts
@@ -29,7 +29,6 @@ dependencies {
     implementation(project(":extensions:in-memory:transfer-store-memory"))
     implementation(project(":extensions:in-memory:negotiation-store-memory"))
     implementation(project(":extensions:in-memory:contractdefinition-store-memory"))
-    implementation(project(":extensions:http"))
 
     implementation(project(":extensions:api:observability"))
 

--- a/samples/05-file-transfer-cloud/api/src/main/java/org/eclipse/dataspaceconnector/extensions/api/ApiEndpointExtension.java
+++ b/samples/05-file-transfer-cloud/api/src/main/java/org/eclipse/dataspaceconnector/extensions/api/ApiEndpointExtension.java
@@ -18,6 +18,6 @@ public class ApiEndpointExtension implements ServiceExtension {
         var webService = context.getService(WebService.class);
         var processManager = context.getService(TransferProcessManager.class);
         var processStore = context.getService(TransferProcessStore.class);
-        webService.registerController(new ConsumerApiController(context.getMonitor(), processManager, processStore));
+        webService.registerResource(new ConsumerApiController(context.getMonitor(), processManager, processStore));
     }
 }

--- a/samples/other/streaming/src/main/java/org/eclipse/dataspaceconnector/transfer/demo/protocols/DemoProtocolsTransferExtension.java
+++ b/samples/other/streaming/src/main/java/org/eclipse/dataspaceconnector/transfer/demo/protocols/DemoProtocolsTransferExtension.java
@@ -90,7 +90,7 @@ public class DemoProtocolsTransferExtension implements ServiceExtension {
         new WebSocketFactory().publishEndpoint(PubSubServerEndpoint.class, () -> new PubSubServerEndpoint(topicManager, objectMapper, monitor), jettyService);
 
         httpEndpoint = new PubSubHttpEndpoint(topicManager);
-        context.getService(WebService.class).registerController(httpEndpoint);
+        context.getService(WebService.class).registerResource(httpEndpoint);
 
         var messageDispatcher = context.getService(RemoteMessageDispatcherRegistry.class);
         var processManager = context.getService(TransferProcessManager.class);

--- a/spi/web-spi/src/main/java/org/eclipse/dataspaceconnector/spi/WebService.java
+++ b/spi/web-spi/src/main/java/org/eclipse/dataspaceconnector/spi/WebService.java
@@ -23,14 +23,6 @@ import org.eclipse.dataspaceconnector.spi.system.Feature;
 public interface WebService {
 
     /**
-     * Registers a JAX-RS resource instance, or controller. Extensions may contribute bespoke APIs to the runtime.
-     *
-     * @deprecated Use {@link WebService#registerResource(Object)} instead, as it is actually a resource we're registering.
-     */
-    @Deprecated
-    void registerController(Object controller);
-
-    /**
      * Registers a resource (e.g. a controller or a filter) with the webservice, making it available for the default port mapping.
      *
      * @param resource a resource


### PR DESCRIPTION
this Pull request
* removes a deprecated method (registerController) and replaces usages with the supported method
* removes components that are not used from the 04-file-transfer example