### PR TITLE
core: give possibility to configure state machine batch sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,10 @@ the detailed section referring to by linking pull requests or issues.
 * `ContractDefinitionStore` supports paging (#717)
 * Add okhttp client timeouts (#735)
 * Unit test framework for Dependency Injection (#843)
-* Implemented S3BucketReader (#675)
 * Add a deleteById method to the AssetLoader interface (#880)
 * Apply 2-state transition pattern to `ContractNegotiationManager`s (#870)
+* Implement S3BucketReader (#675)
+* Add configuration setting for state machine batch size (#872)
 
 #### Changed
 

--- a/core/contract/README.md
+++ b/core/contract/README.md
@@ -1,2 +1,11 @@
-# Contract Extension 
+# Contract
+
+## Configuration
+
+* `edc.negotiation.consumer.state-machine.batch-size`
+  * the size of the batch of entity fetched for every consumer `ContractNegotiation` state machine iteration. 
+  * _Default value_: 5
+* `edc.negotiation.consumer.state-machine.batch-size`
+  * the size of the batch of entity fetched for every provider `ContractNegotiation` state machine iteration. 
+  * _Default value_: 5
 

--- a/core/contract/build.gradle.kts
+++ b/core/contract/build.gradle.kts
@@ -12,7 +12,6 @@
 *
 */
 
-val slf4jVersion: String by project
 val openTelemetryVersion: String by project
 
 plugins {
@@ -26,7 +25,6 @@ dependencies {
     api(project(":common:state-machine-lib"))
     api(project(":common:util"))
 
-    api("org.slf4j:slf4j-api:${slf4jVersion}")
     implementation("io.opentelemetry:opentelemetry-extension-annotations:${openTelemetryVersion}")
 
     testImplementation(project(":extensions:in-memory:negotiation-store-memory"))

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021 Daimler TSS GmbH
+ *  Copyright (c) 2021 - 2022 Daimler TSS GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
  *       Fraunhofer Institute for Software and Systems Engineering - add contract negotiation functionality
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 
@@ -23,6 +24,7 @@ import org.eclipse.dataspaceconnector.contract.offer.ContractDefinitionServiceIm
 import org.eclipse.dataspaceconnector.contract.offer.ContractOfferServiceImpl;
 import org.eclipse.dataspaceconnector.contract.policy.PolicyEngineImpl;
 import org.eclipse.dataspaceconnector.contract.validation.ContractValidationServiceImpl;
+import org.eclipse.dataspaceconnector.spi.EdcSetting;
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.command.BoundedCommandQueue;
 import org.eclipse.dataspaceconnector.spi.command.CommandHandlerRegistry;
@@ -59,6 +61,12 @@ public class ContractServiceExtension implements ServiceExtension {
     private Monitor monitor;
     private ConsumerContractNegotiationManagerImpl consumerNegotiationManager;
     private ProviderContractNegotiationManagerImpl providerNegotiationManager;
+
+    @EdcSetting
+    private static final String NEGOTIATION_CONSUMER_STATE_MACHINE_BATCH_SIZE = "edc.negotiation.consumer.state-machine.batch-size";
+
+    @EdcSetting
+    private static final String NEGOTIATION_PROVIDER_STATE_MACHINE_BATCH_SIZE = "edc.negotiation.provider.state-machine.batch-size";
 
     @Inject
     private AssetIndex assetIndex;
@@ -141,6 +149,7 @@ public class ContractServiceExtension implements ServiceExtension {
                 .observable(observable)
                 .telemetry(telemetry)
                 .store(store)
+                .batchSize(context.getSetting(NEGOTIATION_CONSUMER_STATE_MACHINE_BATCH_SIZE, 5))
                 .build();
 
         providerNegotiationManager = ProviderContractNegotiationManagerImpl.Builder.newInstance()
@@ -153,6 +162,7 @@ public class ContractServiceExtension implements ServiceExtension {
                 .observable(observable)
                 .telemetry(telemetry)
                 .store(store)
+                .batchSize(context.getSetting(NEGOTIATION_PROVIDER_STATE_MACHINE_BATCH_SIZE, 5))
                 .build();
 
         context.registerService(ConsumerContractNegotiationManager.class, consumerNegotiationManager);

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/AbstractContractNegotiationManager.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/AbstractContractNegotiationManager.java
@@ -1,0 +1,120 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ */
+
+package org.eclipse.dataspaceconnector.contract.negotiation;
+
+import org.eclipse.dataspaceconnector.spi.command.CommandProcessor;
+import org.eclipse.dataspaceconnector.spi.command.CommandQueue;
+import org.eclipse.dataspaceconnector.spi.command.CommandRunner;
+import org.eclipse.dataspaceconnector.spi.contract.negotiation.observe.ContractNegotiationObservable;
+import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
+import org.eclipse.dataspaceconnector.spi.contract.validation.ContractValidationService;
+import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.retry.WaitStrategy;
+import org.eclipse.dataspaceconnector.spi.telemetry.Telemetry;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.command.ContractNegotiationCommand;
+
+import java.util.Objects;
+
+public abstract class AbstractContractNegotiationManager {
+
+    protected ContractNegotiationStore negotiationStore;
+    protected ContractValidationService validationService;
+    protected RemoteMessageDispatcherRegistry dispatcherRegistry;
+    protected ContractNegotiationObservable observable;
+    protected CommandQueue<ContractNegotiationCommand> commandQueue;
+    protected CommandRunner<ContractNegotiationCommand> commandRunner;
+    protected CommandProcessor<ContractNegotiationCommand> commandProcessor;
+    protected Monitor monitor;
+    protected Telemetry telemetry;
+    protected int batchSize = 5;
+    protected WaitStrategy waitStrategy = () -> 5000L;  // default wait five seconds
+
+    public static class Builder<T extends AbstractContractNegotiationManager> {
+
+        private final T manager;
+
+        protected Builder(T manager) {
+            this.manager = manager;
+            this.manager.telemetry = new Telemetry(); // default noop implementation
+        }
+
+        public Builder<T> validationService(ContractValidationService validationService) {
+            manager.validationService = validationService;
+            return this;
+        }
+
+        public Builder<T> monitor(Monitor monitor) {
+            manager.monitor = monitor;
+            return this;
+        }
+
+        public Builder<T> batchSize(int batchSize) {
+            manager.batchSize = batchSize;
+            return this;
+        }
+
+        public Builder<T> waitStrategy(WaitStrategy waitStrategy) {
+            manager.waitStrategy = waitStrategy;
+            return this;
+        }
+
+        public Builder<T> dispatcherRegistry(RemoteMessageDispatcherRegistry dispatcherRegistry) {
+            manager.dispatcherRegistry = dispatcherRegistry;
+            return this;
+        }
+
+        public Builder<T> commandQueue(CommandQueue<ContractNegotiationCommand> commandQueue) {
+            manager.commandQueue = commandQueue;
+            return this;
+        }
+
+        public Builder<T> commandRunner(CommandRunner<ContractNegotiationCommand> commandRunner) {
+            manager.commandRunner = commandRunner;
+            return this;
+        }
+
+        public Builder<T> telemetry(Telemetry telemetry) {
+            manager.telemetry = telemetry;
+            return this;
+        }
+
+        public Builder<T> observable(ContractNegotiationObservable observable) {
+            manager.observable = observable;
+            return this;
+        }
+
+        public Builder<T> store(ContractNegotiationStore store) {
+            manager.negotiationStore = store;
+            return this;
+        }
+
+        public T build() {
+            Objects.requireNonNull(manager.validationService, "contractValidationService");
+            Objects.requireNonNull(manager.monitor, "monitor");
+            Objects.requireNonNull(manager.dispatcherRegistry, "dispatcherRegistry");
+            Objects.requireNonNull(manager.commandQueue, "commandQueue");
+            Objects.requireNonNull(manager.commandRunner, "commandRunner");
+            Objects.requireNonNull(manager.observable, "observable");
+            Objects.requireNonNull(manager.telemetry, "telemetry");
+            Objects.requireNonNull(manager.negotiationStore, "store");
+            manager.commandProcessor = new CommandProcessor<>(manager.commandQueue, manager.commandRunner, manager.monitor);
+
+            return manager;
+        }
+
+    }
+
+}

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -13,26 +13,17 @@
  *       Daimler TSS GmbH - fixed contract dates to epoch seconds
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  */
+
 package org.eclipse.dataspaceconnector.contract.negotiation;
 
 import io.opentelemetry.extension.annotations.WithSpan;
 import org.eclipse.dataspaceconnector.common.statemachine.StateMachine;
 import org.eclipse.dataspaceconnector.common.statemachine.StateProcessorImpl;
 import org.eclipse.dataspaceconnector.contract.common.ContractId;
-import org.eclipse.dataspaceconnector.spi.command.CommandProcessor;
-import org.eclipse.dataspaceconnector.spi.command.CommandQueue;
-import org.eclipse.dataspaceconnector.spi.command.CommandRunner;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.ConsumerContractNegotiationManager;
-import org.eclipse.dataspaceconnector.spi.contract.negotiation.observe.ContractNegotiationObservable;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.response.NegotiationResult;
-import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
-import org.eclipse.dataspaceconnector.spi.contract.validation.ContractValidationService;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
-import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
-import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
-import org.eclipse.dataspaceconnector.spi.retry.WaitStrategy;
-import org.eclipse.dataspaceconnector.spi.telemetry.Telemetry;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreementRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
@@ -44,7 +35,6 @@ import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOf
 import org.jetbrains.annotations.NotNull;
 
 import java.time.Instant;
-import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 import java.util.UUID;
@@ -67,21 +57,8 @@ import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiati
 /**
  * Implementation of the {@link ConsumerContractNegotiationManager}.
  */
-public class ConsumerContractNegotiationManagerImpl implements ConsumerContractNegotiationManager {
-    private ContractNegotiationStore negotiationStore;
-    private ContractValidationService validationService;
+public class ConsumerContractNegotiationManagerImpl extends AbstractContractNegotiationManager implements ConsumerContractNegotiationManager {
 
-    private int batchSize = 5;
-    private WaitStrategy waitStrategy = () -> 5000L;  // default wait five seconds
-
-    private RemoteMessageDispatcherRegistry dispatcherRegistry;
-
-    private ContractNegotiationObservable observable;
-    private CommandQueue<ContractNegotiationCommand> commandQueue;
-    private CommandRunner<ContractNegotiationCommand> commandRunner;
-    private CommandProcessor<ContractNegotiationCommand> commandProcessor;
-    private Telemetry telemetry;
-    private Monitor monitor;
     private StateMachine stateMachine;
 
     private ConsumerContractNegotiationManagerImpl() { }
@@ -536,80 +513,14 @@ public class ConsumerContractNegotiationManagerImpl implements ConsumerContractN
     /**
      * Builder for ConsumerContractNegotiationManagerImpl.
      */
-    public static class Builder {
-        private final ConsumerContractNegotiationManagerImpl manager;
+    public static class Builder extends AbstractContractNegotiationManager.Builder<ConsumerContractNegotiationManagerImpl> {
 
         private Builder() {
-            manager = new ConsumerContractNegotiationManagerImpl();
-            manager.telemetry = new Telemetry(); // default noop implementation
+            super(new ConsumerContractNegotiationManagerImpl());
         }
 
-        public static Builder newInstance() {
+        public static ConsumerContractNegotiationManagerImpl.Builder newInstance() {
             return new Builder();
-        }
-
-        public Builder validationService(ContractValidationService validationService) {
-            manager.validationService = validationService;
-            return this;
-        }
-
-        public Builder monitor(Monitor monitor) {
-            manager.monitor = monitor;
-            return this;
-        }
-
-        public Builder batchSize(int batchSize) {
-            manager.batchSize = batchSize;
-            return this;
-        }
-
-        public Builder waitStrategy(WaitStrategy waitStrategy) {
-            manager.waitStrategy = waitStrategy;
-            return this;
-        }
-
-        public Builder dispatcherRegistry(RemoteMessageDispatcherRegistry dispatcherRegistry) {
-            manager.dispatcherRegistry = dispatcherRegistry;
-            return this;
-        }
-
-        public Builder commandQueue(CommandQueue<ContractNegotiationCommand> commandQueue) {
-            manager.commandQueue = commandQueue;
-            return this;
-        }
-
-        public Builder commandRunner(CommandRunner<ContractNegotiationCommand> commandRunner) {
-            manager.commandRunner = commandRunner;
-            return this;
-        }
-
-        public Builder telemetry(Telemetry telemetry) {
-            manager.telemetry = telemetry;
-            return this;
-        }
-
-        public Builder observable(ContractNegotiationObservable observable) {
-            manager.observable = observable;
-            return this;
-        }
-
-        public Builder store(ContractNegotiationStore store) {
-            manager.negotiationStore = store;
-            return this;
-        }
-
-        public ConsumerContractNegotiationManagerImpl build() {
-            Objects.requireNonNull(manager.validationService, "contractValidationService");
-            Objects.requireNonNull(manager.monitor, "monitor");
-            Objects.requireNonNull(manager.dispatcherRegistry, "dispatcherRegistry");
-            Objects.requireNonNull(manager.commandQueue, "commandQueue");
-            Objects.requireNonNull(manager.commandRunner, "commandRunner");
-            Objects.requireNonNull(manager.observable, "observable");
-            Objects.requireNonNull(manager.telemetry, "telemetry");
-            Objects.requireNonNull(manager.negotiationStore, "store");
-            manager.commandProcessor = new CommandProcessor<>(manager.commandQueue, manager.commandRunner, manager.monitor);
-
-            return manager;
         }
     }
 }

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -20,20 +20,10 @@ import io.opentelemetry.extension.annotations.WithSpan;
 import org.eclipse.dataspaceconnector.common.statemachine.StateMachine;
 import org.eclipse.dataspaceconnector.common.statemachine.StateProcessorImpl;
 import org.eclipse.dataspaceconnector.contract.common.ContractId;
-import org.eclipse.dataspaceconnector.spi.command.CommandProcessor;
-import org.eclipse.dataspaceconnector.spi.command.CommandQueue;
-import org.eclipse.dataspaceconnector.spi.command.CommandRunner;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.ProviderContractNegotiationManager;
-import org.eclipse.dataspaceconnector.spi.contract.negotiation.observe.ContractNegotiationObservable;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.response.NegotiationResult;
-import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
-import org.eclipse.dataspaceconnector.spi.contract.validation.ContractValidationService;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
-import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
-import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
-import org.eclipse.dataspaceconnector.spi.retry.WaitStrategy;
-import org.eclipse.dataspaceconnector.spi.telemetry.Telemetry;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreementRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
@@ -46,7 +36,6 @@ import org.jetbrains.annotations.NotNull;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -63,20 +52,8 @@ import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiati
 /**
  * Implementation of the {@link ProviderContractNegotiationManager}.
  */
-public class ProviderContractNegotiationManagerImpl implements ProviderContractNegotiationManager {
+public class ProviderContractNegotiationManagerImpl extends AbstractContractNegotiationManager implements ProviderContractNegotiationManager {
 
-    private int batchSize = 5;
-    private WaitStrategy waitStrategy = () -> 5000L;  // default wait five seconds
-
-    private ContractNegotiationStore negotiationStore;
-    private ContractValidationService validationService;
-    private RemoteMessageDispatcherRegistry dispatcherRegistry;
-    private ContractNegotiationObservable observable;
-    private CommandQueue<ContractNegotiationCommand> commandQueue;
-    private CommandRunner<ContractNegotiationCommand> commandRunner;
-    private CommandProcessor<ContractNegotiationCommand> commandProcessor;
-    private Monitor monitor;
-    private Telemetry telemetry;
     private StateMachine stateMachine;
 
     private ProviderContractNegotiationManagerImpl() {
@@ -468,81 +445,14 @@ public class ProviderContractNegotiationManagerImpl implements ProviderContractN
     /**
      * Builder for ProviderContractNegotiationManagerImpl.
      */
-    public static class Builder {
-        private final ProviderContractNegotiationManagerImpl manager;
+    public static class Builder extends AbstractContractNegotiationManager.Builder<ProviderContractNegotiationManagerImpl> {
 
         private Builder() {
-            manager = new ProviderContractNegotiationManagerImpl();
-            manager.telemetry = new Telemetry(); // default noop implementation
+            super(new ProviderContractNegotiationManagerImpl());
         }
 
         public static Builder newInstance() {
             return new Builder();
         }
-
-        public Builder validationService(ContractValidationService validationService) {
-            manager.validationService = validationService;
-            return this;
-        }
-
-        public Builder monitor(Monitor monitor) {
-            manager.monitor = monitor;
-            return this;
-        }
-
-        public Builder batchSize(int batchSize) {
-            manager.batchSize = batchSize;
-            return this;
-        }
-
-        public Builder waitStrategy(WaitStrategy waitStrategy) {
-            manager.waitStrategy = waitStrategy;
-            return this;
-        }
-
-        public Builder dispatcherRegistry(RemoteMessageDispatcherRegistry dispatcherRegistry) {
-            manager.dispatcherRegistry = dispatcherRegistry;
-            return this;
-        }
-
-        public Builder commandQueue(CommandQueue<ContractNegotiationCommand> commandQueue) {
-            manager.commandQueue = commandQueue;
-            return this;
-        }
-
-        public Builder commandRunner(CommandRunner<ContractNegotiationCommand> commandRunner) {
-            manager.commandRunner = commandRunner;
-            return this;
-        }
-
-        public Builder telemetry(Telemetry telemetry) {
-            manager.telemetry = telemetry;
-            return this;
-        }
-
-        public Builder observable(ContractNegotiationObservable observable) {
-            manager.observable = observable;
-            return this;
-        }
-
-        public Builder store(ContractNegotiationStore store) {
-            manager.negotiationStore = store;
-            return this;
-        }
-
-        public ProviderContractNegotiationManagerImpl build() {
-            Objects.requireNonNull(manager.validationService, "contractValidationService");
-            Objects.requireNonNull(manager.monitor, "monitor");
-            Objects.requireNonNull(manager.dispatcherRegistry, "dispatcherRegistry");
-            Objects.requireNonNull(manager.commandQueue, "commandQueue");
-            Objects.requireNonNull(manager.commandRunner, "commandRunner");
-            Objects.requireNonNull(manager.observable, "observable");
-            Objects.requireNonNull(manager.telemetry, "telemetry");
-            Objects.requireNonNull(manager.negotiationStore, "store");
-            manager.commandProcessor = new CommandProcessor<>(manager.commandQueue, manager.commandRunner, manager.monitor);
-
-            return manager;
-        }
-
     }
 }

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -1,5 +1,9 @@
 /*
+<<<<<<< HEAD
  *  Copyright (c) 2021-2022 Fraunhofer Institute for Software and Systems Engineering
+=======
+ *  Copyright (c) 2021 - 2022 Fraunhofer Institute for Software and Systems Engineering
+>>>>>>> 9d998cb09 (core: add configuration setting to set state machine batch sizes)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -32,18 +36,14 @@ import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.Cont
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractOfferRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.command.ContractNegotiationCommand;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import static java.util.Collections.emptyList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -79,12 +79,17 @@ class ConsumerContractNegotiationManagerImplTest {
 
     @BeforeEach
     void setUp() {
+        CommandQueue<ContractNegotiationCommand> queue = mock(CommandQueue.class);
+        when(queue.dequeue(anyInt())).thenReturn(new ArrayList<>());
+
+        CommandRunner<ContractNegotiationCommand> commandRunner = mock(CommandRunner.class);
+
         negotiationManager = ConsumerContractNegotiationManagerImpl.Builder.newInstance()
                 .validationService(validationService)
                 .dispatcherRegistry(dispatcherRegistry)
                 .monitor(mock(Monitor.class))
-                .commandQueue(mock(CommandQueue.class))
-                .commandRunner(mock(CommandRunner.class))
+                .commandQueue(queue)
+                .commandRunner(commandRunner)
                 .observable(mock(ContractNegotiationObservable.class))
                 .store(store)
                 .build();

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -1,5 +1,9 @@
 /*
+<<<<<<< HEAD
  *  Copyright (c) 2021-2022 Fraunhofer Institute for Software and Systems Engineering
+=======
+ *  Copyright (c) 2021 - 2022 Fraunhofer Institute for Software and Systems Engineering
+>>>>>>> 9d998cb09 (core: add configuration setting to set state machine batch sizes)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -31,6 +35,7 @@ import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.Contra
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractOfferRequest;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.command.ContractNegotiationCommand;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +43,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
@@ -49,15 +55,10 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONFIRMED;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONFIRMING;
-import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONSUMER_APPROVED;
-import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONSUMER_APPROVING;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.DECLINED;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.DECLINING;
-import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.INITIAL;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.PROVIDER_OFFERED;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.PROVIDER_OFFERING;
-import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.REQUESTED;
-import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.REQUESTING;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -80,12 +81,17 @@ class ProviderContractNegotiationManagerImplTest {
 
     @BeforeEach
     void setUp() {
+        CommandQueue<ContractNegotiationCommand> queue = mock(CommandQueue.class);
+        when(queue.dequeue(anyInt())).thenReturn(new ArrayList<>());
+
+        CommandRunner<ContractNegotiationCommand> commandRunner = mock(CommandRunner.class);
+
         negotiationManager = ProviderContractNegotiationManagerImpl.Builder.newInstance()
                 .validationService(validationService)
                 .dispatcherRegistry(dispatcherRegistry)
                 .monitor(mock(Monitor.class))
-                .commandQueue(mock(CommandQueue.class))
-                .commandRunner(mock(CommandRunner.class))
+                .commandQueue(queue)
+                .commandRunner(commandRunner)
                 .observable(mock(ContractNegotiationObservable.class))
                 .store(store)
                 .build();

--- a/core/transfer/README.md
+++ b/core/transfer/README.md
@@ -1,0 +1,7 @@
+# Transfer
+
+## Configuration
+
+* `edc.transfer.state-machine.batch-size` 
+  * the size of the batch of entity fetched for every `TransferProcess` state machine iteration. 
+  * _Default value_: 5

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2021 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -9,11 +9,13 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 
 package org.eclipse.dataspaceconnector.transfer.core;
 
+import org.eclipse.dataspaceconnector.spi.EdcSetting;
 import org.eclipse.dataspaceconnector.spi.command.BoundedCommandQueue;
 import org.eclipse.dataspaceconnector.spi.command.CommandHandlerRegistry;
 import org.eclipse.dataspaceconnector.spi.command.CommandRunner;
@@ -58,6 +60,9 @@ import org.eclipse.dataspaceconnector.transfer.core.transfer.TransferProcessMana
         EndpointDataReferenceReceiverRegistry.class, EndpointDataReferenceTransformer.class})
 public class CoreTransferExtension implements ServiceExtension {
     private static final long DEFAULT_ITERATION_WAIT = 5000; // millis
+
+    @EdcSetting
+    private static final String TRANSFER_STATE_MACHINE_BATCH_SIZE = "edc.transfer.state-machine.batch-size";
 
     @Inject
     private TransferProcessStore transferProcessStore;
@@ -128,6 +133,7 @@ public class CoreTransferExtension implements ServiceExtension {
                 .commandRunner(new CommandRunner<>(registry, monitor))
                 .observable(observable)
                 .store(transferProcessStore)
+                .batchSize(context.getSetting(TRANSFER_STATE_MACHINE_BATCH_SIZE, 5))
                 .build();
 
         context.registerService(TransferProcessManager.class, processManager);

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/store/ContractNegotiationStore.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/store/ContractNegotiationStore.java
@@ -13,14 +13,13 @@
  */
 package org.eclipse.dataspaceconnector.spi.contract.negotiation.store;
 
+import org.eclipse.dataspaceconnector.spi.persistence.StateEntityStore;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.system.Feature;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.List;
 import java.util.stream.Stream;
 
 /**
@@ -28,7 +27,7 @@ import java.util.stream.Stream;
  * <p>
  */
 @Feature(ContractNegotiationStore.FEATURE)
-public interface ContractNegotiationStore {
+public interface ContractNegotiationStore extends StateEntityStore<ContractNegotiation> {
 
     String FEATURE = "edc:core:contract:contractnegotiation:store";
 
@@ -59,12 +58,6 @@ public interface ContractNegotiationStore {
      * Removes a contract negotiation for the given id.
      */
     void delete(String negotiationId);
-
-    /**
-     * Returns the next batch of contract negotiations for the given state.
-     */
-    @NotNull
-    List<ContractNegotiation> nextForState(int state, int max);
 
     /**
      * Finds all contract negotiations that are covered by a specific {@link QuerySpec}. If no {@link QuerySpec#getSortField()}

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/persistence/StateEntityStore.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/persistence/StateEntityStore.java
@@ -1,0 +1,35 @@
+package org.eclipse.dataspaceconnector.spi.persistence;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * Define a store that can be used within a state machine
+ */
+public interface StateEntityStore<T> {
+
+    /**
+     * Returns a list of entities that are in a specific state.
+     * <br/>
+     * Implementors MUST handle these requirements: <br/>
+     * <ul>
+     *     <il>
+     *         * entities should be fetched from the oldest to the newest, by a timestamp that reports the last state transition on the entity
+     *         <br/><br/>
+     *     </il>
+     *     <il>
+     *         * fetched entities should be leased for a configurable timeout, that will be released after the timeout expires or when the entity will be updated.
+     *         This will avoid consecutive fetches in the state machine loop
+     *         <br/><br/>
+     *     </il>
+     * </ul>
+     *
+     * @param state The state that the processes of interest should be in.
+     * @param max   The maximum amount of result items.
+     * @return A list of entities (at most _max_) that are in the desired state.
+     */
+    @NotNull
+    List<T> nextForState(int state, int max);
+
+}

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/store/TransferProcessStore.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/store/TransferProcessStore.java
@@ -14,20 +14,19 @@
 
 package org.eclipse.dataspaceconnector.spi.transfer.store;
 
+import org.eclipse.dataspaceconnector.spi.persistence.StateEntityStore;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.system.Feature;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.List;
 import java.util.stream.Stream;
 
 /**
  * Manages persistent storage of {@link TransferProcess} state.
  */
 @Feature(TransferProcessStore.FEATURE)
-public interface TransferProcessStore {
+public interface TransferProcessStore extends StateEntityStore<TransferProcess> {
     String FEATURE = "edc:core:transfer:transferprocessstore";
 
     /**
@@ -41,23 +40,6 @@ public interface TransferProcessStore {
      */
     @Nullable
     String processIdForTransferId(String id);
-
-    /**
-     * Returns a list of TransferProcesses that are in a specific state.
-     * <br/>
-     * Implementors MUST handle the starvation scenario, i.e. when the number of processes is greater than the number
-     * passedin via {@code max}.
-     * E.g. database-based implementations should perform a query along the lines of {@code SELECT ... ORDER BY TransferProcess#stateTimestamp}.
-     * Then, after the check, users of this method must update the {@code TransferProcess#stateTimestamp} even if the process
-     * remains unchanged.
-     * Some database frameworks such as Spring have automatic lastChanged columns.
-     *
-     * @param state The state that the processes of interest should be in.
-     * @param max   The maximum amount of result items.
-     * @return A list of TransferProcesses (at most _max_) that are in the desired state.
-     */
-    @NotNull
-    List<TransferProcess> nextForState(int state, int max);
 
     /**
      * Creates a transfer process.


### PR DESCRIPTION
## What this PR changes/adds

Add configuration settings to set the batch size of the state machines:
- `edc.negotiation.consumer.state-machine.batch-size`: `ConsumerContractNegotiationManagerImpl`
- `edc.negotiation.provider.state-machine.batch-size`: `ProviderContractNegotiationManagerImpl`
- `edc.transfer.state-machine.batch-size`: `TransferProcessManagerImpl`

## Why it does that

As stated in #393 currently the batch size is hard-coded, adding settings will permit more fine-grained configuration of the EDC

## Further notes

Extracted `StateMachineStore` interface that is extended by `TransferProcessStore` and `ContractNegotiationStore`, this will permit to have a unique documentation point for `nextForState`, and in the future could lead to a stronger abstraction that could avoid further duplications.

Extracted `AbstractContractNegotiationManager` that for the moment will be a container for the collaborators (that are the same between the two implementations` and for the builder abstraction. In the future could be used to contain other common code.

## Linked Issue(s)

Fix #393 

## Checklist

- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request)
      and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) 
      for details_)
- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] linked GitHub project? (_see the section on the right-hand side -->_)
