### PR TITLE
Helm chart with minikube tests (#432)

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -118,3 +118,38 @@ jobs:
           killall java      
 
       # we cannot check sample 5 currently because we'd need repo secrets for that (client id,...)
+
+
+  Helm-Chart:
+    runs-on: ubuntu-latest
+    name: Test Helm chart in minikube
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          # Do not use cache, as it would cause the test not to run on cache hit
+
+      - name: Install and start minikube
+        run: |
+          curl -fLo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+          chmod +x minikube
+          ./minikube start --wait all
+
+      - name: Build JARs
+        run: ./gradlew samples:04.0-file-transfer:consumer:shadowJar samples:04.0-file-transfer:provider:shadowJar --no-daemon
+
+      - name: Test
+        run: |
+          eval $(minikube -p minikube docker-env)
+          samples/04.0-file-transfer/integration-tests/minikube/minikube-test.sh
+
+      - name: Kubernetes logs
+        if: always()
+        run: |
+          set -x
+          kubectl get pods
+          kubectl logs deployment/provider-dataspace-connector --tail=200
+          kubectl logs deployment/consumer-dataspace-connector --tail=200

--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ connector to become operational the `runtime` needs to perform several important
 example take a look at
 [this runtime](launchers/basic/src/main/java/org/eclipse/dataspaceconnector/runtime/ConnectorRuntime.java)
 
+### `resources/charts`
+
+Contains a Helm chart for the EDC runtime. You can use the `launchers/generic/Dockerfile` to build a runtime image
+for your connector runtime, and deploy the resulting image to Kubernetes.
+
 ### `data-protocols`
 
 Contains implementations for communication protocols a connector might use, such as IDS.

--- a/common/util/src/testFixtures/java/org/eclipse/dataspaceconnector/common/testfixtures/TestUtils.java
+++ b/common/util/src/testFixtures/java/org/eclipse/dataspaceconnector/common/testfixtures/TestUtils.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
@@ -118,5 +119,18 @@ public class TestUtils {
             throw new IllegalArgumentException(format("No free ports in the range [%d - %d]", lowerBound, upperBound));
         }
         return port;
+    }
+
+    /**
+     * Helper method to create a temporary directory.
+     *
+     * @return a newly create temporary directory.
+     */
+    public static String tempDirectory() {
+        try {
+            return Files.createTempDirectory(TestUtils.class.getSimpleName()).toString();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/docs/developer/decision-records/2022-02-14-helm-chart/README.md
+++ b/docs/developer/decision-records/2022-02-14-helm-chart/README.md
@@ -1,0 +1,25 @@
+# Helm chart
+
+## Decision
+
+A [Helm Chart](https://helm.sh) is provided to be used to deploy the EDC runtime in Kubernetes environments.
+
+### Chart design
+
+The chart is highly configurable:
+
+- Configurable runtime based on Docker image of base EDC, Data Plane Framework Server, or custom runtime.
+- Configurable environment variables (as [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/)) for runtime settings, following [12-factor principles](https://12factor.net/config).
+- Configurable secrets (injected as environment variables into pods).
+- Configurable labels and annotations.
+- Configurable ingress.
+
+The chart was generated using `helm create` in order to follow best practice for components, configurability and ingress definitions, and adapted to fit the EDC runtime.
+
+A generic Dockerfile was created that builds a Docker image using any runtime JAR. It is designed to be used as-is and take configuration from environment variables. Alternatively, implementors can extend the Dockerfile to package a configuration file.
+
+### Testing
+
+The chart must be tested in CI, like any other code, to ensure it remains valid as either the chart or EDC code evolves.
+
+A GitHub worklow installs minikube (a local lightweight kubernetes installation) and deploys two releases of the chart, for the Consumer and Provider EDC connector of sample 04.0. The workflow then triggers file copy and verifies that the destination file was created on the Provider pod.

--- a/launchers/generic/Dockerfile
+++ b/launchers/generic/Dockerfile
@@ -1,0 +1,22 @@
+#
+#  Copyright (c) 2022 Microsoft Corporation
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Microsoft Corporation - initial API and implementation
+#
+#
+
+FROM openjdk:11-jre-slim
+ARG JAR
+
+COPY $JAR app.jar
+
+# Use "exec" for Kubernetes graceful termination (SIGINT) to reach JVM.
+ENTRYPOINT [ "sh", "-c", \
+    "exec java $JVM_ARGS -jar app.jar"]

--- a/launchers/generic/README.md
+++ b/launchers/generic/README.md
@@ -1,0 +1,7 @@
+# Generic Connector Launcher
+
+This launcher contains a Dockerfile that can be used to run any packaged connector JAR.
+
+For build, a mandatory build argument named `JAR` must be set, with the path to the connector runtime JAR file.
+
+Configuration can be provided at runtime through environment variables.  The special environment variable `JVM_ARGS` may be used to set execution JVM arguments.

--- a/resources/charts/dataspace-connector/Chart.yaml
+++ b/resources/charts/dataspace-connector/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: dataspace-connector
+description: A Helm chart to deploy the Eclipse Dataspace Connector to Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 0.0.1-SNAPSHOT

--- a/resources/charts/dataspace-connector/templates/NOTES.txt
+++ b/resources/charts/dataspace-connector/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL below or by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "dataspace-connector.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "dataspace-connector.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "dataspace-connector.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "dataspace-connector.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/resources/charts/dataspace-connector/templates/_helpers.tpl
+++ b/resources/charts/dataspace-connector/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "dataspace-connector.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "dataspace-connector.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "dataspace-connector.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "dataspace-connector.labels" -}}
+helm.sh/chart: {{ include "dataspace-connector.chart" . }}
+{{ include "dataspace-connector.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "dataspace-connector.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "dataspace-connector.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/resources/charts/dataspace-connector/templates/configmap.yaml
+++ b/resources/charts/dataspace-connector/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "dataspace-connector.fullname" . }}-envvars
+  labels:
+    {{- include "dataspace-connector.labels" . | nindent 4 }}
+data:
+  {{- range $envName, $value := .Values.edc.env }}
+  {{ $envName | quote }}: {{ $value | quote }}
+  {{- end }}

--- a/resources/charts/dataspace-connector/templates/deployment.yaml
+++ b/resources/charts/dataspace-connector/templates/deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "dataspace-connector.fullname" . }}
+  labels:
+    {{- include "dataspace-connector.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "dataspace-connector.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "dataspace-connector.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.edc.port }} 
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "dataspace-connector.fullname" . }}-envvars
+            - secretRef:
+                name: {{ include "dataspace-connector.fullname" . }}-envvars
+          livenessProbe:
+            httpGet:
+              path: /api/check/liveness
+              port: http
+            initialDelaySeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /api/check/readiness
+              port: http
+            initialDelaySeconds: 10
+          startupProbe:
+            httpGet:
+              path: /api/check/liveness
+              port: http
+            failureThreshold: 60
+            initialDelaySeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/resources/charts/dataspace-connector/templates/hpa.yaml
+++ b/resources/charts/dataspace-connector/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "dataspace-connector.fullname" . }}
+  labels:
+    {{- include "dataspace-connector.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "dataspace-connector.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/resources/charts/dataspace-connector/templates/ingress.yaml
+++ b/resources/charts/dataspace-connector/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "dataspace-connector.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "dataspace-connector.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/resources/charts/dataspace-connector/templates/secret.yaml
+++ b/resources/charts/dataspace-connector/templates/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "dataspace-connector.fullname" . }}-envvars
+  labels:
+    {{- include "dataspace-connector.labels" . | nindent 4 }}
+type: Opaque
+data:
+{{- range $secretName, $value := .Values.edc.envSecrets }}
+  {{ $secretName }}: {{ $value | b64enc }}
+{{- end }}

--- a/resources/charts/dataspace-connector/templates/service.yaml
+++ b/resources/charts/dataspace-connector/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dataspace-connector.fullname" . }}
+  labels:
+    {{- include "dataspace-connector.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.edc.port }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "dataspace-connector.selectorLabels" . | nindent 4 }}

--- a/resources/charts/dataspace-connector/values.yaml
+++ b/resources/charts/dataspace-connector/values.yaml
@@ -1,0 +1,75 @@
+# Default values for dataspace-connector.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  # repository: <container-registry-repository>
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+edc:
+  port: 8181
+  env: {}
+  envSecrets: {}
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  ingressClassName: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: dataspace-connector.local
+      paths: []
+  tls: []
+  #  - secretName: dataspace-connector-tls
+  #    hosts:
+  #      - dataspace-connector.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/samples/04.0-file-transfer/README.md
+++ b/samples/04.0-file-transfer/README.md
@@ -194,12 +194,12 @@ addition to just confirming or declining an offer.
 
 In order to trigger the negotiation, we use the endpoint previously created in the `api` extension. We specify the
 address of the provider connector as a query parameter and set our contract offer in the request body. The contract
-offer is prepared in [contractoffer.json](integration-tests/src/test/resources/contractoffer.json)
+offer is prepared in [contractoffer.json](client/src/main/resources/contractoffer.json)
 and can be used as is. In a real scenario, a potential consumer would first need to request a description of the
 provider's offers in order to get the provider's contract offer.
 
 ```bash
-curl -X POST -H "Content-Type: application/json" -d @samples/04.0-file-transfer/integration-tests/src/test/resources/contractoffer.json "http://localhost:9191/api/negotiation?connectorAddress=http://localhost:8181/api/ids/multipart"
+curl -X POST -H "Content-Type: application/json" -d @samples/04.0-file-transfer/client/src/main/resources/contractoffer.json "http://localhost:9191/api/negotiation?connectorAddress=http://localhost:8181/api/ids/multipart"
 ```
 
 In the response we'll get a UUID that we can use to get the contract agreement negotiated between provider and consumer.

--- a/samples/04.0-file-transfer/consumer/build.gradle.kts
+++ b/samples/04.0-file-transfer/consumer/build.gradle.kts
@@ -30,6 +30,8 @@ dependencies {
     implementation(project(":extensions:in-memory:negotiation-store-memory"))
     implementation(project(":extensions:in-memory:contractdefinition-store-memory"))
 
+    implementation(project(":extensions:api:observability"))
+
     implementation(project(":extensions:filesystem:configuration-fs"))
     implementation(project(":extensions:iam:iam-mock"))
 

--- a/samples/04.0-file-transfer/integration-tests/minikube/README.md
+++ b/samples/04.0-file-transfer/integration-tests/minikube/README.md
@@ -1,0 +1,41 @@
+# File transfer system tests
+
+This system test serves to validate both the connector runtime and the EDC Helm chart with an end-to-end flow.
+It runs within GitHub Actions.
+
+To run it locally, install:
+- [Minikube and Kubectl](https://kubernetes.io/docs/tasks/tools/)
+- [Helm](https://helm.sh/docs/intro/install/)
+- [Docker](https://docs.docker.com/get-docker/)
+
+## Install helm release with minikube
+
+Start minikube:
+
+```bash
+minikube start
+```
+
+[Set minikube docker environment](https://minikube.sigs.k8s.io/docs/handbook/pushing/#1-pushing-directly-to-the-in-cluster-docker-daemon-docker-env).
+
+```bash
+eval $(minikube docker-env)
+```
+
+The first step to running this sample is building and starting both the provider and the consumer connector. This is
+done the same way as in the previous samples.
+
+Build EDC consumer and provider runtime JAR files:
+
+```bash
+./gradlew samples:04.0-file-transfer:consumer:build
+./gradlew samples:04.0-file-transfer:provider:build
+````
+
+Run tests:
+
+```bash
+samples/04.0-file-transfer/integration-tests/minikube/minikube-test.sh
+```
+
+Note: on certain Mac platforms, the `minikube service` commands run within the script hangs during execution. If that happens consider using a different minikube driver, such as Parallels or VirtualBox.

--- a/samples/04.0-file-transfer/integration-tests/minikube/minikube-test.sh
+++ b/samples/04.0-file-transfer/integration-tests/minikube/minikube-test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# CI script for testing Helm chart with data transfer sample on minikube.
+#
+# See README.md for preconditions for running this script manually.
+
+set -euxo pipefail
+
+dir=$(dirname $0)
+
+# Build and install Consumer and Provider connectors
+
+for target in consumer provider; do
+  docker build -t $target --build-arg JAR=samples/04.0-file-transfer/$target/build/libs/$target.jar -f launchers/generic/Dockerfile .
+  helm upgrade --install -f $dir/values-$target.yaml $target resources/charts/dataspace-connector
+done
+
+# Wait for pods to be live
+
+for target in consumer provider; do
+  kubectl wait --for=condition=available deployment $target-dataspace-connector --timeout=120s
+done
+
+# Resolve service address for Consumer
+
+export CONSUMER_URL=$(minikube service --url consumer-dataspace-connector)
+
+# Perform negotiation and file transfer. See sample root directory README.md file for more details.
+
+export PROVIDER_URL="http://provider-dataspace-connector"
+export DESTINATION_PATH="/tmp/destination-file-$RANDOM"
+export API_KEY="password"
+export RUN_INTEGRATION_TEST="true"
+
+./gradlew :samples:04.0-file-transfer:integration-tests:test --tests org.eclipse.dataspaceconnector.samples.FileTransferAsClientIntegrationTest
+
+kubectl exec deployment/provider-dataspace-connector -- wc -l $DESTINATION_PATH
+echo "Test succeeded."

--- a/samples/04.0-file-transfer/integration-tests/minikube/values-consumer.yaml
+++ b/samples/04.0-file-transfer/integration-tests/minikube/values-consumer.yaml
@@ -1,0 +1,11 @@
+image:
+  repository: consumer
+  tag: latest
+service:
+  type: NodePort
+  port: 8181
+edc:
+  env:
+    IDS_WEBHOOK_ADDRESS: http://consumer-dataspace-connector:8181
+  envSecrets:
+    EDC_API_CONTROL_AUTH_APIKEY_VALUE: password

--- a/samples/04.0-file-transfer/integration-tests/minikube/values-provider.yaml
+++ b/samples/04.0-file-transfer/integration-tests/minikube/values-provider.yaml
@@ -1,0 +1,8 @@
+image:
+  repository: provider
+  tag: latest
+edc:
+  env:
+    IDS_WEBHOOK_ADDRESS: http://provider-dataspace-connector
+    # Use /etc/hosts as a copy source as it is a well-known file
+    EDC_SAMPLES_04_ASSET_PATH: /etc/hosts

--- a/samples/04.0-file-transfer/integration-tests/src/test/java/org/eclipse/dataspaceconnector/samples/FileTransferAsClientIntegrationTest.java
+++ b/samples/04.0-file-transfer/integration-tests/src/test/java/org/eclipse/dataspaceconnector/samples/FileTransferAsClientIntegrationTest.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.samples;
+
+import org.eclipse.dataspaceconnector.common.annotations.IntegrationTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Objects;
+
+/**
+ * Client application for performing a file transfer
+ */
+@IntegrationTest
+public class FileTransferAsClientIntegrationTest {
+
+    @Test
+    public void performFileTransfer() {
+
+        var client = new FileTransferTestUtils();
+        client.setConsumerUrl(get("CONSUMER_URL"));
+        client.setProviderUrl(get("PROVIDER_URL"));
+        client.setDestinationPath(get("DESTINATION_PATH"));
+        client.setApiKey(get("API_KEY"));
+
+        var contractAgreementId = client.negotiateContractAgreement();
+        client.performFileTransfer(contractAgreementId);
+    }
+
+    private static String get(String value) {
+        return Objects.requireNonNull(System.getenv(value), "Environment variable " + value + " not set");
+    }
+}

--- a/samples/04.0-file-transfer/integration-tests/src/test/java/org/eclipse/dataspaceconnector/samples/FileTransferIntegrationTest.java
+++ b/samples/04.0-file-transfer/integration-tests/src/test/java/org/eclipse/dataspaceconnector/samples/FileTransferIntegrationTest.java
@@ -14,63 +14,40 @@
 
 package org.eclipse.dataspaceconnector.samples;
 
-import io.restassured.http.ContentType;
-import io.restassured.response.ValidatableResponse;
-import io.restassured.specification.RequestSpecification;
-import org.apache.http.HttpStatus;
-import org.eclipse.dataspaceconnector.common.testfixtures.TestUtils;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcRuntimeExtension;
-import org.eclipse.dataspaceconnector.spi.EdcException;
-import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.UUID;
 
-import static io.restassured.RestAssured.given;
 import static java.lang.String.format;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
-import static org.eclipse.dataspaceconnector.common.configuration.ConfigurationFunctions.propOrEnv;
 import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.getFreePort;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.tempDirectory;
+import static org.eclipse.dataspaceconnector.samples.FileTransferTestUtils.PROVIDER_ASSET_NAME;
 
 
 /**
  * System Test for Sample 04.0-file-transfer
  */
-public class FileTransferIntegrationTest {
+class FileTransferIntegrationTest {
+    static final String PROVIDER_ASSET_PATH = format("%s/%s.txt", tempDirectory(), PROVIDER_ASSET_NAME);
 
-    private static final String PROVIDER_ASSET_NAME = "test-document";
+    static final String CONSUMER_ASSET_PATH = tempDirectory();
+    static final int CONSUMER_CONNECTOR_PORT = getFreePort();
+    static final String CONSUMER_CONNECTOR_HOST = "http://localhost:" + CONSUMER_CONNECTOR_PORT;
 
-    private static final String CONTRACT_NEGOTIATION_PATH = "/api/negotiation";
-    private static final String CONTRACT_AGREEMENT_PATH = "/api/control/negotiation/{contractNegotiationRequestId}";
-    private static final String TRANSFER_PATH = "/api/transfer/{transferId}";
-    private static final String FILE_TRANSFER_PATH = "/api/file/{filename}";
+    static final int PROVIDER_CONNECTOR_PORT = getFreePort();
+    static final String PROVIDER_CONNECTOR_HOST = "http://localhost:" + PROVIDER_CONNECTOR_PORT;
 
-    private static final String CONNECTOR_ADDRESS_PARAM = "connectorAddress";
-    private static final String CONTRACT_NEGOTIATION_REQUEST_ID_PARAM = "contractNegotiationRequestId";
-    private static final String TRANSFER_ID_PARAM = "transferId";
-    private static final String DESTINATION_PARAM = "destination";
-    private static final String CONTRACT_ID_PARAM = "contractId";
-    private static final String FILE_NAME_PARAM = "filename";
+    static final String API_KEY_CONTROL_AUTH = "password";
 
-    private static final String CONSUMER_ASSET_PATH = propOrEnv("edc.samples.04.consumer.asset.path", tempDirectory());
-    private static final int CONSUMER_CONNECTOR_PORT = getFreePort();
-    private static final String API_KEY_CONTROL_AUTH = propOrEnv("edc.api.control.auth.apikey.value", "password");
-    private static final String API_KEY_HEADER = "X-Api-Key";
-    private static final String CONSUMER_CONNECTOR_HOST = "http://localhost:" + CONSUMER_CONNECTOR_PORT;
     @RegisterExtension
     static EdcRuntimeExtension consumer = new EdcRuntimeExtension(
-
             ":samples:04.0-file-transfer:consumer",
             "consumer",
             Map.of(
@@ -78,9 +55,6 @@ public class FileTransferIntegrationTest {
                     "edc.api.control.auth.apikey.value", API_KEY_CONTROL_AUTH,
                     "ids.webhook.address", CONSUMER_CONNECTOR_HOST));
 
-    private static final int PROVIDER_CONNECTOR_PORT = getFreePort();
-    private static final String PROVIDER_CONNECTOR_HOST = "http://localhost:" + PROVIDER_CONNECTOR_PORT;
-    private static final String PROVIDER_ASSET_PATH = propOrEnv("edc.samples.04.asset.path", format("%s/%s.txt", tempDirectory(), PROVIDER_ASSET_NAME));
     @RegisterExtension
     static EdcRuntimeExtension provider = new EdcRuntimeExtension(
             ":samples:04.0-file-transfer:provider",
@@ -90,119 +64,31 @@ public class FileTransferIntegrationTest {
                     "edc.samples.04.asset.path", PROVIDER_ASSET_PATH,
                     "ids.webhook.address", PROVIDER_CONNECTOR_HOST));
 
-
-    /**
-     * Helper method to create a temporary directory.
-     *
-     * @return a newly create temporary directory.
-     */
-    private static String tempDirectory() {
-        try {
-            return Files.createTempDirectory(FileTransferIntegrationTest.class.getSimpleName()).toString();
-        } catch (IOException e) {
-            throw new EdcException(e);
-        }
-    }
-
     @Test
     public void transferFile_success() throws Exception {
         // Arrange
-        var contractOffer = TestUtils.getFileFromResourceName("contractoffer.json");
         // Create a file with test data on provider file system.
         var fileContent = "Sample04-test-" + UUID.randomUUID();
         Files.write(Path.of(PROVIDER_ASSET_PATH), fileContent.getBytes(StandardCharsets.UTF_8));
 
-        // Act & Assert
-        // Initiate a contract negotiation
-        var contractNegotiationRequestId =
-                givenConsumerRequest()
-                        .contentType(ContentType.JSON)
-                        .queryParam(CONNECTOR_ADDRESS_PARAM, format("%s/api/ids/multipart", PROVIDER_CONNECTOR_HOST))
-                        .body(contractOffer)
-                        .when()
-                        .post(CONTRACT_NEGOTIATION_PATH)
-                        .then()
-                        .assertThat().statusCode(HttpStatus.SC_OK)
-                        .extract().asString();
+        // Act
+        var client = new FileTransferTestUtils();
+        client.setConsumerUrl(CONSUMER_CONNECTOR_HOST);
+        client.setProviderUrl(PROVIDER_CONNECTOR_HOST);
+        client.setDestinationPath(CONSUMER_ASSET_PATH);
+        client.setApiKey(API_KEY_CONTROL_AUTH);
 
-        // UUID is returned to get the contract agreement negotiated between provider and consumer.
-        assertThat(contractNegotiationRequestId)
-                .withFailMessage("Contract negotiation requestId is null").isNotBlank();
+        var contractAgreementId = client.negotiateContractAgreement();
+        client.performFileTransfer(contractAgreementId);
 
-        // Verify ContractNegotiation is CONFIRMED
-        await().atMost(30, SECONDS).untilAsserted(() ->
-                fetchNegotiatedAgreement(contractNegotiationRequestId)
-                        .body("id", equalTo(contractNegotiationRequestId))
-                        .body("state", equalTo(ContractNegotiationStates.CONFIRMED.code()))
-                        .body("contractAgreement.id", notNullValue()));
-
-        // Obtain contract agreement ID
-        var contractAgreementId = fetchNegotiatedAgreement(contractNegotiationRequestId)
-                .extract().jsonPath().get("contractAgreement.id");
-
-        // Initiate file transfer
-        var transferProcessId =
-                givenConsumerRequest()
-                        .noContentType()
-                        .pathParam(FILE_NAME_PARAM, PROVIDER_ASSET_NAME)
-                        .queryParam(CONNECTOR_ADDRESS_PARAM, format("%s/api/ids/multipart", PROVIDER_CONNECTOR_HOST))
-                        .queryParam(DESTINATION_PARAM, CONSUMER_ASSET_PATH)
-                        .queryParam(CONTRACT_ID_PARAM, contractAgreementId)
-                        .when()
-                        .post(FILE_TRANSFER_PATH)
-                        .then()
-                        .assertThat().statusCode(HttpStatus.SC_OK)
-                        .extract().asString();
-
-        // Verify TransferProcessId
-        assertThat(transferProcessId).isNotNull();
-
-        // Verify file transfer is completed and file contents
-        await().atMost(30, SECONDS).untilAsserted(() ->
-                fetchTransfer(transferProcessId)
-                        .body("id", equalTo(transferProcessId))
-                        .body("state", equalTo(TransferProcessStates.COMPLETED.code())
-                        ));
-
+        // Assert
         var copiedFilePath = Path.of(format(CONSUMER_ASSET_PATH + "/%s.txt", PROVIDER_ASSET_NAME));
+        assertThat(copiedFilePath)
+                .withFailMessage("Destination file %s not created", copiedFilePath)
+                .exists();
         var actualFileContent = Files.readString(copiedFilePath);
-        assertThat(actualFileContent)
-                .withFailMessage("Transferred file contents are null")
-                .isNotNull();
         assertThat(actualFileContent)
                 .withFailMessage("Transferred file contents are not same as the source file")
                 .isEqualTo(fileContent);
-    }
-
-    private ValidatableResponse fetchTransfer(String transferProcessId) {
-        return
-                givenConsumerRequest()
-                        .pathParam(TRANSFER_ID_PARAM, transferProcessId)
-                        .when()
-                        .get(TRANSFER_PATH)
-                        .then()
-                        .assertThat().statusCode(HttpStatus.SC_OK);
-    }
-
-    /**
-     * Fetch negotiated contract agreement.
-     *
-     * @param contractNegotiationRequestId ID of the ongoing contract negotiation between consumer and provider.
-     * @return Negotiation as {@link ValidatableResponse}.
-     */
-    private ValidatableResponse fetchNegotiatedAgreement(String contractNegotiationRequestId) {
-        return
-                givenConsumerRequest()
-                        .pathParam(CONTRACT_NEGOTIATION_REQUEST_ID_PARAM, contractNegotiationRequestId)
-                        .header(API_KEY_HEADER, API_KEY_CONTROL_AUTH)
-                        .when()
-                        .get(CONTRACT_AGREEMENT_PATH)
-                        .then()
-                        .assertThat().statusCode(HttpStatus.SC_OK);
-    }
-
-    private RequestSpecification givenConsumerRequest() {
-        return given()
-                .baseUri(CONSUMER_CONNECTOR_HOST);
     }
 }

--- a/samples/04.0-file-transfer/integration-tests/src/test/java/org/eclipse/dataspaceconnector/samples/FileTransferTestUtils.java
+++ b/samples/04.0-file-transfer/integration-tests/src/test/java/org/eclipse/dataspaceconnector/samples/FileTransferTestUtils.java
@@ -1,0 +1,169 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.samples;
+
+import io.restassured.http.ContentType;
+import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
+import org.apache.http.HttpStatus;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
+
+import static io.restassured.RestAssured.given;
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+
+/**
+ * Client utility for performing file transfer, including preliminary contract negotiation.
+ */
+public class FileTransferTestUtils {
+
+    public static final String PROVIDER_ASSET_NAME = "test-document";
+
+    private static final String CONTRACT_NEGOTIATION_PATH = "/api/negotiation";
+    private static final String CONTRACT_AGREEMENT_PATH = "/api/control/negotiation/{contractNegotiationRequestId}";
+    private static final String TRANSFER_PATH = "/api/transfer/{transferId}";
+    private static final String FILE_TRANSFER_PATH = "/api/file/{filename}";
+
+    private static final String CONNECTOR_ADDRESS_PARAM = "connectorAddress";
+    private static final String CONTRACT_NEGOTIATION_REQUEST_ID_PARAM = "contractNegotiationRequestId";
+    private static final String TRANSFER_ID_PARAM = "transferId";
+    private static final String DESTINATION_PARAM = "destination";
+    private static final String CONTRACT_ID_PARAM = "contractId";
+    private static final String FILE_NAME_PARAM = "filename";
+
+    private static final String API_KEY_HEADER = "X-Api-Key";
+
+    private String consumerUrl;
+    private String providerUrl;
+    private String destinationPath;
+    private String apiKey;
+
+    public void setConsumerUrl(String consumerUrl) {
+        this.consumerUrl = consumerUrl;
+    }
+
+    public void setProviderUrl(String providerUrl) {
+        this.providerUrl = providerUrl;
+    }
+
+    public void setDestinationPath(String destinationPath) {
+        this.destinationPath = destinationPath;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    public void performFileTransfer(String contractAgreementId) {
+        // Initiate file transfer
+        var transferProcessId =
+                givenConsumerRequest()
+                        .noContentType()
+                        .pathParam(FILE_NAME_PARAM, PROVIDER_ASSET_NAME)
+                        .queryParam(CONNECTOR_ADDRESS_PARAM, format("%s/api/ids/multipart", providerUrl))
+                        .queryParam(DESTINATION_PARAM, destinationPath)
+                        .queryParam(CONTRACT_ID_PARAM, contractAgreementId)
+                .when()
+                        .post(FILE_TRANSFER_PATH)
+                .then()
+                        .assertThat().statusCode(HttpStatus.SC_OK)
+                        .extract().asString();
+
+        // Verify TransferProcessId
+        assertThat(transferProcessId).isNotNull();
+
+        // Verify file transfer is completed and file contents
+        await().atMost(30, SECONDS).untilAsserted(() ->
+                fetchTransfer(transferProcessId)
+                        .body("id", equalTo(transferProcessId))
+                        .body("state", equalTo(TransferProcessStates.COMPLETED.code())
+                        ));
+    }
+
+    public String negotiateContractAgreement() {
+        // Arrange
+        var contractOffer = getClass().getClassLoader().getResourceAsStream("contractoffer.json");
+        assertThat(contractOffer)
+                .withFailMessage("Resource not found")
+                .isNotNull();
+
+        // Act & Assert
+        // Initiate a contract negotiation
+        var contractNegotiationRequestId =
+                givenConsumerRequest()
+                        .contentType(ContentType.JSON)
+                        .queryParam(CONNECTOR_ADDRESS_PARAM, format("%s/api/ids/multipart", providerUrl))
+                        .body(contractOffer)
+                .when()
+                        .post(CONTRACT_NEGOTIATION_PATH)
+                .then()
+                        .assertThat().statusCode(HttpStatus.SC_OK)
+                        .extract().asString();
+
+        // UUID is returned to get the contract agreement negotiated between provider and consumer.
+        assertThat(contractNegotiationRequestId)
+                .withFailMessage("Contract negotiation requestId is null").isNotBlank();
+
+        // Verify ContractNegotiation is CONFIRMED
+        await().atMost(30, SECONDS).untilAsserted(() ->
+                fetchNegotiatedAgreement(contractNegotiationRequestId)
+                        .body("id", equalTo(contractNegotiationRequestId))
+                        .body("state", equalTo(ContractNegotiationStates.CONFIRMED.code()))
+                        .body("contractAgreement.id", notNullValue()));
+
+        // Obtain contract agreement ID
+        var contractAgreementId = fetchNegotiatedAgreement(contractNegotiationRequestId)
+                .extract().jsonPath().getString("contractAgreement.id");
+        return contractAgreementId;
+    }
+
+    private ValidatableResponse fetchTransfer(String transferProcessId) {
+        return
+                givenConsumerRequest()
+                        .pathParam(TRANSFER_ID_PARAM, transferProcessId)
+                .when()
+                        .get(TRANSFER_PATH)
+                .then()
+                        .assertThat().statusCode(HttpStatus.SC_OK);
+    }
+
+    /**
+     * Fetch negotiated contract agreement.
+     *
+     * @param contractNegotiationRequestId ID of the ongoing contract negotiation between consumer and provider.
+     * @return Negotiation as {@link ValidatableResponse}.
+     */
+    private ValidatableResponse fetchNegotiatedAgreement(String contractNegotiationRequestId) {
+        return
+                givenConsumerRequest()
+                        .pathParam(CONTRACT_NEGOTIATION_REQUEST_ID_PARAM, contractNegotiationRequestId)
+                        .header(API_KEY_HEADER, apiKey)
+                .when()
+                        .get(CONTRACT_AGREEMENT_PATH)
+                .then()
+                        .assertThat().statusCode(HttpStatus.SC_OK);
+    }
+
+    private RequestSpecification givenConsumerRequest() {
+        return given()
+                        .baseUri(consumerUrl);
+    }
+}

--- a/samples/04.0-file-transfer/provider/build.gradle.kts
+++ b/samples/04.0-file-transfer/provider/build.gradle.kts
@@ -31,6 +31,8 @@ dependencies {
     implementation(project(":extensions:in-memory:contractdefinition-store-memory"))
     implementation(project(":extensions:http"))
 
+    implementation(project(":extensions:api:observability"))
+
     implementation(project(":extensions:filesystem:configuration-fs"))
     implementation(project(":extensions:iam:iam-mock"))
 

--- a/samples/04.1-file-transfer-listener/README.md
+++ b/samples/04.1-file-transfer-listener/README.md
@@ -56,7 +56,7 @@ Assuming you didn't change the config files, the consumer will listen on port `9
 Open another terminal window (or any REST client of your choice) and execute the following REST requests like in the previous sample:
 
 ```bash
-curl -X POST -H "Content-Type: application/json" -d @samples/04.0-file-transfer/contractoffer.json "http://localhost:9191/api/negotiation?connectorAddress=http://localhost:8181/api/ids/multipart"
+curl -X POST -H "Content-Type: application/json" -d @samples/04.0-file-transfer/client/src/main/resources/contractoffer.json "http://localhost:9191/api/negotiation?connectorAddress=http://localhost:8181/api/ids/multipart"
 curl -X GET -H 'X-Api-Key: password' "http://localhost:9191/api/control/negotiation/{negotiation ID}/state"
 curl -X POST "http://localhost:9191/api/file/test-document?connectorAddress=http://localhost:8181/api/ids/multipart/&destination=/path/on/yourmachine&contractId={agreement ID}"
 ```


### PR DESCRIPTION

A [Helm Chart](https://helm.sh) is provided to be used to deploy the EDC runtime in Kubernetes environments.

### Chart design

The chart is highly configurable:

- Configurable runtime based on Docker image of base EDC, Data Plane Framework Server, or custom runtime.
- Configurable environment variables (as [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/)) for runtime settings, following [12-factor principles](https://12factor.net/config).
- Configurable secrets (injected as environment variables into pods).
- Configurable labels and annotations.
- Configurable ingress.

The chart was generated using `helm create` in order to follow best practice for components, configurability and ingress definitions, and adapted to fit the EDC runtime.

A generic Dockerfile was created that builds a Docker image using any runtime JAR. It is designed to be used as-is and take configuration from environment variables. Alternatively, implementors can extend the Dockerfile to package a configuration file.

### Testing

The chart must be tested in CI, like any other code, to ensure it remains valid as either the chart or EDC code evolves.

A GitHub worklow installs minikube (a local lightweight kubernetes installation) and deploys two releases of the chart, for the Consumer and Provider EDC connector of sample 04.0. The workflow then triggers file copy and verifies that the destination file was created on the Provider pod.