### PR TITLE
Removed default `KEYSTORE_PASSWORD` from `FsConfiguration`

### DIFF
--- a/extensions/filesystem/vault-fs/src/main/java/org/eclipse/dataspaceconnector/core/security/fs/FsConfiguration.java
+++ b/extensions/filesystem/vault-fs/src/main/java/org/eclipse/dataspaceconnector/core/security/fs/FsConfiguration.java
@@ -27,7 +27,7 @@ public final class FsConfiguration {
     static final String KEYSTORE_LOCATION = propOrEnv("edc.keystore", "dataspaceconnector-keystore.jks");
 
     @EdcSetting
-    static final String KEYSTORE_PASSWORD = propOrEnv("edc.keystore.password", "test123");
+    static final String KEYSTORE_PASSWORD = propOrEnv("edc.keystore.password", null);
 
     @EdcSetting
     static final boolean PERSISTENT_VAULT = Boolean.parseBoolean(propOrEnv("edc.vault.persistent", "true"));

--- a/extensions/filesystem/vault-fs/src/main/java/org/eclipse/dataspaceconnector/core/security/fs/FsVaultExtension.java
+++ b/extensions/filesystem/vault-fs/src/main/java/org/eclipse/dataspaceconnector/core/security/fs/FsVaultExtension.java
@@ -84,6 +84,10 @@ public class FsVaultExtension implements VaultExtension {
             throw new EdcException("Key store does not exist: " + KEYSTORE_LOCATION);
         }
 
+        if (KEYSTORE_PASSWORD == null) {
+            throw new EdcException("Key store password was not specified");
+        }
+        
         try (InputStream stream = Files.newInputStream(keyStorePath)) {
             KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
             keyStore.load(stream, KEYSTORE_PASSWORD.toCharArray());


### PR DESCRIPTION
This PR removes the default value (`"test123"`) from the `FsConfiguration`. 

Providing a default password is not very useful in the first place, but more importantly CodeQL will qualify hard-coded credentials as High Risk (PR #692 by @Izzzu), so this serves as preliminary work for that.


Unrelated: the `ConsoleMonitor` in ithe `EdcRuntimeExtension` was replaced with a `Monitor` to avoid spamming STDOUT during testing.