### PR TITLE
Added section about flaky tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,24 @@ we would appreciate if your pull request applies to the following points:
       has been signed as well as commits have been signed-off and
     * _Continuous Integration_ performing various test conventions.
 
+### Report on flaky tests
+
+If you discover a randomly failing ("flaky") test, please take the time to check whether an issue for that already
+exists and if not, create an issue yourself, providing meaningful description and a link to the failing run. Please also
+label it with `Bug` and `FlakyTest`. Then assign it to whoever was the original author of the relevant piece of code or
+whoever worked on it last. If assigning the issue is not possible due to missing rights, please just comment and
+@mention the author/last editor.
+
+Please do not just restart the run, as this would overwrite the results. If you need to, a better way of doing this is
+to push an empty commit. This will trigger another run.
+
+```bash
+git commit --allow-empty -m "trigger CI" && git push
+```
+
+We are taking the quality of our code very serious and reporting on flaky tests is an important step toward improvement
+in that area.
+
 ## Project and Milestone Planning
 
 We use milestones to set a common focus for a period of 6 to 8 weeks. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ the [Eclipse Dataspace Connector](https://projects.eclipse.org/projects/technolo
   * [Discuss](#discuss)
   * [Create an Issue](#create-an-issue)
   * [Submit a Pull Request](#submit-a-pull-request)
+  * [Report on Flaky Tests](#report-on-flaky-tests)
 * [Project and Milestone Planning](#project-and-milestone-planning)
   * [Milestones](#milestones)
   * [Projects](#projects)
@@ -136,7 +137,7 @@ we would appreciate if your pull request applies to the following points:
       has been signed as well as commits have been signed-off and
     * _Continuous Integration_ performing various test conventions.
 
-### Report on flaky tests
+### Report on Flaky Tests
 
 If you discover a randomly failing ("flaky") test, please take the time to check whether an issue for that already
 exists and if not, create an issue yourself, providing meaningful description and a link to the failing run. Please also

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,7 @@ to push an empty commit. This will trigger another run.
 git commit --allow-empty -m "trigger CI" && git push
 ```
 
+If an issue labeled with `Bug` and `FlakyTest` is assigned to you, please prioritize addressing this issue as other people will be affected.
 We are taking the quality of our code very serious and reporting on flaky tests is an important step toward improvement
 in that area.
 


### PR DESCRIPTION
## What this PR changes/adds:

Added a section to `CONTRIBUTING.md` about reporting flaky tests.

## Why it does that

All contributors should be on the lookout for potential SW quality issues. This addition makes sure no-one can claim ignorance.

## Further notes


## Linked Issue(s)

Closes #768 

## Checklist

- [x] added/updated relevant documentation?