### PR TITLE
ids: generate `DataRequest` id on consumer side and forward it into `ArtifactRequestMessage`

### DIFF
--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartArtifactRequestSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartArtifactRequestSender.java
@@ -36,6 +36,7 @@ import org.jetbrains.annotations.NotNull;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.UUID;
 
 import static org.eclipse.dataspaceconnector.ids.spi.IdsConstants.IDS_WEBHOOK_ADDRESS_PROPERTY;
 
@@ -99,7 +100,8 @@ public class MultipartArtifactRequestSender extends IdsMultipartSender<DataReque
         var artifactId = artifactTransformationResult.getContent();
         var contractId = contractTransformationResult.getContent();
 
-        var message = new ArtifactRequestMessageBuilder()
+        var artifactRequestId = request.getId() != null ? request.getId() : UUID.randomUUID().toString();
+        var message = new ArtifactRequestMessageBuilder(URI.create(artifactRequestId))
                 ._modelVersion_(IdsProtocol.INFORMATION_MODEL_VERSION)
                 //._issued_(gregorianNow()) TODO once https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/236 is done
                 ._securityToken_(token)

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartArtifactRequestSenderTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartArtifactRequestSenderTest.java
@@ -74,6 +74,7 @@ class MultipartArtifactRequestSenderTest {
         assertThat(message).isInstanceOf(ArtifactRequestMessage.class);
         assertThat((ArtifactRequestMessage) message)
                 .satisfies(msg -> {
+                    assertThat(msg.getId()).hasToString(request.getId());
                     assertThat(msg.getModelVersion()).isEqualTo(IdsProtocol.INFORMATION_MODEL_VERSION);
                     assertThat(msg.getSecurityToken()).isEqualTo(token);
                     assertThat(msg.getIssuerConnector()).isEqualTo(sender.getConnectorId());

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ArtifactRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ArtifactRequestHandler.java
@@ -40,7 +40,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 
 import static org.eclipse.dataspaceconnector.ids.api.multipart.util.RejectionMessageUtil.badParameters;
 import static org.eclipse.dataspaceconnector.ids.spi.IdsConstants.IDS_WEBHOOK_ADDRESS_PROPERTY;
@@ -137,7 +136,7 @@ public class ArtifactRequestHandler implements Handler {
         }
 
         var dataRequest = DataRequest.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
+                .id(artifactRequestMessage.getId().toString())
                 .protocol(Protocols.IDS_MULTIPART)
                 .dataDestination(dataAddress)
                 .connectorId(connectorId)

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ArtifactRequestHandlerTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ArtifactRequestHandlerTest.java
@@ -74,9 +74,10 @@ class ArtifactRequestHandlerTest {
     @Test
     void handleRequestOkTest() throws JsonProcessingException {
         var artifactId = UUID.randomUUID().toString();
+        var artifactRequestId = UUID.randomUUID().toString();
         var contractId = UUID.randomUUID().toString();
         var destination = DataAddress.Builder.newInstance().keyName(UUID.randomUUID().toString()).type("test").build();
-        var multipartRequest = createMultipartRequest(destination, artifactId, contractId);
+        var multipartRequest = createMultipartRequest(destination, artifactRequestId, artifactId, contractId);
         var header = (ArtifactRequestMessage) multipartRequest.getHeader();
         var agreement = createContractAgreement();
         var verificationResult = ClaimToken.Builder.newInstance().build();
@@ -90,6 +91,7 @@ class ArtifactRequestHandlerTest {
 
         verify(transferProcessManager).initiateProviderRequest(drCapture.capture());
 
+        assertThat(drCapture.getValue().getId()).hasToString(artifactRequestId);
         assertThat(drCapture.getValue().getDataDestination().getKeyName()).isEqualTo(destination.getKeyName());
         assertThat(drCapture.getValue().getConnectorId()).isEqualTo(connectorId);
         assertThat(drCapture.getValue().getAssetId()).isEqualTo(artifactId);
@@ -98,8 +100,8 @@ class ArtifactRequestHandlerTest {
         assertThat(drCapture.getValue().getProperties()).containsExactlyEntriesOf(Map.of("foo", "bar"));
     }
 
-    private MultipartRequest createMultipartRequest(DataAddress dataDestination, String artifactId, String contractId) throws JsonProcessingException {
-        var message = new ArtifactRequestMessageBuilder()
+    private MultipartRequest createMultipartRequest(DataAddress dataDestination, String artifactRequestId, String artifactId, String contractId) throws JsonProcessingException {
+        var message = new ArtifactRequestMessageBuilder(URI.create(artifactRequestId))
                 ._modelVersion_(IdsProtocol.INFORMATION_MODEL_VERSION)
                 ._securityToken_(new DynamicAttributeTokenBuilder()._tokenValue_(UUID.randomUUID().toString()).build())
                 ._requestedArtifact_(createUri(IdsType.ARTIFACT, artifactId))


### PR DESCRIPTION
## Overview
In current implementation the id of the `DataRequest` is generated on provider side. Thus there is no correlation that can be made between the `DataRequest` sent to the consumer and the one the is actually processed by the provider. 

In this PR we propose a modification that consists in generating the `DataRequest` id on the consumer side (if none already exists) and then to forward it through the IDS `ArtifactRequestMessage`.

We also take the opportunity of this PR to perform minor fix related to the data plane framework and add some documentation.

## Why?
In the case of synchronous data transfer (see #585) , the provider data plane is used to collect the data from the source. During the Artifact Request, the provider control plane will thus return to the consumer the url and token (see `EndpointDataReference`)  from which it can retrieve the data. This process of sending back the `EndpointDataReference` to the consumer is perform asynchronously, thus we need an identifier in order to be able to link an incoming `DataRequest` to the actual `EndpointDataReference` that will be pushed back to the consumer. This is obtained by mapping the id of the `DataRequest` into the `EndpointDataReference` `correlationId` field.