### PR TITLE
Fix unstable tests in CI

### DIFF
--- a/common/util/build.gradle.kts
+++ b/common/util/build.gradle.kts
@@ -20,11 +20,13 @@ plugins {
 
 val jupiterVersion: String by project
 val mockitoVersion: String by project
+val okHttpVersion: String by project
 
 dependencies {
     testFixturesImplementation("org.mockito:mockito-core:${mockitoVersion}")
     testFixturesImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
     testFixturesRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")
+    testFixturesImplementation("com.squareup.okhttp3:okhttp:${okHttpVersion}")
 }
 
 publishing {

--- a/common/util/src/testFixtures/java/org/eclipse/dataspaceconnector/common/testfixtures/TestUtils.java
+++ b/common/util/src/testFixtures/java/org/eclipse/dataspaceconnector/common/testfixtures/TestUtils.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.dataspaceconnector.common.testfixtures;
 
+import okhttp3.OkHttpClient;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -25,6 +27,7 @@ import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.Random;
 import java.util.Scanner;
+import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -132,5 +135,19 @@ public class TestUtils {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Create an {@link OkHttpClient} suitable for using in unit tests. The client configured with long timeouts
+     * suitable for high-contention scenarios in CI.
+     *
+     * @return an {@link OkHttpClient.Builder}.
+     */
+    public static OkHttpClient testOkHttpClient() {
+        return new OkHttpClient.Builder()
+                .connectTimeout(1, TimeUnit.MINUTES)
+                .writeTimeout(1, TimeUnit.MINUTES)
+                .readTimeout(1, TimeUnit.MINUTES)
+                .build();
     }
 }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/MultipartDispatcherIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/MultipartDispatcherIntegrationTest.java
@@ -25,7 +25,6 @@ import de.fraunhofer.iais.eis.PermissionBuilder;
 import de.fraunhofer.iais.eis.RejectionMessage;
 import de.fraunhofer.iais.eis.RequestInProcessMessageImpl;
 import de.fraunhofer.iais.eis.ResponseMessage;
-import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.IdsMultipartRemoteMessageDispatcher;
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.message.MultipartDescriptionResponse;
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.message.MultipartMessageProcessedResponse;
@@ -59,9 +58,9 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -81,11 +80,7 @@ class MultipartDispatcherIntegrationTest extends AbstractMultipartDispatcherInte
         transformerRegistry = mock(TransformerRegistry.class);
 
         Vault vault = mock(Vault.class);
-        var httpClient = new OkHttpClient.Builder()
-                .connectTimeout(1, TimeUnit.MINUTES)
-                .writeTimeout(1, TimeUnit.MINUTES)
-                .readTimeout(1, TimeUnit.MINUTES)
-                .build();
+        var httpClient = testOkHttpClient();
 
         var idsWebhookAddress = "http://webhook";
 

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/MultipartControllerIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/MultipartControllerIntegrationTest.java
@@ -36,9 +36,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
 
 public class MultipartControllerIntegrationTest extends AbstractMultipartControllerIntegrationTest {
     private static final String CONNECTOR_ID = UUID.randomUUID().toString();
@@ -48,11 +48,7 @@ public class MultipartControllerIntegrationTest extends AbstractMultipartControl
 
     @BeforeAll
     static void setUp() {
-        httpClient = new OkHttpClient.Builder()
-                .connectTimeout(1, TimeUnit.MINUTES)
-                .writeTimeout(1, TimeUnit.MINUTES)
-                .readTimeout(1, TimeUnit.MINUTES)
-                .build();
+        httpClient = testOkHttpClient();
     }
 
     @Test

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetControllerIntegrationTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetControllerIntegrationTest.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.api.datamanagement.asset.TestFunctions.createAssetEntryDto;
 import static org.eclipse.dataspaceconnector.api.datamanagement.asset.TestFunctions.createAssetEntryDto_emptyAttributes;
+import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
 import static org.mockito.Mockito.mock;
 
 public class AssetControllerIntegrationTest {
@@ -63,7 +64,7 @@ public class AssetControllerIntegrationTest {
     @BeforeEach
     void setup() {
         objectMapper = new ObjectMapper();
-        client = new OkHttpClient();
+        client = testOkHttpClient();
     }
 
     @Test

--- a/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionsApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionsApiControllerIntegrationTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
 import static org.mockito.Mockito.mock;
 
 public class ContractDefinitionsApiControllerIntegrationTest {
@@ -57,7 +58,7 @@ public class ContractDefinitionsApiControllerIntegrationTest {
 
     @BeforeEach
     void setup() {
-        client = new OkHttpClient();
+        client = testOkHttpClient();
     }
 
     @Test

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
 import static org.mockito.Mockito.mock;
 
 class ContractNegotiationApiControllerIntegrationTest {
@@ -55,7 +56,7 @@ class ContractNegotiationApiControllerIntegrationTest {
 
     @BeforeEach
     void setup() {
-        client = new OkHttpClient();
+        client = testOkHttpClient();
     }
 
     @Test

--- a/extensions/api/data-management/policydefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/policydefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyApiControllerIntegrationTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
 import static org.mockito.Mockito.mock;
 
 public class PolicyApiControllerIntegrationTest {
@@ -57,7 +58,7 @@ public class PolicyApiControllerIntegrationTest {
 
     @BeforeEach
     void setup() {
-        client = new OkHttpClient();
+        client = testOkHttpClient();
     }
 
     @Test

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/TransferProcessApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/TransferProcessApiControllerIntegrationTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
 import static org.mockito.Mockito.mock;
 
 class TransferProcessApiControllerIntegrationTest {
@@ -57,7 +58,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @BeforeEach
     void setup() {
-        client = new OkHttpClient();
+        client = testOkHttpClient();
     }
 
     @Test

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/loader/LoaderManagerImplTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/loader/LoaderManagerImplTest.java
@@ -40,7 +40,7 @@ class LoaderManagerImplTest {
     @Test
     @DisplayName("Verify that the loader manager waits one pass when the queue does not yet contain sufficient elements")
     void batchSizeNotReachedWithinTimeframe() throws InterruptedException {
-        range(0, batchSize).forEach(i -> queue.offer(new UpdateResponse()));
+        range(0, batchSize - 1).forEach(i -> queue.offer(new UpdateResponse()));
         var completionSignal = new CountDownLatch(1);
         when(waitStrategyMock.retryInMillis()).thenAnswer(i -> {
             completionSignal.countDown();
@@ -49,7 +49,7 @@ class LoaderManagerImplTest {
 
         loaderManager.start(queue);
 
-        assertThat(completionSignal.await(100L, TimeUnit.MILLISECONDS)).isTrue();
+        assertThat(completionSignal.await(300L, TimeUnit.MILLISECONDS)).isTrue();
         verify(waitStrategyMock, atLeastOnce()).retryInMillis();
     }
 

--- a/extensions/data-plane/data-plane-http/build.gradle.kts
+++ b/extensions/data-plane/data-plane-http/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     implementation(project(":common:util"))
     implementation("com.squareup.okhttp3:okhttp:${okHttpVersion}")
     implementation("net.jodah:failsafe:${jodahFailsafeVersion}")
+    testImplementation(testFixtures(project(":common:util")))
 }
 
 publishing {

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/DataSourceToDataSinkTests.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/DataSourceToDataSinkTests.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -52,7 +53,7 @@ class DataSourceToDataSinkTests {
         when(interceptor.intercept(isA(Interceptor.Chain.class)))
                 .thenAnswer(invocation -> createResponse(200, getRequest(invocation)));
 
-        var sourceClient = new OkHttpClient.Builder()
+        var sourceClient = testOkHttpClient().newBuilder()
                 .addInterceptor(interceptor)
                 .build();
 
@@ -66,7 +67,7 @@ class DataSourceToDataSinkTests {
                 .method("GET")
                 .build();
 
-        var sinkClient = new OkHttpClient.Builder()
+        var sinkClient = testOkHttpClient().newBuilder()
                 .addInterceptor(interceptor)
                 .build();
 
@@ -95,7 +96,7 @@ class DataSourceToDataSinkTests {
         when(sourceInterceptor.intercept(isA(Interceptor.Chain.class)))
                 .thenAnswer(invocation -> createResponse(500, getRequest(invocation)));
 
-        var sourceClient = new OkHttpClient.Builder()
+        var sourceClient = testOkHttpClient().newBuilder()
                 .addInterceptor(sourceInterceptor)
                 .build();
 
@@ -136,7 +137,7 @@ class DataSourceToDataSinkTests {
         when(sourceInterceptor.intercept(isA(Interceptor.Chain.class)))
                 .thenAnswer(invocation -> createResponse(200, getRequest(invocation)));
 
-        var sourceClient = new OkHttpClient.Builder()
+        var sourceClient = testOkHttpClient().newBuilder()
                 .addInterceptor(sourceInterceptor)
                 .build();
 
@@ -155,7 +156,8 @@ class DataSourceToDataSinkTests {
         when(sinkInterceptor.intercept(isA(Interceptor.Chain.class)))
                 .thenAnswer(invocation -> createResponse(500, getRequest(invocation)));
 
-        var sinkClient = new OkHttpClient.Builder()
+
+        var sinkClient = testOkHttpClient().newBuilder()
                 .addInterceptor(sinkInterceptor)
                 .build();
 

--- a/extensions/http/jersey/src/test/java/org/eclipse/dataspaceconnector/extension/jersey/JerseyRestServiceTest.java
+++ b/extensions/http/jersey/src/test/java/org/eclipse/dataspaceconnector/extension/jersey/JerseyRestServiceTest.java
@@ -20,7 +20,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.core.MediaType;
-import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.eclipse.dataspaceconnector.extension.jetty.JettyConfiguration;
@@ -37,11 +36,11 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.getFreePort;
+import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -235,7 +234,7 @@ public class JerseyRestServiceTest {
     private Response executeRequest(String url) {
 
         try {
-            var client = new OkHttpClient.Builder().build();
+            var client = testOkHttpClient();
             var request = new Request.Builder().url(url).build();
             return client.newCall(request).execute();
         } catch (IOException e) {

--- a/extensions/http/jetty/build.gradle.kts
+++ b/extensions/http/jetty/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     testImplementation("org.glassfish.jersey.media:jersey-media-multipart:${jerseyVersion}")
     testImplementation("org.glassfish.jersey.inject:jersey-hk2:${jerseyVersion}")
     testImplementation("org.glassfish.jersey.containers:jersey-container-servlet:${jerseyVersion}")
+    testImplementation(testFixtures(project(":common:util")))
 }
 
 publishing {

--- a/extensions/http/jetty/src/test/java/org/eclipse/dataspaceconnector/extension/jetty/JettyServiceTest.java
+++ b/extensions/http/jetty/src/test/java/org/eclipse/dataspaceconnector/extension/jetty/JettyServiceTest.java
@@ -18,7 +18,6 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
-import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.eclipse.dataspaceconnector.spi.EdcException;
@@ -36,10 +35,10 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
 
 class JettyServiceTest {
     private JettyService jettyService;
@@ -154,11 +153,7 @@ class JettyServiceTest {
     private Response executeRequest(String url) {
 
         try {
-            var client = new OkHttpClient.Builder()
-                    .connectTimeout(1, TimeUnit.MINUTES)
-                    .writeTimeout(1, TimeUnit.MINUTES)
-                    .readTimeout(1, TimeUnit.MINUTES)
-                    .build();
+            var client = testOkHttpClient();
             var rq = new Request.Builder().url(url).build();
             return client.newCall(rq).execute();
         } catch (IOException e) {

--- a/extensions/iam/decentralized-identity/identity-did-web/build.gradle.kts
+++ b/extensions/iam/decentralized-identity/identity-did-web/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     api(project(":common:util"))
 
     implementation("com.squareup.okhttp3:okhttp-dnsoverhttps:${okHttpVersion}")
+    testImplementation(testFixtures(project(":common:util")))
 }
 
 publishing {

--- a/extensions/iam/decentralized-identity/identity-did-web/src/test/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/WebDidResolverTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-web/src/test/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/WebDidResolverTest.java
@@ -16,7 +16,6 @@ package org.eclipse.dataspaceconnector.iam.did.web.resolution;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
@@ -28,6 +27,7 @@ import java.nio.charset.StandardCharsets;
 
 import static okhttp3.Protocol.HTTP_1_1;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
 import static org.mockito.Mockito.mock;
 
 class WebDidResolverTest {
@@ -70,7 +70,7 @@ class WebDidResolverTest {
     }
 
     private WebDidResolver createResolver(Interceptor... interceptors) {
-        var builder = new OkHttpClient.Builder();
+        var builder = testOkHttpClient().newBuilder();
         for (Interceptor interceptor : interceptors) {
             builder.addInterceptor(interceptor);
         }

--- a/extensions/iam/oauth2/oauth2-core/build.gradle.kts
+++ b/extensions/iam/oauth2/oauth2-core/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:${okHttpVersion}")
 
     testImplementation(testFixtures(project(":launchers:junit")))
+    testImplementation(testFixtures(project(":common:util")))
 }
 
 publishing {

--- a/extensions/iam/oauth2/oauth2-core/src/test/java/org/eclipse/dataspaceconnector/iam/oauth2/core/identity/Oauth2ServiceImplTest.java
+++ b/extensions/iam/oauth2/oauth2-core/src/test/java/org/eclipse/dataspaceconnector/iam/oauth2/core/identity/Oauth2ServiceImplTest.java
@@ -25,7 +25,6 @@ import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
-import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.iam.oauth2.core.Oauth2Configuration;
 import org.eclipse.dataspaceconnector.iam.oauth2.core.jwt.JwtDecoratorRegistryImpl;
 import org.eclipse.dataspaceconnector.spi.iam.PublicKeyResolver;
@@ -40,6 +39,7 @@ import java.util.Date;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -75,7 +75,7 @@ class Oauth2ServiceImplTest {
                 .identityProviderKeyResolver(publicKeyResolverMock)
                 .build();
 
-        authService = new Oauth2ServiceImpl(configuration, jwsSigner, new OkHttpClient.Builder().build(), new JwtDecoratorRegistryImpl(), new TypeManager());
+        authService = new Oauth2ServiceImpl(configuration, jwsSigner, testOkHttpClient(), new JwtDecoratorRegistryImpl(), new TypeManager());
     }
 
     @Test

--- a/extensions/ion/ion-client/build.gradle.kts
+++ b/extensions/ion/ion-client/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:${okHttpVersion}")
 
     testImplementation(project(":extensions:iam:decentralized-identity:identity-did-crypto")) // for the KeyPairFactory
+    testImplementation(testFixtures(project(":common:util")))
 }
 
 publishing {

--- a/extensions/transfer-functions/transfer-functions-core/build.gradle.kts
+++ b/extensions/transfer-functions/transfer-functions-core/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     testImplementation(project(":core:transfer"))
     testImplementation(project(":extensions:in-memory:transfer-store-memory"))
     testImplementation(testFixtures(project(":launchers:junit")))
+    testImplementation(testFixtures(project(":common:util")))
 }
 
 publishing {

--- a/extensions/transfer-functions/transfer-functions-core/src/test/java/org/eclipse/dataspaceconnector/transfer/functions/core/flow/http/HttpDataFlowControllerTest.java
+++ b/extensions/transfer-functions/transfer-functions-core/src/test/java/org/eclipse/dataspaceconnector/transfer/functions/core/flow/http/HttpDataFlowControllerTest.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 
 import static okhttp3.Protocol.HTTP_1_1;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
 import static org.eclipse.dataspaceconnector.spi.response.ResponseStatus.ERROR_RETRY;
 import static org.eclipse.dataspaceconnector.spi.response.ResponseStatus.FATAL_ERROR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -64,7 +65,7 @@ class HttpDataFlowControllerTest {
                 .body(ResponseBody.create("", MediaType.get("application/json"))).message("ok")
                 .build();
 
-        httpClient = new OkHttpClient.Builder().addInterceptor(delegate).build();
+        httpClient = testOkHttpClient().newBuilder().addInterceptor(delegate).build();
 
         var dataRequest = createDataRequest();
 
@@ -79,7 +80,7 @@ class HttpDataFlowControllerTest {
                 .body(ResponseBody.create("", MediaType.get("application/json"))).message("ok")
                 .build();
 
-        httpClient = new OkHttpClient.Builder().addInterceptor(delegate).build();
+        httpClient = testOkHttpClient().newBuilder().addInterceptor(delegate).build();
 
         var dataRequest = createDataRequest();
 
@@ -94,7 +95,7 @@ class HttpDataFlowControllerTest {
                 .body(ResponseBody.create("", MediaType.get("application/json"))).message("ok")
                 .build();
 
-        httpClient = new OkHttpClient.Builder().addInterceptor(delegate).build();
+        httpClient = testOkHttpClient().newBuilder().addInterceptor(delegate).build();
 
         var dataRequest = createDataRequest();
 

--- a/extensions/transfer-functions/transfer-functions-core/src/test/java/org/eclipse/dataspaceconnector/transfer/functions/core/flow/http/HttpStatusCheckerTest.java
+++ b/extensions/transfer-functions/transfer-functions-core/src/test/java/org/eclipse/dataspaceconnector/transfer/functions/core/flow/http/HttpStatusCheckerTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 
 import static okhttp3.Protocol.HTTP_1_1;
+import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -59,7 +60,7 @@ class HttpStatusCheckerTest {
                 .body(ResponseBody.create(typeManager.writeValueAsString(true), MediaType.get("application/json"))).message("ok")
                 .build();
 
-        httpClient = new OkHttpClient.Builder().addInterceptor(delegate).build();
+        httpClient = testOkHttpClient().newBuilder().addInterceptor(delegate).build();
 
         assertTrue(checker.isComplete(TransferProcess.Builder.newInstance().id("123").build(), Collections.emptyList()));
     }
@@ -72,7 +73,7 @@ class HttpStatusCheckerTest {
                 .body(ResponseBody.create(typeManager.writeValueAsString(false), MediaType.get("application/json"))).message("ok")
                 .build();
 
-        httpClient = new OkHttpClient.Builder().addInterceptor(delegate).build();
+        httpClient = testOkHttpClient().newBuilder().addInterceptor(delegate).build();
 
         assertFalse(checker.isComplete(TransferProcess.Builder.newInstance().id("123").build(), Collections.emptyList()));
     }
@@ -86,7 +87,7 @@ class HttpStatusCheckerTest {
                 .body(ResponseBody.create(typeManager.writeValueAsString(false), MediaType.get("txt/html"))).message("ok")
                 .build();
 
-        httpClient = new OkHttpClient.Builder().addInterceptor(delegate).build();
+        httpClient = testOkHttpClient().newBuilder().addInterceptor(delegate).build();
 
         assertFalse(checker.isComplete(TransferProcess.Builder.newInstance().id("123").build(), Collections.emptyList()));
     }


### PR DESCRIPTION
## What this PR changes/adds:

This PR introduces diverse fixes for unstable tests.

## Why it does that

It seems the introduction of Jacoco (https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/pull/702) has increased test time by ~50%, which might cause some timeouts or race conditions to be hit.

## Further notes

- Multiple tests using OkHttp client have been fixed. Default timeouts are quite short and they were increased.
- `LoaderManagerImplTest#batchSizeNotReachedWithinTimeframe` was using a queue with 3 elements, which was not testing what was intended ("Verify that the loader manager waits one pass when the queue does not yet contain sufficient elements"), as 3 is exactly the limit for the LoaderManager to start processing. This processing took sometimes longer than the configured 100ms timeout, making the test fail.

This should solve 16 out of 17 failures observed in 100 CI runs.

## Linked Issue(s)

Closes #728