### PR TITLE
Prevent publish workflow execution on forks

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,8 +11,11 @@ on:
       - completed
 
 jobs:
-  Unit-Test:
+  Publish:
+    # run only on upstream repo
+    if: github.repository_owner == 'eclipse-dataspaceconnector'
     runs-on: ubuntu-latest
+
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
closes #707 

Prevent running the `publish` workflow on forks. Artifacts should only be published on the upstream repository.