### PR TITLE
Use correct scope for obtaining token in IdsMultipartSender

### DIFF
--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/IdsMultipartSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/IdsMultipartSender.java
@@ -64,6 +64,8 @@ abstract class IdsMultipartSender<M extends RemoteMessage, R> implements IdsMess
     private final Monitor monitor;
     private final IdentityService identityService;
     private final TransformerRegistry transformerRegistry;
+    
+    private static final String TOKEN_SCOPE = "idsc:IDS_CONNECTOR_ATTRIBUTES_ALL";
 
     protected IdsMultipartSender(@NotNull String connectorId,
                                  @NotNull OkHttpClient httpClient,
@@ -97,11 +99,8 @@ abstract class IdsMultipartSender<M extends RemoteMessage, R> implements IdsMess
      */
     @Override
     public CompletableFuture<R> send(M request, MessageContext context) {
-        // Get connector ID
-        var recipientConnectorId = retrieveRemoteConnectorId(request);
-
         // Get Dynamic Attribute Token
-        var tokenResult = identityService.obtainClientCredentials(recipientConnectorId);
+        var tokenResult = identityService.obtainClientCredentials(TOKEN_SCOPE);
         if (tokenResult.failed()) {
             String message = "Failed to obtain token: " + String.join(",", tokenResult.getFailureMessages());
             monitor.severe(message);
@@ -230,14 +229,6 @@ abstract class IdsMultipartSender<M extends RemoteMessage, R> implements IdsMess
     protected URI getConnectorId() {
         return connectorId;
     }
-
-    /**
-     * Returns the ID of the recipient connector.
-     *
-     * @param request the request.
-     * @return the recipient connector's ID.
-     */
-    protected abstract String retrieveRemoteConnectorId(M request);
 
     /**
      * Returns the address of the recipient connector, which is the destination for the multipart

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartArtifactRequestSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartArtifactRequestSender.java
@@ -68,11 +68,6 @@ public class MultipartArtifactRequestSender extends IdsMultipartSender<DataReque
     }
 
     @Override
-    protected String retrieveRemoteConnectorId(DataRequest request) {
-        return request.getConnectorId();
-    }
-
-    @Override
     protected String retrieveRemoteConnectorAddress(DataRequest request) {
         return request.getConnectorAddress();
     }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartCatalogDescriptionRequestSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartCatalogDescriptionRequestSender.java
@@ -65,11 +65,6 @@ public class MultipartCatalogDescriptionRequestSender extends IdsMultipartSender
     }
 
     @Override
-    protected String retrieveRemoteConnectorId(CatalogRequest request) {
-        return request.getConnectorId();
-    }
-
-    @Override
     protected String retrieveRemoteConnectorAddress(CatalogRequest request) {
         return request.getConnectorAddress();
     }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractAgreementSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractAgreementSender.java
@@ -64,11 +64,6 @@ public class MultipartContractAgreementSender extends IdsMultipartSender<Contrac
     }
 
     @Override
-    protected String retrieveRemoteConnectorId(ContractAgreementRequest request) {
-        return request.getConnectorId();
-    }
-
-    @Override
     protected String retrieveRemoteConnectorAddress(ContractAgreementRequest request) {
         return request.getConnectorAddress();
     }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractOfferSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractOfferSender.java
@@ -63,11 +63,6 @@ public class MultipartContractOfferSender extends IdsMultipartSender<ContractOff
     }
 
     @Override
-    protected String retrieveRemoteConnectorId(ContractOfferRequest request) {
-        return request.getConnectorId();
-    }
-
-    @Override
     protected String retrieveRemoteConnectorAddress(ContractOfferRequest request) {
         return request.getConnectorAddress();
     }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractRejectionSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractRejectionSender.java
@@ -52,11 +52,6 @@ public class MultipartContractRejectionSender extends IdsMultipartSender<Contrac
     }
 
     @Override
-    protected String retrieveRemoteConnectorId(ContractRejection rejection) {
-        return rejection.getConnectorId();
-    }
-
-    @Override
     protected String retrieveRemoteConnectorAddress(ContractRejection rejection) {
         return rejection.getConnectorAddress();
     }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartDescriptionRequestSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartDescriptionRequestSender.java
@@ -60,11 +60,6 @@ public class MultipartDescriptionRequestSender extends IdsMultipartSender<Metada
     }
 
     @Override
-    protected String retrieveRemoteConnectorId(MetadataRequest request) {
-        return request.getConnectorId();
-    }
-
-    @Override
     protected String retrieveRemoteConnectorAddress(MetadataRequest request) {
         return request.getConnectorAddress();
     }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartEndpointDataReferenceRequestSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartEndpointDataReferenceRequestSender.java
@@ -51,11 +51,6 @@ public class MultipartEndpointDataReferenceRequestSender extends IdsMultipartSen
     }
 
     @Override
-    protected String retrieveRemoteConnectorId(EndpointDataReferenceRequest request) {
-        return request.getConnectorId();
-    }
-
-    @Override
     protected String retrieveRemoteConnectorAddress(EndpointDataReferenceRequest request) {
         return request.getConnectorAddress();
     }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/IdsMultipartSenderTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/IdsMultipartSenderTest.java
@@ -9,7 +9,6 @@ import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.message.RemoteMessage;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
@@ -23,7 +22,7 @@ class IdsMultipartSenderTest {
 
     @Test
     void should_fail_if_token_retrieval_fails() {
-        when(identityService.obtainClientCredentials("remoteConnectorId")).thenReturn(Result.failure("error"));
+        when(identityService.obtainClientCredentials("idsc:IDS_CONNECTOR_ATTRIBUTES_ALL")).thenReturn(Result.failure("error"));
         var sender = new TestIdsMultipartSender("any", mock(OkHttpClient.class), new ObjectMapper(), mock(Monitor.class), identityService, mock(TransformerRegistry.class));
 
         var result = sender.send(new TestRemoteMessage(), () -> "any");
@@ -41,11 +40,6 @@ class IdsMultipartSenderTest {
         @Override
         public Class<TestRemoteMessage> messageType() {
             return null;
-        }
-
-        @Override
-        protected String retrieveRemoteConnectorId(TestRemoteMessage request) {
-            return "remoteConnectorId";
         }
 
         @Override

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartEndpointDataReferenceRequestSenderTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartEndpointDataReferenceRequestSenderTest.java
@@ -56,12 +56,6 @@ class MultipartEndpointDataReferenceRequestSenderTest {
     }
 
     @Test
-    void retrieveRemoteConnectorId() {
-        var request = createEdrRequest();
-        assertThat(sender.retrieveRemoteConnectorId(request)).isEqualTo(request.getConnectorId());
-    }
-
-    @Test
     void retrieveRemoteConnectorAddress() {
         var request = createEdrRequest();
         assertThat(sender.retrieveRemoteConnectorAddress(request)).isEqualTo(request.getConnectorAddress());


### PR DESCRIPTION
## What this PR changes/adds:

It changes the scope used to request a token in the `IdsMultipartSender`. Previously, the ID of the recipient connector was used here instead of `idsc:IDS_CONNECTOR_ATTRIBUTES_ALL`.

## Why it does that

As defined [here](https://github.com/International-Data-Spaces-Association/IDS-G/tree/main/Components/IdentityProvider/DAPS/#request-call-to-get-a-token), the DAPS expects the scope to be `idsc:IDS_CONNECTOR_ATTRIBUTES_ALL` for a token request. 

In order to limit the token to certain connectors, the `aud` field should be used as stated [here](https://github.com/International-Data-Spaces-Association/IDS-G/tree/main/Components/IdentityProvider/DAPS/#request-token-that-is-handed-in-at-daps-side). Though at the moment, this feature is not supported by the DAPS.

## Further notes

Changing the scope for the token request eliminates the need for the abstract method `retrieveRemoteConnectorId(M request)`, as the result was only used for the token request. Therefore, it has been removed form the `IdsMultipartSender` and all its implementations. Tests have been adjusted accordingly.
