### PR TITLE
Fix dates to epoch seconds, related #236

### DIFF
--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021 Microsoft Corporation
+ *  Copyright (c) 2021-2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -10,7 +10,7 @@
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
  *       Fraunhofer Institute for Software and Systems Engineering - extended method implementation
- *
+ *       Daimler TSS GmbH - fixed contract dates to epoch seconds
  */
 package org.eclipse.dataspaceconnector.contract.negotiation;
 
@@ -41,7 +41,9 @@ import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.comm
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -406,9 +408,9 @@ public class ConsumerContractNegotiationManagerImpl implements ConsumerContractN
 
         var agreement = ContractAgreement.Builder.newInstance()
                 .id(ContractId.createContractId(definitionId))
-                .contractSigningDate(LocalDate.MIN.toEpochDay())
-                .contractStartDate(LocalDate.MIN.toEpochDay())
-                .contractEndDate(LocalDate.MAX.toEpochDay())
+                .contractStartDate(Instant.now().getEpochSecond())
+                .contractEndDate(Instant.now().plus(365, ChronoUnit.DAYS).getEpochSecond()) // TODO Make configurable (issue #722)
+                .contractSigningDate(Instant.now().getEpochSecond())
                 .providerAgentId(String.valueOf(lastOffer.getProvider()))
                 .consumerAgentId(String.valueOf(lastOffer.getConsumer()))
                 .policy(lastOffer.getPolicy())

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021 Microsoft Corporation
+ *  Copyright (c) 2021-2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
  *       Fraunhofer Institute for Software and Systems Engineering - extended method implementation
+ *       Daimler TSS GmbH - fixed contract dates to epoch seconds
  *
  */
 package org.eclipse.dataspaceconnector.contract.negotiation;
@@ -42,6 +43,7 @@ import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOf
 import org.jetbrains.annotations.NotNull;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
@@ -447,9 +449,9 @@ public class ProviderContractNegotiationManagerImpl implements ProviderContractN
             //TODO move to own service
             agreement = ContractAgreement.Builder.newInstance()
                     .id(ContractId.createContractId(definitionId))
-                    .contractEndDate(Instant.now().getEpochSecond() + 60 * 60 /* Five Minutes */) // TODO
-                    .contractSigningDate(Instant.now().getEpochSecond() - 60 * 5 /* Five Minutes */)
                     .contractStartDate(Instant.now().getEpochSecond())
+                    .contractEndDate(Instant.now().plus(365, ChronoUnit.DAYS).getEpochSecond()) // TODO Make configurable (issue #722)
+                    .contractSigningDate(Instant.now().getEpochSecond())
                     .providerAgentId(String.valueOf(lastOffer.getProvider()))
                     .consumerAgentId(String.valueOf(lastOffer.getConsumer()))
                     .policy(lastOffer.getPolicy())

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImplTest.java
@@ -1,3 +1,18 @@
+/*
+ *  Copyright (c) 2021-2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *       Daimler TSS GmbH - fixed contract dates to epoch seconds
+ *
+ */
+
 package org.eclipse.dataspaceconnector.contract.validation;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
@@ -18,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import java.net.URI;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.stream.Stream;
 
 import static java.time.Instant.MAX;
@@ -90,9 +106,9 @@ class ContractValidationServiceImplTest {
                 .consumerAgentId("consumer")
                 .policy(originalPolicy)
                 .asset(Asset.Builder.newInstance().build())
-                .contractSigningDate(LocalDate.MIN.toEpochDay())
-                .contractStartDate(LocalDate.MIN.toEpochDay())
-                .contractEndDate(LocalDate.MAX.toEpochDay())
+                .contractStartDate(Instant.now().getEpochSecond())
+                .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())
+                .contractSigningDate(Instant.now().getEpochSecond())
                 .id("1:2").build();
 
         assertThat(validationService.validate(claimToken, agreement)).isTrue();

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *       Daimler TSS GmbH - fixed contract dates to epoch seconds
  *
  */
 
@@ -53,7 +54,8 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.time.LocalDate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -89,9 +91,9 @@ class IdsApiMultipartDispatcherV1IntegrationTestServiceExtension implements Serv
                         .consumerAgentId("consumer")
                         .asset(Asset.Builder.newInstance().build())
                         .policy(Policy.Builder.newInstance().build())
-                        .contractSigningDate(LocalDate.MIN.toEpochDay())
-                        .contractStartDate(LocalDate.MIN.toEpochDay())
-                        .contractEndDate(LocalDate.MAX.toEpochDay())
+                        .contractSigningDate(Instant.now().getEpochSecond())
+                        .contractStartDate(Instant.now().getEpochSecond())
+                        .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())
                         .id("1:2").build())
                 .state(ContractNegotiationStates.CONFIRMED.code())
                 .build();

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
  *       Fraunhofer Institute for Software and Systems Engineering - extend tests
+ *       Daimler TSS GmbH - fixed contract dates to epoch seconds
  *
  */
 
@@ -55,7 +56,9 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -90,9 +93,9 @@ class IdsApiMultipartEndpointV1IntegrationTestServiceExtension implements Servic
                         .consumerAgentId("consumer")
                         .asset(Asset.Builder.newInstance().build())
                         .policy(Policy.Builder.newInstance().build())
-                        .contractSigningDate(LocalDate.MIN.toEpochDay())
-                        .contractStartDate(LocalDate.MIN.toEpochDay())
-                        .contractEndDate(LocalDate.MAX.toEpochDay())
+                        .contractStartDate(Instant.now().getEpochSecond())
+                        .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())
+                        .contractSigningDate(Instant.now().getEpochSecond())
                         .id("1:2").build())
                 .state(ContractNegotiationStates.CONFIRMED.code())
                 .build();

--- a/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/dataspaceconnector/ids/transform/IdsContractAgreementToContractAgreementTransformer.java
+++ b/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/dataspaceconnector/ids/transform/IdsContractAgreementToContractAgreementTransformer.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Fraunhofer Institute for Software and Systems Engineering - Initial Implementation
+ *       Daimler TSS GmbH - fixed contract dates to epoch seconds
  *
  */
 
@@ -107,15 +108,15 @@ public class IdsContractAgreementToContractAgreementTransformer implements IdsTy
         }
 
         if (contractAgreement.getContractEnd() != null) {
-            builder.contractEndDate(contractAgreement.getContractEnd().toGregorianCalendar().getTimeInMillis());
+            builder.contractEndDate(contractAgreement.getContractEnd().toGregorianCalendar().toZonedDateTime().toEpochSecond());
         }
 
         if (contractAgreement.getContractStart() != null) {
-            builder.contractStartDate(contractAgreement.getContractStart().toGregorianCalendar().getTimeInMillis());
+            builder.contractStartDate(contractAgreement.getContractStart().toGregorianCalendar().toZonedDateTime().toEpochSecond());
         }
 
         if (contractAgreement.getContractDate() != null) {
-            builder.contractSigningDate(contractAgreement.getContractDate().toGregorianCalendar().getTimeInMillis());
+            builder.contractSigningDate(contractAgreement.getContractDate().toGregorianCalendar().toZonedDateTime().toEpochSecond());
         }
 
         return builder.build();

--- a/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/dataspaceconnector/ids/transform/ContractAgreementToIdsContractAgreementTransformerTest.java
+++ b/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/dataspaceconnector/ids/transform/ContractAgreementToIdsContractAgreementTransformerTest.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Fraunhofer Institute for Software and Systems Engineering - initial implementation
+ *       Daimler TSS GmbH - fixed contract dates to epoch seconds
  *
  */
 
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -113,8 +115,8 @@ public class ContractAgreementToIdsContractAgreementTransformerTest {
                 .providerAgentId(PROVIDER_ID)
                 .asset(Asset.Builder.newInstance().build())
                 .consumerAgentId("id")
-                .contractStartDate(Instant.MIN.getEpochSecond())
-                .contractEndDate(Instant.MAX.getEpochSecond())
+                .contractStartDate(Instant.now().getEpochSecond())
+                .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())
                 .contractSigningDate(Instant.now().getEpochSecond())
                 .policy(policy)
                 .build();

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/TestFunctions.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/TestFunctions.java
@@ -1,3 +1,18 @@
+/*
+ *  Copyright (c) 2021-2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *       Daimler TSS GmbH - fixed contract dates to epoch seconds
+ *
+ */
+
 package org.eclipse.dataspaceconnector.contract.negotiation.store;
 
 import org.eclipse.dataspaceconnector.contract.negotiation.store.model.ContractNegotiationDocument;
@@ -7,7 +22,8 @@ import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.Contra
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates;
 
-import java.time.LocalDate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
 public class TestFunctions {
@@ -33,9 +49,9 @@ public class TestFunctions {
                         .consumerAgentId("consumer")
                         .asset(Asset.Builder.newInstance().build())
                         .policy(Policy.Builder.newInstance().build())
-                        .contractSigningDate(LocalDate.MIN.toEpochDay())
-                        .contractStartDate(LocalDate.MIN.toEpochDay())
-                        .contractEndDate(LocalDate.MAX.toEpochDay())
+                        .contractStartDate(Instant.now().getEpochSecond())
+                        .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())
+                        .contractSigningDate(Instant.now().getEpochSecond())
                         .id("1:2").build())
                 .state(state.code())
                 .build();

--- a/extensions/in-memory/negotiation-store-memory/src/test/java/org/eclipse/dataspaceconnector/negotiation/store/memory/TestFunctions.java
+++ b/extensions/in-memory/negotiation-store-memory/src/test/java/org/eclipse/dataspaceconnector/negotiation/store/memory/TestFunctions.java
@@ -1,3 +1,18 @@
+/*
+ *  Copyright (c) 2021-2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *       Daimler TSS GmbH - fixed contract dates to epoch seconds
+ *
+ */
+
 package org.eclipse.dataspaceconnector.negotiation.store.memory;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
@@ -6,7 +21,8 @@ import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.Contra
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 
-import java.time.LocalDate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 public class TestFunctions {
@@ -31,9 +47,9 @@ public class TestFunctions {
                 .consumerAgentId("consumer")
                 .asset(Asset.Builder.newInstance().build())
                 .policy(Policy.Builder.newInstance().build())
-                .contractSigningDate(LocalDate.MIN.toEpochDay())
-                .contractStartDate(LocalDate.MIN.toEpochDay())
-                .contractEndDate(LocalDate.MAX.toEpochDay())
+                .contractStartDate(Instant.now().getEpochSecond())
+                .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())
+                .contractSigningDate(Instant.now().getEpochSecond())
                 .build();
     }
 }


### PR DESCRIPTION
Signed-off-by: Dominik Pinsel <dominik.pinsel@daimler.com>

## What this PR changes/adds:

Contract dates should be in epoch seconds. Where this is not the case the PR fixes it.

## Why it does that

This is necessary for the IDS-Serializer update, which validate the dates.

## Further notes

-

## Linked Issue(s)

Relates #236

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?

<sub>Dominik Pinsel <dominik.pinsel@daimler.com>, Daimler TSS GmbH, [legal info/Impressum](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md) </sub>
