### PR TITLE
Fixes some minor (and some less minor) bugs

### DIFF
--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImpl.java
@@ -23,6 +23,8 @@ import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -52,8 +54,22 @@ public class ContractOfferServiceImpl implements ContractOfferService {
                     .id(ContractId.createContractId(definition.getId()))
                     .policy(definition.getContractPolicy())
                     .asset(asset)
+                    // TODO: this is a workaround for the bug described in https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/753
+                    .provider(uri("urn:connector:provider"))
+                    .consumer(uri("urn:connector:consumer"))
                     .build());
         });
+    }
+
+    /**
+     * swallows any exception during uri generation
+     */
+    private URI uri(String str) {
+        try {
+            return new URI(str);
+        } catch (URISyntaxException ignored) {
+            return null;
+        }
     }
 
 }

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/LoaderImpl.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/LoaderImpl.java
@@ -1,5 +1,6 @@
 package org.eclipse.dataspaceconnector.catalog.cache;
 
+import org.eclipse.dataspaceconnector.catalog.spi.CachedAsset;
 import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheStore;
 import org.eclipse.dataspaceconnector.catalog.spi.Loader;
 import org.eclipse.dataspaceconnector.catalog.spi.model.UpdateResponse;
@@ -18,7 +19,10 @@ public class LoaderImpl implements Loader {
 
         for (var response : responses) {
             var catalog = response.getCatalog();
-            catalog.getContractOffers().forEach(store::save);
+            catalog.getContractOffers().forEach(offer -> {
+                offer.getAsset().getProperties().put(CachedAsset.PROPERTY_ORIGINATOR, response.getSource());
+                store.save(offer);
+            });
         }
     }
 }

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/CachedAsset.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/CachedAsset.java
@@ -16,7 +16,7 @@ import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 @JsonDeserialize(builder = CachedAsset.Builder.class)
 public class CachedAsset extends Asset {
 
-    private static final String PROPERTY_ORIGINATOR = "asset:prop:originator";
+    public static final String PROPERTY_ORIGINATOR = "asset:prop:originator";
     private static final String PROPERTY_POLICY = "asset:prop:policy";
 
     private CachedAsset() {


### PR DESCRIPTION
## What this PR changes/adds:

- Adds the `originator` to `CachedAsset`s, which are used during catalog queries
- Provides dummy values for `ContractOffer#provider` and `ContractOffer#consumer`, which is a quick workaround for issue #753 

## Why it does that

During testing with the [EDC Showcase](https://github.com/microsoft/edc-showcase) I noticed some minor bugs.

## Further notes


## Linked Issue(s)

Relates to #753 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?