### PR TITLE
core: initialize store at manager build

### DIFF
--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
@@ -86,8 +86,8 @@ public class ContractServiceExtension implements ServiceExtension {
 
     @Override
     public void start() {
-        consumerNegotiationManager.start(store);
-        providerNegotiationManager.start(store);
+        consumerNegotiationManager.start();
+        providerNegotiationManager.start();
     }
 
     @Override
@@ -140,6 +140,7 @@ public class ContractServiceExtension implements ServiceExtension {
                 .commandRunner(commandRunner)
                 .observable(observable)
                 .telemetry(telemetry)
+                .store(store)
                 .build();
 
         providerNegotiationManager = ProviderContractNegotiationManagerImpl.Builder.newInstance()
@@ -151,6 +152,7 @@ public class ContractServiceExtension implements ServiceExtension {
                 .commandRunner(commandRunner)
                 .observable(observable)
                 .telemetry(telemetry)
+                .store(store)
                 .build();
 
         context.registerService(ConsumerContractNegotiationManager.class, consumerNegotiationManager);

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -85,8 +85,7 @@ public class ConsumerContractNegotiationManagerImpl implements ConsumerContractN
 
     private ConsumerContractNegotiationManagerImpl() { }
 
-    public void start(ContractNegotiationStore store) {
-        negotiationStore = store;
+    public void start() {
         active.set(true);
         executor = Executors.newSingleThreadExecutor();
         executor.submit(this::run);
@@ -617,6 +616,11 @@ public class ConsumerContractNegotiationManagerImpl implements ConsumerContractN
             return this;
         }
 
+        public Builder store(ContractNegotiationStore store) {
+            manager.negotiationStore = store;
+            return this;
+        }
+
         public ConsumerContractNegotiationManagerImpl build() {
             Objects.requireNonNull(manager.validationService, "contractValidationService");
             Objects.requireNonNull(manager.monitor, "monitor");
@@ -625,6 +629,7 @@ public class ConsumerContractNegotiationManagerImpl implements ConsumerContractN
             Objects.requireNonNull(manager.commandRunner, "commandRunner");
             Objects.requireNonNull(manager.observable, "observable");
             Objects.requireNonNull(manager.telemetry, "telemetry");
+            Objects.requireNonNull(manager.negotiationStore, "store");
             manager.commandProcessor = new CommandProcessor<>(manager.commandQueue, manager.commandRunner, manager.monitor);
 
             return manager;

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -87,8 +87,7 @@ public class ProviderContractNegotiationManagerImpl implements ProviderContractN
 
     //TODO validate previous offers against hash?
 
-    public void start(ContractNegotiationStore store) {
-        negotiationStore = store;
+    public void start() {
         active.set(true);
         executor = Executors.newSingleThreadExecutor();
         executor.submit(this::run);
@@ -563,6 +562,11 @@ public class ProviderContractNegotiationManagerImpl implements ProviderContractN
             return this;
         }
 
+        public Builder store(ContractNegotiationStore store) {
+            manager.negotiationStore = store;
+            return this;
+        }
+
         public ProviderContractNegotiationManagerImpl build() {
             Objects.requireNonNull(manager.validationService, "contractValidationService");
             Objects.requireNonNull(manager.monitor, "monitor");
@@ -571,9 +575,11 @@ public class ProviderContractNegotiationManagerImpl implements ProviderContractN
             Objects.requireNonNull(manager.commandRunner, "commandRunner");
             Objects.requireNonNull(manager.observable, "observable");
             Objects.requireNonNull(manager.telemetry, "telemetry");
+            Objects.requireNonNull(manager.negotiationStore, "store");
             manager.commandProcessor = new CommandProcessor<>(manager.commandQueue, manager.commandRunner, manager.monitor);
 
             return manager;
         }
+
     }
 }

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/AbstractContractNegotiationIntegrationTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/AbstractContractNegotiationIntegrationTest.java
@@ -92,7 +92,9 @@ public abstract class AbstractContractNegotiationIntegrationTest {
         // Create CommandRunner mock
         CommandRunner<ContractNegotiationCommand> runner = (CommandRunner<ContractNegotiationCommand>) mock(CommandRunner.class);
 
-        // Create the provider contract negotiation manager
+        providerStore = new InMemoryContractNegotiationStore();
+        consumerStore = new InMemoryContractNegotiationStore();
+
         providerManager = ProviderContractNegotiationManagerImpl.Builder.newInstance()
                 .dispatcherRegistry(new FakeProviderDispatcherRegistry())
                 .monitor(monitor)
@@ -101,10 +103,9 @@ public abstract class AbstractContractNegotiationIntegrationTest {
                 .commandQueue(queue)
                 .commandRunner(runner)
                 .observable(providerObservable)
+                .store(providerStore)
                 .build();
-        providerStore = new InMemoryContractNegotiationStore();
 
-        // Create the consumer contract negotiation manager
         consumerManager = ConsumerContractNegotiationManagerImpl.Builder.newInstance()
                 .dispatcherRegistry(new FakeConsumerDispatcherRegistry())
                 .monitor(monitor)
@@ -113,9 +114,9 @@ public abstract class AbstractContractNegotiationIntegrationTest {
                 .commandQueue(queue)
                 .commandRunner(runner)
                 .observable(consumerObservable)
+                .store(consumerStore)
                 .build();
-        consumerStore = new InMemoryContractNegotiationStore();
-        
+
         countDownLatch = new CountDownLatch(2);
     }
     

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -60,30 +60,19 @@ class ConsumerContractNegotiationManagerImplTest {
     private ConsumerContractNegotiationManagerImpl negotiationManager;
 
     @BeforeEach
-    void setUp() throws Exception {
-
-        Monitor monitor = mock(Monitor.class);
-
-        // Create CommandQueue mock
-        CommandQueue<ContractNegotiationCommand> queue = (CommandQueue<ContractNegotiationCommand>) mock(CommandQueue.class);
+    void setUp() {
+        CommandQueue<ContractNegotiationCommand> queue = mock(CommandQueue.class);
         when(queue.dequeue(anyInt())).thenReturn(new ArrayList<>());
-
-        // Create CommandRunner mock
-        CommandRunner<ContractNegotiationCommand> runner = (CommandRunner<ContractNegotiationCommand>) mock(CommandRunner.class);
 
         negotiationManager = ConsumerContractNegotiationManagerImpl.Builder.newInstance()
                 .validationService(validationService)
                 .dispatcherRegistry(dispatcherRegistry)
-                .monitor(monitor)
+                .monitor(mock(Monitor.class))
                 .commandQueue(queue)
-                .commandRunner(runner)
+                .commandRunner(mock(CommandRunner.class))
                 .observable(mock(ContractNegotiationObservable.class))
+                .store(store)
                 .build();
-
-        //TODO hand over store in start method:, but run method should not be executed
-        var negotiationStoreField = ConsumerContractNegotiationManagerImpl.class.getDeclaredField("negotiationStore");
-        negotiationStoreField.setAccessible(true);
-        negotiationStoreField.set(negotiationManager, store);
     }
 
     @Test

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -45,8 +45,8 @@ class ContractNegotiationIntegrationTest extends AbstractContractNegotiationInte
         consumerObservable.registerListener(new ConfirmedContractNegotiationListener(countDownLatch));
 
         // Start provider and consumer negotiation managers
-        providerManager.start(providerStore);
-        consumerManager.start(consumerStore);
+        providerManager.start();
+        consumerManager.start();
 
         // Create an initial request and trigger consumer manager
         ContractOfferRequest request = ContractOfferRequest.Builder.newInstance()
@@ -93,8 +93,8 @@ class ContractNegotiationIntegrationTest extends AbstractContractNegotiationInte
         consumerObservable.registerListener(new DeclinedContractNegotiationListener(countDownLatch));
 
         // Start provider and consumer negotiation managers
-        providerManager.start(providerStore);
-        consumerManager.start(consumerStore);
+        providerManager.start();
+        consumerManager.start();
 
         // Create an initial request and trigger consumer manager
         ContractOfferRequest request = ContractOfferRequest.Builder.newInstance()
@@ -142,8 +142,8 @@ class ContractNegotiationIntegrationTest extends AbstractContractNegotiationInte
         consumerObservable.registerListener(new DeclinedContractNegotiationListener(countDownLatch));
 
         // Start provider and consumer negotiation managers
-        providerManager.start(providerStore);
-        consumerManager.start(consumerStore);
+        providerManager.start();
+        consumerManager.start();
 
         // Create an initial request and trigger consumer manager
         ContractOfferRequest request = ContractOfferRequest.Builder.newInstance()
@@ -195,8 +195,8 @@ class ContractNegotiationIntegrationTest extends AbstractContractNegotiationInte
         consumerObservable.registerListener(new ConfirmedContractNegotiationListener(countDownLatch));
 
         // Start provider and consumer negotiation managers
-        providerManager.start(providerStore);
-        consumerManager.start(consumerStore);
+        providerManager.start();
+        consumerManager.start();
 
         // Create an initial request and trigger consumer manager
         ContractOfferRequest request = ContractOfferRequest.Builder.newInstance()
@@ -254,8 +254,8 @@ class ContractNegotiationIntegrationTest extends AbstractContractNegotiationInte
         consumerObservable.registerListener(new DeclinedContractNegotiationListener(countDownLatch));
 
         // Start provider and consumer negotiation managers
-        providerManager.start(providerStore);
-        consumerManager.start(consumerStore);
+        providerManager.start();
+        consumerManager.start();
 
         // Create an initial request and trigger consumer manager
         ContractOfferRequest request = ContractOfferRequest.Builder.newInstance()
@@ -323,8 +323,8 @@ class ContractNegotiationIntegrationTest extends AbstractContractNegotiationInte
         consumerObservable.registerListener(new ConfirmedContractNegotiationListener(countDownLatch));
 
         // Start provider and consumer negotiation managers
-        providerManager.start(providerStore);
-        consumerManager.start(consumerStore);
+        providerManager.start();
+        consumerManager.start();
 
         // Create an initial request and trigger consumer manager
         ContractOfferRequest request = ContractOfferRequest.Builder.newInstance()
@@ -394,8 +394,8 @@ class ContractNegotiationIntegrationTest extends AbstractContractNegotiationInte
         consumerObservable.registerListener(new DeclinedContractNegotiationListener(countDownLatch));
 
         // Start provider and consumer negotiation managers
-        providerManager.start(providerStore);
-        consumerManager.start(consumerStore);
+        providerManager.start();
+        consumerManager.start();
 
         // Create an initial request and trigger consumer manager
         ContractOfferRequest request = ContractOfferRequest.Builder.newInstance()

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -60,11 +60,11 @@ class ProviderContractNegotiationManagerImplTest {
     private final String correlationId = "correlationId";
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         negotiations.clear();
 
         // Mock contract negotiation store -> persist negotiations in map
-        ContractNegotiationStore negotiationStore = mock(ContractNegotiationStore.class);
+        var negotiationStore = mock(ContractNegotiationStore.class);
 
         doAnswer(invocation -> {
             var negotiation = invocation.getArgument(0, ContractNegotiation.class);
@@ -88,32 +88,19 @@ class ProviderContractNegotiationManagerImplTest {
         // Create contract validation service mock, method mocking has to be done in test methods
         validationService = mock(ContractValidationService.class);
 
-        // Create dispatcher registry mock in order to create manager, not used in unit tests
-        RemoteMessageDispatcherRegistry dispatcherRegistry = mock(RemoteMessageDispatcherRegistry.class);
-
-        // Create monitor mock
-        Monitor monitor = mock(Monitor.class);
-        
         // Create CommandQueue mock
-        CommandQueue<ContractNegotiationCommand> queue = (CommandQueue<ContractNegotiationCommand>) mock(CommandQueue.class);
+        CommandQueue<ContractNegotiationCommand> queue = mock(CommandQueue.class);
         when(queue.dequeue(anyInt())).thenReturn(new ArrayList<>());
-        
-        // Create CommandRunner mock
-        CommandRunner<ContractNegotiationCommand> runner = (CommandRunner<ContractNegotiationCommand>) mock(CommandRunner.class);
 
         negotiationManager = ProviderContractNegotiationManagerImpl.Builder.newInstance()
                 .validationService(validationService)
-                .dispatcherRegistry(dispatcherRegistry)
-                .monitor(monitor)
+                .dispatcherRegistry(mock(RemoteMessageDispatcherRegistry.class))
+                .monitor(mock(Monitor.class))
                 .commandQueue(queue)
-                .commandRunner(runner)
+                .commandRunner(mock(CommandRunner.class))
                 .observable(mock(ContractNegotiationObservable.class))
+                .store(negotiationStore)
                 .build();
-
-        //TODO hand over store in start method, but run method should not be executed
-        var negotiationStoreField = ProviderContractNegotiationManagerImpl.class.getDeclaredField("negotiationStore");
-        negotiationStoreField.setAccessible(true);
-        negotiationStoreField.set(negotiationManager, negotiationStore);
     }
 
     @Test

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/command/ContractNegotiationCommandQueueIntegrationTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/command/ContractNegotiationCommandQueueIntegrationTest.java
@@ -100,8 +100,9 @@ class ContractNegotiationCommandQueueIntegrationTest {
                 .commandQueue(commandQueue)
                 .commandRunner(commandRunner)
                 .observable(observable)
+                .store(store)
                 .build();
-        negotiationManager.start(store);
+        negotiationManager.start();
 
         // Enqueue command
         negotiationManager.enqueueCommand(command);
@@ -130,8 +131,9 @@ class ContractNegotiationCommandQueueIntegrationTest {
                 .commandQueue(commandQueue)
                 .commandRunner(commandRunner)
                 .observable(observable)
+                .store(store)
                 .build();
-        negotiationManager.start(store);
+        negotiationManager.start();
 
         // Enqueue command
         negotiationManager.enqueueCommand(command);

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
@@ -149,6 +149,7 @@ public class CoreTransferExtension implements ServiceExtension {
                 .dataProxyManager(dataProxyManager)
                 .proxyEntryHandlerRegistry(proxyEntryHandlerRegistry)
                 .observable(observable)
+                .store(transferProcessStore)
                 .build();
 
 
@@ -157,7 +158,7 @@ public class CoreTransferExtension implements ServiceExtension {
 
     @Override
     public void start() {
-        processManager.start(transferProcessStore);
+        processManager.start();
     }
 
     @Override

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
@@ -116,8 +116,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
 
     private TransferProcessManagerImpl() { }
 
-    public void start(TransferProcessStore processStore) {
-        transferProcessStore = processStore;
+    public void start() {
         active.set(true);
         executor = Executors.newSingleThreadExecutor();
         executor.submit(this::run);
@@ -656,6 +655,11 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
             return this;
         }
 
+        public Builder store(TransferProcessStore transferProcessStore) {
+            manager.transferProcessStore = transferProcessStore;
+            return this;
+        }
+
         public TransferProcessManagerImpl build() {
             Objects.requireNonNull(manager.manifestGenerator, "manifestGenerator");
             Objects.requireNonNull(manager.provisionManager, "provisionManager");
@@ -669,6 +673,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
             Objects.requireNonNull(manager.proxyEntryHandlers, "ProxyEntryHandlerRegistry cannot be null!");
             Objects.requireNonNull(manager.observable, "Observable cannot be null");
             Objects.requireNonNull(manager.telemetry, "Telemetry cannot be null");
+            Objects.requireNonNull(manager.transferProcessStore, "Store cannot be null");
             manager.commandProcessor = new CommandProcessor<>(manager.commandQueue, manager.commandRunner, manager.monitor);
 
             return manager;

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplIntegrationTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplIntegrationTest.java
@@ -71,9 +71,10 @@ class TransferProcessManagerImplIntegrationTest {
                 .dataProxyManager(mock(DataProxyManager.class))
                 .proxyEntryHandlerRegistry(new ProxyEntryHandlerRegistryImpl())
                 .observable(mock(TransferProcessObservable.class))
+                .store(store)
                 .build();
 
-        transferProcessManager.start(store);
+        transferProcessManager.start();
     }
 
     @Test


### PR DESCRIPTION
Follow up of #690 .
Since we decided to change the lock implementation as decided in #690, and given that there was a test that persisted to fail on github action (but it passed on my machine) I decided to extract the only feature it remained in that PR

## What brings
Currently, on the managers (TransferProcess and ContractNegotiation) the store object is injected on the "start" method invocation. Since there are no reasons to do that, I added a `store` method on the builders and make it as a mandatory field on the managers.