### PR TITLE
refactor: Improve unit test for HttpDataSource and HttpDataSourceFactory

### DIFF
--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpDataSourceFactoryTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpDataSourceFactoryTest.java
@@ -14,17 +14,20 @@
 package org.eclipse.dataspaceconnector.dataplane.http.pipeline;
 
 import net.jodah.failsafe.RetryPolicy;
+import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -32,7 +35,12 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.dataplane.http.HttpTestFixtures.createDataAddress;
 import static org.eclipse.dataspaceconnector.dataplane.http.HttpTestFixtures.createRequest;
+import static org.eclipse.dataspaceconnector.dataplane.spi.schema.DataFlowRequestSchema.BODY;
+import static org.eclipse.dataspaceconnector.dataplane.spi.schema.DataFlowRequestSchema.MEDIA_TYPE;
 import static org.eclipse.dataspaceconnector.dataplane.spi.schema.DataFlowRequestSchema.METHOD;
+import static org.eclipse.dataspaceconnector.dataplane.spi.schema.DataFlowRequestSchema.QUERY_PARAMS;
+import static org.eclipse.dataspaceconnector.dataplane.spi.schema.HttpDataSchema.AUTHENTICATION_CODE;
+import static org.eclipse.dataspaceconnector.dataplane.spi.schema.HttpDataSchema.AUTHENTICATION_KEY;
 import static org.eclipse.dataspaceconnector.dataplane.spi.schema.HttpDataSchema.ENDPOINT;
 import static org.eclipse.dataspaceconnector.dataplane.spi.schema.HttpDataSchema.NAME;
 import static org.eclipse.dataspaceconnector.dataplane.spi.schema.HttpDataSchema.TYPE;
@@ -41,79 +49,130 @@ import static org.mockito.Mockito.mock;
 
 class HttpDataSourceFactoryTest {
 
-    private static final String TEST_ENDPOINT = "http://example.com";
+    private static final OkHttpClient HTTP_CLIENT = mock(OkHttpClient.class);
+    private static final RetryPolicy<Object> RETRY_POLICY = new RetryPolicy<>();
+    private static final Monitor MONITOR = mock(Monitor.class);
 
     private HttpDataSourceFactory factory;
 
-    @Test
-    void verifyCanHandle() {
-        assertThat(factory.canHandle(createRequest(TYPE).build())).isTrue();
+    @BeforeEach
+    void setUp() {
+        factory = new HttpDataSourceFactory(HTTP_CLIENT, RETRY_POLICY, MONITOR);
     }
-
-    @Test
-    void verifyCannotHandle() {
-        assertThat(factory.canHandle(createRequest("dummy").build())).isFalse();
-    }
-
-    @Test
-    void verifyValidation_success() {
-        var request = defaultRequest(defaultDataAddress());
-
-        assertThat(factory.validate(request).succeeded()).isTrue();
+    
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = "dummy")
+    void verifyCannotHandle(String type) {
+        assertThat(factory.canHandle(createRequest(type).build())).isFalse();
     }
 
     @ParameterizedTest(name = "{index} {0}")
     @MethodSource("provideInvalidRequests")
-    void verifyValidation_failure(String name, DataFlowRequest request) {
+    void verifySourceValidationAndCreation_failure(String name, DataFlowRequest request) {
         assertThat(factory.validate(request).failed()).isTrue();
-    }
-
-    @Test
-    void verifyCreateSource_success() {
-        var request = defaultRequest(defaultDataAddress());
-
-        assertThat(factory.createSource(request)).isNotNull();
-    }
-
-    @ParameterizedTest(name = "{index} {0}")
-    @MethodSource("provideInvalidRequests")
-    void verifyCreateSource_failure(String name, DataFlowRequest request) {
         assertThrows(EdcException.class, () -> factory.createSource(request));
     }
 
-    private static DataAddress defaultDataAddress() {
-        return DataAddress.Builder.newInstance()
-                .type(TYPE)
-                .property(ENDPOINT, TEST_ENDPOINT)
-                .property(NAME, "foo.json")
-                .build();
-    }
+    @ParameterizedTest(name = "{index} {0}")
+    @MethodSource("provideValidRequestsWithExpectedSource")
+    void verifySourceValidationAndCreation(String name, DataFlowRequest request, HttpDataSource expectedSource) {
+        assertThat(factory.canHandle(request)).isTrue();
+        assertThat(factory.validate(request).succeeded()).isTrue();
+        var source = factory.createSource(request);
+        assertThat(source).isNotNull();
 
-    private static DataFlowRequest defaultRequest(DataAddress address) {
-        return defaultRequest(address, Map.of());
-    }
-
-    private static DataFlowRequest defaultRequest(DataAddress address, Map<String, String> additional) {
-        var properties = new HashMap<String, String>();
-        properties.put(METHOD, "GET");
-        properties.putAll(additional);
-        return createRequest(TYPE).sourceDataAddress(address).properties(properties).build();
+        // validate the generated data source field by field using reflection
+        Arrays.stream(HttpDataSource.class.getDeclaredFields()).forEach(f -> {
+            f.setAccessible(true);
+            try {
+                assertThat(f.get(source)).isEqualTo(f.get(expectedSource));
+            } catch (IllegalAccessException e) {
+                throw new AssertionError(e);
+            }
+        });
     }
 
     /**
      * Serves some invalid {@link DataFlowRequest}.
      */
     private static Stream<Arguments> provideInvalidRequests() {
-        var validAddress = defaultDataAddress();
+        var endpoint = "http://example.com";
+        var validAddress = createDataAddress(TYPE, Map.of(ENDPOINT, endpoint)).build();
         var missingEndpoint = createDataAddress(TYPE, Map.of()).build();
         return Stream.of(
                 Arguments.of("MISSING METHOD", createRequest(Map.of(), validAddress, validAddress).build()),
-                Arguments.of("MISSING ENDPOINT", defaultRequest(missingEndpoint))
+                Arguments.of("MISSING ENDPOINT", createHttpRequest(missingEndpoint, "GET")),
+                Arguments.of("UNHANDLED MEDIA TYPE", createHttpRequest(validAddress, "GET", Map.of(MEDIA_TYPE, "dummy", BODY, "body-test")))
         );
     }
 
-    @BeforeEach
-    void setUp() {
-        factory = new HttpDataSourceFactory(mock(OkHttpClient.class), new RetryPolicy<>(), mock(Monitor.class));
+    /**
+     * Serves some valid {@link DataFlowRequest} with the associated expected {@link HttpDataSource} that must be generated.
+     */
+    private static Stream<Arguments> provideValidRequestsWithExpectedSource() {
+        var endpoint = "http://example.com";
+        var name = "foo.json";
+        var authKey = "apikey-test";
+        var authCode = "token-test";
+        var mediaType = "application/json";
+        var body = "test";
+        var queryParams = "?foo=bar";
+        var defaultDataAddress = createDataAddress(TYPE, Map.of(ENDPOINT, endpoint)).build();
+        var dataAddressWithName = createDataAddress(TYPE, Map.of(ENDPOINT, endpoint, NAME, name)).build();
+        var dataAddressWithAuthHeader = createDataAddress(TYPE, Map.of(ENDPOINT, endpoint, AUTHENTICATION_KEY, authKey, AUTHENTICATION_CODE, authCode)).build();
+        var dataAddressWithAuthCodeOnly = createDataAddress(TYPE, Map.of(ENDPOINT, endpoint, AUTHENTICATION_CODE, authCode)).build();
+
+        var basicRequest = createHttpRequest(defaultDataAddress, "GET");
+        var expectedBasicSource = defaultHttpSource(endpoint, "GET", basicRequest.getId()).build();
+
+        var requestWithName = createHttpRequest(dataAddressWithName, "GET");
+        var sourceWithName = defaultHttpSource(endpoint, "GET", requestWithName.getId()).name(name).build();
+
+        var requestWithQueryParams = createHttpRequest(defaultDataAddress, "GET", Map.of(QUERY_PARAMS, queryParams));
+        var sourceWithQueryParams = defaultHttpSource(endpoint, "GET", requestWithQueryParams.getId()).queryParams(queryParams).build();
+
+        var requestWithAuthHeader = createHttpRequest(dataAddressWithAuthHeader, "GET");
+        var sourceWithAuthHeader = defaultHttpSource(endpoint, "GET", requestWithAuthHeader.getId()).header(authKey, authCode).build();
+
+        var requestWithBody = createHttpRequest(defaultDataAddress, "POST", Map.of(MEDIA_TYPE, mediaType, BODY, body));
+        var sourceWithBody = defaultHttpSource(endpoint, "POST", requestWithBody.getId()).requestBody(MediaType.get(mediaType), body).build();
+
+        var requestWithIncompleteHeader = createHttpRequest(dataAddressWithAuthCodeOnly, "GET");
+        var expectedSourceWithoutHeader = defaultHttpSource(endpoint, "GET", requestWithIncompleteHeader.getId()).build();
+
+        var requestWithMediaTypeOnly = createHttpRequest(defaultDataAddress, "PUT", Map.of(ENDPOINT, endpoint, BODY, body));
+        var expectedSourceWithoutBody = defaultHttpSource(endpoint, "PUT", requestWithMediaTypeOnly.getId()).build();
+
+        return Stream.of(
+                Arguments.of("BASIC SOURCE", basicRequest, expectedBasicSource),
+                Arguments.of("WITH NAME", requestWithName, sourceWithName),
+                Arguments.of("WITH QUERY PARAMS", requestWithQueryParams, sourceWithQueryParams),
+                Arguments.of("WITH AUTH HEADER", requestWithAuthHeader, sourceWithAuthHeader),
+                Arguments.of("WITH BODY", requestWithBody, sourceWithBody),
+                Arguments.of("WITHOUT AUTH KEY", requestWithIncompleteHeader, expectedSourceWithoutHeader),
+                Arguments.of("WITHOUT MEDIA TYPE", requestWithMediaTypeOnly, expectedSourceWithoutBody)
+        );
+    }
+
+    private static DataFlowRequest createHttpRequest(DataAddress address, String method) {
+        return createHttpRequest(address, method, Map.of());
+    }
+
+    private static DataFlowRequest createHttpRequest(DataAddress address, String method, Map<String, String> additional) {
+        var properties = new HashMap<String, String>();
+        properties.put(METHOD, method);
+        properties.putAll(additional);
+        return createRequest(TYPE).sourceDataAddress(address).properties(properties).build();
+    }
+
+    private static HttpDataSource.Builder defaultHttpSource(String endpoint, String method, String requestId) {
+        return HttpDataSource.Builder.newInstance()
+                .sourceUrl(endpoint)
+                .method(method)
+                .requestId(requestId)
+                .httpClient(HTTP_CLIENT)
+                .monitor(MONITOR)
+                .retryPolicy(RETRY_POLICY);
     }
 }

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpDataSourceTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpDataSourceTest.java
@@ -4,16 +4,14 @@ import net.jodah.failsafe.RetryPolicy;
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
 import okhttp3.Request;
-import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okio.Okio;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 import java.io.ByteArrayOutputStream;
@@ -23,11 +21,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static okhttp3.Protocol.HTTP_1_1;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
 import static org.eclipse.dataspaceconnector.dataplane.http.pipeline.HttpDataSourceTest.CustomInterceptor.JSON_RESPONSE;
 import static org.mockito.Mockito.mock;
@@ -36,122 +32,84 @@ class HttpDataSourceTest {
 
     private static final String TEST_ENDPOINT = "http://example.com";
 
-    @ParameterizedTest(name = "{index} {0}")
-    @MethodSource("providesInvalidSourceBuilders")
-    void verifyBuilderThrowsIfInvalidInput(String name, HttpDataSource.Builder builder) {
-        assertThatExceptionOfType(NullPointerException.class).isThrownBy(builder::build);
+    private CustomInterceptor interceptor;
+
+    @BeforeEach
+    public void setUp() {
+        interceptor = new CustomInterceptor();
     }
 
     @ParameterizedTest
     @NullAndEmptySource
     void verifyRequest_nameBlankOrNull(String name) {
-        var interceptor = new CustomInterceptor();
-        var source = defaultBuilder(interceptor).method("GET").name(name).build();
+        var source = defaultBuilder().method("GET").name(name).build();
 
         source.openPartStream();
 
-        var requests = interceptor.getRequests();
-        assertThat(requests)
-                .hasSize(1)
-                .allSatisfy(request -> {
-                    assertThat(request.url()).hasToString(TEST_ENDPOINT + "/");
-                    assertThat(request.method()).isEqualTo("GET");
-                });
+        var request = interceptor.getInterceptedRequest();
+        assertThat(request.url()).hasToString(TEST_ENDPOINT + "/");
+        assertThat(request.method()).isEqualTo("GET");
     }
 
 
     @ParameterizedTest
     @NullAndEmptySource
     void verifyRequest_queryParamsBlankOrNull(String queryParams) {
-        var interceptor = new CustomInterceptor();
-        var source = defaultBuilder(interceptor).method("GET").name("testfile").queryParams(queryParams).build();
+        var source = defaultBuilder().method("GET").name("testfile").queryParams(queryParams).build();
 
         source.openPartStream();
 
-        var requests = interceptor.getRequests();
-        assertThat(requests)
-                .hasSize(1)
-                .allSatisfy(request -> {
-                    assertThat(request.url()).hasToString(TEST_ENDPOINT + "/testfile");
-                    assertThat(request.method()).isEqualTo("GET");
-                });
+        var request = interceptor.getInterceptedRequest();
+        assertThat(request.url()).hasToString(TEST_ENDPOINT + "/testfile");
+        assertThat(request.method()).isEqualTo("GET");
     }
 
     @Test
     void verifyRequest_withNameAndQueryParams() {
-        var interceptor = new CustomInterceptor();
-        var source = defaultBuilder(interceptor).method("GET").name("testfile").queryParams("foo=bar&hello=world").build();
+        var source = defaultBuilder().method("GET").name("testfile").queryParams("foo=bar&hello=world").build();
 
         source.openPartStream();
 
-        var requests = interceptor.getRequests();
-        assertThat(requests).hasSize(1);
-        assertThat(requests.get(0)).satisfies(request -> {
-            assertThat(request.url()).hasToString(TEST_ENDPOINT + "/testfile?foo=bar&hello=world");
-            assertThat(request.method()).isEqualTo("GET");
-        });
+        var request = interceptor.getInterceptedRequest();
+        assertThat(request.url()).hasToString(TEST_ENDPOINT + "/testfile?foo=bar&hello=world");
+        assertThat(request.method()).isEqualTo("GET");
     }
 
     @Test
     void verifyRequest_body() {
-        var interceptor = new CustomInterceptor();
         var json = "{ \"foo\" : \"bar\" }";
-        var requestBody = RequestBody.create(json, MediaType.get("application/json"));
-        var source = defaultBuilder(interceptor).method("POST").requestBody(requestBody).build();
+        var source = defaultBuilder().method("POST").requestBody(MediaType.get("application/json"), json).build();
 
         source.openPartStream();
 
-        var requests = interceptor.getRequests();
-        assertThat(requests).hasSize(1);
-        assertThat(requests.get(0)).satisfies(request -> {
-            assertThat(request.url()).hasToString(TEST_ENDPOINT + "/");
-            assertThat(request.method()).isEqualTo("POST");
-            try {
-                // check request body
-                var sink = Okio.sink(new ByteArrayOutputStream());
-                var bufferedSink = Okio.buffer(sink);
-                Objects.requireNonNull(request.body()).writeTo(bufferedSink);
-                assertThat(bufferedSink.getBuffer().readUtf8()).isEqualTo(json);
-            } catch (IOException e) {
-                throw new AssertionError("Failed to write body");
-            }
-        });
+        var request = interceptor.getInterceptedRequest();
+        assertThat(request.url()).hasToString(TEST_ENDPOINT + "/");
+        assertThat(request.method()).isEqualTo("POST");
+        assertThat(extractRequestBody(request)).isEqualTo(json);
     }
 
     @Test
     void verifyOpenPartStream() {
-        var source = defaultBuilder(new CustomInterceptor()).method("GET").build();
+        var source = defaultBuilder().method("GET").build();
 
         var parts = source.openPartStream().collect(Collectors.toList());
 
-        assertThat(parts).hasSize(1)
-                .allSatisfy(part -> {
-                    try {
-                        assertThat(part.size()).isEqualTo(JSON_RESPONSE.length());
-                        assertThat(part.openStream().readAllBytes()).isEqualTo(JSON_RESPONSE.getBytes());
-                    } catch (IOException e) {
-                        throw new AssertionError("Failed to open Part stream");
-                    }
-                });
+        assertThat(parts).hasSize(1);
+        assertThat(parts.get(0).openStream()).hasContent(JSON_RESPONSE);
     }
 
-    /**
-     * Serves some invalid {@link HttpDataSource.Builder} which are expected to throw exception when calling build() method.
-     */
-    private static Stream<Arguments> providesInvalidSourceBuilders() {
-        var nullHeaderKey = defaultBuilder().header(null, "bar");
-        var nullHeaderValue = defaultBuilder().header("foo", null);
-        return Stream.of(
-                Arguments.of("NULL HEADER KEY", nullHeaderKey),
-                Arguments.of("NULL HEADER VALUE", nullHeaderValue)
-        );
+    private static String extractRequestBody(Request request) {
+        try {
+            var sink = Okio.sink(new ByteArrayOutputStream());
+            var bufferedSink = Okio.buffer(sink);
+            Objects.requireNonNull(request.body()).writeTo(bufferedSink);
+            return bufferedSink.getBuffer().readUtf8();
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
     }
 
-    private static HttpDataSource.Builder defaultBuilder() {
-        return defaultBuilder(new CustomInterceptor());
-    }
-
-    private static HttpDataSource.Builder defaultBuilder(Interceptor interceptor) {
+    private HttpDataSource.Builder defaultBuilder() {
         var monitor = mock(Monitor.class);
         var retryPolicy = new RetryPolicy<>().withMaxAttempts(1);
         var httpClient = testOkHttpClient().newBuilder().addInterceptor(interceptor).build();
@@ -180,8 +138,10 @@ class HttpDataSourceTest {
                     .build();
         }
 
-        public List<Request> getRequests() {
-            return requests;
+        public Request getInterceptedRequest() {
+            return requests.stream()
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("No request intercepted"));
         }
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

This improve some unit-tests for `HttpDataSource` and `HttpDataSourceFactory` classes. Especially it adds a step that verifies the actual content of the `HttpDataSource` generated by the factory. 
