### PR TITLE
Fix sample 04.2

### DIFF
--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
@@ -342,8 +342,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
                 transitionToCompleted(process);
                 return true;
             } else {
-                process.transitionInProgress();
-                transferProcessStore.update(process);
+                // Process is not finished yet, so it stays in the IN_PROGRESS state
                 monitor.info(format("Transfer process %s not COMPLETED yet. The process will not advance to the COMPLETED state.", process.getId()));
                 return false;
             }


### PR DESCRIPTION
## What this PR changes/adds:

It removes a transition in the `TransferProcessManagerImpl`, where a process in the  `IN_PROGRESS` state is transitioned to `IN_PROGRESS` again, if it hasn't been completed yet.

## Why it does that

As the transition is not allowed by the `TransferProcess`, it causes an error in sample 04.2 as described in the linked issue. This problem could either be resolved by removing that particular transition or by allowing the transition from `IN_PROGRESS` to `IN_PROGRESS`. As the `IN_PROGRESS` state is an ongoing state, a `TransferProcess` in that state should not be transitioned to it again. That way, the state timestamp indicates the complete time the `TransferProcess` has been in that state and might therefore be used to identify processes that fail to complete in a certain amount of time.

## Linked Issue(s)

Closes #725 