### PR TITLE
DataManagementApi: Add mgmt API to sample-03

### DIFF
--- a/samples/03-configuration/build.gradle.kts
+++ b/samples/03-configuration/build.gradle.kts
@@ -25,6 +25,8 @@ dependencies {
     api(project(":core"))
     api(project(":extensions:http"))
 
+    implementation(project(":extensions:api:data-management"))
+
     implementation(project(":extensions:filesystem:configuration-fs"))
     implementation(project(":extensions:in-memory:transfer-store-memory"))
     implementation(project(":extensions:in-memory:assetindex-memory"))

--- a/samples/03-configuration/config.properties
+++ b/samples/03-configuration/config.properties
@@ -1,2 +1,5 @@
-web.http.port=9192
+web.http.port=9191
+web.http.path=/api
+web.http.data.port=9192
+web.http.data.path=/api/v1/data
 edc.samples.03.logprefix=MyLogPrefix


### PR DESCRIPTION
## What this PR changes/adds:

Add the data management api into the samples-03.

## Why it does that

It's necessary to introduce the management api to all users of the EDC and to show them what they have to do, to add the api into their EDC's.

## Checklist

- [x] ~~added appropriate tests?~~
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] ~~documented public classes/methods?~~
- [x] added/updated relevant documentation?