### PR TITLE
ci: add action to auto assign issues and pull requests to project

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,13 +17,10 @@ Closes # <-- _insert Issue number if one exists_
 
 ## Checklist
 
-- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request)
-      and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) 
-      for details_)
 - [ ] added appropriate tests?
 - [ ] performed checkstyle check locally?
 - [ ] added/updated copyright headers?
 - [ ] documented public classes/methods?
 - [ ] added/updated relevant documentation?
 - [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
-- [ ] linked GitHub project? (_see the section on the right-hand side -->_)
+- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)

--- a/.github/workflows/issue-auto-assign-project.yaml
+++ b/.github/workflows/issue-auto-assign-project.yaml
@@ -1,0 +1,17 @@
+name: New Issue
+
+on:
+  issues:
+    types: [ opened ]
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  assign-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign to basic project
+        uses: Senzing/github-action-add-issue-to-project@1.0.0
+        with:
+          project: 'https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/projects/1'
+          column_name: 'Backlog'

--- a/.github/workflows/pull-request-auto-assign-project.yaml
+++ b/.github/workflows/pull-request-auto-assign-project.yaml
@@ -1,0 +1,17 @@
+name: New Pull Request
+
+on:
+  pull_request:
+    types: [ opened ]
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  assign-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign to basic project
+        uses: Senzing/github-action-add-issue-to-project@1.0.0
+        with:
+          project: 'https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/projects/1'
+          column_name: 'In progress'


### PR DESCRIPTION
## What this PR changes/adds

Adds an action to auto assign issues and pull requests to the basic project. Fixes formatting of checklist in pr template (see below).

## Why it does that

Avoids having to do this manually as long as there is only one GitHub project.

## Checklist

- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request)
      and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) 
      for details_)
- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] linked GitHub project? (_see the section on the right-hand side -->_)
