### PR TITLE
Add an in-memory Data Plane store

### DIFF
--- a/common/util/src/main/java/org/eclipse/dataspaceconnector/common/collection/LruCache.java
+++ b/common/util/src/main/java/org/eclipse/dataspaceconnector/common/collection/LruCache.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.common.collection;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * An LRU cache with a specified capacity.
+ *
+ * N.B. This class is not threadsafe.
+ */
+public class LruCache<K, V> extends LinkedHashMap<K, V> {
+    private final int capacity;
+
+    /**
+     * Constructor.
+     *
+     * @param capacity the maximum cache capacity before the olded entry is evicted.
+     */
+    public LruCache(int capacity) {
+        super(capacity + 1, 1, true);
+        this.capacity = capacity;
+    }
+
+    @Override
+    protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+        return size() > capacity;
+    }
+}

--- a/common/util/src/main/java/org/eclipse/dataspaceconnector/common/concurrency/LockException.java
+++ b/common/util/src/main/java/org/eclipse/dataspaceconnector/common/concurrency/LockException.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.common.concurrency;
+
+/**
+ * Raised when there is lock-related exception.
+ */
+public class LockException extends RuntimeException {
+
+    public LockException(String message) {
+        super(message);
+    }
+
+    public LockException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public LockException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/common/util/src/main/java/org/eclipse/dataspaceconnector/common/concurrency/LockManager.java
+++ b/common/util/src/main/java/org/eclipse/dataspaceconnector/common/concurrency/LockManager.java
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.common.concurrency;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.function.Supplier;
+
+/**
+ * Handles acquiring and releasing read and write locks.
+ */
+public class LockManager {
+    private static final int DEFAULT_TIMEOUT = 1000;
+
+    private final ReadWriteLock lock;
+    private final int timeout;
+
+    /**
+     * Constructor. Uses the default timeout specified by {@link #DEFAULT_TIMEOUT}.
+     */
+    public LockManager(ReadWriteLock lock) {
+        this(lock, DEFAULT_TIMEOUT);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param lock the backing lock.
+     * @param timeout the timeout this instance will wait for a lock in milliseconds.
+     */
+    public LockManager(ReadWriteLock lock, int timeout) {
+        this.lock = lock;
+        this.timeout = timeout;
+    }
+
+    /**
+     * Attempts to obtain a read lock.
+     */
+    public <T> T readLock(Supplier<T> work) {
+        try {
+            if (!lock.readLock().tryLock(timeout, TimeUnit.MILLISECONDS)) {
+                throw new LockException("Timeout acquiring read lock");
+            }
+            try {
+                return work.get();
+            } finally {
+                lock.readLock().unlock();
+            }
+        } catch (InterruptedException e) {
+            Thread.interrupted();
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * Attempts to obtain a write lock.
+     */
+    public <T> T writeLock(Supplier<T> work) {
+        try {
+            if (!lock.writeLock().tryLock(timeout, TimeUnit.MILLISECONDS)) {
+                throw new LockException("Timeout acquiring write lock");
+            }
+            try {
+                return work.get();
+            } finally {
+                lock.writeLock().unlock();
+            }
+        } catch (InterruptedException e) {
+            Thread.interrupted();
+            throw new LockException(e);
+        }
+    }
+}

--- a/common/util/src/test/java/org/eclipse/dataspaceconnector/common/collection/LruCacheTest.java
+++ b/common/util/src/test/java/org/eclipse/dataspaceconnector/common/collection/LruCacheTest.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.common.collection;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LruCacheTest {
+    private LruCache<String, String> cache;
+
+    @Test
+    void verifyEviction() {
+        cache.put("foo", "foo");
+        cache.put("bar", "bar");
+        assertThat(cache.containsKey("foo")).isTrue();
+        assertThat(cache.containsKey("bar")).isTrue();
+
+        cache.put("baz", "baz");
+        assertThat(cache.containsKey("baz")).isTrue();
+        assertThat(cache.containsKey("bar")).isTrue();
+        assertThat(cache.containsKey("foo")).isFalse();
+    }
+
+    @BeforeEach
+    void setUp() {
+        cache = new LruCache<>(2);
+    }
+}

--- a/common/util/src/test/java/org/eclipse/dataspaceconnector/common/concurrency/LockManagerTest.java
+++ b/common/util/src/test/java/org/eclipse/dataspaceconnector/common/concurrency/LockManagerTest.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.common.concurrency;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LockManagerTest {
+
+    @Test
+    void verifyReadAndWriteLock() {
+        var lockManager = new LockManager(new ReentrantReadWriteLock());
+        var counter = new AtomicInteger();
+
+        lockManager.readLock(counter::incrementAndGet);
+
+        assertThat(counter.get()).isEqualTo(1);
+
+        lockManager.writeLock(counter::incrementAndGet);
+
+        assertThat(counter.get()).isEqualTo(2);
+    }
+
+    @Test
+    void verifyTimeoutOnWriteLockAttempt() {
+        var lockManager = new LockManager(new ReentrantReadWriteLock(), 10);
+        var counter = new AtomicInteger();
+
+        var latch = new CountDownLatch(1);
+
+        // Attempt to acquire a write lock in another thread, which should timeout as the current thread holds a read lock
+        var thread = new Thread(() -> {
+            try {
+                lockManager.writeLock(() -> {
+                    throw new AssertionError();  // lock should never be acquired
+                });
+            } catch (LockException e) {
+                latch.countDown(); // should timeout, release the latch
+            }
+        });
+
+        lockManager.readLock(() -> {
+            try {
+                thread.start();
+                assertThat(latch.await(1000, TimeUnit.MILLISECONDS)).isTrue();    // latch to be released after the write lock successfully times out
+                counter.incrementAndGet();
+            } catch (InterruptedException e) {
+                throw new AssertionError();
+            }
+            return null;
+        });
+
+        assertThat(counter.get()).isEqualTo(1);
+    }
+}

--- a/extensions/data-plane/data-plane-framework/build.gradle.kts
+++ b/extensions/data-plane/data-plane-framework/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
 
 dependencies {
     api(project(":extensions:data-plane:data-plane-spi"))
+    implementation(project(":common:util"))
 }
 
 

--- a/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/store/InMemoryDataPlaneStore.java
+++ b/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/store/InMemoryDataPlaneStore.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.dataplane.framework.store;
+
+import org.eclipse.dataspaceconnector.common.collection.LruCache;
+import org.eclipse.dataspaceconnector.common.concurrency.LockManager;
+import org.eclipse.dataspaceconnector.dataplane.spi.store.DataPlaneStore;
+
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Implements an in-memory, ephemeral store with a maximum capacity. If the store grows beyond capacity, the oldest entry will be evicted.
+ */
+public class InMemoryDataPlaneStore implements DataPlaneStore {
+    private final LruCache<String, State> cache;
+    private final LockManager lockManager;
+
+    public InMemoryDataPlaneStore(int capacity) {
+        cache = new LruCache<>(capacity);
+        lockManager = new LockManager(new ReentrantReadWriteLock());
+    }
+
+    @Override
+    public void received(String processId) {
+        lockManager.writeLock(() -> cache.put(processId, State.RECEIVED));
+    }
+
+    @Override
+    public void completed(String processId) {
+        lockManager.writeLock(() -> cache.put(processId, State.COMPLETED));
+    }
+
+    @Override
+    public State getState(String processId) {
+        return lockManager.readLock(() -> cache.getOrDefault(processId, State.NOT_TRACKED));
+    }
+
+}

--- a/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/store/InMemoryDataPlaneStoreTest.java
+++ b/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/store/InMemoryDataPlaneStoreTest.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.dataplane.framework.store;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.dataplane.spi.store.DataPlaneStore.State.COMPLETED;
+import static org.eclipse.dataspaceconnector.dataplane.spi.store.DataPlaneStore.State.NOT_TRACKED;
+import static org.eclipse.dataspaceconnector.dataplane.spi.store.DataPlaneStore.State.RECEIVED;
+
+class InMemoryDataPlaneStoreTest {
+    private InMemoryDataPlaneStore store;
+
+    @Test
+    void verifyOperations() {
+        assertThat(store.getState("1")).isEqualTo(NOT_TRACKED);
+        store.received("1");
+        assertThat(store.getState("1")).isEqualTo(RECEIVED);
+        store.completed("1");
+        assertThat(store.getState("1")).isEqualTo(COMPLETED);
+    }
+
+    @BeforeEach
+    void setUp() {
+        store = new InMemoryDataPlaneStore(2);
+    }
+}

--- a/extensions/in-memory/negotiation-store-memory/src/main/java/org/eclipse/dataspaceconnector/negotiation/store/memory/InMemoryContractNegotiationStore.java
+++ b/extensions/in-memory/negotiation-store-memory/src/main/java/org/eclipse/dataspaceconnector/negotiation/store/memory/InMemoryContractNegotiationStore.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.dataspaceconnector.negotiation.store.memory;
 
-import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.common.concurrency.LockManager;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
@@ -30,10 +30,8 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -45,8 +43,7 @@ import static org.eclipse.dataspaceconnector.negotiation.store.memory.ContractNe
  * This implementation is intended for testing purposes only.
  */
 public class InMemoryContractNegotiationStore implements ContractNegotiationStore {
-    private static final int TIMEOUT = 1000;
-    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+    private final LockManager lockManager = new LockManager(new ReentrantReadWriteLock());
     private final Map<String, ContractNegotiation> processesById = new HashMap<>();
     private final Map<String, ContractNegotiation> processesByCorrelationId = new HashMap<>();
     private final Map<String, ContractNegotiation> contractAgreements = new HashMap<>();
@@ -54,7 +51,7 @@ public class InMemoryContractNegotiationStore implements ContractNegotiationStor
 
     @Override
     public ContractNegotiation find(String id) {
-        return readLock(() -> processesById.get(id));
+        return lockManager.readLock(() -> processesById.get(id));
     }
 
     @Override
@@ -72,7 +69,7 @@ public class InMemoryContractNegotiationStore implements ContractNegotiationStor
 
     @Override
     public void save(ContractNegotiation negotiation) {
-        writeLock(() -> {
+        lockManager.writeLock(() -> {
             negotiation.updateStateTimestamp();
             delete(negotiation.getId());
             ContractNegotiation internalCopy = negotiation.copy();
@@ -89,7 +86,7 @@ public class InMemoryContractNegotiationStore implements ContractNegotiationStor
 
     @Override
     public void delete(String processId) {
-        writeLock(() -> {
+        lockManager.writeLock(() -> {
             ContractNegotiation process = processesById.remove(processId);
             if (process != null) {
                 var tempCache = new HashMap<Integer, List<ContractNegotiation>>();
@@ -111,7 +108,7 @@ public class InMemoryContractNegotiationStore implements ContractNegotiationStor
 
     @Override
     public @NotNull List<ContractNegotiation> nextForState(int state, int max) {
-        return readLock(() -> {
+        return lockManager.readLock(() -> {
             var set = stateCache.get(state);
             return set == null ? Collections.emptyList() : set.stream()
                     .sorted(Comparator.comparingLong(ContractNegotiation::getStateTimestamp)) //order by state timestamp, oldest first
@@ -123,7 +120,7 @@ public class InMemoryContractNegotiationStore implements ContractNegotiationStor
 
     @Override
     public Stream<ContractNegotiation> queryNegotiations(QuerySpec querySpec) {
-        return readLock(() -> {
+        return lockManager.readLock(() -> {
             Stream<ContractNegotiation> negotiationStream = processesById.values().stream();
             // filter
             var andPredicate = querySpec.getFilterExpression().stream().map(this::toPredicate).reduce(x -> true, Predicate::and);
@@ -145,6 +142,7 @@ public class InMemoryContractNegotiationStore implements ContractNegotiationStor
     }
 
     @NotNull
+    @SuppressWarnings({"rawtypes", "unchecked"})
     private Comparator<ContractNegotiation> propertyComparator(QuerySpec querySpec, String property) {
         return (negotiation1, negotiation2) -> {
             var o1 = property(negotiation1, property);
@@ -167,36 +165,5 @@ public class InMemoryContractNegotiationStore implements ContractNegotiationStor
         return new ContractNegotiationPredicateConverter().convert(criterion);
     }
 
-    private <T> T readLock(Supplier<T> work) {
-        try {
-            if (!lock.readLock().tryLock(TIMEOUT, TimeUnit.MILLISECONDS)) {
-                throw new EdcException("Timeout acquiring read lock");
-            }
-            try {
-                return work.get();
-            } finally {
-                lock.readLock().unlock();
-            }
-        } catch (InterruptedException e) {
-            Thread.interrupted();
-            throw new EdcException(e);
-        }
-    }
-
-    private <T> T writeLock(Supplier<T> work) {
-        try {
-            if (!lock.writeLock().tryLock(TIMEOUT, TimeUnit.MILLISECONDS)) {
-                throw new EdcException("Timeout acquiring write lock");
-            }
-            try {
-                return work.get();
-            } finally {
-                lock.writeLock().unlock();
-            }
-        } catch (InterruptedException e) {
-            Thread.interrupted();
-            throw new EdcException(e);
-        }
-    }
 
 }

--- a/extensions/in-memory/transfer-store-memory/build.gradle.kts
+++ b/extensions/in-memory/transfer-store-memory/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 
 dependencies {
     api(project(":spi"))
+    implementation(project(":common:util"))
 
 
 }

--- a/extensions/in-memory/transfer-store-memory/src/main/java/org/eclipse/dataspaceconnector/transfer/store/memory/InMemoryTransferProcessStore.java
+++ b/extensions/in-memory/transfer-store-memory/src/main/java/org/eclipse/dataspaceconnector/transfer/store/memory/InMemoryTransferProcessStore.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.dataspaceconnector.transfer.store.memory;
 
-import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.common.concurrency.LockManager;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.jetbrains.annotations.NotNull;
@@ -27,9 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
@@ -39,15 +37,14 @@ import static java.util.stream.Collectors.toList;
  * This implementation is intended for testing purposes only.
  */
 public class InMemoryTransferProcessStore implements TransferProcessStore {
-    private static final int TIMEOUT = 1000;
-    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+    private final LockManager lockManager = new LockManager(new ReentrantReadWriteLock());
     private final Map<String, TransferProcess> processesById = new HashMap<>();
     private final Map<String, TransferProcess> processesByExternalId = new HashMap<>();
     private final Map<Integer, List<TransferProcess>> stateCache = new HashMap<>();
 
     @Override
     public TransferProcess find(String id) {
-        return readLock(() -> processesById.get(id));
+        return lockManager.readLock(() -> processesById.get(id));
     }
 
     @Override
@@ -59,7 +56,7 @@ public class InMemoryTransferProcessStore implements TransferProcessStore {
 
     @Override
     public @NotNull List<TransferProcess> nextForState(int state, int max) {
-        return readLock(() -> {
+        return lockManager.readLock(() -> {
             var set = stateCache.get(state);
             return set == null ? Collections.emptyList() : set.stream()
                     .sorted(Comparator.comparingLong(TransferProcess::getStateTimestamp)) //order by state timestamp, oldest first
@@ -71,7 +68,7 @@ public class InMemoryTransferProcessStore implements TransferProcessStore {
 
     @Override
     public void create(TransferProcess process) {
-        writeLock(() -> {
+        lockManager.writeLock(() -> {
             delete(process.getId());
             TransferProcess internalCopy = process.copy();
             processesById.put(process.getId(), internalCopy);
@@ -83,7 +80,7 @@ public class InMemoryTransferProcessStore implements TransferProcessStore {
 
     @Override
     public void update(TransferProcess process) {
-        writeLock(() -> {
+        lockManager.writeLock(() -> {
             process.updateStateTimestamp();
             delete(process.getId());
             TransferProcess internalCopy = process.copy();
@@ -96,7 +93,7 @@ public class InMemoryTransferProcessStore implements TransferProcessStore {
 
     @Override
     public void delete(String processId) {
-        writeLock(() -> {
+        lockManager.writeLock(() -> {
             TransferProcess process = processesById.remove(processId);
             if (process != null) {
                 var tempCache = new HashMap<Integer, List<TransferProcess>>();
@@ -137,36 +134,5 @@ public class InMemoryTransferProcessStore implements TransferProcessStore {
         throw new UnsupportedOperationException("Not yet implemented");
     }
 
-    private <T> T readLock(Supplier<T> work) {
-        try {
-            if (!lock.readLock().tryLock(TIMEOUT, TimeUnit.MILLISECONDS)) {
-                throw new EdcException("Timeout acquiring read lock");
-            }
-            try {
-                return work.get();
-            } finally {
-                lock.readLock().unlock();
-            }
-        } catch (InterruptedException e) {
-            Thread.interrupted();
-            throw new EdcException(e);
-        }
-    }
-
-    private <T> T writeLock(Supplier<T> work) {
-        try {
-            if (!lock.writeLock().tryLock(TIMEOUT, TimeUnit.MILLISECONDS)) {
-                throw new EdcException("Timeout acquiring write lock");
-            }
-            try {
-                return work.get();
-            } finally {
-                lock.writeLock().unlock();
-            }
-        } catch (InterruptedException e) {
-            Thread.interrupted();
-            throw new EdcException(e);
-        }
-    }
 
 }


### PR DESCRIPTION
Adds a simple in-memory data plane store and consolidates lock management in a utility:

- Abstract lock management for in-memory stores
- Add an LruCache implementation
- Add an in-memory Data Plane store implementation based on the first two items
- 