### PR TITLE
ci: add action to check changelog modifications

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,5 +22,5 @@ Closes # <-- _insert Issue number if one exists_
 - [ ] added/updated copyright headers?
 - [ ] documented public classes/methods?
 - [ ] added/updated relevant documentation?
-- [ ] added relevant details to the changelog?
-- [ ] linked GitHub project?
+- [ ] added relevant details to the changelog? (skip with label `no-changelog`)
+- [ ] linked GitHub project? (see the section on the right-hand side -->)

--- a/.github/workflows/check-changelog.yaml
+++ b/.github/workflows/check-changelog.yaml
@@ -1,0 +1,18 @@
+name: Scan Changelog
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  CheckForChanges:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check for new entries
+        uses: brettcannon/check-for-changed-files@v1
+        with:
+          file-pattern: 'CHANGELOG.md'
+          skip-label: 'no-changelog'
+          failure-message: 'Missing changes in CHANGELOG.md. Please add relevant information if needed.'


### PR DESCRIPTION
## What this PR changes/adds

Adds an action that checks for changelog modifications.

## Why it does that

As an addition to the reminder in the pull request template, the pipeline checks the changelog for changes. If there are none, a warning is displayed. Continue on error is set to true.
