### PR TITLE
cleanup(TransferProcessStore): add `findAll` and remove unneeded methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,13 +27,13 @@ the detailed section referring to by linking pull requests or issues.
 * Change scope used for obtaining a token for ids multipart (#731)
 * Refactor ids token validation as extension (#625)
 * All `CosmosDocument` subclasses now use a configurable partition key (#780)
-* Added `findAll` method to `TransferProcessStore` (#859)
+* Add `findAll` method to `TransferProcessStore` (#859)
 
 #### Removed
 
 * Remove ION extension (#664)
 * Remove module `:samples:other:commandline` (#820)
-* Removed unneeded/unimplemented methods from `TransferProcessStore` (#859)
+* Remove unneeded/unimplemented methods from `TransferProcessStore` (#859)
 
 #### Fixed
 * Flaky S3 StatusChecker Test (#794)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,13 @@ the detailed section referring to by linking pull requests or issues.
 * Change scope used for obtaining a token for ids multipart (#731)
 * Refactor ids token validation as extension (#625)
 * All `CosmosDocument` subclasses now use a configurable partition key (#780)
+* Added `findAll` method to `TransferProcessStore` (#859)
 
 #### Removed
 
 * Remove ION extension (#664)
 * Remove module `:samples:other:commandline` (#820)
+* Removed unneeded/unimplemented methods from `TransferProcessStore` (#859)
 
 #### Fixed
 * Flaky S3 StatusChecker Test (#794)

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
@@ -61,7 +61,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
@@ -197,23 +196,7 @@ class IdsApiMultipartDispatcherV1IntegrationTestServiceExtension implements Serv
         }
 
         @Override
-        public void createData(String processId, String key, Object data) {
-        }
-
-        @Override
-        public void updateData(String processId, String key, Object data) {
-        }
-
-        @Override
-        public void deleteData(String processId, String key) {
-        }
-
-        @Override
-        public void deleteData(String processId, Set<String> keys) {
-        }
-
-        @Override
-        public <T> T findData(Class<T> type, String processId, String resourceDefinitionId) {
+        public Stream<TransferProcess> findAll(QuerySpec querySpec) {
             return null;
         }
     }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
@@ -57,14 +57,12 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.Instant;
-import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
@@ -216,25 +214,10 @@ class IdsApiMultipartEndpointV1IntegrationTestServiceExtension implements Servic
         }
 
         @Override
-        public void createData(String processId, String key, Object data) {
-        }
-
-        @Override
-        public void updateData(String processId, String key, Object data) {
-        }
-
-        @Override
-        public void deleteData(String processId, String key) {
-        }
-
-        @Override
-        public void deleteData(String processId, Set<String> keys) {
-        }
-
-        @Override
-        public <T> T findData(Class<T> type, String processId, String resourceDefinitionId) {
+        public Stream<TransferProcess> findAll(QuerySpec querySpec) {
             return null;
         }
+
     }
 
     private static class FakeRemoteMessageDispatcherRegistry implements RemoteMessageDispatcherRegistry {

--- a/extensions/azure/cosmos/transfer-process-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStore.java
+++ b/extensions/azure/cosmos/transfer-process-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStore.java
@@ -27,6 +27,7 @@ import org.eclipse.dataspaceconnector.azure.cosmos.CosmosDbApi;
 import org.eclipse.dataspaceconnector.azure.cosmos.CosmosDocument;
 import org.eclipse.dataspaceconnector.azure.cosmos.util.LeaseContext;
 import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
@@ -38,8 +39,8 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static net.jodah.failsafe.Failsafe.with;
 
@@ -165,28 +166,8 @@ public class CosmosTransferProcessStore implements TransferProcessStore {
     }
 
     @Override
-    public void createData(String processId, String key, Object data) {
-        throw new UnsupportedOperationException("Not yet implemented");
-    }
-
-    @Override
-    public void updateData(String processId, String key, Object data) {
-        throw new UnsupportedOperationException("Not yet implemented");
-    }
-
-    @Override
-    public void deleteData(String processId, String key) {
-        throw new UnsupportedOperationException("Not yet implemented");
-    }
-
-    @Override
-    public void deleteData(String processId, Set<String> keys) {
-        throw new UnsupportedOperationException("Not yet implemented");
-    }
-
-    @Override
-    public <T> T findData(Class<T> type, String processId, String resourceDefinitionId) {
-        throw new UnsupportedOperationException("Not yet implemented");
+    public Stream<TransferProcess> findAll(QuerySpec querySpec) {
+        return null;
     }
 
     private TransferProcessDocument convertToDocument(Object databaseDocument) {

--- a/extensions/azure/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStoreIntegrationTest.java
@@ -29,6 +29,8 @@ import org.eclipse.dataspaceconnector.azure.cosmos.CosmosDbApiImpl;
 import org.eclipse.dataspaceconnector.azure.testfixtures.CosmosTestClient;
 import org.eclipse.dataspaceconnector.common.annotations.IntegrationTest;
 import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceManifest;
@@ -44,14 +46,17 @@ import org.junit.jupiter.api.Test;
 
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Scanner;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.dataspaceconnector.transfer.store.cosmos.TestHelper.createTransferProcess;
+import static org.eclipse.dataspaceconnector.transfer.store.cosmos.TestHelper.createTransferProcessDocument;
 
 @IntegrationTest
 class CosmosTransferProcessStoreIntegrationTest {
@@ -496,6 +501,85 @@ class CosmosTransferProcessStoreIntegrationTest {
                     .hasFieldOrProperty("leasedAt");
         });
 
+    }
+
+    @Test
+    void findAll_noQuerySpec() {
+        var doc1 = createTransferProcessDocument("tp1", partitionKey);
+        var doc2 = createTransferProcessDocument("tp2", partitionKey);
+
+        container.createItem(doc1);
+        container.createItem(doc2);
+
+        assertThat(store.findAll(QuerySpec.none())).hasSize(2).extracting(TransferProcess::getId).containsExactlyInAnyOrder(doc1.getId(), doc2.getId());
+    }
+
+    @Test
+    void findAll_verifyPaging() {
+
+        var all = IntStream.range(0, 10)
+                .mapToObj(i -> createTransferProcessDocument("tp" + i, partitionKey))
+                .peek(d -> container.createItem(d))
+                .map(TransferProcessDocument::getId)
+                .collect(Collectors.toList());
+
+        // page size fits
+        assertThat(store.findAll(QuerySpec.Builder.newInstance().offset(3).limit(4).build())).hasSize(4).extracting(TransferProcess::getId).isSubsetOf(all);
+
+    }
+
+    @Test
+    void findAll_verifyPaging_pageSizeLargerThanCollection() {
+
+        var all = IntStream.range(0, 10)
+                .mapToObj(i -> createTransferProcessDocument("tp" + i, partitionKey))
+                .peek(d -> container.createItem(d)).map(TransferProcessDocument::getId)
+                .collect(Collectors.toList());
+
+        // page size fits
+        assertThat(store.findAll(QuerySpec.Builder.newInstance().offset(3).limit(40).build())).hasSize(7).extracting(TransferProcess::getId).isSubsetOf(all);
+    }
+
+    @Test
+    void findAll_verifyFiltering() {
+        var documents = IntStream.range(0, 10)
+                .mapToObj(i -> createTransferProcessDocument("tp" + i, partitionKey))
+                .peek(d -> container.createItem(d))
+                .collect(Collectors.toList());
+
+        var expectedId = documents.get(3).getId();
+
+        var query = QuerySpec.Builder.newInstance().filter("id=" + expectedId).build();
+        assertThat(store.findAll(query)).extracting(TransferProcess::getId).containsOnly(expectedId);
+    }
+
+    @Test
+    void findAll_verifyFiltering_invalidFilterExpression() {
+        IntStream.range(0, 10).mapToObj(i -> createTransferProcessDocument("tp" + i, partitionKey)).forEach(d -> container.createItem(d));
+
+        var query = QuerySpec.Builder.newInstance().filter("something contains other").build();
+
+        assertThatThrownBy(() -> store.findAll(query)).isInstanceOfAny(IllegalArgumentException.class).hasMessage("Cannot build SqlParameter for operator: contains");
+    }
+
+    @Test
+    void findAll_verifyFiltering_unsuccessfulFilterExpression() {
+        IntStream.range(0, 10).mapToObj(i -> createTransferProcessDocument("tp" + i, partitionKey)).forEach(d -> container.createItem(d));
+
+        var query = QuerySpec.Builder.newInstance().filter("something = other").build();
+
+        assertThat(store.findAll(query)).isEmpty();
+    }
+
+    @Test
+    void findAll_verifySorting() {
+
+        IntStream.range(0, 10).mapToObj(i -> createTransferProcessDocument("tp" + i, partitionKey)).forEach(d -> container.createItem(d));
+
+        var ascendingQuery = QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.ASC).build();
+        assertThat(store.findAll(ascendingQuery)).hasSize(10).isSortedAccordingTo(Comparator.comparing(TransferProcess::getId));
+        var descendingQuery = QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.DESC).build();
+        assertThat(store.findAll(descendingQuery)).hasSize(10).isSortedAccordingTo((c1, c2) -> c2.getId().compareTo(c1.getId()));
     }
 
     private TransferProcessDocument convert(Object obj) {

--- a/extensions/azure/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStoreIntegrationTest.java
@@ -46,7 +46,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Scanner;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -473,15 +472,6 @@ class CosmosTransferProcessStoreIntegrationTest {
     void delete_notExist() {
         store.delete("not-exist");
         //no exception should be raised
-    }
-
-    @Test
-    void verifyAllNotImplemented() {
-        assertThatThrownBy(() -> store.createData("pid", "key", new Object())).isInstanceOf(UnsupportedOperationException.class);
-        assertThatThrownBy(() -> store.updateData("pid", "key", new Object())).isInstanceOf(UnsupportedOperationException.class);
-        assertThatThrownBy(() -> store.deleteData("pid", "key")).isInstanceOf(UnsupportedOperationException.class);
-        assertThatThrownBy(() -> store.deleteData("pid", Set.of("k1", "k2"))).isInstanceOf(UnsupportedOperationException.class);
-        assertThatThrownBy(() -> store.findData(String.class, "pid", "key")).isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test

--- a/extensions/azure/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/TestHelper.java
+++ b/extensions/azure/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/TestHelper.java
@@ -20,6 +20,7 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceManifest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
+import org.eclipse.dataspaceconnector.transfer.store.cosmos.model.TransferProcessDocument;
 
 public class TestHelper {
 
@@ -56,6 +57,10 @@ public class TestHelper {
 
     public static TransferProcess createTransferProcess(String processId) {
         return createTransferProcess(processId, TransferProcessStates.UNSAVED);
+    }
+
+    public static TransferProcessDocument createTransferProcessDocument(String id, String partitionKey) {
+        return new TransferProcessDocument(createTransferProcess(id), partitionKey);
     }
 
 }

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FccTestExtension.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FccTestExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.cache;
 
 import kotlin.NotImplementedError;
@@ -35,7 +49,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
@@ -144,23 +157,7 @@ public class FccTestExtension implements ServiceExtension {
         }
 
         @Override
-        public void createData(String processId, String key, Object data) {
-        }
-
-        @Override
-        public void updateData(String processId, String key, Object data) {
-        }
-
-        @Override
-        public void deleteData(String processId, String key) {
-        }
-
-        @Override
-        public void deleteData(String processId, Set<String> keys) {
-        }
-
-        @Override
-        public <T> T findData(Class<T> type, String processId, String resourceDefinitionId) {
+        public Stream<TransferProcess> findAll(QuerySpec querySpec) {
             return null;
         }
     }

--- a/extensions/in-memory/transfer-store-memory/src/main/java/org/eclipse/dataspaceconnector/transfer/store/memory/InMemoryTransferProcessStore.java
+++ b/extensions/in-memory/transfer-store-memory/src/main/java/org/eclipse/dataspaceconnector/transfer/store/memory/InMemoryTransferProcessStore.java
@@ -15,7 +15,9 @@
 package org.eclipse.dataspaceconnector.transfer.store.memory;
 
 import org.eclipse.dataspaceconnector.common.concurrency.LockManager;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.jetbrains.annotations.NotNull;
@@ -28,10 +30,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
+import static org.eclipse.dataspaceconnector.common.reflection.ReflectionUtil.propertyComparator;
 
 /**
  * An in-memory, threadsafe process store.
@@ -112,7 +116,29 @@ public class InMemoryTransferProcessStore implements TransferProcessStore {
 
     @Override
     public Stream<TransferProcess> findAll(QuerySpec querySpec) {
-        return null;
+        return lockManager.readLock(() -> {
+            Stream<TransferProcess> transferProcessStream = processesById.values().stream();
+            // filter
+            var andPredicate = querySpec.getFilterExpression().stream().map(this::toPredicate).reduce(x -> true, Predicate::and);
+            transferProcessStream = transferProcessStream.filter(andPredicate);
+
+            // sort
+            var sortField = querySpec.getSortField();
+
+            if (sortField != null) {
+                var comparator = propertyComparator(querySpec.getSortOrder() == SortOrder.ASC, sortField);
+                transferProcessStream = transferProcessStream.sorted(comparator);
+            }
+
+            //limit
+            transferProcessStream = transferProcessStream.skip(querySpec.getOffset()).limit(querySpec.getLimit());
+
+            return transferProcessStream;
+        });
+    }
+
+    private Predicate<TransferProcess> toPredicate(Criterion criterion) {
+        return new TransferProcessPredicateConverter().convert(criterion);
     }
 
 }

--- a/extensions/in-memory/transfer-store-memory/src/main/java/org/eclipse/dataspaceconnector/transfer/store/memory/InMemoryTransferProcessStore.java
+++ b/extensions/in-memory/transfer-store-memory/src/main/java/org/eclipse/dataspaceconnector/transfer/store/memory/InMemoryTransferProcessStore.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.transfer.store.memory;
 
 import org.eclipse.dataspaceconnector.common.concurrency.LockManager;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.jetbrains.annotations.NotNull;
@@ -26,9 +27,9 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
 
@@ -110,29 +111,8 @@ public class InMemoryTransferProcessStore implements TransferProcessStore {
     }
 
     @Override
-    public void createData(String processId, String key, Object data) {
-        throw new UnsupportedOperationException("Not yet implemented");
+    public Stream<TransferProcess> findAll(QuerySpec querySpec) {
+        return null;
     }
-
-    @Override
-    public void updateData(String processId, String key, Object data) {
-        throw new UnsupportedOperationException("Not yet implemented");
-    }
-
-    @Override
-    public void deleteData(String processId, String key) {
-        throw new UnsupportedOperationException("Not yet implemented");
-    }
-
-    @Override
-    public void deleteData(String processId, Set<String> keys) {
-        throw new UnsupportedOperationException("Not yet implemented");
-    }
-
-    @Override
-    public <T> T findData(Class<T> type, String processId, String resourceDefinitionId) {
-        throw new UnsupportedOperationException("Not yet implemented");
-    }
-
 
 }

--- a/extensions/in-memory/transfer-store-memory/src/main/java/org/eclipse/dataspaceconnector/transfer/store/memory/TransferProcessPredicateConverter.java
+++ b/extensions/in-memory/transfer-store-memory/src/main/java/org/eclipse/dataspaceconnector/transfer/store/memory/TransferProcessPredicateConverter.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.transfer.store.memory;
+
+import org.eclipse.dataspaceconnector.spi.query.BaseCriterionToPredicateConverter;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+
+import java.util.function.Predicate;
+
+import static org.eclipse.dataspaceconnector.common.reflection.ReflectionUtil.getFieldValueSilent;
+
+/**
+ * Converts a {@link Criterion} into a {@link Predicate} for use with an {@link InMemoryTransferProcessStore}.
+ * Currently, only the "=" and "in" operators are supported (cf. {@link Criterion#getOperator()} and {@link BaseCriterionToPredicateConverter}).
+ */
+class TransferProcessPredicateConverter extends BaseCriterionToPredicateConverter<TransferProcess> {
+    @Override
+    protected <R> R property(String key, Object object) {
+        return getFieldValueSilent(key, object);
+    }
+}

--- a/extensions/in-memory/transfer-store-memory/src/test/java/org/eclipse/dataspaceconnector/transfer/store/memory/TestFunctions.java
+++ b/extensions/in-memory/transfer-store-memory/src/test/java/org/eclipse/dataspaceconnector/transfer/store/memory/TestFunctions.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.transfer.store.memory;
+
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedResourceSet;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
+
+class TestFunctions {
+
+    public static TransferProcess createProcess(String name) {
+        DataRequest mock = DataRequest.Builder.newInstance().destinationType("type").build();
+        return TransferProcess.Builder.newInstance()
+                .type(TransferProcess.Type.CONSUMER)
+                .id(name)
+                .stateTimestamp(0)
+                .state(TransferProcessStates.UNSAVED.code())
+                .provisionedResourceSet(new ProvisionedResourceSet())
+                .dataRequest(mock)
+                .build();
+    }
+}

--- a/extensions/in-memory/transfer-store-memory/src/test/java/org/eclipse/dataspaceconnector/transfer/store/memory/TransferProcessPredicateConverterTest.java
+++ b/extensions/in-memory/transfer-store-memory/src/test/java/org/eclipse/dataspaceconnector/transfer/store/memory/TransferProcessPredicateConverterTest.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.transfer.store.memory;
+
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.dataspaceconnector.transfer.store.memory.TestFunctions.createProcess;
+
+class TransferProcessPredicateConverterTest {
+    private TransferProcessPredicateConverter converter;
+
+    @BeforeEach
+    void setUp() {
+        converter = new TransferProcessPredicateConverter();
+    }
+
+    @Test
+    void convert_nameEquals() {
+        var criterion = new Criterion("id", "=", "test-cn");
+        var n = createProcess("test-cn");
+        var predicate = converter.convert(criterion);
+
+        assertThat(predicate).isNotNull();
+        assertThat(predicate.test(n)).isTrue();
+    }
+
+    @Test
+    void convert_operatorIn() {
+        var n = createProcess("test-cn");
+        var criterion = new Criterion("id", "in", "(bob, test-cn)");
+        var pred = converter.convert(criterion);
+        assertThat(pred).isNotNull().accepts(n);
+
+    }
+
+    @Test
+    void convert_invalidOperator() {
+        var criterion = new Criterion("name", "GREATER_THAN", "(bob, alice)");
+        assertThatThrownBy(() -> converter.convert(criterion)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Operator [GREATER_THAN] is not supported by this converter!");
+
+    }
+}

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/store/TransferProcessStore.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/store/TransferProcessStore.java
@@ -14,13 +14,14 @@
 
 package org.eclipse.dataspaceconnector.spi.transfer.store;
 
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.system.Feature;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
-import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * Manages persistent storage of {@link TransferProcess} state.
@@ -52,7 +53,7 @@ public interface TransferProcessStore {
      * Some database frameworks such as Spring have automatic lastChanged columns.
      *
      * @param state The state that the processes of interest should be in.
-     * @param max The maximum amount of result items.
+     * @param max   The maximum amount of result items.
      * @return A list of TransferProcesses (at most _max_) that are in the desired state.
      */
     @NotNull
@@ -73,14 +74,11 @@ public interface TransferProcessStore {
      */
     void delete(String processId);
 
-    void createData(String processId, String key, Object data);
-
-    void updateData(String processId, String key, Object data);
-
-    void deleteData(String processId, String key);
-
-    void deleteData(String processId, Set<String> keys);
-
-    <T> T findData(Class<T> type, String processId, String resourceDefinitionId);
-
+    /**
+     * Returns all the transfer processes in the store that are covered by a given {@link QuerySpec}.
+     * <p>
+     * Note: supplying a sort field that does not exist on the {@link TransferProcess} may cause some implementations
+     * to return an empty Stream, others will return an unsorted Stream, depending on the backing storage implementation.
+     */
+    Stream<TransferProcess> findAll(QuerySpec querySpec);
 }


### PR DESCRIPTION
## What this PR changes/adds

1. Adds a `findAll(QuerySpec spec)` method, which returns all TPs covered by a specific query
2. Removes a couple of methods, that were not implemented anywhere. 

## Why it does that

ad 1. This is necessary because the Data Management API allows for querying TPs. This impl apparently slipped through the cracks in Milestone 2.
ad 2. The methods that were removed always threw an `UnsupportedOperationException`. Better not to have dead code.


## Further notes
n/a

## Linked Issue(s)

Closes #859 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (skip with label `no-changelog`)
- [x] linked GitHub project? (see the section on the right-hand side -->)
