### PR TITLE
chore: add issue template for feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Create a report to help us improve.
+about: Create a report to help us improve
 title: ''
 labels: 'bug'
 assignees: ''
@@ -10,15 +10,15 @@ assignees: ''
 # Bug Report
 
 ## Describe the Bug
-A clear and concise description of the bug.
+_A clear and concise description of the bug._
 
 ### Expected Behavior
-A clear and concise description of what you expected to happen.
+_A clear and concise description of what you expected to happen._
 
 ### Observed Behavior
-A clear and concise description of what happened instead.
+_A clear and concise description of what happened instead._
 
-## Steps To Reproduce
+## Steps to Reproduce
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
@@ -26,14 +26,14 @@ Steps to reproduce the behavior:
 4. See error
 
 ## Context Information
-Add any other context about the problem here.
+_Add any other context about the problem here._
 
 - Used version [e.g. EDC v1.0.0]
 - OS: [e.g. iOS, Windows]
 - ...
 
 ## Detailed Description
-If applicable, add screenshots and logs to help explain your problem.
+_If applicable, add screenshots and logs to help explain your problem._
 
 ## Possible Implementation
-You already know the root cause of the erroneous state and how to fix it? Feel free to share your thoughts.
+_You already know the root cause of the erroneous state and how to fix it? Feel free to share your thoughts._

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,12 +1,12 @@
 ---
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
+  - name: Open up a blank issue
+    url: https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/new
+    about: Don’t see your issue here? Open up a blank one
   - name: Ask a question or get support
     url: https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/discussions/categories/q-a
-    about: Ask a question or request support for using the Eclipse Dataspace Connector.
-  - name: Add a feature request
-    url: https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/discussions/categories/ideas
-    about: You have an idea or want to suggest an improvement for this project? Let's discuss it first.
+    about: Ask a question or request support for using the Eclipse Dataspace Connector
   - name: Take a look at the documentation
     url: https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/tree/main/docs
-    about: Browse the documentation for finding more information.
+    about: Browse the documentation for more information

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature Request
+about: Help us with new ideas
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+# Feature Request
+
+_If you have an idea or an improvement for this project that should be discussed first, please feel 
+free to open up a [discussion](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/discussions/categories/ideas)._
+
+## What Area Will This Influence?
+_e.g., DPF, CI, build, transfer, etc._
+
+## Why Is the Feature Wanted?
+_Are there any requirements?_
+
+## Solution Proposal
+_If possible, provide a (brief!) solution proposal._
+
+## Type of Issue
+_i.e., new feature, improvement, cleanup, etc._
+
+## Checklist
+
+- [ ] assigned correct label?
+- [ ] assigned project, if necessary? (_see the section on the right-hand side -->_)
+- [x] **Do NOT select a milestone or an assignee!**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,13 +9,13 @@ assignees: ''
 
 # Feature Request
 
-_If you have an idea or an improvement for this project that should be discussed first, please feel 
-free to open up a [discussion](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/discussions/categories/ideas)._
+_If you are missing a feature or have an idea how to improve this project that should first be 
+discussed, please feel free to open up a [discussion](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/discussions/categories/ideas)._
 
-## What Area Will This Influence?
+## Which Areas Would Be Affected?
 _e.g., DPF, CI, build, transfer, etc._
 
-## Why Is the Feature Wanted?
+## Why Is the Feature Desired?
 _Are there any requirements?_
 
 ## Solution Proposal
@@ -26,6 +26,5 @@ _i.e., new feature, improvement, cleanup, etc._
 
 ## Checklist
 
-- [ ] assigned correct label?
-- [ ] assigned project, if necessary? (_see the section on the right-hand side -->_)
+- [ ] assigned appropriate label?
 - [x] **Do NOT select a milestone or an assignee!**


### PR DESCRIPTION
## What this PR changes/adds

Adds an issue template for feature requests and provides a link to blank issues.

## Why it does that

To make people's lives easier.

## Linked Issue(s)

Closes #841 

## Checklist

- [x] added relevant details to the changelog? (skip with label `no-changelog`)
- [x] linked GitHub project? (see the section on the right-hand side -->)
