### PR TITLE
publish test results

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -24,13 +24,18 @@ jobs:
           reporter: 'github-check'
           filter_mode: 'nofilter'
 
-
       - name: Gradle Test Core
         env:
           INTEGRATION_TEST: false
           JACOCO: true
         # checkstyle would also run as part of the `check` task
         run: ./gradlew clean check jacocoTestReport -x checkstyleMain -x checkstyleTest
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: always()
+        with:
+          files: "**/test-results/**/*.xml"
 
       - name: CodeCov
         uses: codecov/codecov-action@v2


### PR DESCRIPTION
## What this PR changes/adds

Adds a step on the `Test Code` workflow that will publish and show test results on github action user interface in this way:

![Screenshot_20220308_112254](https://user-images.githubusercontent.com/8570990/157217526-e52222e4-16dd-4bae-9118-5a342dd6f914.png)

## Why it does that

It will be more easy to understand which test failed and why instead of having to go through all the gradle output

## Further notes

-

## Linked Issue(s)

Closes #849 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (skip with label `no-changelog`)
- [x] linked GitHub project? (see the section on the right-hand side -->)
