### PR TITLE
Added health probe to wait for MinIO

### DIFF
--- a/.github/workflows/integrationtests.yaml
+++ b/.github/workflows/integrationtests.yaml
@@ -79,8 +79,8 @@ jobs:
         ports:
           - 9000:9000
         env:
-          MINIO_ACCESS_KEY: root
-          MINIO_SECRET_KEY: password
+          MINIO_ROOT_USER: root
+          MINIO_ROOT_PASSWORD: password
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ or issues.
 * Remove module `:samples:other:commandline` (#820)
 
 #### Fixed
+Flaky S3 StatusChecker Test (#794)
 
 ---
 

--- a/extensions/aws/aws-test/build.gradle.kts
+++ b/extensions/aws/aws-test/build.gradle.kts
@@ -20,6 +20,9 @@ plugins {
 
 val awsVersion: String by project
 val jupiterVersion: String by project
+val okHttpVersion: String by project
+val awaitility: String by project
+
 
 dependencies {
     api(project(":spi"))
@@ -28,6 +31,9 @@ dependencies {
 
     testFixturesApi("software.amazon.awssdk:s3:${awsVersion}")
 
+    // needed for MinIO health probe
+    testFixturesImplementation("com.squareup.okhttp3:okhttp:${okHttpVersion}")
+    testFixturesImplementation("org.awaitility:awaitility:${awaitility}")
     testFixturesImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
     testFixturesRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")
 

--- a/extensions/aws/aws-test/src/testFixtures/java/org/eclipse/dataspaceconnector/aws/testfixtures/AbstractS3Test.java
+++ b/extensions/aws/aws-test/src/testFixtures/java/org/eclipse/dataspaceconnector/aws/testfixtures/AbstractS3Test.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2021 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -14,8 +14,11 @@
 
 package org.eclipse.dataspaceconnector.aws.testfixtures;
 
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
@@ -33,13 +36,16 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
+import static org.awaitility.Awaitility.await;
 import static org.eclipse.dataspaceconnector.common.configuration.ConfigurationFunctions.propOrEnv;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -54,11 +60,36 @@ public abstract class AbstractS3Test {
     // when bucket is rapidly added/deleted and consistency propagation causes this error.
     // (Should not be necessary if REGION remains static, but added to prevent future frustration.)
     // [see http://stackoverflow.com/questions/13898057/aws-error-message-a-conflicting-conditional-operation-is-currently-in-progress]
-
+    protected static final String S3_ENDPOINT = "http://localhost:9000";
     protected final UUID processId = UUID.randomUUID();
     protected String bucketName = createBucketName();
     protected S3AsyncClient client;
-    protected final String s3Endpoint = "http://localhost:9000";
+
+    @BeforeAll
+    static void prepareAll() {
+        if (S3_ENDPOINT.contains("localhost")) { // only run this when localhost is used.
+            await().atLeast(Duration.ofSeconds(2))
+                    .atMost(Duration.ofSeconds(15))
+                    .with()
+                    .pollInterval(Duration.ofSeconds(2))
+                    .ignoreException(IOException.class) // thrown by pingMinio
+                    .until(AbstractS3Test::pingMinio);
+        }
+    }
+
+    /**
+     * pings MinIO's health endpoint https://docs.min.io/minio/baremetal/monitoring/healthcheck-probe.html
+     *
+     * @return true if HTTP status [200..300[
+     */
+
+    private static boolean pingMinio() throws IOException {
+        var httpClient = new OkHttpClient();
+        var healthRq = new Request.Builder().url(S3_ENDPOINT + "/minio/health/live").get().build();
+        try (var response = httpClient.newCall(healthRq).execute()) {
+            return response.isSuccessful();
+        }
+    }
 
     @BeforeEach
     public void setupClient() throws URISyntaxException {
@@ -68,7 +99,7 @@ public abstract class AbstractS3Test {
                         .build())
                 .region(Region.of(REGION))
                 .credentialsProvider(this::getCredentials)
-                .endpointOverride(new URI(s3Endpoint))
+                .endpointOverride(new URI(S3_ENDPOINT))
                 .build();
 
         createBucket(bucketName);
@@ -82,20 +113,6 @@ public abstract class AbstractS3Test {
     @NotNull
     protected String createBucketName() {
         return "test-bucket-" + processId + "-" + REGION;
-    }
-
-    private @NotNull AwsCredentials getCredentials() {
-        String profile = propOrEnv("AWS_PROFILE", null);
-        if (profile != null) {
-            return ProfileCredentialsProvider.create(profile).resolveCredentials();
-        }
-
-        var accessKeyId = propOrEnv("S3_ACCESS_KEY_ID", null);
-        Objects.requireNonNull(accessKeyId, "S3_ACCESS_KEY_ID cannot be null!");
-        var secretKey = propOrEnv("S3_SECRET_ACCESS_KEY", null);
-        Objects.requireNonNull(secretKey, "S3_SECRET_ACCESS_KEY cannot be null");
-
-        return AwsBasicCredentials.create(accessKeyId, secretKey);
     }
 
     protected void createBucket(String bucketName) {
@@ -129,6 +146,24 @@ public abstract class AbstractS3Test {
         }
     }
 
+    protected CompletableFuture<PutObjectResponse> putTestFile(String key, File file, String bucketName) {
+        return client.putObject(PutObjectRequest.builder().bucket(bucketName).key(key).build(), file.toPath());
+    }
+
+    private @NotNull AwsCredentials getCredentials() {
+        String profile = propOrEnv("AWS_PROFILE", null);
+        if (profile != null) {
+            return ProfileCredentialsProvider.create(profile).resolveCredentials();
+        }
+
+        var accessKeyId = propOrEnv("S3_ACCESS_KEY_ID", null);
+        Objects.requireNonNull(accessKeyId, "S3_ACCESS_KEY_ID cannot be null!");
+        var secretKey = propOrEnv("S3_SECRET_ACCESS_KEY", null);
+        Objects.requireNonNull(secretKey, "S3_SECRET_ACCESS_KEY cannot be null");
+
+        return AwsBasicCredentials.create(accessKeyId, secretKey);
+    }
+
     private void deleteBucketObjects(String bucketName) {
         var objectListing = client.listObjects(ListObjectsRequest.builder().bucket(bucketName).build()).join();
 
@@ -158,10 +193,6 @@ public abstract class AbstractS3Test {
                 throw e;
             }
         }
-    }
-
-    protected CompletableFuture<PutObjectResponse> putTestFile(String key, File file, String bucketName) {
-        return client.putObject(PutObjectRequest.builder().bucket(bucketName).key(key).build(), file.toPath());
     }
 
 }

--- a/extensions/aws/aws-test/src/testFixtures/java/org/eclipse/dataspaceconnector/aws/testfixtures/AbstractS3Test.java
+++ b/extensions/aws/aws-test/src/testFixtures/java/org/eclipse/dataspaceconnector/aws/testfixtures/AbstractS3Test.java
@@ -37,6 +37,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.ConnectException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
@@ -73,6 +74,7 @@ public abstract class AbstractS3Test {
                     .with()
                     .pollInterval(Duration.ofSeconds(2))
                     .ignoreException(IOException.class) // thrown by pingMinio
+                    .ignoreException(ConnectException.class)
                     .until(AbstractS3Test::pingMinio);
         }
     }


### PR DESCRIPTION
## What this PR changes/adds

Adds a HTTP call to evaluate MinIO's [health endpoint](https://docs.min.io/minio/baremetal/monitoring/healthcheck-probe.html), retries every 2 seconds for at most 10 seconds.

## Why it does that

When the Github runner starts the MinIO container and simultaneously launches the test, sometimes this causes the AWS S3 StatusChecker test to fail with strange errors due to MinIO not completely booted.

## Further notes
- The wait loop uses Awaitility, as we already have that in our test environment
- The names of the MinIO credentials were also updated, as the old ones are deprecated

## Linked Issue(s)

Closes #795 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (skip with label `no-changelog`)
- [x] linked GitHub project? (see the section on the right-hand side -->)
