### PR TITLE
DI test harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ or issues.
 #### Added
 * `ContractDefinitionStore` supports paging (#717)
 * Add okhttp client timeouts (#735)
+* Unit test framework for Dependency Injection (#843)
 
 #### Changed
 * Change scope used for obtaining a token for ids multipart (#731)

--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/runtime/BaseRuntime.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/runtime/BaseRuntime.java
@@ -55,15 +55,7 @@ public class BaseRuntime {
      * Main entry point to runtime initialization. Calls all methods.
      */
     protected void boot() {
-        var typeManager = createTypeManager();
-        monitor = createMonitor();
-        MonitorProvider.setInstance(monitor);
-
-        var telemetry = loadTelemetry();
-
-        var context = createContext(typeManager, monitor, telemetry);
-        initializeContext(context);
-
+        ServiceExtensionContext context = createServiceExtensionContext();
 
         var name = getRuntimeName(context);
         try {
@@ -85,6 +77,19 @@ public class BaseRuntime {
 
         monitor.info(format("%s ready", name));
 
+    }
+
+    @NotNull
+    protected ServiceExtensionContext createServiceExtensionContext() {
+        var typeManager = createTypeManager();
+        monitor = createMonitor();
+        MonitorProvider.setInstance(monitor);
+
+        var telemetry = loadTelemetry();
+
+        var context = createContext(typeManager, monitor, telemetry);
+        initializeContext(context);
+        return context;
     }
 
     /**

--- a/data-protocols/ids/ids-transform-v1/build.gradle.kts
+++ b/data-protocols/ids/ids-transform-v1/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     api("de.fraunhofer.iais.eis.ids.infomodel:java:${infoModelVersion}")
 
     implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
+    testImplementation(testFixtures(project(":launchers:junit")))
 
 }
 

--- a/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/dataspaceconnector/ids/transform/IdsTransformServiceExtension.java
+++ b/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/dataspaceconnector/ids/transform/IdsTransformServiceExtension.java
@@ -26,13 +26,6 @@ public class IdsTransformServiceExtension implements ServiceExtension {
     @Inject
     private TransformerRegistry registry;
 
-    public IdsTransformServiceExtension(TransformerRegistry registry) {
-        this.registry = registry;
-    }
-
-    public IdsTransformServiceExtension() {
-    }
-
     @Override
     public String name() {
         return "IDS Transform Extension";

--- a/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/dataspaceconnector/ids/transform/IdsTransformServiceExtensionTest.java
+++ b/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/dataspaceconnector/ids/transform/IdsTransformServiceExtensionTest.java
@@ -27,6 +27,7 @@ import org.eclipse.dataspaceconnector.ids.spi.transform.TransformerRegistry;
 import org.eclipse.dataspaceconnector.ids.spi.types.Connector;
 import org.eclipse.dataspaceconnector.ids.spi.types.SecurityProfile;
 import org.eclipse.dataspaceconnector.ids.spi.types.container.OfferedAsset;
+import org.eclipse.dataspaceconnector.junit.launcher.DependencyInjectionExtension;
 import org.eclipse.dataspaceconnector.policy.model.Action;
 import org.eclipse.dataspaceconnector.policy.model.Constraint;
 import org.eclipse.dataspaceconnector.policy.model.Duty;
@@ -36,12 +37,14 @@ import org.eclipse.dataspaceconnector.policy.model.Permission;
 import org.eclipse.dataspaceconnector.policy.model.Prohibition;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.system.injection.ObjectFactory;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -57,8 +60,9 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
+
+@ExtendWith(DependencyInjectionExtension.class)
 class IdsTransformServiceExtensionTest {
 
     private Map<Class<?>, List<Class<?>>> knownConvertibles;
@@ -67,13 +71,13 @@ class IdsTransformServiceExtensionTest {
     private ServiceExtensionContext serviceExtensionContext;
 
     @BeforeEach
-    void setUp() {
+    void setUp(ServiceExtensionContext context, ObjectFactory factory) {
         knownConvertibles = new HashMap<>();
 
         var transformerRegistry = new TestTransformerRegistry(knownConvertibles);
-        idsTransformServiceExtension = new IdsTransformServiceExtension(transformerRegistry);
-        serviceExtensionContext = mock(ServiceExtensionContext.class);
-
+        context.registerService(TransformerRegistry.class, transformerRegistry);
+        idsTransformServiceExtension = factory.constructInstance(IdsTransformServiceExtension.class);
+        serviceExtensionContext = context;
     }
 
     @ParameterizedTest(name = "[{index}] can transform {0} to {1}")

--- a/docs/developer/dependency_resolution.md
+++ b/docs/developer/dependency_resolution.md
@@ -136,6 +136,12 @@ method. This implies that every extension can assume that by the time its `initi
 dependencies are already instantiated and registered, because the extension(s) providing them were ordered at previous
 positions in the list, and thus have already been initialized.
 
+## Tests for classes using injection
+
+To test classes using the `@Inject` annotation, use the appropriate JUnit extension:
+- If only basic dependency injection is needed (unit testing), use the `DependencyInjectionExtension`.
+- If the full EDC runtime should be run (integration testing), use the `EdcExtension`.
+
 ## Limitations and differences to fully-fledged IoC containers
 
 #### Only available in `ServiceExtensions`

--- a/extensions/api/observability/src/main/java/org/eclipse/dataspaceconnector/api/observability/ObservabilityApiExtension.java
+++ b/extensions/api/observability/src/main/java/org/eclipse/dataspaceconnector/api/observability/ObservabilityApiExtension.java
@@ -14,14 +14,6 @@ public class ObservabilityApiExtension implements ServiceExtension {
     @Inject
     private HealthCheckService healthCheckService;
 
-    public ObservabilityApiExtension(WebService webServiceMock, HealthCheckService healthCheckService) {
-        webService = webServiceMock;
-        this.healthCheckService = healthCheckService;
-    }
-
-    public ObservabilityApiExtension() {
-    }
-
     @Override
     public String name() {
         return "Observability API";

--- a/extensions/api/observability/src/test/java/org/eclipse/dataspaceconnector/api/observability/ObservabilityApiExtensionTest.java
+++ b/extensions/api/observability/src/test/java/org/eclipse/dataspaceconnector/api/observability/ObservabilityApiExtensionTest.java
@@ -1,18 +1,22 @@
 package org.eclipse.dataspaceconnector.api.observability;
 
+import org.eclipse.dataspaceconnector.junit.launcher.DependencyInjectionExtension;
 import org.eclipse.dataspaceconnector.spi.WebService;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.system.health.HealthCheckService;
 import org.eclipse.dataspaceconnector.spi.system.health.LivenessProvider;
 import org.eclipse.dataspaceconnector.spi.system.health.ReadinessProvider;
+import org.eclipse.dataspaceconnector.spi.system.injection.ObjectFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+@ExtendWith(DependencyInjectionExtension.class)
 class ObservabilityApiExtensionTest {
 
     private ObservabilityApiExtension extension;
@@ -20,10 +24,12 @@ class ObservabilityApiExtensionTest {
     private HealthCheckService healthServiceMock;
 
     @BeforeEach
-    void setup() {
+    void setup(ServiceExtensionContext context, ObjectFactory factory) {
         webServiceMock = mock(WebService.class);
+        context.registerService(WebService.class, webServiceMock);
         healthServiceMock = mock(HealthCheckService.class);
-        extension = new ObservabilityApiExtension(webServiceMock, healthServiceMock);
+        context.registerService(HealthCheckService.class, healthServiceMock);
+        extension = factory.constructInstance(ObservabilityApiExtension.class);
     }
 
     @Test

--- a/extensions/iam/decentralized-identity/identity-did-core/build.gradle.kts
+++ b/extensions/iam/decentralized-identity/identity-did-core/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:${okHttpVersion}")
 
     testImplementation(testFixtures(project(":extensions:iam:decentralized-identity:identity-common-test")))
+    testImplementation(testFixtures(project(":launchers:junit")))
 }
 
 publishing {

--- a/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtension.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtension.java
@@ -49,14 +49,6 @@ public class IdentityDidCoreExtension implements ServiceExtension {
     @Inject
     private WebService webService;
 
-    public IdentityDidCoreExtension() {
-    }
-
-    public IdentityDidCoreExtension(IdentityHubStore hubStore, WebService webService) {
-        this.hubStore = hubStore;
-        this.webService = webService;
-    }
-
     @Override
     public String name() {
         return "Identity Did Core";

--- a/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtensionTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtensionTest.java
@@ -10,51 +10,49 @@ import org.eclipse.dataspaceconnector.iam.did.spi.hub.IdentityHubClient;
 import org.eclipse.dataspaceconnector.iam.did.spi.hub.IdentityHubStore;
 import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidPublicKeyResolver;
 import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidResolverRegistry;
+import org.eclipse.dataspaceconnector.junit.launcher.DependencyInjectionExtension;
 import org.eclipse.dataspaceconnector.spi.WebService;
-import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.security.PrivateKeyResolver;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.system.health.HealthCheckService;
-import org.eclipse.dataspaceconnector.spi.types.TypeManager;
+import org.eclipse.dataspaceconnector.spi.system.injection.ObjectFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.mockito.ArgumentMatchers.eq;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 
+@ExtendWith(DependencyInjectionExtension.class)
 class IdentityDidCoreExtensionTest {
 
     private IdentityDidCoreExtension extension;
-    private ServiceExtensionContext contextMock;
     private WebService webserviceMock;
 
     @BeforeEach
-    void setUp() {
+    void setUp(ServiceExtensionContext context, ObjectFactory factory) {
         var hubStore = mock(IdentityHubStore.class);
+        context.registerService(IdentityHubStore.class, hubStore);
         webserviceMock = mock(WebService.class);
-        extension = new IdentityDidCoreExtension(hubStore, webserviceMock);
-        contextMock = mock(ServiceExtensionContext.class);
+        context.registerService(WebService.class, webserviceMock);
+        extension = factory.constructInstance(IdentityDidCoreExtension.class);
     }
 
     @Test
-    void verifyCorrectInitialization_withPkResolverPresent() {
-        when(contextMock.getTypeManager()).thenReturn(new TypeManager());
-        when(contextMock.getService(PrivateKeyResolver.class)).thenReturn(mock(PrivateKeyResolver.class));
-        when(contextMock.getConnectorId()).thenReturn("test-connector");
-        when(contextMock.getService(OkHttpClient.class)).thenReturn(mock(OkHttpClient.class));
-        when(contextMock.getMonitor()).thenReturn(mock(Monitor.class));
-        when(contextMock.getService(HealthCheckService.class, true)).thenReturn(mock(HealthCheckService.class));
+    void verifyCorrectInitialization_withPkResolverPresent(ServiceExtensionContext context) {
+        context.registerService(PrivateKeyResolver.class, mock(PrivateKeyResolver.class));
+        context.registerService(OkHttpClient.class, mock(OkHttpClient.class));
+        context.registerService(HealthCheckService.class, mock(HealthCheckService.class));
 
-        extension.initialize(contextMock);
+        extension.initialize(context);
 
-        verify(contextMock).registerService(eq(DidResolverRegistry.class), isA(DidResolverRegistry.class));
-        verify(contextMock).registerService(eq(DidPublicKeyResolver.class), isA(DidPublicKeyResolverImpl.class));
-        verify(contextMock).registerService(eq(IdentityHub.class), isA(IdentityHubImpl.class));
-        verify(contextMock).registerService(eq(IdentityHubClient.class), isA(IdentityHubClientImpl.class));
+        assertThat(context.getService(DidResolverRegistry.class)).isInstanceOf(DidResolverRegistry.class);
+        assertThat(context.getService(DidPublicKeyResolver.class)).isInstanceOf(DidPublicKeyResolverImpl.class);
+        assertThat(context.getService(IdentityHub.class)).isInstanceOf(IdentityHubImpl.class);
+        assertThat(context.getService(IdentityHubClient.class)).isInstanceOf(IdentityHubClientImpl.class);
         verify(webserviceMock).registerResource(isA(IdentityHubController.class));
     }
 }

--- a/launchers/junit/src/testFixtures/java/org/eclipse/dataspaceconnector/junit/launcher/DependencyInjectionExtension.java
+++ b/launchers/junit/src/testFixtures/java/org/eclipse/dataspaceconnector/junit/launcher/DependencyInjectionExtension.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.junit.launcher;
+
+import org.eclipse.dataspaceconnector.boot.system.injection.InjectorImpl;
+import org.eclipse.dataspaceconnector.boot.system.injection.ReflectiveObjectFactory;
+import org.eclipse.dataspaceconnector.boot.system.runtime.BaseRuntime;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.system.injection.InjectionPointScanner;
+import org.eclipse.dataspaceconnector.spi.system.injection.ObjectFactory;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+import static org.eclipse.dataspaceconnector.common.types.Cast.cast;
+
+/**
+ * A JUnit extension for running an embedded EDC dependency injection container as part of a test fixture.
+ * This extension attaches a dependency injection container to the test lifecycle. Parameter injection of runtime services is supported.
+ * <p>
+ * If additional lifecycle services are needed (detection, loading and booting of extensions), use {@link EdcExtension} instead.
+ */
+public class DependencyInjectionExtension extends BaseRuntime implements BeforeEachCallback, ParameterResolver {
+    private ServiceExtensionContext context;
+    private ObjectFactory factory;
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        context = super.createServiceExtensionContext();
+        context.initialize();
+        factory = new ReflectiveObjectFactory(
+                new InjectorImpl(),
+                new InjectionPointScanner(),
+                context
+        );
+    }
+
+    @Override
+    protected @NotNull ServiceExtensionContext createServiceExtensionContext() {
+        return context;
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        var type = parameterContext.getParameter().getParameterizedType();
+        if (type.equals(ObjectFactory.class)) {
+            return true;
+        } else if (type.equals(ServiceExtensionContext.class)) {
+            return true;
+        } else if (type instanceof Class) {
+            return context.hasService(cast(type));
+        }
+        return false;
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        var type = parameterContext.getParameter().getParameterizedType();
+        if (type.equals(ServiceExtensionContext.class)) {
+            return context;
+        } else if (type.equals(ObjectFactory.class)) {
+            return factory;
+        } else if (type instanceof Class) {
+            return context.getService(cast(type));
+        }
+        return null;
+    }
+}

--- a/launchers/junit/src/testFixtures/java/org/eclipse/dataspaceconnector/junit/launcher/EdcExtension.java
+++ b/launchers/junit/src/testFixtures/java/org/eclipse/dataspaceconnector/junit/launcher/EdcExtension.java
@@ -45,7 +45,9 @@ import static org.eclipse.dataspaceconnector.common.types.Cast.cast;
 
 /**
  * A JUnit extension for running an embedded EDC runtime as part of a test fixture.
- * This extension attaches a EDC runtime to the {@link BeforeTestExecutionCallback} and {@link AfterTestExecutionCallback} lifecycle hooks. Parameter injection of runtime services is supported.
+ * This extension attaches an EDC runtime to the {@link BeforeTestExecutionCallback} and {@link AfterTestExecutionCallback} lifecycle hooks. Parameter injection of runtime services is supported.
+ * <p>
+ * If only basic dependency injection is needed, use {@link DependencyInjectionExtension} instead.
  */
 public class EdcExtension extends BaseRuntime implements BeforeTestExecutionCallback, AfterTestExecutionCallback, ParameterResolver {
     private final LinkedHashMap<Class<?>, Object> serviceMocks = new LinkedHashMap<>();


### PR DESCRIPTION
## What this PR changes/adds:

Created a JUnit extension to provide lightweight dependency injection (DI) services for unit tests.

## Why it does that

Need for mocking private fields that are injected by the DI container.

## Further notes

Refactored relevant tests that were relying on dedicated constructors to circumvent the DI mechanism.

## Linked Issue(s)

Closes #817 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?