### PR TITLE
CosmosDB: Use static partition key for all `CosmosDocuments`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,34 @@
 # Changelog
 
-All notable changes to this project will be documented in this file - formatted and maintained 
-according to the rules documented on <http://keepachangelog.com>.
+All notable changes to this project will be documented in this file - formatted and maintained according to the rules
+documented on <http://keepachangelog.com>.
 
-This file will not cover changes about documentation, code clean-up, samples, or the CI pipeline.
-With each version (respectively milestone), the core features are highlighted. Relevant changes to
-existing implementations can be found in the detailed section referring to by linking pull requests 
-or issues.
+This file will not cover changes about documentation, code clean-up, samples, or the CI pipeline. With each version (
+respectively milestone), the core features are highlighted. Relevant changes to existing implementations can be found in
+the detailed section referring to by linking pull requests or issues.
 
 ## [Unreleased] - XXXX-XX-XX (Milestone 3)
 
 ### Overview
-* ...
+
+* Removed deprecated code
+* Improved CosmosDB interaction
 
 ### Detailed Changes
 
 #### Added
+
 * `ContractDefinitionStore` supports paging (#717)
 * Add okhttp client timeouts (#735)
 
 #### Changed
+
 * Change scope used for obtaining a token for ids multipart (#731)
 * Refactor ids token validation as extension (#625)
+* All `CosmosDocument` subclasses now use a configurable partition key (#780)
 
 #### Removed
+
 * Remove ION extension (#664)
 * Remove module `:samples:other:commandline` (#820)
 
@@ -34,6 +39,7 @@ or issues.
 ## [0.2.0] - 2021-02-21 (Milestone 2)
 
 ### Overview
+
 * DataPlaneFramework (DPF): first working version
 * Data Management API: controller stubs and OpenApi Spec
 * Code Quality: coverage analysis, system test framework
@@ -42,6 +48,7 @@ or issues.
 ### Detailed Changes
 
 #### Added
+
 * Enable Sync and Async `TransferProcesses` (#223)
 * Extend `DataRequest` with custom properties field (#300)
 * Add consistent update of transfer processes to `TransferProcessManager` (#325)
@@ -78,6 +85,7 @@ or issues.
 * Introduce extensions for synchronous data transfer using data plane (#711)
 
 #### Changed
+
 * Replace old aws sdk with the new one (#294)
 * Replace `easymock` with `mockito` (#384)
 * Isolate `TransferProcessStore` usage into `TransferProcessManager` (#421)
@@ -98,6 +106,7 @@ or issues.
 * Map IDS webhook address into `DataRequest` (#676)
 
 #### Removed
+
 * Remove usage of `JsonUnwrapped` (#257)
 * Remove old IDS-REST modules and related code (#493)
 * Remove deprecated `IdsPolicyService` and related extension (#512)
@@ -106,6 +115,7 @@ or issues.
 * Remove default `KEYSTORE_PASSWORD` from `FsConfiguration` (#704)
 
 #### Fixed
+
 * Fix modularity drift (#695)
 
 ---
@@ -113,6 +123,7 @@ or issues.
 ## [0.1.0] - 2021-12-13 (Milestone 1)
 
 ### Overview
+
 * Setup basic project structure: modules and spi, add mandatory project files
 * Asset Index: introduce basic domain model
 * Data Transfer: minor improvements
@@ -125,6 +136,7 @@ or issues.
 ### Detailed Changes
 
 #### Added
+
 * Add basic launcher
 * Add contract offer interfaces (#80)
 * Add Distributed Identity improvements (#109)
@@ -133,17 +145,17 @@ or issues.
 * Add warning and error level to monitoring (#130)
 * Add IDS object transformer concept (#148)
 * Add Web DID feature
-  * Clean-up module dependencies (#153)
-  * Implement `DidResolverRegistry` (#163)
-  * Implement Web DID Resolver (#179)
+    * Clean-up module dependencies (#153)
+    * Implement `DidResolverRegistry` (#163)
+    * Implement Web DID Resolver (#179)
 * Allow Asset to contain custom properties (#156)
 * Implement persistent `AssetIndex` using CosmosDB (#192)
 * Create `assetLoader` (#199)
 * Add multipart API for `DescriptionRequestMessage`(s) (#208)
 * Add ability to expose data contract offers (#217)
 * Integrate `ContractService` and policy management
-  * Refactor `ContractService` and `ContractOfferFramework` interfaces (#235)
-  * Add policy engine implementation and working `ContractDescriptors` (#237)
+    * Refactor `ContractService` and `ContractOfferFramework` interfaces (#235)
+    * Add policy engine implementation and working `ContractDescriptors` (#237)
 * Add contract domain obj to spi (#241)
 * Add transformer from IDS to EDC (#248)
 * Add initial implementation of control API (#259)
@@ -154,8 +166,8 @@ or issues.
 * Add ids policy extension (#278)
 * Add cosmos `ContractDefinition` store (#282)
 * Add contract negotiation capabilities (#284)
-  * Introduce types, service interfaces, and integrate policy validation (#269)
-  * Add a CosmosDB-based implementation for the `ContractNegotiationStore` (#319)
+    * Introduce types, service interfaces, and integrate policy validation (#269)
+    * Add a CosmosDB-based implementation for the `ContractNegotiationStore` (#319)
 * Add validation of agreement start/end time (#313)
 * Add ids multipart handler for contract messages (#315)
 * Add endpoint to the control api to initiate a contract negotiation (#318)
@@ -163,6 +175,7 @@ or issues.
 * Support IDS logical constraint transformations (#342)
 
 #### Changed
+
 * Modularize common/utils (#30)
 * Set java version to 11 (#91)
 * Decouple status checking from provisioned resources (#98)
@@ -179,10 +192,12 @@ or issues.
 * Change `ContractOffer` & `ContractAgreement` reference a single asset (#316)
 
 #### Removed
+
 * Remove Atlas and Nifi (#69)
 * Remove `CompositeContractOfferFramework` (#154)
 * Remove data entry and data catalog entry from spi (#222)
 
 #### Fixed
+
 * Fix stuck processes when they don't have managed resources (#42)
 * Fix problem when no `ContractOfferFramework` extension provided (#171)

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStore.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStore.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.contract.definition.store;
 
 import net.jodah.failsafe.RetryPolicy;
@@ -38,13 +52,14 @@ public class CosmosContractDefinitionStore implements ContractDefinitionStore {
     private final TypeManager typeManager;
     private final RetryPolicy<Object> retryPolicy;
     private final LockManager lockManager;
+    private final String partitionKey;
     private AtomicReference<Map<String, ContractDefinition>> objectCache;
 
-    public CosmosContractDefinitionStore(CosmosDbApi cosmosDbApi, TypeManager typeManager, RetryPolicy<Object> retryPolicy) {
+    public CosmosContractDefinitionStore(CosmosDbApi cosmosDbApi, TypeManager typeManager, RetryPolicy<Object> retryPolicy, String partitionKey) {
         this.cosmosDbApi = cosmosDbApi;
         this.typeManager = typeManager;
         this.retryPolicy = retryPolicy;
-
+        this.partitionKey = partitionKey;
         lockManager = new LockManager(new ReentrantReadWriteLock(true));
     }
 
@@ -139,7 +154,7 @@ public class CosmosContractDefinitionStore implements ContractDefinitionStore {
 
     @NotNull
     private ContractDefinitionDocument convertToDocument(ContractDefinition def) {
-        return new ContractDefinitionDocument(def);
+        return new ContractDefinitionDocument(def, partitionKey);
     }
 
     private Map<String, ContractDefinition> getCache() {

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreExtension.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreExtension.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2021 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -39,7 +39,8 @@ public class CosmosContractDefinitionStoreExtension implements ServiceExtension 
         Vault vault = context.getService(Vault.class);
 
         var cosmosDbApi = new CosmosDbApiImpl(vault, configuration);
-        var store = new CosmosContractDefinitionStore(cosmosDbApi, context.getTypeManager(), (RetryPolicy<Object>) context.getService(RetryPolicy.class));
+
+        var store = new CosmosContractDefinitionStore(cosmosDbApi, context.getTypeManager(), (RetryPolicy<Object>) context.getService(RetryPolicy.class), configuration.getPartitionKey());
         context.registerService(ContractDefinitionStore.class, store);
 
         ContractDefinitionLoader loader = store::save;

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/model/ContractDefinitionDocument.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/model/ContractDefinitionDocument.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2021 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -24,9 +24,10 @@ import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDe
 public class ContractDefinitionDocument extends CosmosDocument<ContractDefinition> {
 
     @JsonCreator
-    public ContractDefinitionDocument(@JsonProperty("wrappedInstance") ContractDefinition contractDefinition) {
+    public ContractDefinitionDocument(@JsonProperty("wrappedInstance") ContractDefinition contractDefinition,
+                                      @JsonProperty("partitionKey") String partitionKey) {
         //todo: lets think about whether this a good partition key
-        super(contractDefinition, contractDefinition.getAccessPolicy().getUid());
+        super(contractDefinition, partitionKey);
     }
 
 

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/model/ContractDefinitionDocument.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/model/ContractDefinitionDocument.java
@@ -26,7 +26,6 @@ public class ContractDefinitionDocument extends CosmosDocument<ContractDefinitio
     @JsonCreator
     public ContractDefinitionDocument(@JsonProperty("wrappedInstance") ContractDefinition contractDefinition,
                                       @JsonProperty("partitionKey") String partitionKey) {
-        //todo: lets think about whether this a good partition key
         super(contractDefinition, partitionKey);
     }
 

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreTest.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.contract.definition.store;
 
 import com.azure.cosmos.models.SqlQuerySpec;
@@ -33,6 +47,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 class CosmosContractDefinitionStoreTest {
+    private static final String TEST_PART_KEY = "test_part_key";
     private CosmosContractDefinitionStore store;
     private CosmosDbApi cosmosDbApiMock;
 
@@ -41,13 +56,13 @@ class CosmosContractDefinitionStoreTest {
         cosmosDbApiMock = mock(CosmosDbApi.class);
         var typeManager = new TypeManager();
         var retryPolicy = new RetryPolicy<>();
-        store = new CosmosContractDefinitionStore(cosmosDbApiMock, typeManager, retryPolicy);
+        store = new CosmosContractDefinitionStore(cosmosDbApiMock, typeManager, retryPolicy, TEST_PART_KEY);
     }
 
     @Test
     void findAll() {
-        var doc1 = generateDocument();
-        var doc2 = generateDocument();
+        var doc1 = generateDocument(TEST_PART_KEY);
+        var doc2 = generateDocument(TEST_PART_KEY);
         when(cosmosDbApiMock.queryAllItems()).thenReturn(List.of(doc1, doc2));
 
         store.reload();
@@ -121,7 +136,7 @@ class CosmosContractDefinitionStoreTest {
     @Test
     void findAll_noQuerySpec() {
 
-        when(cosmosDbApiMock.queryAllItems()).thenReturn(IntStream.range(0, 10).mapToObj(i -> generateDocument()).collect(Collectors.toList()));
+        when(cosmosDbApiMock.queryAllItems()).thenReturn(IntStream.range(0, 10).mapToObj(i -> generateDocument(TEST_PART_KEY)).collect(Collectors.toList()));
 
         var all = store.findAll(QuerySpec.Builder.newInstance().build());
         assertThat(all).hasSize(10);
@@ -131,7 +146,7 @@ class CosmosContractDefinitionStoreTest {
 
     @Test
     void findAll_verifyPaging() {
-        when(cosmosDbApiMock.queryAllItems()).thenReturn(IntStream.range(0, 4).mapToObj(i -> generateDocument()).collect(Collectors.toList()));
+        when(cosmosDbApiMock.queryAllItems()).thenReturn(IntStream.range(0, 4).mapToObj(i -> generateDocument(TEST_PART_KEY)).collect(Collectors.toList()));
 
         // page size fits
         assertThat(store.findAll(QuerySpec.Builder.newInstance().offset(3).limit(4).build())).hasSize(1);
@@ -141,7 +156,7 @@ class CosmosContractDefinitionStoreTest {
 
     @Test
     void findAll_verifyPaging_tooLarge() {
-        when(cosmosDbApiMock.queryAllItems()).thenReturn(IntStream.range(0, 15).mapToObj(i -> generateDocument()).collect(Collectors.toList()));
+        when(cosmosDbApiMock.queryAllItems()).thenReturn(IntStream.range(0, 15).mapToObj(i -> generateDocument(TEST_PART_KEY)).collect(Collectors.toList()));
 
         // page size too large
         assertThat(store.findAll(QuerySpec.Builder.newInstance().offset(5).limit(100).build())).hasSize(10);
@@ -152,7 +167,7 @@ class CosmosContractDefinitionStoreTest {
 
     @Test
     void findAll_verifyFiltering() {
-        var doc = generateDocument();
+        var doc = generateDocument(TEST_PART_KEY);
         when(cosmosDbApiMock.queryAllItems()).thenReturn(List.of(doc));
 
         var all = store.findAll(QuerySpec.Builder.newInstance().filter("id=" + doc.getId()).build());
@@ -168,7 +183,7 @@ class CosmosContractDefinitionStoreTest {
 
     @Test
     void findAll_verifySorting_asc() {
-        when(cosmosDbApiMock.queryAllItems()).thenReturn(IntStream.range(0, 10).mapToObj(i -> generateDocument()).sorted(Comparator.comparing(ContractDefinitionDocument::getId).reversed()).collect(Collectors.toList()));
+        when(cosmosDbApiMock.queryAllItems()).thenReturn(IntStream.range(0, 10).mapToObj(i -> generateDocument(TEST_PART_KEY)).sorted(Comparator.comparing(ContractDefinitionDocument::getId).reversed()).collect(Collectors.toList()));
 
         var all = store.findAll(QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.DESC).build()).collect(Collectors.toList());
         assertThat(all).hasSize(10).isSortedAccordingTo((c1, c2) -> c2.getId().compareTo(c1.getId()));
@@ -179,7 +194,7 @@ class CosmosContractDefinitionStoreTest {
 
     @Test
     void findAll_verifySorting_desc() {
-        when(cosmosDbApiMock.queryAllItems()).thenReturn(IntStream.range(0, 10).mapToObj(i -> generateDocument()).sorted(Comparator.comparing(ContractDefinitionDocument::getId)).collect(Collectors.toList()));
+        when(cosmosDbApiMock.queryAllItems()).thenReturn(IntStream.range(0, 10).mapToObj(i -> generateDocument(TEST_PART_KEY)).sorted(Comparator.comparing(ContractDefinitionDocument::getId)).collect(Collectors.toList()));
 
 
         var all = store.findAll(QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.ASC).build()).collect(Collectors.toList());

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/TestFunctions.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/TestFunctions.java
@@ -23,13 +23,14 @@ import java.util.UUID;
 
 public class TestFunctions {
 
-    public static final String PARTITION_KEY = "test-ap-id1";
+    public static final String ACCESS_POLICY_ID = "test-ap-id1";
+    public static final String CONTRACT_POLICY_ID = "test-cp-id1";
 
     public static ContractDefinition generateDefinition() {
         return ContractDefinition.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
-                .contractPolicy(Policy.Builder.newInstance().id("test-cp-id1").build())
-                .accessPolicy(Policy.Builder.newInstance().id(PARTITION_KEY).build())
+                .contractPolicy(Policy.Builder.newInstance().id(CONTRACT_POLICY_ID).build())
+                .accessPolicy(Policy.Builder.newInstance().id(ACCESS_POLICY_ID).build())
                 .selectorExpression(AssetSelectorExpression.Builder.newInstance().whenEquals("somekey", "someval").build())
                 .build();
     }

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/TestFunctions.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/TestFunctions.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.contract.definition.store;
 
 import org.eclipse.dataspaceconnector.contract.definition.store.model.ContractDefinitionDocument;
@@ -20,7 +34,7 @@ public class TestFunctions {
                 .build();
     }
 
-    public static ContractDefinitionDocument generateDocument() {
-        return new ContractDefinitionDocument(generateDefinition());
+    public static ContractDefinitionDocument generateDocument(String partitionKey) {
+        return new ContractDefinitionDocument(generateDefinition(), partitionKey);
     }
 }

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/model/ContractDefinitionDocumentSerializationTest.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/model/ContractDefinitionDocumentSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2021 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -35,9 +35,9 @@ class ContractDefinitionDocumentSerializationTest {
     @Test
     void testSerialization() {
         var def = generateDefinition();
-        var pk = def.getAccessPolicy().getUid();
+        var pk = "test-part-key";
 
-        var document = new ContractDefinitionDocument(def);
+        var document = new ContractDefinitionDocument(def, pk);
 
         String s = typeManager.writeValueAsString(document);
 
@@ -52,7 +52,7 @@ class ContractDefinitionDocumentSerializationTest {
     void testDeserialization() {
         var def = generateDefinition();
 
-        var document = new ContractDefinitionDocument(def);
+        var document = new ContractDefinitionDocument(def, "test-part-key");
         String json = typeManager.writeValueAsString(document);
 
         var transferProcessDeserialized = typeManager.readValue(json, ContractDefinitionDocument.class);

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStore.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStore.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.contract.negotiation.store;
 
 import com.azure.cosmos.implementation.BadRequestException;

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreExtension.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreExtension.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2021 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -39,7 +39,7 @@ public class CosmosContractNegotiationStoreExtension implements ServiceExtension
         Vault vault = context.getService(Vault.class);
 
         var cosmosDbApi = new CosmosDbApiImpl(vault, configuration);
-        var store = new CosmosContractNegotiationStore(cosmosDbApi, context.getTypeManager(), (RetryPolicy<Object>) context.getService(RetryPolicy.class), context.getConnectorId());
+        var store = new CosmosContractNegotiationStore(cosmosDbApi, context.getTypeManager(), (RetryPolicy<Object>) context.getService(RetryPolicy.class), configuration.getPartitionKey());
         context.registerService(ContractNegotiationStore.class, store);
 
         context.getTypeManager().registerTypes(ContractNegotiationDocument.class);

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/store/model/ContractNegotiationDocument.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/store/model/ContractNegotiationDocument.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2021 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/TestFunctions.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/TestFunctions.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021-2022 Microsoft Corporation
+ *  Copyright (c) 2020-2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/model/ContractNegotiationDocumentSerializationTest.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/model/ContractNegotiationDocumentSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2021 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -23,9 +23,8 @@ import static org.eclipse.dataspaceconnector.contract.negotiation.store.TestFunc
 
 class ContractNegotiationDocumentSerializationTest {
 
-    private TypeManager typeManager;
     private final String partitionKey = "test-connector-partition";
-
+    private TypeManager typeManager;
 
     @BeforeEach
     void setup() {

--- a/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/AbstractCosmosConfig.java
+++ b/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/AbstractCosmosConfig.java
@@ -51,7 +51,7 @@ public abstract class AbstractCosmosConfig {
 
         accountName = context.getSetting(getAccountNameSetting(), null);
         dbName = context.getSetting(getDbNameSetting(), null);
-        partitionKey = context.getSetting(getPartitionKeySetting(), context.getConnectorId());
+        partitionKey = context.getSetting(getPartitionKeySetting(), "0");
         preferredRegion = context.getSetting(getCosmosPreferredRegionSetting(), DEFAULT_REGION);
         containerName = context.getSetting(getContainerNameSetting(), null);
         queryMetricsEnabled = Boolean.parseBoolean(context.getSetting(getQueryMetricsEnabledSetting(), "true"));

--- a/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/AbstractCosmosConfig.java
+++ b/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/AbstractCosmosConfig.java
@@ -17,7 +17,6 @@ package org.eclipse.dataspaceconnector.azure.cosmos;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.EdcSetting;
-import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
 import java.util.ArrayList;
@@ -30,11 +29,9 @@ public abstract class AbstractCosmosConfig {
 
     public static final String DEFAULT_REGION = "westeurope";
     @EdcSetting
-    private static final String DEFAULT_PARTITION_KEY_SETTING = "edc.cosmos.partition-key";
+    private static final String PARTITION_KEY_SETTING = "edc.cosmos.partition-key";
     @EdcSetting
-    private static final String DEFAULT_QUERY_METRICS_ENABLED_SETTING = "edc.cosmos.query-metrics-enabled";
-    private static final String DEFAULT_PARTITION_KEY = "dataspaceconnector";
-    private static Monitor monitor;
+    private static final String QUERY_METRICS_ENABLED_SETTING = "edc.cosmos.query-metrics-enabled";
 
 
     private final String containerName;
@@ -51,11 +48,10 @@ public abstract class AbstractCosmosConfig {
      */
     protected AbstractCosmosConfig(ServiceExtensionContext context) {
         Objects.requireNonNull(context);
-        monitor = context.getMonitor();
 
         accountName = context.getSetting(getAccountNameSetting(), null);
         dbName = context.getSetting(getDbNameSetting(), null);
-        partitionKey = context.getSetting(getPartitionKeySetting(), DEFAULT_PARTITION_KEY);
+        partitionKey = context.getSetting(getPartitionKeySetting(), context.getConnectorId());
         preferredRegion = context.getSetting(getCosmosPreferredRegionSetting(), DEFAULT_REGION);
         containerName = context.getSetting(getContainerNameSetting(), null);
         queryMetricsEnabled = Boolean.parseBoolean(context.getSetting(getQueryMetricsEnabledSetting(), "true"));
@@ -115,11 +111,11 @@ public abstract class AbstractCosmosConfig {
     protected abstract String getContainerNameSetting();
 
     protected String getPartitionKeySetting() {
-        return DEFAULT_PARTITION_KEY_SETTING;
+        return PARTITION_KEY_SETTING;
     }
 
     protected String getQueryMetricsEnabledSetting() {
-        return DEFAULT_QUERY_METRICS_ENABLED_SETTING;
+        return QUERY_METRICS_ENABLED_SETTING;
     }
 
 }

--- a/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/CosmosDocument.java
+++ b/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/CosmosDocument.java
@@ -18,8 +18,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * This is a wrapper solely used to store objects in an Azure CosmosDB.
- * Some features or requirements of CosmosDB don't fit into an object data model,
+ * Some features or requirements of CosmosDB don't fit into the EDCs object data model,
  * such as the "partition key", which is required by CosmosDB to achieve a better distribution of read/write load.
+ * <p>
+ * Considerations when choosing a partition key:
+ * Generally it's advisable to adhere to the <a href="https://docs.microsoft.com/en-us/azure/cosmos-db/partitioning-overview#choose-partitionkey">official documentation</a>.
+ * <p><br/>
+ * Note that it is not possible to execute stored procedures across logical partitions, which makes using the item ID impossible
+ * when an SP is used to query multiple items. In those cases it is recommended to use a static partition key, like a configuration value.
  */
 public abstract class CosmosDocument<T> {
 


### PR DESCRIPTION
## What this PR changes/adds:

Harmonizes the usage of partition keys across all subclasses of `CosmosDocument`: partition keys must be static and should be passed in from "the outside", e.g. the connector ID or a configured value. 
This effectively causes all documents to be put into a single logical partition. 


## Why it does that

There was a variety of approaches to partition keys, e.g. the `ContractDefinitionDocument` used an `accessPolicyId`. 

This could produce unexpected results, even bugs, e.g. updating the access policy would move the document into another logical partition, even causing it to get ignored by the SPROC.


## Further notes

- Our initial plan to use the document ID turned out to be impossible, because there is no way to execute stored procedures across logical partitions, specifically the `nextForState` SPROC would then become useless.
- I-tests have been reverted to creating and deleting containers in the `@BeforeEach` and `@AfterEach` respectively, because deleting by partition key only seems to be available in the emulator, not in the actual instance.
- In practice, only subclasses of `LeaseableCosmosDocument` neet to have a shared partition key, because only those are currently queried with `nextForState`. However from a modelling perspective the fact that a document is "leasable" and it being queryable with an SPROC seem to be orthogonal concerns. This might be something we could improve on in the future should the need arise.

## Linked Issue(s)

Closes #780 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?