### PR TITLE
feat: add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -36,4 +36,4 @@ Add any other context about the problem here.
 If applicable, add screenshots and logs to help explain your problem.
 
 ## Possible Implementation
-You already have an idea why this happened and how to fix it? Feel free to share your thoughts.
+You already know the root cause of the erroneous state and how to fix it? Feel free to share your thoughts.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug Report
+about: Create a report to help us improve.
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+# Bug Report
+
+## Describe the Bug
+A clear and concise description of what the bug is.
+
+### Expected Behavior
+A clear and concise description of what you expected to happen.
+
+### Current Behavior
+A clear and concise description of what happened instead.
+
+## Steps To Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Context Information
+Add any other context about the problem here.
+
+- Used version [e.g. EDC v1.0.0]
+- OS: [e.g. iOS, Windows]
+- ...
+
+## Detailed Description
+If applicable, add screenshots and logs to help explain your problem.
+
+## Possible Implementation
+You already have an idea why this happened and how to fix it? Feel free to share your thoughts.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ assignees: ''
 # Bug Report
 
 ## Describe the Bug
-A clear and concise description of what the bug is.
+A clear and concise description of the bug.
 
 ### Expected Behavior
 A clear and concise description of what you expected to happen.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,7 +15,7 @@ A clear and concise description of what the bug is.
 ### Expected Behavior
 A clear and concise description of what you expected to happen.
 
-### Current Behavior
+### Observed Behavior
 A clear and concise description of what happened instead.
 
 ## Steps To Reproduce

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+---
+blank_issues_enabled: true
+contact_links:
+  - name: Ask a question or get support
+    url: https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/discussions/categories/q-a
+    about: Ask a question or request support for using the Eclipse Dataspace Connector.
+  - name: Add a feature request
+    url: https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/discussions/categories/ideas
+    about: You have an idea or want to suggest an improvement for this project? Let's discuss it first.
+  - name: Take a look at the documentation
+    url: https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/tree/main/docs
+    about: Browse the documentation for finding more information.


### PR DESCRIPTION
## What this PR changes/adds:

Add an issue template for a bug report. Additionally add important links to submit feature requests, ask for help, or find the documentation.

## Why it does that

This improves the way of contributing to the project. We used this in the DSC project before (see screenshot below). It helps to guide people to the right links. I enabled blank issues so it should be possible to add an issue without using a template (in DSC, we turned it off).

![image](https://user-images.githubusercontent.com/72392527/156581957-d2e23d2b-db9f-4b10-b30f-623baea71202.png)

Please note that our issue page will look differently as I modified the content.

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?