### PR TITLE
`ContractDefinitionStore` supports paging

### DIFF
--- a/common/util/src/main/java/org/eclipse/dataspaceconnector/common/reflection/ReflectionUtil.java
+++ b/common/util/src/main/java/org/eclipse/dataspaceconnector/common/reflection/ReflectionUtil.java
@@ -14,6 +14,9 @@
 
 package org.eclipse.dataspaceconnector.common.reflection;
 
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Comparator;
 import java.util.Objects;
 
 public class ReflectionUtil {
@@ -52,6 +55,25 @@ public class ReflectionUtil {
         } catch (ReflectionException ignored) {
             return null;
         }
+    }
+
+    @NotNull
+    public static <T> Comparator<T> propertyComparator(boolean isAscending, String property) {
+        return (def1, def2) -> {
+            var o1 = ReflectionUtil.getFieldValueSilent(property, def1);
+            var o2 = ReflectionUtil.getFieldValueSilent(property, def2);
+
+            if (o1 == null || o2 == null) {
+                return 0;
+            }
+
+            if (!(o1 instanceof Comparable)) {
+                throw new IllegalArgumentException("A property '" + property + "' is not comparable!");
+            }
+            var comp1 = (Comparable) o1;
+            var comp2 = (Comparable) o2;
+            return isAscending ? comp1.compareTo(comp2) : comp2.compareTo(comp1);
+        };
     }
 
 

--- a/common/util/src/main/java/org/eclipse/dataspaceconnector/common/reflection/ReflectionUtil.java
+++ b/common/util/src/main/java/org/eclipse/dataspaceconnector/common/reflection/ReflectionUtil.java
@@ -16,8 +16,14 @@ package org.eclipse.dataspaceconnector.common.reflection;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class ReflectionUtil {
 
@@ -32,14 +38,27 @@ public class ReflectionUtil {
     public static <T> T getFieldValue(String propertyName, Object object) {
         Objects.requireNonNull(propertyName, "propertyName");
         Objects.requireNonNull(object, "object");
-        try {
-            var field = object.getClass().getDeclaredField(propertyName);
-            field.setAccessible(true);
-            return (T) field.get(object);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new ReflectionException(e);
+
+        if (propertyName.contains(".")) {
+            var dotIx = propertyName.indexOf(".");
+            var field = propertyName.substring(0, dotIx);
+            var rest = propertyName.substring(dotIx + 1);
+            object = getFieldValue(field, object);
+            return getFieldValue(rest, object);
+        } else {
+            try {
+                var field = getFieldRecursive(object.getClass(), propertyName);
+                if (field == null) {
+                    throw new ReflectionException(propertyName);
+                }
+                field.setAccessible(true);
+                return (T) field.get(object);
+            } catch (IllegalAccessException e) {
+                throw new ReflectionException(e);
+            }
         }
     }
+
 
     /**
      * Utility function to get value of a field from an object. Essentially the same as {@link ReflectionUtil#getFieldValue(String, Object)}
@@ -76,5 +95,33 @@ public class ReflectionUtil {
         };
     }
 
+
+    /**
+     * Gets a field with a given name from all declared fields of a class including supertypes. Will include protected and private fields.
+     *
+     * @param clazz     The class of the object
+     * @param fieldName The fieldname
+     * @return A field with the given name, null if the field does not exist
+     */
+    public static Field getFieldRecursive(Class<?> clazz, String fieldName) {
+        return getAllFieldsRecursive(clazz).stream().filter(f -> f.getName().equals(fieldName)).findFirst().orElse(null);
+    }
+
+    /**
+     * Recursively gets all fields declared in the class and all its superclasses
+     *
+     * @param clazz The class of the object
+     * @return A list of {@link Field}s
+     */
+    public static List<Field> getAllFieldsRecursive(Class<?> clazz) {
+        if (clazz == null) {
+            return Collections.emptyList();
+        }
+
+        List<Field> result = new ArrayList<>(getAllFieldsRecursive(clazz.getSuperclass()));
+        List<Field> filteredFields = Arrays.stream(clazz.getDeclaredFields()).collect(Collectors.toList());
+        result.addAll(filteredFields);
+        return result;
+    }
 
 }

--- a/common/util/src/test/java/org/eclipse/dataspaceconnector/common/reflection/ReflectionUtilTest.java
+++ b/common/util/src/test/java/org/eclipse/dataspaceconnector/common/reflection/ReflectionUtilTest.java
@@ -16,6 +16,10 @@ package org.eclipse.dataspaceconnector.common.reflection;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Comparator;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -86,5 +90,24 @@ class ReflectionUtilTest {
                 .isInstanceOf(NullPointerException.class).hasMessage("object");
     }
 
+    @Test
+    void propertyComparator_whenAscending() {
+        var testObjects = IntStream.range(0, 10).mapToObj(i -> new TestObject("id" + i, i)).collect(Collectors.toList());
+        var comparator = ReflectionUtil.propertyComparator(true, "description");
+        assertThat(testObjects.stream().sorted(comparator)).isSortedAccordingTo(Comparator.comparing(TestObject::getDescription));
+    }
 
+    @Test
+    void propertyComparator_whenDescending() {
+        var testObjects = IntStream.range(0, 10).mapToObj(i -> new TestObject("id" + i, i)).collect(Collectors.toList());
+        var comparator = ReflectionUtil.propertyComparator(false, "description");
+        assertThat(testObjects.stream().sorted(comparator)).isSortedAccordingTo(Comparator.comparing(TestObject::getDescription).reversed());
+    }
+
+    @Test
+    void propertyComparator_whenPropertyNotFound() {
+        var testObjects = IntStream.range(0, 10).mapToObj(i -> new TestObject("id" + i, i)).collect(Collectors.toList());
+        var comparator = ReflectionUtil.propertyComparator(true, "notexist");
+        assertThat(testObjects.stream().sorted(comparator)).containsExactlyInAnyOrder(testObjects.toArray(new TestObject[]{}));
+    }
 }

--- a/common/util/src/test/java/org/eclipse/dataspaceconnector/common/reflection/ReflectionUtilTest.java
+++ b/common/util/src/test/java/org/eclipse/dataspaceconnector/common/reflection/ReflectionUtilTest.java
@@ -14,8 +14,10 @@
 
 package org.eclipse.dataspaceconnector.common.reflection;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.util.Comparator;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -109,5 +111,41 @@ class ReflectionUtilTest {
         var testObjects = IntStream.range(0, 10).mapToObj(i -> new TestObject("id" + i, i)).collect(Collectors.toList());
         var comparator = ReflectionUtil.propertyComparator(true, "notexist");
         assertThat(testObjects.stream().sorted(comparator)).containsExactlyInAnyOrder(testObjects.toArray(new TestObject[]{}));
+    }
+
+    @Test
+    void getAllFieldsRecursive() {
+        var to = new TestObjectSubclass("test-desc", 1, "foobar");
+
+        assertThat(ReflectionUtil.getAllFieldsRecursive(to.getClass())).hasSize(3).extracting(Field::getName)
+                .containsExactlyInAnyOrder("description", "priority", "testProperty");
+    }
+
+    @Test
+    void getFieldRecursive_whenDeclaredInSuperclass() {
+        var to = new TestObjectSubclass("test-desc", 1, "foobar");
+        assertThat(ReflectionUtil.getFieldRecursive(to.getClass(), "description")).isNotNull();
+    }
+
+    @Test
+    void getFieldRecursive_whenDeclaredInClass() throws IllegalAccessException {
+        var to = new TestObjectSubclass("test-desc", 1, "foobar");
+        Field testProperty = ReflectionUtil.getFieldRecursive(to.getClass(), "testProperty");
+        assertThat(testProperty).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Should pick the property from the object highest in the object hierarchy")
+    void getFieldRecursive_whenDeclaredInBoth() {
+        var to = new TestObjectSubSubclass("test-desc", 2, "foobar");
+        assertThat(ReflectionUtil.getFieldRecursive(to.getClass(), "description")).isNotNull().extracting(Field::getDeclaringClass)
+                .isEqualTo(TestObject.class);
+
+    }
+
+    @Test
+    void getFieldRecursive_whenNotDeclared() {
+        var to = new TestObjectSubclass("test-desc", 1, "foobar");
+        assertThat(ReflectionUtil.getFieldRecursive(to.getClass(), "notExist")).isNull();
     }
 }

--- a/common/util/src/test/java/org/eclipse/dataspaceconnector/common/reflection/TestObjectSubSubclass.java
+++ b/common/util/src/test/java/org/eclipse/dataspaceconnector/common/reflection/TestObjectSubSubclass.java
@@ -14,12 +14,16 @@
 
 package org.eclipse.dataspaceconnector.common.reflection;
 
-public class ReflectionException extends RuntimeException {
-    public ReflectionException(Throwable root) {
-        super(root);
+public class TestObjectSubSubclass extends TestObjectSubclass {
+    private final String description;
+
+    public TestObjectSubSubclass(String description, int priority, String testProperty) {
+        super(description, priority, testProperty);
+        this.description = "Sub_" + description;
     }
 
-    public ReflectionException(String propertyName) {
-        super("Error during reflective access: " + propertyName);
+    @Override
+    public String getDescription() {
+        return description;
     }
 }

--- a/common/util/src/test/java/org/eclipse/dataspaceconnector/common/reflection/TestObjectSubclass.java
+++ b/common/util/src/test/java/org/eclipse/dataspaceconnector/common/reflection/TestObjectSubclass.java
@@ -14,12 +14,16 @@
 
 package org.eclipse.dataspaceconnector.common.reflection;
 
-public class ReflectionException extends RuntimeException {
-    public ReflectionException(Throwable root) {
-        super(root);
+public class TestObjectSubclass extends TestObject {
+    private final String testProperty;
+
+    public TestObjectSubclass(String description, int priority, String testProperty) {
+        super(description, priority);
+        this.testProperty = testProperty;
     }
 
-    public ReflectionException(String propertyName) {
-        super("Error during reflective access: " + propertyName);
+    public String getTestProperty() {
+        return testProperty;
     }
+
 }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
@@ -258,6 +258,11 @@ class IdsApiMultipartDispatcherV1IntegrationTestServiceExtension implements Serv
         }
 
         @Override
+        public @NotNull Stream<ContractDefinition> findAll(QuerySpec spec) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public void save(Collection<ContractDefinition> definitions) {
             contractDefinitions.addAll(definitions);
         }
@@ -312,7 +317,11 @@ class IdsApiMultipartDispatcherV1IntegrationTestServiceExtension implements Serv
         public NegotiationResult declined(ClaimToken token, String negotiationId) {
             return NegotiationResult.success(fakeContractNegotiation());
         }
-    
+
+        @Override
+        public void enqueueCommand(ContractNegotiationCommand command) {
+        }
+
         @Override
         public NegotiationResult requested(ClaimToken token, ContractOfferRequest request) {
             return NegotiationResult.success(fakeContractNegotiation());
@@ -326,10 +335,6 @@ class IdsApiMultipartDispatcherV1IntegrationTestServiceExtension implements Serv
         @Override
         public NegotiationResult consumerApproved(ClaimToken token, String correlationId, ContractAgreement agreement, String hash) {
             return NegotiationResult.success(fakeContractNegotiation());
-        }
-    
-        @Override
-        public void enqueueCommand(ContractNegotiationCommand command) {
         }
     }
 
@@ -354,7 +359,7 @@ class IdsApiMultipartDispatcherV1IntegrationTestServiceExtension implements Serv
         public NegotiationResult declined(ClaimToken token, String negotiationId) {
             return NegotiationResult.success(fakeContractNegotiation());
         }
-    
+
         @Override
         public void enqueueCommand(ContractNegotiationCommand command) {
         }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
@@ -256,6 +256,11 @@ class IdsApiMultipartEndpointV1IntegrationTestServiceExtension implements Servic
         }
 
         @Override
+        public @NotNull Stream<ContractDefinition> findAll(QuerySpec spec) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public void save(Collection<ContractDefinition> definitions) {
             contractDefinitions.addAll(definitions);
         }

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStore.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStore.java
@@ -5,6 +5,7 @@ import net.jodah.failsafe.function.CheckedSupplier;
 import org.eclipse.dataspaceconnector.contract.definition.store.model.ContractDefinitionDocument;
 import org.eclipse.dataspaceconnector.cosmos.azure.CosmosDbApi;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
 import org.jetbrains.annotations.NotNull;
@@ -16,6 +17,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static net.jodah.failsafe.Failsafe.with;
 
@@ -42,6 +44,11 @@ public class CosmosContractDefinitionStore implements ContractDefinitionStore {
     @Override
     public @NotNull Collection<ContractDefinition> findAll() {
         return getCache().values();
+    }
+
+    @Override
+    public @NotNull Stream<ContractDefinition> findAll(QuerySpec spec) {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStore.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStore.java
@@ -69,6 +69,10 @@ public class CosmosContractDefinitionStore implements ContractDefinitionStore {
             var sortField = spec.getSortField();
 
             if (sortField != null) {
+                // if the sortfield doesn't exist on the object -> return empty
+                if (ReflectionUtil.getFieldRecursive(ContractDefinition.class, sortField) == null) {
+                    return Stream.empty();
+                }
                 var comparator = propertyComparator(spec.getSortOrder() == SortOrder.ASC, sortField);
                 stream = stream.sorted(comparator);
             }

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStore.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStore.java
@@ -2,10 +2,15 @@ package org.eclipse.dataspaceconnector.contract.definition.store;
 
 import net.jodah.failsafe.RetryPolicy;
 import net.jodah.failsafe.function.CheckedSupplier;
+import org.eclipse.dataspaceconnector.common.concurrency.LockManager;
+import org.eclipse.dataspaceconnector.common.reflection.ReflectionUtil;
 import org.eclipse.dataspaceconnector.contract.definition.store.model.ContractDefinitionDocument;
 import org.eclipse.dataspaceconnector.cosmos.azure.CosmosDbApi;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
+import org.eclipse.dataspaceconnector.spi.query.BaseCriterionToPredicateConverter;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
 import org.jetbrains.annotations.NotNull;
@@ -16,10 +21,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static net.jodah.failsafe.Failsafe.with;
+import static org.eclipse.dataspaceconnector.common.reflection.ReflectionUtil.propertyComparator;
 
 /**
  * Implementation of the {@link ContractDefinitionStore} based on CosmosDB. This store implements simple write-through
@@ -30,7 +37,7 @@ public class CosmosContractDefinitionStore implements ContractDefinitionStore {
     private final CosmosDbApi cosmosDbApi;
     private final TypeManager typeManager;
     private final RetryPolicy<Object> retryPolicy;
-    private final ReentrantReadWriteLock lock; //used to synchronize write operations to the cache and the DB
+    private final LockManager lockManager;
     private AtomicReference<Map<String, ContractDefinition>> objectCache;
 
     public CosmosContractDefinitionStore(CosmosDbApi cosmosDbApi, TypeManager typeManager, RetryPolicy<Object> retryPolicy) {
@@ -38,7 +45,7 @@ public class CosmosContractDefinitionStore implements ContractDefinitionStore {
         this.typeManager = typeManager;
         this.retryPolicy = retryPolicy;
 
-        lock = new ReentrantReadWriteLock(true);
+        lockManager = new LockManager(new ReentrantReadWriteLock(true));
     }
 
     @Override
@@ -46,42 +53,56 @@ public class CosmosContractDefinitionStore implements ContractDefinitionStore {
         return getCache().values();
     }
 
+    /**
+     * Note: will return the entire stream when the sortField of the QuerySpec refers to a non-existent property
+     */
     @Override
     public @NotNull Stream<ContractDefinition> findAll(QuerySpec spec) {
-        throw new UnsupportedOperationException();
+        return lockManager.readLock(() -> {
+            var stream = getCache().values().stream();
+
+            //filter
+            var andPredicate = spec.getFilterExpression().stream().map(this::toPredicate).reduce(x -> true, Predicate::and);
+            stream = stream.filter(andPredicate);
+
+            //sort
+            var sortField = spec.getSortField();
+
+            if (sortField != null) {
+                var comparator = propertyComparator(spec.getSortOrder() == SortOrder.ASC, sortField);
+                stream = stream.sorted(comparator);
+            }
+
+            // limit
+            return stream.skip(spec.getOffset()).limit(spec.getLimit());
+        });
     }
 
     @Override
     public void save(Collection<ContractDefinition> definitions) {
-        lock.writeLock().lock();
-        try {
+        lockManager.writeLock(() -> {
             with(retryPolicy).run(() -> cosmosDbApi.saveItems(definitions.stream().map(this::convertToDocument).collect(Collectors.toList())));
             definitions.forEach(this::storeInCache);
-        } finally {
-            lock.writeLock().unlock();
-        }
+            return null;
+        });
     }
 
     @Override
     public void save(ContractDefinition definition) {
-        lock.writeLock().lock();
-        try {
+        lockManager.writeLock(() -> {
             with(retryPolicy).run(() -> cosmosDbApi.saveItem(convertToDocument(definition)));
             storeInCache(definition);
-        } finally {
-            lock.writeLock().unlock();
-        }
+            return null;
+        });
     }
 
     @Override
     public void update(ContractDefinition definition) {
-        lock.writeLock().lock();
-        try {
+        lockManager.writeLock(() -> {
             save(definition); //cosmos db api internally uses "upsert" semantics
             storeInCache(definition);
-        } finally {
-            lock.writeLock().unlock();
-        }
+            return null;
+        });
     }
 
     @Override
@@ -91,8 +112,7 @@ public class CosmosContractDefinitionStore implements ContractDefinitionStore {
 
     @Override
     public void reload() {
-        lock.readLock().lock();
-        try {
+        lockManager.readLock(() -> {
             // this reloads ALL items from the database. We might want something more elaborate in the future, especially
             // if large amounts of ContractDefinitions need to be held in memory
             var databaseObjects = with(retryPolicy)
@@ -105,10 +125,8 @@ public class CosmosContractDefinitionStore implements ContractDefinitionStore {
                 objectCache = new AtomicReference<>(new HashMap<>());
             }
             objectCache.set(databaseObjects);
-        } finally {
-            lock.readLock().unlock();
-        }
-
+            return null;
+        });
     }
 
     private void storeInCache(ContractDefinition definition) {
@@ -131,5 +149,17 @@ public class CosmosContractDefinitionStore implements ContractDefinitionStore {
     private ContractDefinition convert(Object object) {
         var json = typeManager.writeValueAsString(object);
         return typeManager.readValue(json, ContractDefinitionDocument.class).getWrappedInstance();
+    }
+
+    private Predicate<ContractDefinition> toPredicate(Criterion criterion) {
+        return new ContractDefinitionPredicateConverter().convert(criterion);
+    }
+
+
+    private static class ContractDefinitionPredicateConverter extends BaseCriterionToPredicateConverter<ContractDefinition> {
+        @Override
+        protected <R> R property(String key, Object object) {
+            return ReflectionUtil.getFieldValueSilent(key, object);
+        }
     }
 }

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreIntegrationTest.java
@@ -9,11 +9,12 @@ import com.azure.cosmos.models.CosmosContainerResponse;
 import com.azure.cosmos.models.CosmosDatabaseResponse;
 import com.azure.cosmos.models.PartitionKey;
 import net.jodah.failsafe.RetryPolicy;
-import org.eclipse.dataspaceconnector.common.annotations.IntegrationTest;
 import org.eclipse.dataspaceconnector.contract.definition.store.model.ContractDefinitionDocument;
 import org.eclipse.dataspaceconnector.cosmos.azure.CosmosDbApi;
 import org.eclipse.dataspaceconnector.cosmos.azure.CosmosDbApiImpl;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
 import org.junit.jupiter.api.AfterAll;
@@ -24,8 +25,11 @@ import org.junit.jupiter.api.TestInfo;
 
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -33,7 +37,7 @@ import static org.eclipse.dataspaceconnector.common.configuration.ConfigurationF
 import static org.eclipse.dataspaceconnector.contract.definition.store.TestFunctions.generateDefinition;
 import static org.eclipse.dataspaceconnector.contract.definition.store.TestFunctions.generateDocument;
 
-@IntegrationTest
+//@IntegrationTest
 public class CosmosContractDefinitionStoreIntegrationTest {
     public static final String REGION = "westeurope";
     private static final String TEST_ID = UUID.randomUUID().toString();
@@ -47,7 +51,7 @@ public class CosmosContractDefinitionStoreIntegrationTest {
 
     @BeforeAll
     static void prepareCosmosClient() {
-        var key = propOrEnv("COSMOS_KEY", null);
+        var key = propOrEnv("COSMOS_KEY", "RYNecVDtJq2WKAcIoONBLzuTBys06kUcP8Rw9Yz5zOzsOQFVGaP8oGuI5qgF5ONQY4VukjkpQ4x7a2jwVvo7SQ==");
         if (key != null) {
             var client = new CosmosClientBuilder()
                     .key(key)
@@ -208,6 +212,104 @@ public class CosmosContractDefinitionStoreIntegrationTest {
     void reload() {
 
     }
+
+    @Test
+    void findAll_noQuerySpec() {
+        var doc1 = generateDocument();
+        var doc2 = generateDocument();
+
+        container.createItem(doc1);
+        container.createItem(doc2);
+
+        assertThat(store.findAll(QuerySpec.none())).hasSize(2).extracting(ContractDefinition::getId).containsExactlyInAnyOrder(doc1.getId(), doc2.getId());
+    }
+
+    @Test
+    void findAll_verifyPaging() {
+
+        var all = IntStream.range(0, 10).mapToObj(i -> generateDocument())
+                .peek(d -> container.createItem(d))
+                .map(ContractDefinitionDocument::getId)
+                .collect(Collectors.toList());
+
+        // page size fits
+        assertThat(store.findAll(QuerySpec.Builder.newInstance().offset(3).limit(4).build())).hasSize(4)
+                .extracting(ContractDefinition::getId).isSubsetOf(all);
+
+    }
+
+    @Test
+    void findAll_verifyPaging_pageSizeLargerThanCollection() {
+
+        var all = IntStream.range(0, 10).mapToObj(i -> generateDocument())
+                .peek(d -> container.createItem(d))
+                .map(ContractDefinitionDocument::getId)
+                .collect(Collectors.toList());
+
+        // page size fits
+        assertThat(store.findAll(QuerySpec.Builder.newInstance().offset(3).limit(40).build())).hasSize(7)
+                .extracting(ContractDefinition::getId).isSubsetOf(all);
+    }
+
+    @Test
+    void findAll_verifyFiltering() {
+        var documents = IntStream.range(0, 10).mapToObj(i -> generateDocument())
+                .peek(d -> container.createItem(d))
+                .collect(Collectors.toList());
+
+        var expectedId = documents.get(3).getId();
+
+        var query = QuerySpec.Builder.newInstance().filter("id=" + expectedId).build();
+        assertThat(store.findAll(query)).extracting(ContractDefinition::getId).containsOnly(expectedId);
+    }
+
+    @Test
+    void findAll_verifyFiltering_invalidFilterExpression() {
+        IntStream.range(0, 10).mapToObj(i -> generateDocument())
+                .forEach(d -> container.createItem(d));
+
+        var query = QuerySpec.Builder.newInstance().filter("something contains other").build();
+
+        assertThatThrownBy(() -> store.findAll(query)).isInstanceOfAny(IllegalArgumentException.class).hasMessage("Cannot build SqlParameter for operator: contains");
+    }
+
+    @Test
+    void findAll_verifyFiltering_unsuccessfulFilterExpression() {
+        IntStream.range(0, 10).mapToObj(i -> generateDocument())
+                .forEach(d -> container.createItem(d));
+
+        var query = QuerySpec.Builder.newInstance().filter("something = other").build();
+
+        assertThat(store.findAll(query)).isEmpty();
+    }
+
+    @Test
+    void findAll_verifySorting() {
+
+        IntStream.range(0, 10).mapToObj(i -> generateDocument())
+                .forEach(d -> container.createItem(d));
+
+        var ascendingQuery = QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.ASC).build();
+        assertThat(store.findAll(ascendingQuery)).hasSize(10).isSortedAccordingTo(Comparator.comparing(ContractDefinition::getId));
+        var descendingQuery = QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.DESC).build();
+        assertThat(store.findAll(descendingQuery)).hasSize(10).isSortedAccordingTo((c1, c2) -> c2.getId().compareTo(c1.getId()));
+    }
+
+    @Test
+    void findAll_sorting_nonExistentProperty() {
+
+        var allIds = IntStream.range(0, 10).mapToObj(i -> generateDocument())
+                .peek(d -> container.createItem(d))
+                .map(ContractDefinitionDocument::getId)
+                .collect(Collectors.toList());
+
+
+        var query = QuerySpec.Builder.newInstance().sortField("notexist").sortOrder(SortOrder.DESC).build();
+
+        var all = store.findAll(query).collect(Collectors.toList());
+        assertThat(all).isEmpty();
+    }
+
 
     private ContractDefinition convert(Object object) {
         var json = typeManager.writeValueAsString(object);

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreIntegrationTest.java
@@ -9,9 +9,12 @@ import com.azure.cosmos.models.CosmosContainerResponse;
 import com.azure.cosmos.models.CosmosDatabaseResponse;
 import com.azure.cosmos.models.PartitionKey;
 import net.jodah.failsafe.RetryPolicy;
+import org.eclipse.dataspaceconnector.common.annotations.IntegrationTest;
 import org.eclipse.dataspaceconnector.contract.definition.store.model.ContractDefinitionDocument;
 import org.eclipse.dataspaceconnector.cosmos.azure.CosmosDbApi;
 import org.eclipse.dataspaceconnector.cosmos.azure.CosmosDbApiImpl;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
@@ -37,7 +40,7 @@ import static org.eclipse.dataspaceconnector.common.configuration.ConfigurationF
 import static org.eclipse.dataspaceconnector.contract.definition.store.TestFunctions.generateDefinition;
 import static org.eclipse.dataspaceconnector.contract.definition.store.TestFunctions.generateDocument;
 
-//@IntegrationTest
+@IntegrationTest
 public class CosmosContractDefinitionStoreIntegrationTest {
     public static final String REGION = "westeurope";
     private static final String TEST_ID = UUID.randomUUID().toString();
@@ -51,14 +54,9 @@ public class CosmosContractDefinitionStoreIntegrationTest {
 
     @BeforeAll
     static void prepareCosmosClient() {
-        var key = propOrEnv("COSMOS_KEY", "RYNecVDtJq2WKAcIoONBLzuTBys06kUcP8Rw9Yz5zOzsOQFVGaP8oGuI5qgF5ONQY4VukjkpQ4x7a2jwVvo7SQ==");
+        var key = propOrEnv("COSMOS_KEY", null);
         if (key != null) {
-            var client = new CosmosClientBuilder()
-                    .key(key)
-                    .preferredRegions(Collections.singletonList(REGION))
-                    .consistencyLevel(ConsistencyLevel.SESSION)
-                    .endpoint("https://" + ACCOUNT_NAME + ".documents.azure.com:443/")
-                    .buildClient();
+            var client = new CosmosClientBuilder().key(key).preferredRegions(Collections.singletonList(REGION)).consistencyLevel(ConsistencyLevel.SESSION).endpoint("https://" + ACCOUNT_NAME + ".documents.azure.com:443/").buildClient();
 
             CosmosDatabaseResponse response = client.createDatabaseIfNotExists(DATABASE_NAME);
             database = client.getDatabase(response.getProperties().getId());
@@ -171,12 +169,11 @@ public class CosmosContractDefinitionStoreIntegrationTest {
 
         var updatedDefinition = convert(container.readItem(doc1.getId(), new PartitionKey(doc1.getPartitionKey()), Object.class).getItem());
         assertThat(updatedDefinition.getId()).isEqualTo(definition.getId());
-        assertThat(updatedDefinition.getSelectorExpression().getCriteria()).hasSize(2)
-                .anySatisfy(criterion -> {
-                    assertThat(criterion.getOperandLeft()).isNotEqualTo("anotherKey");
-                    assertThat(criterion.getOperator()).isNotEqualTo("NOT EQUAL");
-                    assertThat(criterion.getOperandLeft()).isNotEqualTo("anotherValue");
-                }); //we modified that earlier
+        assertThat(updatedDefinition.getSelectorExpression().getCriteria()).hasSize(2).anySatisfy(criterion -> {
+            assertThat(criterion.getOperandLeft()).isNotEqualTo("anotherKey");
+            assertThat(criterion.getOperator()).isNotEqualTo("NOT EQUAL");
+            assertThat(criterion.getOperandLeft()).isNotEqualTo("anotherValue");
+        }); //we modified that earlier
     }
 
     @Test
@@ -203,9 +200,7 @@ public class CosmosContractDefinitionStoreIntegrationTest {
 
     @Test
     void delete_notExist() {
-        assertThatThrownBy(() -> store.delete("not-exist-id"))
-                .isInstanceOf(NotFoundException.class)
-                .hasMessageContaining("An object with the ID not-exist-id could not be found!");
+        assertThatThrownBy(() -> store.delete("not-exist-id")).isInstanceOf(NotFoundException.class).hasMessageContaining("An object with the ID not-exist-id could not be found!");
     }
 
     @Test
@@ -227,35 +222,25 @@ public class CosmosContractDefinitionStoreIntegrationTest {
     @Test
     void findAll_verifyPaging() {
 
-        var all = IntStream.range(0, 10).mapToObj(i -> generateDocument())
-                .peek(d -> container.createItem(d))
-                .map(ContractDefinitionDocument::getId)
-                .collect(Collectors.toList());
+        var all = IntStream.range(0, 10).mapToObj(i -> generateDocument()).peek(d -> container.createItem(d)).map(ContractDefinitionDocument::getId).collect(Collectors.toList());
 
         // page size fits
-        assertThat(store.findAll(QuerySpec.Builder.newInstance().offset(3).limit(4).build())).hasSize(4)
-                .extracting(ContractDefinition::getId).isSubsetOf(all);
+        assertThat(store.findAll(QuerySpec.Builder.newInstance().offset(3).limit(4).build())).hasSize(4).extracting(ContractDefinition::getId).isSubsetOf(all);
 
     }
 
     @Test
     void findAll_verifyPaging_pageSizeLargerThanCollection() {
 
-        var all = IntStream.range(0, 10).mapToObj(i -> generateDocument())
-                .peek(d -> container.createItem(d))
-                .map(ContractDefinitionDocument::getId)
-                .collect(Collectors.toList());
+        var all = IntStream.range(0, 10).mapToObj(i -> generateDocument()).peek(d -> container.createItem(d)).map(ContractDefinitionDocument::getId).collect(Collectors.toList());
 
         // page size fits
-        assertThat(store.findAll(QuerySpec.Builder.newInstance().offset(3).limit(40).build())).hasSize(7)
-                .extracting(ContractDefinition::getId).isSubsetOf(all);
+        assertThat(store.findAll(QuerySpec.Builder.newInstance().offset(3).limit(40).build())).hasSize(7).extracting(ContractDefinition::getId).isSubsetOf(all);
     }
 
     @Test
     void findAll_verifyFiltering() {
-        var documents = IntStream.range(0, 10).mapToObj(i -> generateDocument())
-                .peek(d -> container.createItem(d))
-                .collect(Collectors.toList());
+        var documents = IntStream.range(0, 10).mapToObj(i -> generateDocument()).peek(d -> container.createItem(d)).collect(Collectors.toList());
 
         var expectedId = documents.get(3).getId();
 
@@ -265,18 +250,17 @@ public class CosmosContractDefinitionStoreIntegrationTest {
 
     @Test
     void findAll_verifyFiltering_invalidFilterExpression() {
-        IntStream.range(0, 10).mapToObj(i -> generateDocument())
-                .forEach(d -> container.createItem(d));
+        IntStream.range(0, 10).mapToObj(i -> generateDocument()).forEach(d -> container.createItem(d));
 
         var query = QuerySpec.Builder.newInstance().filter("something contains other").build();
 
-        assertThatThrownBy(() -> store.findAll(query)).isInstanceOfAny(IllegalArgumentException.class).hasMessage("Cannot build SqlParameter for operator: contains");
+        // message is coming from the predicate converter rather than the SQL statement translation layer
+        assertThatThrownBy(() -> store.findAll(query)).isInstanceOfAny(IllegalArgumentException.class).hasMessage("Operator [contains] is not supported by this converter!");
     }
 
     @Test
     void findAll_verifyFiltering_unsuccessfulFilterExpression() {
-        IntStream.range(0, 10).mapToObj(i -> generateDocument())
-                .forEach(d -> container.createItem(d));
+        IntStream.range(0, 10).mapToObj(i -> generateDocument()).forEach(d -> container.createItem(d));
 
         var query = QuerySpec.Builder.newInstance().filter("something = other").build();
 
@@ -286,8 +270,7 @@ public class CosmosContractDefinitionStoreIntegrationTest {
     @Test
     void findAll_verifySorting() {
 
-        IntStream.range(0, 10).mapToObj(i -> generateDocument())
-                .forEach(d -> container.createItem(d));
+        IntStream.range(0, 10).mapToObj(i -> generateDocument()).forEach(d -> container.createItem(d));
 
         var ascendingQuery = QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.ASC).build();
         assertThat(store.findAll(ascendingQuery)).hasSize(10).isSortedAccordingTo(Comparator.comparing(ContractDefinition::getId));
@@ -298,16 +281,35 @@ public class CosmosContractDefinitionStoreIntegrationTest {
     @Test
     void findAll_sorting_nonExistentProperty() {
 
-        var allIds = IntStream.range(0, 10).mapToObj(i -> generateDocument())
-                .peek(d -> container.createItem(d))
-                .map(ContractDefinitionDocument::getId)
-                .collect(Collectors.toList());
+        var ids = IntStream.range(0, 10).mapToObj(i -> generateDocument()).peek(d -> container.createItem(d)).map(ContractDefinitionDocument::getId).collect(Collectors.toList());
 
 
         var query = QuerySpec.Builder.newInstance().sortField("notexist").sortOrder(SortOrder.DESC).build();
 
         var all = store.findAll(query).collect(Collectors.toList());
         assertThat(all).isEmpty();
+    }
+
+    @Test
+    void verify_readWriteFindAll() {
+        // add an object
+        var def = generateDefinition();
+        store.save(def);
+        assertThat(store.findAll()).containsExactly(def);
+
+        // modify the object
+        var modifiedDef = ContractDefinition.Builder.newInstance().id(def.getId())
+                .contractPolicy(Policy.Builder.newInstance().id("test-cp-id-new").build())
+                .accessPolicy(Policy.Builder.newInstance().id("test-ap-id-new").build())
+                .selectorExpression(AssetSelectorExpression.Builder.newInstance().whenEquals("somekey", "someval").build())
+                .build();
+
+        store.update(modifiedDef);
+
+        // re-read
+        var all = store.findAll(QuerySpec.Builder.newInstance().filter("contractPolicy.uid=test-cp-id-new").build()).collect(Collectors.toList());
+        assertThat(all).hasSize(1).containsExactly(modifiedDef);
+
     }
 
 

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreTest.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreTest.java
@@ -1,8 +1,13 @@
 package org.eclipse.dataspaceconnector.contract.definition.store;
 
+import com.azure.cosmos.models.SqlQuerySpec;
 import net.jodah.failsafe.RetryPolicy;
+import org.eclipse.dataspaceconnector.common.matchers.PredicateMatcher;
+import org.eclipse.dataspaceconnector.contract.definition.store.model.ContractDefinitionDocument;
 import org.eclipse.dataspaceconnector.cosmos.azure.CosmosDbApi;
 import org.eclipse.dataspaceconnector.cosmos.azure.CosmosDocument;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,11 +15,18 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.dataspaceconnector.contract.definition.store.TestFunctions.generateDefinition;
 import static org.eclipse.dataspaceconnector.contract.definition.store.TestFunctions.generateDocument;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -107,4 +119,82 @@ class CosmosContractDefinitionStoreTest {
         verify(cosmosDbApiMock).deleteItem(notNull());
     }
 
+    @Test
+    void findAll_noQuerySpec() {
+
+        when(cosmosDbApiMock.queryItems(isA(SqlQuerySpec.class))).thenReturn(IntStream.range(0, 10).mapToObj(i -> generateDocument()));
+
+        var all = store.findAll(QuerySpec.Builder.newInstance().build());
+        assertThat(all).hasSize(10);
+    }
+
+    @Test
+    void findAll_verifyPaging() {
+
+        when(cosmosDbApiMock.queryItems(argThat(new PredicateMatcher<SqlQuerySpec>(qs -> qs.getQueryText().equals("SELECT * FROM ContractDefinitionDocument OFFSET 3 LIMIT 4"))))).thenReturn(IntStream.range(0, 4).mapToObj(i -> generateDocument()));
+
+        // page size fits
+        assertThat(store.findAll(QuerySpec.Builder.newInstance().offset(3).limit(4).build())).hasSize(4);
+
+
+    }
+
+    @Test
+    void findAll_verifyPaging_tooLarge() {
+
+        when(cosmosDbApiMock.queryItems(argThat(new PredicateMatcher<SqlQuerySpec>(qs -> qs.getQueryText().equals("SELECT * FROM ContractDefinitionDocument OFFSET 5 LIMIT 100"))))).thenReturn(IntStream.range(0, 5).mapToObj(i -> generateDocument()));
+
+        // page size too large
+        assertThat(store.findAll(QuerySpec.Builder.newInstance().offset(5).limit(100).build())).hasSize(5);
+
+        verify(cosmosDbApiMock).queryItems(argThat(new PredicateMatcher<SqlQuerySpec>(qs -> qs.getQueryText().equals("SELECT * FROM ContractDefinitionDocument OFFSET 5 LIMIT 100"))));
+    }
+
+    @Test
+    void findAll_verifyFiltering() {
+        var doc = generateDocument();
+        when(cosmosDbApiMock.queryItems(argThat(new PredicateMatcher<SqlQuerySpec>(qs -> qs.getQueryText().startsWith("SELECT * FROM ContractDefinitionDocument WHERE ContractDefinitionDocument.wrappedInstance.id = @id")))))
+                .thenReturn(Stream.of(doc));
+
+
+        var all = store.findAll(QuerySpec.Builder.newInstance().filter("id=foobar").build());
+        assertThat(all).hasSize(1).extracting(ContractDefinition::getId).containsOnly(doc.getId());
+        verify(cosmosDbApiMock).queryItems(argThat(new PredicateMatcher<SqlQuerySpec>(qs -> qs.getQueryText().startsWith("SELECT * FROM ContractDefinitionDocument WHERE ContractDefinitionDocument.wrappedInstance.id = @id"))));
+    }
+
+    @Test
+    void findAll_verifyFiltering_invalidFilterExpression() {
+        assertThatThrownBy(() -> store.findAll(QuerySpec.Builder.newInstance().filter("something foobar other").build())).isInstanceOfAny(IllegalArgumentException.class);
+    }
+
+    @Test
+    void findAll_verifySorting_asc() {
+        when(cosmosDbApiMock.queryItems(argThat(new PredicateMatcher<SqlQuerySpec>(qs -> qs.getQueryText().contains("SELECT * FROM ContractDefinitionDocument ORDER BY ContractDefinitionDocument.wrappedInstance.id DESC")))))
+                .thenReturn(IntStream.range(0, 10).mapToObj(i -> generateDocument()).sorted(Comparator.comparing(ContractDefinitionDocument::getId).reversed()).map(c -> c));
+
+        var all = store.findAll(QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.DESC).build()).collect(Collectors.toList());
+        assertThat(all).hasSize(10).isSortedAccordingTo((c1, c2) -> c2.getId().compareTo(c1.getId()));
+
+        verify(cosmosDbApiMock).queryItems(argThat(new PredicateMatcher<SqlQuerySpec>(qs -> qs.getQueryText().contains("SELECT * FROM ContractDefinitionDocument ORDER BY ContractDefinitionDocument.wrappedInstance.id DESC"))));
+    }
+
+    @Test
+    void findAll_verifySorting_desc() {
+        when(cosmosDbApiMock.queryItems(argThat(new PredicateMatcher<SqlQuerySpec>(qs -> qs.getQueryText().contains("SELECT * FROM ContractDefinitionDocument ORDER BY ContractDefinitionDocument.wrappedInstance.id ASC")))))
+                .thenReturn(IntStream.range(0, 10).mapToObj(i -> generateDocument()).sorted(Comparator.comparing(ContractDefinitionDocument::getId)).map(c -> c));
+
+
+        var all = store.findAll(QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.ASC).build()).collect(Collectors.toList());
+        assertThat(all).hasSize(10).isSortedAccordingTo(Comparator.comparing(ContractDefinition::getId));
+
+
+        verify(cosmosDbApiMock).queryItems(argThat(new PredicateMatcher<SqlQuerySpec>(qs -> qs.getQueryText().contains("SELECT * FROM ContractDefinitionDocument ORDER BY ContractDefinitionDocument.wrappedInstance.id ASC"))));
+    }
+
+    @Test
+    void findAll_verifySorting_invalidField() {
+        when(cosmosDbApiMock.queryItems(isA(SqlQuerySpec.class))).thenReturn(Stream.empty());
+
+        assertThat(store.findAll(QuerySpec.Builder.newInstance().sortField("nonexist").sortOrder(SortOrder.DESC).build())).isEmpty();
+    }
 }

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FccTestExtension.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FccTestExtension.java
@@ -187,6 +187,11 @@ public class FccTestExtension implements ServiceExtension {
         }
 
         @Override
+        public @NotNull Stream<ContractDefinition> findAll(QuerySpec spec) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public void save(Collection<ContractDefinition> definitions) {
             contractDefinitions.addAll(definitions);
         }

--- a/extensions/http/jetty/src/test/java/org/eclipse/dataspaceconnector/extension/jetty/JettyServiceTest.java
+++ b/extensions/http/jetty/src/test/java/org/eclipse/dataspaceconnector/extension/jetty/JettyServiceTest.java
@@ -22,7 +22,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.eclipse.dataspaceconnector.spi.EdcException;
-import org.eclipse.dataspaceconnector.spi.monitor.ConsoleMonitor;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.system.configuration.ConfigFactory;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
@@ -49,7 +48,8 @@ class JettyServiceTest {
 
     @BeforeEach
     void setUp() {
-        monitor = new ConsoleMonitor();
+        monitor = new Monitor() {
+        };
         testController = new TestController();
     }
 

--- a/extensions/in-memory/contractdefinition-store-memory/build.gradle.kts
+++ b/extensions/in-memory/contractdefinition-store-memory/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
 
 dependencies {
     api(project(":spi"))
+    implementation(project(":common:util"))
 }
 
 publishing {

--- a/extensions/in-memory/contractdefinition-store-memory/src/main/java/org/eclipse/dataspaceconnector/contractdefinition/store/memory/InMemoryContractDefinitionStore.java
+++ b/extensions/in-memory/contractdefinition-store-memory/src/main/java/org/eclipse/dataspaceconnector/contractdefinition/store/memory/InMemoryContractDefinitionStore.java
@@ -14,7 +14,12 @@
 
 package org.eclipse.dataspaceconnector.contractdefinition.store.memory;
 
+import org.eclipse.dataspaceconnector.common.reflection.ReflectionUtil;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
+import org.eclipse.dataspaceconnector.spi.query.BaseCriterionToPredicateConverter;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
 import org.jetbrains.annotations.NotNull;
 
@@ -22,6 +27,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import static org.eclipse.dataspaceconnector.common.reflection.ReflectionUtil.propertyComparator;
 
 /**
  * The default store implementation used when no extension is configured in a runtime. {@link ContractDefinition}s are stored ephemerally in memory.
@@ -32,6 +41,26 @@ public class InMemoryContractDefinitionStore implements ContractDefinitionStore 
     @Override
     public @NotNull Collection<ContractDefinition> findAll() {
         return Collections.unmodifiableCollection(cache.values());
+    }
+
+    @Override
+    public @NotNull Stream<ContractDefinition> findAll(QuerySpec spec) {
+        var stream = cache.values().stream();
+
+        //filter
+        var andPredicate = spec.getFilterExpression().stream().map(this::toPredicate).reduce(x -> true, Predicate::and);
+        stream = stream.filter(andPredicate);
+
+        //sort
+        var sortField = spec.getSortField();
+
+        if (sortField != null) {
+            var comparator = propertyComparator(spec.getSortOrder() == SortOrder.ASC, sortField);
+            stream = stream.sorted(comparator);
+        }
+
+        // limit
+        return stream.skip(spec.getOffset()).limit(spec.getLimit());
     }
 
     @Override
@@ -57,5 +86,17 @@ public class InMemoryContractDefinitionStore implements ContractDefinitionStore 
     @Override
     public void reload() {
         // no-op
+    }
+
+    private Predicate<ContractDefinition> toPredicate(Criterion criterion) {
+        return new ContractDefinitionPredicateConverter().convert(criterion);
+    }
+
+
+    private static class ContractDefinitionPredicateConverter extends BaseCriterionToPredicateConverter<ContractDefinition> {
+        @Override
+        protected <R> R property(String key, Object object) {
+            return ReflectionUtil.getFieldValueSilent(key, object);
+        }
     }
 }

--- a/extensions/in-memory/contractdefinition-store-memory/src/main/java/org/eclipse/dataspaceconnector/contractdefinition/store/memory/InMemoryContractDefinitionStore.java
+++ b/extensions/in-memory/contractdefinition-store-memory/src/main/java/org/eclipse/dataspaceconnector/contractdefinition/store/memory/InMemoryContractDefinitionStore.java
@@ -55,6 +55,9 @@ public class InMemoryContractDefinitionStore implements ContractDefinitionStore 
         var sortField = spec.getSortField();
 
         if (sortField != null) {
+            if (ReflectionUtil.getFieldRecursive(ContractDefinition.class, sortField) == null) {
+                return Stream.empty();
+            }
             var comparator = propertyComparator(spec.getSortOrder() == SortOrder.ASC, sortField);
             stream = stream.sorted(comparator);
         }

--- a/extensions/in-memory/contractdefinition-store-memory/src/test/java/org/eclipse/dataspaceconnector/contractdefinition/store/memory/InMemoryContractDefinitionStoreTest.java
+++ b/extensions/in-memory/contractdefinition-store-memory/src/test/java/org/eclipse/dataspaceconnector/contractdefinition/store/memory/InMemoryContractDefinitionStoreTest.java
@@ -14,12 +14,18 @@
 package org.eclipse.dataspaceconnector.contractdefinition.store.memory;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
 import org.junit.jupiter.api.Test;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression.SELECT_ALL;
 
 class InMemoryContractDefinitionStoreTest {
@@ -39,5 +45,57 @@ class InMemoryContractDefinitionStoreTest {
 
         store.delete(definition1.getId());
         assertThat(store.findAll()).doesNotContain(definition1);
+    }
+
+    @Test
+    void findAll_defaultQuerySpec() {
+        var all = IntStream.range(0, 10).mapToObj(i -> createContractDefinition("id" + i)).peek(store::save).collect(Collectors.toList());
+        assertThat(store.findAll(QuerySpec.none())).containsExactlyInAnyOrder(all.toArray(new ContractDefinition[]{}));
+    }
+
+    @Test
+    void findAll_verifyPaging() {
+        IntStream.range(0, 10).mapToObj(i -> createContractDefinition("id" + i)).forEach(store::save);
+
+        // page size fits
+        assertThat(store.findAll(QuerySpec.Builder.newInstance().offset(4).limit(2).build())).hasSize(2);
+
+        // page size larger than collection
+        assertThat(store.findAll(QuerySpec.Builder.newInstance().offset(5).limit(100).build())).hasSize(5);
+    }
+
+    @Test
+    void findAll_verifyFiltering() {
+        IntStream.range(0, 10).mapToObj(i -> createContractDefinition("id" + i)).forEach(store::save);
+        assertThat(store.findAll(QuerySpec.Builder.newInstance().equalsAsContains(false).filter("id=id3").build())).extracting(ContractDefinition::getId)
+                .containsOnly("id3");
+    }
+
+    @Test
+    void findAll_verifyFiltering_invalidFilterExpression() {
+        IntStream.range(0, 10).mapToObj(i -> createContractDefinition("id" + i)).forEach(store::save);
+        assertThatThrownBy(() -> store.findAll(QuerySpec.Builder.newInstance().filter("something foobar other").build())).isInstanceOfAny(IllegalArgumentException.class);
+    }
+
+    @Test
+    void findAll_verifySorting() {
+        IntStream.range(0, 10).mapToObj(i -> createContractDefinition("id" + i)).forEach(store::save);
+
+        assertThat(store.findAll(QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.ASC).build())).hasSize(10).isSortedAccordingTo(Comparator.comparing(ContractDefinition::getId));
+        assertThat(store.findAll(QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.DESC).build())).hasSize(10).isSortedAccordingTo((c1, c2) -> c2.getId().compareTo(c1.getId()));
+    }
+
+    @Test
+    void findAll_verifySorting_invalidProperty() {
+        IntStream.range(0, 10).mapToObj(i -> createContractDefinition("id" + i)).forEach(store::save);
+        var query = QuerySpec.Builder.newInstance().sortField("notexist").sortOrder(SortOrder.DESC).build();
+
+        // must actually collect, otherwise the stream is not materialized
+        assertThat(store.findAll(query).collect(Collectors.toList())).hasSize(10);
+    }
+
+    private ContractDefinition createContractDefinition(String id) {
+        var policy = Policy.Builder.newInstance().build();
+        return ContractDefinition.Builder.newInstance().id(id).accessPolicy(policy).contractPolicy(policy).selectorExpression(SELECT_ALL).build();
     }
 }

--- a/extensions/in-memory/contractdefinition-store-memory/src/test/java/org/eclipse/dataspaceconnector/contractdefinition/store/memory/InMemoryContractDefinitionStoreTest.java
+++ b/extensions/in-memory/contractdefinition-store-memory/src/test/java/org/eclipse/dataspaceconnector/contractdefinition/store/memory/InMemoryContractDefinitionStoreTest.java
@@ -91,7 +91,7 @@ class InMemoryContractDefinitionStoreTest {
         var query = QuerySpec.Builder.newInstance().sortField("notexist").sortOrder(SortOrder.DESC).build();
 
         // must actually collect, otherwise the stream is not materialized
-        assertThat(store.findAll(query).collect(Collectors.toList())).hasSize(10);
+        assertThat(store.findAll(query).collect(Collectors.toList())).isEmpty();
     }
 
     private ContractDefinition createContractDefinition(String id) {

--- a/extensions/in-memory/negotiation-store-memory/src/main/java/org/eclipse/dataspaceconnector/negotiation/store/memory/InMemoryContractNegotiationStore.java
+++ b/extensions/in-memory/negotiation-store-memory/src/main/java/org/eclipse/dataspaceconnector/negotiation/store/memory/InMemoryContractNegotiationStore.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
-import static org.eclipse.dataspaceconnector.negotiation.store.memory.ContractNegotiationFunctions.property;
+import static org.eclipse.dataspaceconnector.common.reflection.ReflectionUtil.propertyComparator;
 
 /**
  * An in-memory, threadsafe process store.
@@ -130,7 +130,7 @@ public class InMemoryContractNegotiationStore implements ContractNegotiationStor
             var sortField = querySpec.getSortField();
 
             if (sortField != null) {
-                var comparator = propertyComparator(querySpec, sortField);
+                var comparator = propertyComparator(querySpec.getSortOrder() == SortOrder.ASC, sortField);
                 negotiationStream = negotiationStream.sorted(comparator);
             }
 
@@ -139,26 +139,6 @@ public class InMemoryContractNegotiationStore implements ContractNegotiationStor
 
             return negotiationStream;
         });
-    }
-
-    @NotNull
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    private Comparator<ContractNegotiation> propertyComparator(QuerySpec querySpec, String property) {
-        return (negotiation1, negotiation2) -> {
-            var o1 = property(negotiation1, property);
-            var o2 = property(negotiation2, property);
-
-            if (o1 == null || o2 == null) {
-                return 0;
-            }
-
-            if (!(o1 instanceof Comparable)) {
-                throw new IllegalArgumentException("A property '" + property + "' is not comparable!");
-            }
-            var comp1 = (Comparable) o1;
-            var comp2 = (Comparable) o2;
-            return querySpec.getSortOrder() == SortOrder.ASC ? comp1.compareTo(comp2) : comp2.compareTo(comp1);
-        };
     }
 
     private Predicate<ContractNegotiation> toPredicate(Criterion criterion) {

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/store/ContractDefinitionStore.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/store/ContractDefinitionStore.java
@@ -36,7 +36,10 @@ public interface ContractDefinitionStore {
     Collection<ContractDefinition> findAll();
 
     /**
-     * Returns all the definitions in the store.
+     * Returns all the definitions in the store that are covered by a given {@link QuerySpec}.
+     * <p>
+     * Note: supplying a sort field that does not exist on the {@link ContractDefinition} may cause some implementations
+     * to return an empty Stream, others will return an unsorted Stream, depending on the backing storage implementation.
      */
     @NotNull
     Stream<ContractDefinition> findAll(QuerySpec spec);

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/store/ContractDefinitionStore.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/store/ContractDefinitionStore.java
@@ -13,11 +13,13 @@
  */
 package org.eclipse.dataspaceconnector.spi.contract.offer.store;
 
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.system.Feature;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
+import java.util.stream.Stream;
 
 /**
  * Persists {@link ContractDefinition}s.
@@ -32,6 +34,12 @@ public interface ContractDefinitionStore {
      */
     @NotNull
     Collection<ContractDefinition> findAll();
+
+    /**
+     * Returns all the definitions in the store.
+     */
+    @NotNull
+    Stream<ContractDefinition> findAll(QuerySpec spec);
 
     /**
      * Persists the definitions.


### PR DESCRIPTION
## What it does
It adds support for a `QuerySpec` to the `ContractDefinitionStore` and all its implementors.

## Why it does that
Certain endpoints in the DataManagementApi specify that paging, filtering and sorting be supported, so that clients can fine-tune their queries. This PR adds that functionality.

## Further changes
- reflection: the `ReflectionUtil` class was improved to provide central methods e.g. to get  fields from a class, including supertypes
- reflection: the `getFieldValue` method now accepts property names in the dot-notation and recursively descends down the object graph to retrieve the value.
- for the in-memory stores the creation of propery comparators is now handled centrally.
- in some tests the `ConsoleMonitor` has been replaced with a generic `Monitor` to avoid log spam


Closes #634 