### PR TITLE
core: apply 2-state transition pattern to ContractNegotiationManagers

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -29,7 +29,7 @@ jobs:
           INTEGRATION_TEST: false
           JACOCO: true
         # checkstyle would also run as part of the `check` task
-        run: ./gradlew clean check jacocoTestReport -x checkstyleMain -x checkstyleTest
+        run: ./gradlew clean check jacocoTestReport -x checkstyleMain -x checkstyleTest -quiet
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ the detailed section referring to by linking pull requests or issues.
 * Unit test framework for Dependency Injection (#843)
 * Implemented S3BucketReader (#675)
 * Add a deleteById method to the AssetLoader interface (#880)
+* Apply 2-state transition pattern to `ContractNegotiationManager`s (#870)
 
 #### Changed
 

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *       Fraunhofer Institute for Software and Systems Engineering - extended method implementation
  *       Daimler TSS GmbH - fixed contract dates to epoch seconds
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 package org.eclipse.dataspaceconnector.contract.negotiation;
@@ -432,8 +433,6 @@ public class ProviderContractNegotiationManagerImpl implements ProviderContractN
                 .build();
 
         //TODO protocol-independent response type?
-        negotiation.transitionConfirmingSent();
-        negotiationStore.save(negotiation);
         dispatcherRegistry.send(Object.class, request, () -> null)
                 .whenComplete(onAgreementSent(negotiation.getId(), agreement));
         return true;

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021 Fraunhofer Institute for Software and Systems Engineering
+ *  Copyright (c) 2021-2022 Fraunhofer Institute for Software and Systems Engineering
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -9,11 +9,13 @@
  *
  *  Contributors:
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 package org.eclipse.dataspaceconnector.contract.negotiation;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.command.CommandQueue;
 import org.eclipse.dataspaceconnector.spi.command.CommandRunner;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.observe.ContractNegotiationObservable;
@@ -24,31 +26,47 @@ import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractOfferRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.command.ContractNegotiationCommand;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
+import static java.util.Collections.emptyList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONFIRMED;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONSUMER_APPROVED;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONSUMER_APPROVING;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONSUMER_OFFERED;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONSUMER_OFFERING;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.DECLINED;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.DECLINING;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.INITIAL;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.REQUESTED;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.REQUESTING;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -61,14 +79,11 @@ class ConsumerContractNegotiationManagerImplTest {
 
     @BeforeEach
     void setUp() {
-        CommandQueue<ContractNegotiationCommand> queue = mock(CommandQueue.class);
-        when(queue.dequeue(anyInt())).thenReturn(new ArrayList<>());
-
         negotiationManager = ConsumerContractNegotiationManagerImpl.Builder.newInstance()
                 .validationService(validationService)
                 .dispatcherRegistry(dispatcherRegistry)
                 .monitor(mock(Monitor.class))
-                .commandQueue(queue)
+                .commandQueue(mock(CommandQueue.class))
                 .commandRunner(mock(CommandRunner.class))
                 .observable(mock(ContractNegotiationObservable.class))
                 .store(store)
@@ -76,7 +91,7 @@ class ConsumerContractNegotiationManagerImplTest {
     }
 
     @Test
-    void initiate_should_save_a_new_negotiation_in_initial_state() {
+    void initiateShouldSaveNewNegotiationInInitialState() {
         var contractOffer = contractOffer();
 
         ContractOfferRequest request = ContractOfferRequest.Builder.newInstance()
@@ -208,40 +223,184 @@ class ConsumerContractNegotiationManagerImplTest {
         verify(store).save(argThat(negotiation -> negotiation.getState() == DECLINED.code()));
     }
 
+    @Test
+    void initial_shouldTransitionRequesting() throws InterruptedException {
+        var negotiation = contractNegotiationBuilder().state(INITIAL.code()).build();
+        when(store.nextForState(eq(INITIAL.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
+        var latch = countDownOnUpdateLatch();
+
+        negotiationManager.start();
+
+        assertThat(latch.await(5, SECONDS)).isTrue();
+        verify(store).save(argThat(p -> p.getState() == REQUESTING.code()));
+    }
+
+    @Test
+    void requesting_shouldSendOfferAndTransitionRequested() throws InterruptedException {
+        var negotiation = contractNegotiationBuilder().state(REQUESTING.code()).contractOffer(contractOffer()).build();
+        when(store.nextForState(eq(REQUESTING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
+        when(dispatcherRegistry.send(any(), any(), any())).thenReturn(completedFuture(null));
+        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        var latch = countDownOnUpdateLatch();
+
+        negotiationManager.start();
+
+        assertThat(latch.await(5, SECONDS)).isTrue();
+        verify(store).save(argThat(p -> p.getState() == REQUESTED.code()));
+        verify(dispatcherRegistry, only()).send(any(), any(), any());
+    }
+
+    @Test
+    void requesting_shouldTransitionInitialIfSendFails() throws InterruptedException {
+        var negotiation = contractNegotiationBuilder().state(REQUESTING.code()).contractOffer(contractOffer()).build();
+        when(store.nextForState(eq(REQUESTING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
+        when(dispatcherRegistry.send(any(), any(), any())).thenReturn(failedFuture(new EdcException("error")));
+        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        var latch = countDownOnUpdateLatch();
+
+        negotiationManager.start();
+
+        assertThat(latch.await(5, SECONDS)).isTrue();
+        verify(store).save(argThat(p -> p.getState() == INITIAL.code()));
+        verify(dispatcherRegistry, only()).send(any(), any(), any());
+    }
+
+    @Test
+    void consumerOffering_shouldSendOfferAndTransitionOffered() throws InterruptedException {
+        var negotiation = contractNegotiationBuilder().state(CONSUMER_OFFERING.code()).contractOffer(contractOffer()).build();
+        when(store.nextForState(eq(CONSUMER_OFFERING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
+        when(dispatcherRegistry.send(any(), any(), any())).thenReturn(completedFuture(null));
+        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        var latch = countDownOnUpdateLatch();
+
+        negotiationManager.start();
+
+        assertThat(latch.await(5, SECONDS)).isTrue();
+        verify(store).save(argThat(p -> p.getState() == CONSUMER_OFFERED.code()));
+        verify(dispatcherRegistry, only()).send(any(), any(), any());
+    }
+
+    @Test
+    void consumerOffering_shouldTransitionOfferingIfSendFails() throws InterruptedException {
+        var negotiation = contractNegotiationBuilder().state(CONSUMER_OFFERING.code()).contractOffer(contractOffer()).build();
+        when(store.nextForState(eq(CONSUMER_OFFERING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
+        when(dispatcherRegistry.send(any(), any(), any())).thenReturn(failedFuture(new EdcException("error")));
+        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        var latch = countDownOnUpdateLatch();
+
+        negotiationManager.start();
+
+        assertThat(latch.await(5, SECONDS)).isTrue();
+        verify(store).save(argThat(p -> p.getState() == CONSUMER_OFFERING.code()));
+        verify(dispatcherRegistry, only()).send(any(), any(), any());
+    }
+
+    @Test
+    void consumerApproving_shouldSendAgreementAndTransitionApproved() throws InterruptedException {
+        var negotiation = contractNegotiationBuilder().state(CONSUMER_APPROVING.code()).contractOffer(contractOffer()).build();
+        when(store.nextForState(eq(CONSUMER_APPROVING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
+        when(dispatcherRegistry.send(any(), any(), any())).thenReturn(completedFuture(null));
+        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        var latch = countDownOnUpdateLatch();
+
+        negotiationManager.start();
+
+        assertThat(latch.await(5, SECONDS)).isTrue();
+        verify(store).save(argThat(p -> p.getState() == CONSUMER_APPROVED.code()));
+        verify(dispatcherRegistry, only()).send(any(), any(), any());
+    }
+
+    @Test
+    void consumerApproving_shouldTransitionApprovingIfSendFails() throws InterruptedException {
+        var negotiation = contractNegotiationBuilder().state(CONSUMER_APPROVING.code()).contractOffer(contractOffer()).build();
+        when(store.nextForState(eq(CONSUMER_APPROVING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
+        when(dispatcherRegistry.send(any(), any(), any())).thenReturn(failedFuture(new EdcException("error")));
+        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        var latch = countDownOnUpdateLatch();
+
+        negotiationManager.start();
+
+        assertThat(latch.await(5, SECONDS)).isTrue();
+        verify(store).save(argThat(p -> p.getState() == CONSUMER_APPROVING.code()));
+        verify(dispatcherRegistry, only()).send(any(), any(), any());
+    }
+
+    @Test
+    void declining_shouldSendRejectionAndTransitionDeclined() throws InterruptedException {
+        var negotiation = contractNegotiationBuilder().state(DECLINING.code()).contractOffer(contractOffer()).build();
+        negotiation.setErrorDetail("an error");
+        when(store.nextForState(eq(DECLINING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
+        when(dispatcherRegistry.send(any(), any(), any())).thenReturn(completedFuture(null));
+        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        var latch = countDownOnUpdateLatch();
+
+        negotiationManager.start();
+
+        assertThat(latch.await(5, SECONDS)).isTrue();
+        verify(store).save(argThat(p -> p.getState() == DECLINED.code()));
+        verify(dispatcherRegistry, only()).send(any(), any(), any());
+    }
+
+    @Test
+    void declining_shouldTransitionDecliningIfSendFails() throws InterruptedException {
+        var negotiation = contractNegotiationBuilder().state(DECLINING.code()).contractOffer(contractOffer()).build();
+        negotiation.setErrorDetail("an error");
+        when(store.nextForState(eq(DECLINING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
+        when(dispatcherRegistry.send(any(), any(), any())).thenReturn(failedFuture(new EdcException("error")));
+        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        var latch = countDownOnUpdateLatch();
+
+        negotiationManager.start();
+
+        assertThat(latch.await(5, SECONDS)).isTrue();
+        verify(store).save(argThat(p -> p.getState() == DECLINING.code()));
+        verify(dispatcherRegistry, only()).send(any(), any(), any());
+    }
+
+    private CountDownLatch countDownOnUpdateLatch() {
+        var latch = new CountDownLatch(1);
+
+        doAnswer(i -> {
+            latch.countDown();
+            return null;
+        }).when(store).save(any());
+
+        return latch;
+    }
+
     private ContractNegotiation createContractNegotiationRequested() {
         var lastOffer = contractOffer();
 
-        var negotiation = ContractNegotiation.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
-                .correlationId("correlationId")
-                .counterPartyId("connectorId")
-                .counterPartyAddress("connectorAddress")
-                .protocol("protocol")
+        return contractNegotiationBuilder()
                 .state(REQUESTED.code())
-                .stateTimestamp(Instant.now().toEpochMilli())
+                .contractOffer(lastOffer)
                 .build();
-        negotiation.addContractOffer(lastOffer);
-        return negotiation;
     }
 
     private ContractNegotiation createContractNegotiationConsumerOffered() {
         var lastOffer = contractOffer();
 
-        var negotiation = ContractNegotiation.Builder.newInstance()
+        return contractNegotiationBuilder()
+                .state(CONSUMER_OFFERED.code())
+                .contractOffer(lastOffer)
+                .build();
+    }
+
+    private ContractNegotiation.Builder contractNegotiationBuilder() {
+        return ContractNegotiation.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .correlationId("correlationId")
                 .counterPartyId("connectorId")
                 .counterPartyAddress("connectorAddress")
                 .protocol("protocol")
-                .state(CONSUMER_OFFERED.code())
-                .stateTimestamp(Instant.now().toEpochMilli())
-                .build();
-        negotiation.addContractOffer(lastOffer);
-        return negotiation;
+                .stateTimestamp(Instant.now().toEpochMilli());
     }
 
     private ContractOffer contractOffer() {
-        return ContractOffer.Builder.newInstance().id("id").policy(Policy.Builder.newInstance().build()).build();
+        return ContractOffer.Builder.newInstance().id("id:id")
+                .policy(Policy.Builder.newInstance().build())
+                .asset(Asset.Builder.newInstance().id("assetId").build())
+                .build();
     }
 
 }

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021 Fraunhofer Institute for Software and Systems Engineering
+ *  Copyright (c) 2021-2022 Fraunhofer Institute for Software and Systems Engineering
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -9,11 +9,13 @@
  *
  *  Contributors:
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 package org.eclipse.dataspaceconnector.contract.negotiation;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.command.CommandQueue;
 import org.eclipse.dataspaceconnector.spi.command.CommandRunner;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.observe.ContractNegotiationObservable;
@@ -24,82 +26,68 @@ import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractOfferRequest;
-import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.command.ContractNegotiationCommand;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 
+import static java.util.Collections.emptyList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONFIRMED;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONFIRMING;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONSUMER_APPROVED;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONSUMER_APPROVING;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.DECLINED;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.DECLINING;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.INITIAL;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.PROVIDER_OFFERED;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.PROVIDER_OFFERING;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.REQUESTED;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.REQUESTING;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ProviderContractNegotiationManagerImplTest {
 
-    private ContractValidationService validationService;
+    private final ContractNegotiationStore store = mock(ContractNegotiationStore.class);
+    private final ContractValidationService validationService = mock(ContractValidationService.class);
+    private final RemoteMessageDispatcherRegistry dispatcherRegistry = mock(RemoteMessageDispatcherRegistry.class);
     private ProviderContractNegotiationManagerImpl negotiationManager;
-
-    private final Map<String, ContractNegotiation> negotiations = new HashMap<>();
 
     private final String correlationId = "correlationId";
 
     @BeforeEach
     void setUp() {
-        negotiations.clear();
-
-        // Mock contract negotiation store -> persist negotiations in map
-        var negotiationStore = mock(ContractNegotiationStore.class);
-
-        doAnswer(invocation -> {
-            var negotiation = invocation.getArgument(0, ContractNegotiation.class);
-            negotiations.put(negotiation.getId(), negotiation);
-            return null;
-        }).when(negotiationStore).save(any(ContractNegotiation.class));
-        when(negotiationStore.find(anyString())).thenAnswer(invocation -> {
-            var id = invocation.getArgument(0, String.class);
-            return negotiations.get(id);
-        });
-        when(negotiationStore.findForCorrelationId(anyString())).thenAnswer(invocation -> {
-            var id = invocation.getArgument(0, String.class);
-            for (Map.Entry<String, ContractNegotiation> entry : negotiations.entrySet()) {
-                if (entry.getValue().getCorrelationId().equals(id)) {
-                    return entry.getValue();
-                }
-            }
-            return null;
-        });
-
-        // Create contract validation service mock, method mocking has to be done in test methods
-        validationService = mock(ContractValidationService.class);
-
-        // Create CommandQueue mock
-        CommandQueue<ContractNegotiationCommand> queue = mock(CommandQueue.class);
-        when(queue.dequeue(anyInt())).thenReturn(new ArrayList<>());
-
         negotiationManager = ProviderContractNegotiationManagerImpl.Builder.newInstance()
                 .validationService(validationService)
-                .dispatcherRegistry(mock(RemoteMessageDispatcherRegistry.class))
+                .dispatcherRegistry(dispatcherRegistry)
                 .monitor(mock(Monitor.class))
-                .commandQueue(queue)
+                .commandQueue(mock(CommandQueue.class))
                 .commandRunner(mock(CommandRunner.class))
                 .observable(mock(ContractNegotiationObservable.class))
-                .store(negotiationStore)
+                .store(store)
                 .build();
     }
 
@@ -120,15 +108,15 @@ class ProviderContractNegotiationManagerImplTest {
         var result = negotiationManager.requested(token, request);
 
         assertThat(result.succeeded()).isTrue();
-        assertThat(negotiations).hasSize(1);
-        var negotiation = negotiations.values().iterator().next();
-        assertThat(negotiation.getState()).isEqualTo(ContractNegotiationStates.CONFIRMING.code());
-        assertThat(negotiation.getCounterPartyId()).isEqualTo(request.getConnectorId());
-        assertThat(negotiation.getCounterPartyAddress()).isEqualTo(request.getConnectorAddress());
-        assertThat(negotiation.getProtocol()).isEqualTo(request.getProtocol());
-        assertThat(negotiation.getCorrelationId()).isEqualTo(request.getCorrelationId());
-        assertThat(negotiation.getContractOffers()).hasSize(1);
-        assertThat(negotiation.getLastContractOffer()).isEqualTo(contractOffer);
+        verify(store, atLeastOnce()).save(argThat(n ->
+                n.getState() == ContractNegotiationStates.CONFIRMING.code() &&
+                n.getCounterPartyId().equals(request.getConnectorId()) &&
+                n.getCounterPartyAddress().equals(request.getConnectorAddress()) &&
+                n.getProtocol().equals(request.getProtocol()) &&
+                n.getCorrelationId().equals(request.getCorrelationId()) &&
+                n.getContractOffers().size() == 1 &&
+                n.getLastContractOffer().equals(contractOffer)
+        ));
         verify(validationService).validate(token, contractOffer);
     }
 
@@ -149,15 +137,15 @@ class ProviderContractNegotiationManagerImplTest {
         var result = negotiationManager.requested(token, request);
 
         assertThat(result.succeeded()).isTrue();
-        assertThat(negotiations).hasSize(1);
-        var negotiation = negotiations.values().iterator().next();
-        assertThat(negotiation.getState()).isEqualTo(ContractNegotiationStates.DECLINING.code());
-        assertThat(negotiation.getCounterPartyId()).isEqualTo(request.getConnectorId());
-        assertThat(negotiation.getCounterPartyAddress()).isEqualTo(request.getConnectorAddress());
-        assertThat(negotiation.getProtocol()).isEqualTo(request.getProtocol());
-        assertThat(negotiation.getCorrelationId()).isEqualTo(request.getCorrelationId());
-        assertThat(negotiation.getContractOffers()).hasSize(1);
-        assertThat(negotiation.getLastContractOffer()).isEqualTo(contractOffer);
+        verify(store, atLeastOnce()).save(argThat(n ->
+                n.getState() == ContractNegotiationStates.DECLINING.code() &&
+                n.getCounterPartyId().equals(request.getConnectorId()) &&
+                n.getCounterPartyAddress().equals(request.getConnectorAddress()) &&
+                n.getProtocol().equals(request.getProtocol()) &&
+                n.getCorrelationId().equals(request.getCorrelationId()) &&
+                n.getContractOffers().size() == 1 &&
+                n.getLastContractOffer().equals(contractOffer)
+        ));
         verify(validationService).validate(token, contractOffer);
     }
 
@@ -167,7 +155,7 @@ class ProviderContractNegotiationManagerImplTest {
         var token = ClaimToken.Builder.newInstance().build();
         var contractOffer = contractOffer();
         var counterOffer = contractOffer();
-        when(validationService.validate(token, contractOffer)).thenReturn(Result.success(null));
+        when(validationService.validate(token, contractOffer)).thenAnswer(i -> Result.success(i.getArgument(1)));
 
         ContractOfferRequest request = ContractOfferRequest.Builder.newInstance()
                 .connectorId("connectorId")
@@ -180,16 +168,16 @@ class ProviderContractNegotiationManagerImplTest {
         var result = negotiationManager.requested(token, request);
 
         assertThat(result.succeeded()).isTrue();
-        assertThat(negotiations).hasSize(1);
-        var negotiation = negotiations.values().iterator().next();
-        assertThat(negotiation.getState()).isEqualTo(ContractNegotiationStates.PROVIDER_OFFERING.code());
-        assertThat(negotiation.getCounterPartyId()).isEqualTo(request.getConnectorId());
-        assertThat(negotiation.getCounterPartyAddress()).isEqualTo(request.getConnectorAddress());
-        assertThat(negotiation.getProtocol()).isEqualTo(request.getProtocol());
-        assertThat(negotiation.getCorrelationId()).isEqualTo(request.getCorrelationId());
-        assertThat(negotiation.getContractOffers()).hasSize(2);
-        assertThat(negotiation.getContractOffers().get(0)).isEqualTo(contractOffer);
-        assertThat(negotiation.getContractOffers().get(1)).isEqualTo(counterOffer);
+        verify(store).save(argThat(n ->
+                n.getState() == PROVIDER_OFFERING.code() &&
+                n.getCounterPartyId().equals(request.getConnectorId()) &&
+                n.getCounterPartyAddress().equals(request.getConnectorAddress()) &&
+                n.getProtocol().equals(request.getProtocol()) &&
+                n.getCorrelationId().equals(request.getCorrelationId()) &&
+                n.getContractOffers().size() == 2 &&
+                n.getContractOffers().get(0).equals(contractOffer) &&
+                n.getContractOffers().get(1).equals(counterOffer)
+        ));
         verify(validationService).validate(token, contractOffer);
     }
 
@@ -204,29 +192,31 @@ class ProviderContractNegotiationManagerImplTest {
 
     @Test
     void testOfferReceivedConfirmOffer() {
-        var negotiationId = createContractNegotiationProviderOffered();
-
+        var negotiation = createContractNegotiation();
+        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        when(store.findForCorrelationId(correlationId)).thenReturn(negotiation);
         var token = ClaimToken.Builder.newInstance().build();
         var contractOffer = contractOffer();
 
         when(validationService.validate(eq(token), eq(contractOffer), any(ContractOffer.class)))
-                .thenReturn(Result.success(contractOffer));
+                .thenAnswer(i -> Result.success(i.getArgument(2)));
 
         var result = negotiationManager.offerReceived(token, correlationId, contractOffer, "hash");
 
         assertThat(result.succeeded()).isTrue();
-        assertThat(negotiations).hasSize(1);
-        var negotiation = negotiations.values().iterator().next();
-        assertThat(negotiation.getState()).isEqualTo(ContractNegotiationStates.CONFIRMING.code());
-        assertThat(negotiation.getContractOffers()).hasSize(2);
-        assertThat(negotiation.getContractOffers().get(1)).isEqualTo(contractOffer);
+        verify(store, atLeastOnce()).save(argThat(n ->
+                n.getState() == ContractNegotiationStates.CONFIRMING.code() &&
+                n.getContractOffers().size() == 2 &&
+                n.getContractOffers().get(1).equals(contractOffer)
+        ));
         verify(validationService).validate(eq(token), eq(contractOffer), any(ContractOffer.class));
     }
 
     @Test
     void testOfferReceivedDeclineOffer() {
-        var negotiationId = createContractNegotiationProviderOffered();
-
+        var negotiation = createContractNegotiation();
+        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        when(store.findForCorrelationId(correlationId)).thenReturn(negotiation);
         var token = ClaimToken.Builder.newInstance().build();
         var contractOffer = contractOffer();
         when(validationService.validate(eq(token), eq(contractOffer), any(ContractOffer.class)))
@@ -235,34 +225,34 @@ class ProviderContractNegotiationManagerImplTest {
         var result = negotiationManager.offerReceived(token, correlationId, contractOffer, "hash");
 
         assertThat(result.succeeded()).isTrue();
-        assertThat(negotiations).hasSize(1);
-        var negotiation = negotiations.values().iterator().next();
-        assertThat(negotiation.getState()).isEqualTo(ContractNegotiationStates.DECLINING.code());
-        assertThat(negotiation.getContractOffers()).hasSize(2);
-        assertThat(negotiation.getContractOffers().get(1)).isEqualTo(contractOffer);
+        verify(store, atLeastOnce()).save(argThat(n ->
+                n.getState() == ContractNegotiationStates.DECLINING.code() &&
+                n.getContractOffers().size() == 2 &&
+                n.getContractOffers().get(1).equals(contractOffer)
+        ));
         verify(validationService).validate(eq(token), eq(contractOffer), any(ContractOffer.class));
     }
 
     @Test
     @Disabled
     void testOfferReceivedCounterOffer() {
-        var negotiationId = createContractNegotiationProviderOffered();
-
+        var negotiation = createContractNegotiation();
+        when(store.find(negotiation.getId())).thenReturn(negotiation);
         var token = ClaimToken.Builder.newInstance().build();
         var contractOffer = contractOffer();
         var counterOffer = contractOffer();
         when(validationService.validate(eq(token), eq(contractOffer), any(ContractOffer.class)))
-                .thenReturn(Result.success(null));
+                .thenReturn(Result.success(contractOffer));
 
         var result = negotiationManager.offerReceived(token, correlationId, contractOffer, "hash");
 
         assertThat(result.succeeded()).isTrue();
-        assertThat(negotiations).hasSize(1);
-        var negotiation = negotiations.values().iterator().next();
-        assertThat(negotiation.getState()).isEqualTo(ContractNegotiationStates.PROVIDER_OFFERING.code());
-        assertThat(negotiation.getContractOffers()).hasSize(3);
-        assertThat(negotiation.getContractOffers().get(1)).isEqualTo(contractOffer);
-        assertThat(negotiation.getContractOffers().get(2)).isEqualTo(counterOffer);
+        verify(store).save(argThat(n ->
+                n.getState() == PROVIDER_OFFERING.code() &&
+                n.getContractOffers().size() == 3 &&
+                n.getContractOffers().get(1).equals(contractOffer) &&
+                n.getContractOffers().get(2).equals(counterOffer)
+        ));
         verify(validationService).validate(eq(token), eq(contractOffer), any(ContractOffer.class));
     }
 
@@ -278,54 +268,164 @@ class ProviderContractNegotiationManagerImplTest {
 
     @Test
     void testConsumerApprovedConfirmAgreement() {
-        var negotiationId = createContractNegotiationProviderOffered();
-
+        var negotiation = createContractNegotiation();
+        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        when(store.findForCorrelationId(correlationId)).thenReturn(negotiation);
         var token = ClaimToken.Builder.newInstance().build();
         var contractAgreement = (ContractAgreement) mock(ContractAgreement.class);
 
         var result = negotiationManager.consumerApproved(token, correlationId, contractAgreement, "hash");
 
         assertThat(result.succeeded()).isTrue();
-        assertThat(negotiations).hasSize(1);
-        var negotiation = negotiations.values().iterator().next();
-        assertThat(negotiation.getState()).isEqualTo(ContractNegotiationStates.CONFIRMING.code());
-        assertThat(negotiation.getContractAgreement()).isNull();
+        verify(store, atLeastOnce()).save(argThat(n ->
+                n.getState() == ContractNegotiationStates.CONFIRMING.code() &&
+                n.getContractAgreement() == null
+        ));
     }
 
     @Test
     void testDeclined() {
-        var negotiationId = createContractNegotiationProviderOffered();
+        var negotiation = createContractNegotiation();
+        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        when(store.findForCorrelationId(correlationId)).thenReturn(negotiation);
         var token = ClaimToken.Builder.newInstance().build();
 
         var result = negotiationManager.declined(token, correlationId);
 
         assertThat(result.succeeded()).isTrue();
-        assertThat(negotiations).hasSize(1);
-        var negotiation = negotiations.values().iterator().next();
-        assertThat(negotiation.getState()).isEqualTo(ContractNegotiationStates.DECLINED.code());
+        verify(store, atLeastOnce()).save(argThat(n ->
+                n.getState() == ContractNegotiationStates.DECLINED.code()
+        ));
     }
 
-    private String createContractNegotiationProviderOffered() {
-        var lastOffer = contractOffer();
+    @Test
+    void providerOffering_shouldSendOfferAndTransitionOffered() throws InterruptedException {
+        var negotiation = contractNegotiationBuilder().state(PROVIDER_OFFERING.code()).contractOffer(contractOffer()).build();
+        when(store.nextForState(eq(PROVIDER_OFFERING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
+        when(dispatcherRegistry.send(any(), any(), any())).thenReturn(completedFuture(null));
+        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        var latch = countDownOnUpdateLatch();
 
-        var negotiation = ContractNegotiation.Builder.newInstance()
+        negotiationManager.start();
+
+        assertThat(latch.await(5, SECONDS)).isTrue();
+        verify(store).save(argThat(p -> p.getState() == PROVIDER_OFFERED.code()));
+        verify(dispatcherRegistry, only()).send(any(), any(), any());
+    }
+
+    @Test
+    void providerOffering_shouldTransitionOfferingIfSendFails() throws InterruptedException {
+        var negotiation = contractNegotiationBuilder().state(PROVIDER_OFFERING.code()).contractOffer(contractOffer()).build();
+        when(store.nextForState(eq(PROVIDER_OFFERING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
+        when(dispatcherRegistry.send(any(), any(), any())).thenReturn(failedFuture(new EdcException("error")));
+        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        var latch = countDownOnUpdateLatch();
+
+        negotiationManager.start();
+
+        assertThat(latch.await(5, SECONDS)).isTrue();
+        verify(store).save(argThat(p -> p.getState() == PROVIDER_OFFERING.code()));
+        verify(dispatcherRegistry, only()).send(any(), any(), any());
+    }
+
+    @Test
+    void declining_shouldSendRejectionAndTransitionDeclined() throws InterruptedException {
+        var negotiation = contractNegotiationBuilder().state(DECLINING.code()).contractOffer(contractOffer()).build();
+        negotiation.setErrorDetail("an error");
+        when(store.nextForState(eq(DECLINING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
+        when(dispatcherRegistry.send(any(), any(), any())).thenReturn(completedFuture(null));
+        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        var latch = countDownOnUpdateLatch();
+
+        negotiationManager.start();
+
+        assertThat(latch.await(5, SECONDS)).isTrue();
+        verify(store).save(argThat(p -> p.getState() == DECLINED.code()));
+        verify(dispatcherRegistry, only()).send(any(), any(), any());
+    }
+
+    @Test
+    void declining_shouldTransitionDecliningIfSendFails() throws InterruptedException {
+        var negotiation = contractNegotiationBuilder().state(DECLINING.code()).contractOffer(contractOffer()).build();
+        negotiation.setErrorDetail("an error");
+        when(store.nextForState(eq(DECLINING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
+        when(dispatcherRegistry.send(any(), any(), any())).thenReturn(failedFuture(new EdcException("error")));
+        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        var latch = countDownOnUpdateLatch();
+
+        negotiationManager.start();
+
+        assertThat(latch.await(5, SECONDS)).isTrue();
+        verify(store).save(argThat(p -> p.getState() == DECLINING.code()));
+        verify(dispatcherRegistry, only()).send(any(), any(), any());
+    }
+
+    @Test
+    void confirming_shouldSendAgreementAndTransitionConfirmed() throws InterruptedException {
+        var negotiation = contractNegotiationBuilder().state(CONFIRMING.code()).contractOffer(contractOffer()).build();
+        when(store.nextForState(eq(CONFIRMING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
+        when(dispatcherRegistry.send(any(), any(), any())).thenReturn(completedFuture(null));
+        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        var latch = countDownOnUpdateLatch();
+
+        negotiationManager.start();
+
+        assertThat(latch.await(5, SECONDS)).isTrue();
+        verify(store).save(argThat(p -> p.getState() == CONFIRMED.code()));
+        verify(dispatcherRegistry, only()).send(any(), any(), any());
+    }
+
+    @Test
+    void confirming_shouldTransitionConfirmingIfSendFails() throws InterruptedException {
+        var negotiation = contractNegotiationBuilder().state(CONFIRMING.code()).contractOffer(contractOffer()).build();
+        when(store.nextForState(eq(CONFIRMING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
+        when(dispatcherRegistry.send(any(), any(), any())).thenReturn(failedFuture(new EdcException("error")));
+        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        var latch = countDownOnUpdateLatch();
+
+        negotiationManager.start();
+
+        assertThat(latch.await(5, SECONDS)).isTrue();
+        verify(store).save(argThat(p -> p.getState() == CONFIRMING.code()));
+        verify(dispatcherRegistry, only()).send(any(), any(), any());
+    }
+
+    private CountDownLatch countDownOnUpdateLatch() {
+        var latch = new CountDownLatch(1);
+
+        doAnswer(i -> {
+            latch.countDown();
+            return null;
+        }).when(store).save(any());
+
+        return latch;
+    }
+
+    @NotNull
+    private ContractNegotiation createContractNegotiation() {
+        return contractNegotiationBuilder()
+                .contractOffer(contractOffer())
+                .build();
+    }
+
+    private ContractNegotiation.Builder contractNegotiationBuilder() {
+        return ContractNegotiation.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
+                .type(ContractNegotiation.Type.PROVIDER)
                 .correlationId(correlationId)
                 .counterPartyId("connectorId")
                 .counterPartyAddress("connectorAddress")
                 .protocol("protocol")
                 .state(400)
-                .stateCount(0)
-                .stateTimestamp(Instant.now().toEpochMilli())
-                .type(ContractNegotiation.Type.PROVIDER)
-                .build();
-        negotiation.addContractOffer(lastOffer);
-        negotiations.put(negotiation.getId(), negotiation);
-        return negotiation.getId();
+                .stateTimestamp(Instant.now().toEpochMilli());
     }
 
     private ContractOffer contractOffer() {
-        return ContractOffer.Builder.newInstance().id("id").policy(Policy.Builder.newInstance().build()).build();
+        return ContractOffer.Builder.newInstance()
+                .id("id:id")
+                .policy(Policy.Builder.newInstance().build())
+                .asset(Asset.Builder.newInstance().id("assetId").build())
+                .build();
     }
 
 }

--- a/launchers/junit/src/testFixtures/java/org/eclipse/dataspaceconnector/junit/launcher/EdcExtension.java
+++ b/launchers/junit/src/testFixtures/java/org/eclipse/dataspaceconnector/junit/launcher/EdcExtension.java
@@ -54,7 +54,6 @@ public class EdcExtension extends BaseRuntime implements BeforeTestExecutionCall
     private final LinkedHashMap<Class<? extends SystemExtension>, List<SystemExtension>> systemExtensions = new LinkedHashMap<>();
     private List<ServiceExtension> runningServiceExtensions;
     private DefaultServiceExtensionContext context;
-    private Monitor monitor;
 
     /**
      * Registers a mock service with the runtime.
@@ -79,8 +78,9 @@ public class EdcExtension extends BaseRuntime implements BeforeTestExecutionCall
 
     @Override
     public void afterTestExecution(ExtensionContext context) throws Exception {
+        // TODO: this shutdown is duplicated but it's necessary to DataPlaneHttpIntegrationTests, needs to be fixed
         if (runningServiceExtensions != null) {
-            shutdown(runningServiceExtensions, monitor);
+            shutdown(runningServiceExtensions, getMonitor());
         }
 
         // clear the systemExtensions map to prevent it from piling up between subsequent runs
@@ -102,7 +102,6 @@ public class EdcExtension extends BaseRuntime implements BeforeTestExecutionCall
     @Override
     protected void initializeContext(ServiceExtensionContext context) {
         serviceMocks.forEach((key, value) -> context.registerService(cast(key), value));
-        this.monitor = context.getMonitor();
         super.initializeContext(context);
     }
 

--- a/launchers/junit/src/testFixtures/java/org/eclipse/dataspaceconnector/junit/launcher/EdcRuntimeExtension.java
+++ b/launchers/junit/src/testFixtures/java/org/eclipse/dataspaceconnector/junit/launcher/EdcRuntimeExtension.java
@@ -14,6 +14,7 @@
 package org.eclipse.dataspaceconnector.junit.launcher;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.monitor.ConsoleMonitor;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
@@ -123,8 +124,7 @@ public class EdcRuntimeExtension extends EdcExtension {
 
         // Create a ClassLoader that only has the target module class path, and is not
         // parented with the current ClassLoader.
-        var classLoader = URLClassLoader.newInstance(classPathEntries,
-                ClassLoader.getSystemClassLoader());
+        var classLoader = URLClassLoader.newInstance(classPathEntries, ClassLoader.getSystemClassLoader());
 
         // Temporarily inject system properties.
         var savedProperties = (Properties) System.getProperties().clone();
@@ -161,7 +161,6 @@ public class EdcRuntimeExtension extends EdcExtension {
         System.setProperties(savedProperties);
     }
 
-
     @Override
     public void afterTestExecution(ExtensionContext context) throws Exception {
         if (runtimeThread != null) {
@@ -172,8 +171,13 @@ public class EdcRuntimeExtension extends EdcExtension {
 
     @Override
     protected @NotNull Monitor createMonitor() {
-        return new Monitor() {
-        };
+        // disable logs when "quiet" log level is set
+        if (System.getProperty("org.gradle.logging.level") != null) {
+            return new Monitor() {
+            };
+        } else {
+            return new ConsoleMonitor(logPrefix, ConsoleMonitor.Level.DEBUG);
+        }
     }
 
     /**

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/negotiation/ContractNegotiation.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/negotiation/ContractNegotiation.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021 Microsoft Corporation
+ *  Copyright (c) 2021 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
  *       Fraunhofer Institute for Software and Systems Engineering - extended method implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 package org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation;
@@ -37,11 +38,15 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONFIRMED;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONFIRMING;
-import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONFIRMING_SENT;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONSUMER_APPROVED;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONSUMER_APPROVING;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONSUMER_OFFERED;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONSUMER_OFFERING;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.DECLINED;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.DECLINING;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.INITIAL;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.PROVIDER_OFFERED;
+import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.PROVIDER_OFFERING;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.REQUESTED;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.REQUESTING;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.UNSAVED;
@@ -216,7 +221,7 @@ public class ContractNegotiation implements TraceCarrier {
         if (Type.PROVIDER == type) {
             throw new IllegalStateException("Provider processes have no REQUESTING state");
         }
-        transition(ContractNegotiationStates.REQUESTING, ContractNegotiationStates.REQUESTING, INITIAL);
+        transition(REQUESTING, REQUESTING, INITIAL);
     }
 
     /**
@@ -226,7 +231,7 @@ public class ContractNegotiation implements TraceCarrier {
         if (Type.PROVIDER == type) {
             transition(REQUESTED, UNSAVED);
         } else {
-            transition(REQUESTED, REQUESTED, ContractNegotiationStates.REQUESTING);
+            transition(REQUESTED, REQUESTED, REQUESTING);
         }
     }
 
@@ -235,9 +240,9 @@ public class ContractNegotiation implements TraceCarrier {
      */
     public void transitionOffering() {
         if (Type.CONSUMER == type) {
-            transition(ContractNegotiationStates.CONSUMER_OFFERING, REQUESTED);
+            transition(CONSUMER_OFFERING, CONSUMER_OFFERING, REQUESTED);
         } else {
-            transition(ContractNegotiationStates.PROVIDER_OFFERING, ContractNegotiationStates.PROVIDER_OFFERING, PROVIDER_OFFERED, REQUESTED);
+            transition(PROVIDER_OFFERING, PROVIDER_OFFERING, PROVIDER_OFFERED, REQUESTED);
         }
     }
 
@@ -247,9 +252,9 @@ public class ContractNegotiation implements TraceCarrier {
      */
     public void transitionOffered() {
         if (Type.CONSUMER == type) {
-            transition(CONSUMER_OFFERED, PROVIDER_OFFERED, ContractNegotiationStates.CONSUMER_OFFERING);
+            transition(CONSUMER_OFFERED, PROVIDER_OFFERED, CONSUMER_OFFERING);
         } else {
-            transition(PROVIDER_OFFERED, PROVIDER_OFFERED, ContractNegotiationStates.PROVIDER_OFFERING);
+            transition(PROVIDER_OFFERED, PROVIDER_OFFERED, PROVIDER_OFFERING);
         }
     }
 
@@ -260,7 +265,7 @@ public class ContractNegotiation implements TraceCarrier {
         if (Type.PROVIDER == type) {
             throw new IllegalStateException("Provider processes have no CONSUMER_APPROVING state");
         }
-        transition(ContractNegotiationStates.CONSUMER_APPROVING, ContractNegotiationStates.CONSUMER_APPROVING, CONSUMER_OFFERED, REQUESTED);
+        transition(CONSUMER_APPROVING, CONSUMER_APPROVING, CONSUMER_OFFERED, REQUESTED);
     }
 
     /**
@@ -270,7 +275,7 @@ public class ContractNegotiation implements TraceCarrier {
         if (Type.PROVIDER == type) {
             throw new IllegalStateException("Provider processes have no CONSUMER_APPROVED state");
         }
-        transition(CONSUMER_APPROVED, CONSUMER_APPROVED, ContractNegotiationStates.CONSUMER_APPROVING, PROVIDER_OFFERED);
+        transition(CONSUMER_APPROVED, CONSUMER_APPROVED, CONSUMER_APPROVING, PROVIDER_OFFERED);
     }
 
     /**
@@ -278,9 +283,9 @@ public class ContractNegotiation implements TraceCarrier {
      */
     public void transitionDeclining() {
         if (Type.CONSUMER == type) {
-            transition(ContractNegotiationStates.DECLINING, ContractNegotiationStates.DECLINING, REQUESTED, CONSUMER_OFFERED, CONSUMER_APPROVED);
+            transition(DECLINING, DECLINING, REQUESTED, CONSUMER_OFFERED, CONSUMER_APPROVED);
         } else {
-            transition(ContractNegotiationStates.DECLINING, ContractNegotiationStates.DECLINING, REQUESTED, PROVIDER_OFFERED, CONSUMER_APPROVED);
+            transition(DECLINING, DECLINING, REQUESTED, PROVIDER_OFFERED, CONSUMER_APPROVED);
         }
     }
 
@@ -289,9 +294,9 @@ public class ContractNegotiation implements TraceCarrier {
      */
     public void transitionDeclined() {
         if (Type.CONSUMER == type) {
-            transition(ContractNegotiationStates.DECLINED, ContractNegotiationStates.DECLINING, CONSUMER_OFFERED, REQUESTED);
+            transition(DECLINED, DECLINING, CONSUMER_OFFERED, REQUESTED);
         } else {
-            transition(ContractNegotiationStates.DECLINED, ContractNegotiationStates.DECLINING, PROVIDER_OFFERED, ContractNegotiationStates.CONFIRMED, REQUESTED);
+            transition(DECLINED, DECLINING, PROVIDER_OFFERED, CONFIRMED, REQUESTED);
         }
 
     }
@@ -303,11 +308,7 @@ public class ContractNegotiation implements TraceCarrier {
         if (Type.CONSUMER == type) {
             throw new IllegalStateException("Consumer processes have no CONFIRMING state");
         }
-        transition(CONFIRMING, CONFIRMING, REQUESTED, PROVIDER_OFFERED, CONFIRMING_SENT);
-    }
-
-    public void transitionConfirmingSent() {
-        transition(CONFIRMING_SENT, CONFIRMING);
+        transition(CONFIRMING, CONFIRMING, REQUESTED, PROVIDER_OFFERED);
     }
 
     /**
@@ -315,9 +316,9 @@ public class ContractNegotiation implements TraceCarrier {
      */
     public void transitionConfirmed() {
         if (Type.CONSUMER == type) {
-            transition(ContractNegotiationStates.CONFIRMED, CONSUMER_APPROVED, REQUESTED, CONSUMER_OFFERED, CONFIRMED);
+            transition(CONFIRMED, CONSUMER_APPROVED, REQUESTED, CONSUMER_OFFERED, CONFIRMED);
         } else {
-            transition(ContractNegotiationStates.CONFIRMED, CONFIRMING, CONFIRMING_SENT);
+            transition(CONFIRMED, CONFIRMING);
         }
 
     }
@@ -478,6 +479,11 @@ public class ContractNegotiation implements TraceCarrier {
         //used mainly for JSON deserialization
         public Builder contractOffers(List<ContractOffer> contractOffers) {
             negotiation.contractOffers = contractOffers;
+            return this;
+        }
+
+        public Builder contractOffer(ContractOffer contractOffer) {
+            negotiation.contractOffers.add(contractOffer);
             return this;
         }
 

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/negotiation/ContractNegotiationStates.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/negotiation/ContractNegotiationStates.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021 Microsoft Corporation
+ *  Copyright (c) 2021 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
  *       Fraunhofer Institute for Software and Systems Engineering - minor modifications
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 package org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation;
@@ -34,7 +35,6 @@ public enum ContractNegotiationStates {
     DECLINING(900),
     DECLINED(1000),
     CONFIRMING(1100),
-    CONFIRMING_SENT(1150),
     CONFIRMED(1200),
     ERROR(-1);
 

--- a/system-tests/e2e-transfer-test/control-plane/src/main/java/org/eclipse/dataspaceconnector/test/e2e/ControlPlaneTestController.java
+++ b/system-tests/e2e-transfer-test/control-plane/src/main/java/org/eclipse/dataspaceconnector/test/e2e/ControlPlaneTestController.java
@@ -48,7 +48,7 @@ public class ControlPlaneTestController {
         this.transferProcessStore = transferProcessStore;
     }
 
-    // TODO: most of these api will be replaced by data management api
+    // TODO: all of these api will be replaced by data management api
 
     @Path("/assets")
     @POST

--- a/system-tests/e2e-transfer-test/runner/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/runner/build.gradle.kts
@@ -29,6 +29,10 @@ dependencies {
     testImplementation("org.assertj:assertj-core:${assertj}")
     testImplementation("org.awaitility:awaitility:${awaitility}")
     testImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
+
+    testCompileOnly(project(":system-tests:e2e-transfer-test:backend-service"))
+    testCompileOnly(project(":system-tests:e2e-transfer-test:control-plane"))
+    testCompileOnly(project(":system-tests:e2e-transfer-test:data-plane"))
 }
 
 tasks.getByName<Test>("test") {

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/dataspaceconnector/test/e2e/EndToEndTransferTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/dataspaceconnector/test/e2e/EndToEndTransferTest.java
@@ -96,8 +96,8 @@ public class EndToEndTransferTest {
                     put("web.http.path", "/api");
                     put("web.http.public.port", String.valueOf(CONSUMER_DATA_PLANE_PUBLIC.getPort()));
                     put("web.http.public.path", "/public");
-                    put("web.http.control.port", String.valueOf(getFreePort())); // TODO it's needed?
-                    put("web.http.control.path", "/control"); // TODO it's needed?
+                    put("web.http.control.port", String.valueOf(getFreePort()));
+                    put("web.http.control.path", "/control");
                     put("edc.controlplane.validation-endpoint", CONSUMER_CONTROL_PLANE_VALIDATION + "/validation");
                 }
             }
@@ -124,8 +124,8 @@ public class EndToEndTransferTest {
                     put("web.http.path", "/api");
                     put("web.http.public.port", String.valueOf(PROVIDER_DATA_PLANE_PUBLIC.getPort()));
                     put("web.http.public.path", "/public");
-                    put("web.http.control.port", String.valueOf(getFreePort())); // TODO it's needed?
-                    put("web.http.control.path", "/control"); // TODO it's needed?
+                    put("web.http.control.port", String.valueOf(getFreePort()));
+                    put("web.http.control.path", "/control");
                     put("edc.controlplane.validation-endpoint", PROVIDER_CONTROL_PLANE_VALIDATION + "/validation");
                 }
             }

--- a/system-tests/tests/build.gradle.kts
+++ b/system-tests/tests/build.gradle.kts
@@ -34,8 +34,8 @@ dependencies {
     testImplementation(testFixtures(project(":common:util")))
     testImplementation(testFixtures(project(":launchers:junit")))
 
-    testRuntimeOnly(project(":system-tests:runtimes:file-transfer-provider"))
-    testRuntimeOnly(project(":system-tests:runtimes:file-transfer-consumer"))
+    testCompileOnly(project(":system-tests:runtimes:file-transfer-provider"))
+    testCompileOnly(project(":system-tests:runtimes:file-transfer-consumer"))
 }
 
 tasks.getByName<Test>("test") {


### PR DESCRIPTION
## What this PR changes/adds

Migrate all the state transition to the 2-state pattern as described in https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/825 for `ContractNegotiationManager`s

## Why it does that

Use the 3-state pattern could lead to problems, described in https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/825

## Further notes

the `CONFIRMING_SENT` status has been removed since it's not needed anymore
I had to implement a lease mechanism into the `InMemoryContractNegotiationStore` (for the cosmos implementation was already done in #724)

I add the `-quiet` parameter to the gradle test task, to avoid printing the system tests logs on the pipeline

## Linked Issue(s)

Fix #825 (supposing that #831 would be merged before this)

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (skip with label `no-changelog`)
- [x] linked GitHub project? (see the section on the right-hand side -->)
