### PR TITLE
core: Call the listeners before the state transition is persisted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ the detailed section referring to by linking pull requests or issues.
 * Refactor (=generify) transformer subsystem (#779)
 * Extract interfaces for every api controller class to improve swagger documentation (#891)
 * Instrument executors with metrics (#912)
+* Call the listeners before the state transition is persisted. (#876)
 
 #### Removed
 

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -21,6 +21,7 @@ import org.eclipse.dataspaceconnector.common.statemachine.StateMachine;
 import org.eclipse.dataspaceconnector.common.statemachine.StateProcessorImpl;
 import org.eclipse.dataspaceconnector.contract.common.ContractId;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.ConsumerContractNegotiationManager;
+import org.eclipse.dataspaceconnector.spi.contract.negotiation.observe.ContractNegotiationListener;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.response.NegotiationResult;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.result.Result;
@@ -40,6 +41,7 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static java.lang.String.format;
@@ -108,8 +110,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
 
         negotiation.addContractOffer(contractOffer.getContractOffer());
         negotiation.transitionInitial();
-        negotiationStore.save(negotiation);
-        observable.invokeForEach(l -> l.requesting(negotiation));
+        update(negotiation, l -> l.requesting(negotiation));
 
         monitor.debug(String.format("[Consumer] ContractNegotiation initiated. %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
@@ -151,14 +152,12 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
             monitor.debug("[Consumer] Contract offer received. Will be rejected.");
             negotiation.setErrorDetail(result.getFailureMessages().get(0));
             negotiation.transitionDeclining();
-            negotiationStore.save(negotiation);
-            observable.invokeForEach(l -> l.declining(negotiation));
+            update(negotiation, l -> l.declining(negotiation));
         } else {
             // Offer has been approved.
             monitor.debug("[Consumer] Contract offer received. Will be approved.");
             negotiation.transitionApproving();
-            negotiationStore.save(negotiation);
-            observable.invokeForEach(l -> l.consumerApproving(negotiation));
+            update(negotiation, l -> l.consumerApproving(negotiation));
         }
 
         monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
@@ -201,8 +200,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
             monitor.debug("[Consumer] Contract agreement received. Validation failed.");
             negotiation.setErrorDetail("Contract rejected."); //TODO set error detail
             negotiation.transitionDeclining();
-            negotiationStore.save(negotiation);
-            observable.invokeForEach(l -> l.declining(negotiation));
+            update(negotiation, l -> l.declining(negotiation));
             monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
                     negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
             return NegotiationResult.success(negotiation);
@@ -215,8 +213,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
             // TODO: otherwise will fail. But should do it, since it's already confirmed? A duplicated message received shouldn't be an issue
             negotiation.transitionConfirmed();
         }
-        negotiationStore.save(negotiation);
-        observable.invokeForEach(l -> l.confirmed(negotiation));
+        update(negotiation, l -> l.confirmed(negotiation));
         monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
 
@@ -242,8 +239,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
 
         monitor.debug("[Consumer] Contract rejection received. Abort negotiation process.");
         negotiation.transitionDeclined();
-        negotiationStore.save(negotiation);
-        observable.invokeForEach(l -> l.declined(negotiation));
+        update(negotiation, l -> l.declined(negotiation));
         monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
         return NegotiationResult.success(negotiation);
@@ -336,14 +332,12 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
 
             if (throwable == null) {
                 negotiation.transitionRequested();
-                negotiationStore.save(negotiation);
-                observable.invokeForEach(l -> l.requested(negotiation));
+                update(negotiation, l -> l.requested(negotiation));
                 monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
                         negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
             } else {
                 negotiation.transitionInitial();
-                negotiationStore.save(negotiation);
-                observable.invokeForEach(l -> l.requesting(negotiation));
+                update(negotiation, l -> l.requesting(negotiation));
                 String message = format("[Consumer] Failed to send contract offer with id %s. ContractNegotiation %s stays in state %s.",
                         offerId, negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
                 monitor.debug(message, throwable);
@@ -362,14 +356,12 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
 
             if (throwable == null) {
                 negotiation.transitionOffered();
-                negotiationStore.save(negotiation);
-                observable.invokeForEach(l -> l.consumerOffered(negotiation));
+                update(negotiation, l -> l.consumerOffered(negotiation));
                 monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
                         negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
             } else {
                 negotiation.transitionOffering();
-                negotiationStore.save(negotiation);
-                observable.invokeForEach(l -> l.consumerOffering(negotiation));
+                update(negotiation, l -> l.consumerOffering(negotiation));
                 String message = format("[Consumer] Failed to send contract offer with id %s. ContractNegotiation %s stays in state %s.",
                         offerId, negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
                 monitor.debug(message, throwable);
@@ -434,14 +426,12 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
 
             if (throwable == null) {
                 negotiation.transitionApproved();
-                negotiationStore.save(negotiation);
-                observable.invokeForEach(l -> l.consumerApproved(negotiation));
+                update(negotiation, l -> l.consumerApproved(negotiation));
                 monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
                         negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
             } else {
                 negotiation.transitionApproving();
-                negotiationStore.save(negotiation);
-                observable.invokeForEach(l -> l.consumerApproving(negotiation));
+                update(negotiation, l -> l.consumerApproving(negotiation));
                 String message = format("[Consumer] Failed to send contract agreement with id %s. ContractNegotiation %s stays in state %s.",
                         agreementId, negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
                 monitor.debug(message, throwable);
@@ -483,14 +473,12 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
 
             if (throwable == null) {
                 negotiation.transitionDeclined();
-                negotiationStore.save(negotiation);
-                observable.invokeForEach(l -> l.declined(negotiation));
+                update(negotiation, l -> l.declined(negotiation));
                 monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
                         negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
             } else {
                 negotiation.transitionDeclining();
-                negotiationStore.save(negotiation);
-                observable.invokeForEach(l -> l.declining(negotiation));
+                update(negotiation, l -> l.declining(negotiation));
                 String message = format("[Consumer] Failed to send contract rejection. ContractNegotiation %s stays in state %s.",
                         negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
                 monitor.debug(message, throwable);
@@ -508,6 +496,11 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
 
     private boolean processCommand(ContractNegotiationCommand command) {
         return commandProcessor.processCommandQueue(command);
+    }
+
+    private void update(ContractNegotiation negotiation, Consumer<ContractNegotiationListener> observe) {
+        observable.invokeForEach(observe);
+        negotiationStore.save(negotiation);
     }
 
     /**

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -110,7 +110,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
 
         negotiation.addContractOffer(contractOffer.getContractOffer());
         negotiation.transitionInitial();
-        update(negotiation, l -> l.requesting(negotiation));
+        update(negotiation, l -> l.preRequesting(negotiation));
 
         monitor.debug(String.format("[Consumer] ContractNegotiation initiated. %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
@@ -152,12 +152,12 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
             monitor.debug("[Consumer] Contract offer received. Will be rejected.");
             negotiation.setErrorDetail(result.getFailureMessages().get(0));
             negotiation.transitionDeclining();
-            update(negotiation, l -> l.declining(negotiation));
+            update(negotiation, l -> l.preDeclining(negotiation));
         } else {
             // Offer has been approved.
             monitor.debug("[Consumer] Contract offer received. Will be approved.");
             negotiation.transitionApproving();
-            update(negotiation, l -> l.consumerApproving(negotiation));
+            update(negotiation, l -> l.preConsumerApproving(negotiation));
         }
 
         monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
@@ -200,7 +200,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
             monitor.debug("[Consumer] Contract agreement received. Validation failed.");
             negotiation.setErrorDetail("Contract rejected."); //TODO set error detail
             negotiation.transitionDeclining();
-            update(negotiation, l -> l.declining(negotiation));
+            update(negotiation, l -> l.preDeclining(negotiation));
             monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
                     negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
             return NegotiationResult.success(negotiation);
@@ -213,7 +213,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
             // TODO: otherwise will fail. But should do it, since it's already confirmed? A duplicated message received shouldn't be an issue
             negotiation.transitionConfirmed();
         }
-        update(negotiation, l -> l.confirmed(negotiation));
+        update(negotiation, l -> l.preConfirmed(negotiation));
         monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
 
@@ -239,7 +239,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
 
         monitor.debug("[Consumer] Contract rejection received. Abort negotiation process.");
         negotiation.transitionDeclined();
-        update(negotiation, l -> l.declined(negotiation));
+        update(negotiation, l -> l.preDeclined(negotiation));
         monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
         return NegotiationResult.success(negotiation);
@@ -332,12 +332,12 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
 
             if (throwable == null) {
                 negotiation.transitionRequested();
-                update(negotiation, l -> l.requested(negotiation));
+                update(negotiation, l -> l.preRequested(negotiation));
                 monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
                         negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
             } else {
                 negotiation.transitionInitial();
-                update(negotiation, l -> l.requesting(negotiation));
+                update(negotiation, l -> l.preRequesting(negotiation));
                 String message = format("[Consumer] Failed to send contract offer with id %s. ContractNegotiation %s stays in state %s.",
                         offerId, negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
                 monitor.debug(message, throwable);
@@ -356,12 +356,12 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
 
             if (throwable == null) {
                 negotiation.transitionOffered();
-                update(negotiation, l -> l.consumerOffered(negotiation));
+                update(negotiation, l -> l.preConsumerOffered(negotiation));
                 monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
                         negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
             } else {
                 negotiation.transitionOffering();
-                update(negotiation, l -> l.consumerOffering(negotiation));
+                update(negotiation, l -> l.preConsumerOffering(negotiation));
                 String message = format("[Consumer] Failed to send contract offer with id %s. ContractNegotiation %s stays in state %s.",
                         offerId, negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
                 monitor.debug(message, throwable);
@@ -426,12 +426,12 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
 
             if (throwable == null) {
                 negotiation.transitionApproved();
-                update(negotiation, l -> l.consumerApproved(negotiation));
+                update(negotiation, l -> l.preConsumerApproved(negotiation));
                 monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
                         negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
             } else {
                 negotiation.transitionApproving();
-                update(negotiation, l -> l.consumerApproving(negotiation));
+                update(negotiation, l -> l.preConsumerApproving(negotiation));
                 String message = format("[Consumer] Failed to send contract agreement with id %s. ContractNegotiation %s stays in state %s.",
                         agreementId, negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
                 monitor.debug(message, throwable);
@@ -473,12 +473,12 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
 
             if (throwable == null) {
                 negotiation.transitionDeclined();
-                update(negotiation, l -> l.declined(negotiation));
+                update(negotiation, l -> l.preDeclined(negotiation));
                 monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
                         negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
             } else {
                 negotiation.transitionDeclining();
-                update(negotiation, l -> l.declining(negotiation));
+                update(negotiation, l -> l.preDeclining(negotiation));
                 String message = format("[Consumer] Failed to send contract rejection. ContractNegotiation %s stays in state %s.",
                         negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
                 monitor.debug(message, throwable);

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -21,6 +21,7 @@ import org.eclipse.dataspaceconnector.common.statemachine.StateMachine;
 import org.eclipse.dataspaceconnector.common.statemachine.StateProcessorImpl;
 import org.eclipse.dataspaceconnector.contract.common.ContractId;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.ProviderContractNegotiationManager;
+import org.eclipse.dataspaceconnector.spi.contract.negotiation.observe.ContractNegotiationListener;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.response.NegotiationResult;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.result.Result;
@@ -38,6 +39,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static java.lang.String.format;
@@ -109,8 +111,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
             negotiation.setContractAgreement(null);
         }
         negotiation.transitionDeclined();
-        negotiationStore.save(negotiation);
-        observable.invokeForEach(l -> l.declined(negotiation));
+        update(negotiation, l -> l.declined(negotiation));
         monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
 
@@ -150,8 +151,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
 
         negotiation.transitionRequested();
 
-        negotiationStore.save(negotiation);
-        observable.invokeForEach(l -> l.requested(negotiation));
+        update(negotiation, l -> l.requested(negotiation));
 
         monitor.debug(String.format("[Provider] ContractNegotiation initiated. %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
@@ -206,8 +206,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
             monitor.debug("[Provider] Contract offer received. Will be rejected.");
             negotiation.setErrorDetail(result.getFailureMessages().get(0));
             negotiation.transitionDeclining();
-            negotiationStore.save(negotiation);
-            observable.invokeForEach(l -> l.declining(negotiation));
+            update(negotiation, l -> l.declining(negotiation));
 
             monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                     negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
@@ -217,8 +216,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
         monitor.debug("[Provider] Contract offer received. Will be approved.");
         // negotiation.addContractOffer(result.getValidatedOffer()); TODO
         negotiation.transitionConfirming();
-        negotiationStore.save(negotiation);
-        observable.invokeForEach(l -> l.confirming(negotiation));
+        update(negotiation, l -> l.confirming(negotiation));
         monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
 
@@ -244,8 +242,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
 
         monitor.debug("[Provider] Contract offer has been approved by consumer.");
         negotiation.transitionConfirming();
-        negotiationStore.save(negotiation);
-        observable.invokeForEach(l -> l.confirming(negotiation));
+        update(negotiation, l -> l.confirming(negotiation));
         monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
         return NegotiationResult.success(negotiation);
@@ -299,14 +296,12 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
 
             if (throwable == null) {
                 negotiation.transitionOffered();
-                negotiationStore.save(negotiation);
-                observable.invokeForEach(l -> l.providerOffered(negotiation));
+                update(negotiation, l -> l.providerOffered(negotiation));
                 monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                         negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
             } else {
                 negotiation.transitionOffering();
-                negotiationStore.save(negotiation);
-                observable.invokeForEach(l -> l.providerOffering(negotiation));
+                update(negotiation, l -> l.providerOffering(negotiation));
                 String message = format("[Provider] Failed to send contract offer with id %s. ContractNegotiation %s stays in state %s.",
                         offerId, negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
                 monitor.debug(message, throwable);
@@ -349,14 +344,12 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
 
             if (throwable == null) {
                 negotiation.transitionDeclined();
-                negotiationStore.save(negotiation);
-                observable.invokeForEach(l -> l.declined(negotiation));
+                update(negotiation, l -> l.declined(negotiation));
                 monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                         negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
             } else {
                 negotiation.transitionDeclining();
-                negotiationStore.save(negotiation);
-                observable.invokeForEach(l -> l.declining(negotiation));
+                update(negotiation, l -> l.declining(negotiation));
                 String message = format("[Provider] Failed to send contract rejection. ContractNegotiation %s stays in state %s.",
                         negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
                 monitor.debug(message, throwable);
@@ -410,6 +403,8 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                 .build();
 
         //TODO protocol-independent response type?
+        negotiation.transitionConfirmingSent();
+        update(negotiation, l -> l.confirmingSent(negotiation));
         dispatcherRegistry.send(Object.class, request, () -> null)
                 .whenComplete(onAgreementSent(negotiation.getId(), agreement));
         return true;
@@ -427,19 +422,22 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
             if (throwable == null) {
                 negotiation.setContractAgreement(agreement);
                 negotiation.transitionConfirmed();
-                negotiationStore.save(negotiation);
-                observable.invokeForEach(l -> l.confirmed(negotiation));
+                update(negotiation, l -> l.confirmed(negotiation));
                 monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                         negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
             } else {
                 negotiation.transitionConfirming();
-                negotiationStore.save(negotiation);
-                observable.invokeForEach(l -> l.confirming(negotiation));
+                update(negotiation, l -> l.confirming(negotiation));
                 String message = format("[Provider] Failed to send contract agreement with id %s. ContractNegotiation %s stays in state %s.",
                         agreement.getId(), negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
                 monitor.debug(message, throwable);
             }
         };
+    }
+
+    private void update(ContractNegotiation negotiation, Consumer<ContractNegotiationListener> observe) {
+        observable.invokeForEach(observe);
+        negotiationStore.save(negotiation);
     }
 
     /**

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -403,8 +403,6 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                 .build();
 
         //TODO protocol-independent response type?
-        negotiation.transitionConfirmingSent();
-        update(negotiation, l -> l.confirmingSent(negotiation));
         dispatcherRegistry.send(Object.class, request, () -> null)
                 .whenComplete(onAgreementSent(negotiation.getId(), agreement));
         return true;

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -111,7 +111,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
             negotiation.setContractAgreement(null);
         }
         negotiation.transitionDeclined();
-        update(negotiation, l -> l.declined(negotiation));
+        update(negotiation, l -> l.preDeclined(negotiation));
         monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
 
@@ -151,7 +151,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
 
         negotiation.transitionRequested();
 
-        update(negotiation, l -> l.requested(negotiation));
+        update(negotiation, l -> l.preRequested(negotiation));
 
         monitor.debug(String.format("[Provider] ContractNegotiation initiated. %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
@@ -206,7 +206,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
             monitor.debug("[Provider] Contract offer received. Will be rejected.");
             negotiation.setErrorDetail(result.getFailureMessages().get(0));
             negotiation.transitionDeclining();
-            update(negotiation, l -> l.declining(negotiation));
+            update(negotiation, l -> l.preDeclining(negotiation));
 
             monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                     negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
@@ -216,7 +216,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
         monitor.debug("[Provider] Contract offer received. Will be approved.");
         // negotiation.addContractOffer(result.getValidatedOffer()); TODO
         negotiation.transitionConfirming();
-        update(negotiation, l -> l.confirming(negotiation));
+        update(negotiation, l -> l.preConfirming(negotiation));
         monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
 
@@ -242,7 +242,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
 
         monitor.debug("[Provider] Contract offer has been approved by consumer.");
         negotiation.transitionConfirming();
-        update(negotiation, l -> l.confirming(negotiation));
+        update(negotiation, l -> l.preConfirming(negotiation));
         monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
         return NegotiationResult.success(negotiation);
@@ -296,12 +296,12 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
 
             if (throwable == null) {
                 negotiation.transitionOffered();
-                update(negotiation, l -> l.providerOffered(negotiation));
+                update(negotiation, l -> l.preProviderOffered(negotiation));
                 monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                         negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
             } else {
                 negotiation.transitionOffering();
-                update(negotiation, l -> l.providerOffering(negotiation));
+                update(negotiation, l -> l.preProviderOffering(negotiation));
                 String message = format("[Provider] Failed to send contract offer with id %s. ContractNegotiation %s stays in state %s.",
                         offerId, negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
                 monitor.debug(message, throwable);
@@ -344,12 +344,12 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
 
             if (throwable == null) {
                 negotiation.transitionDeclined();
-                update(negotiation, l -> l.declined(negotiation));
+                update(negotiation, l -> l.preDeclined(negotiation));
                 monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                         negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
             } else {
                 negotiation.transitionDeclining();
-                update(negotiation, l -> l.declining(negotiation));
+                update(negotiation, l -> l.preDeclining(negotiation));
                 String message = format("[Provider] Failed to send contract rejection. ContractNegotiation %s stays in state %s.",
                         negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
                 monitor.debug(message, throwable);
@@ -420,12 +420,12 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
             if (throwable == null) {
                 negotiation.setContractAgreement(agreement);
                 negotiation.transitionConfirmed();
-                update(negotiation, l -> l.confirmed(negotiation));
+                update(negotiation, l -> l.preConfirmed(negotiation));
                 monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                         negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
             } else {
                 negotiation.transitionConfirming();
-                update(negotiation, l -> l.confirming(negotiation));
+                update(negotiation, l -> l.preConfirming(negotiation));
                 String message = format("[Provider] Failed to send contract agreement with id %s. ContractNegotiation %s stays in state %s.",
                         agreement.getId(), negotiation.getId(), ContractNegotiationStates.from(negotiation.getState()));
                 monitor.debug(message, throwable);

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/AbstractContractNegotiationIntegrationTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/AbstractContractNegotiationIntegrationTest.java
@@ -133,7 +133,7 @@ public abstract class AbstractContractNegotiationIntegrationTest {
         }
         
         @Override
-        public void confirmed(ContractNegotiation negotiation) {
+        public void preConfirmed(ContractNegotiation negotiation) {
             countDownLatch.countDown();
         }
     }
@@ -151,7 +151,7 @@ public abstract class AbstractContractNegotiationIntegrationTest {
         }
         
         @Override
-        public void declined(ContractNegotiation negotiation) {
+        public void preDeclined(ContractNegotiation negotiation) {
             countDownLatch.countDown();
         }
     }

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
@@ -467,8 +467,6 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
     }
 
     private void sendConsumerRequest(TransferProcess process, DataRequest dataRequest) {
-        process.transitionRequested();
-        updateTransferProcess(process, l -> l.requested(process)); // update before sending to accommodate synchronous transports; reliability will be managed by retry and idempotency
         dispatcherRegistry.send(Object.class, dataRequest, process::getId)
                 .thenApply(result -> {
                     var transferProcess = transferProcessStore.find(process.getId());

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
@@ -168,7 +168,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
         if (process.getState() == TransferProcessStates.UNSAVED.code()) {
             process.transitionInitial();
         }
-        observable.invokeForEach(l -> l.created(process));
+        observable.invokeForEach(l -> l.preCreated(process));
         transferProcessStore.create(process);
         return TransferInitiateResult.success(process.getId());
     }
@@ -187,7 +187,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
 
         var manifest = manifestGenerator.generateResourceManifest(process, policy);
         process.transitionProvisioning(manifest);
-        updateTransferProcess(process, l -> l.provisioning(process));
+        updateTransferProcess(process, l -> l.preProvisioning(process));
         return true;
     }
 
@@ -229,7 +229,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
         if (CONSUMER == process.getType()) {
             process.transitionRequesting();
             transferProcessStore.update(process);
-            observable.invokeForEach(l -> l.requesting(process));
+            observable.invokeForEach(l -> l.preRequesting(process));
         } else {
             processProviderRequest(process, process.getDataRequest());
         }
@@ -266,7 +266,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
     private boolean processRequested(TransferProcess process) {
         if (!process.getDataRequest().isManagedResources() || (process.getProvisionedResourceSet() != null && !process.getProvisionedResourceSet().empty())) {
             process.transitionInProgressOrStreaming();
-            updateTransferProcess(process, l -> l.inProgress(process));
+            updateTransferProcess(process, l -> l.preInProgress(process));
             monitor.debug("Process " + process.getId() + " is now " + TransferProcessStates.from(process.getState()));
             return true;
         } else {
@@ -322,7 +322,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
     private boolean processDeprovisioning(TransferProcess process) {
         // TODO resolve contract agreement policy from the PolicyStore
         var policy = Policy.Builder.newInstance().build();
-        observable.invokeForEach(l -> l.deprovisioning(process)); // TODO: this is called here since it's not callable from the command handler
+        observable.invokeForEach(l -> l.preDeprovisioning(process)); // TODO: this is called here since it's not callable from the command handler
         provisionManager.deprovision(process, policy)
                 .whenComplete((responses, throwable) -> {
                     if (throwable == null) {
@@ -346,7 +346,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
     private boolean processDeprovisioned(TransferProcess process) {
         process.transitionEnded();
         transferProcessStore.update(process);
-        observable.invokeForEach(l -> l.ended(process));
+        observable.invokeForEach(l -> l.preEnded(process));
         monitor.debug("Process " + process.getId() + " is now " + TransferProcessStates.from(process.getState()));
         return true;
     }
@@ -392,7 +392,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
         if (transferProcess.provisioningComplete()) {
             transferProcess.transitionProvisioned();
             transferProcessStore.update(transferProcess);
-            observable.invokeForEach(l -> l.provisioned(transferProcess));
+            observable.invokeForEach(l -> l.preProvisioned(transferProcess));
         } else {
             transferProcessStore.update(transferProcess);
         }
@@ -414,7 +414,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
 
         transferProcess.transitionDeprovisioned();
         transferProcessStore.update(transferProcess);
-        observable.invokeForEach(l -> l.deprovisioned(transferProcess));
+        observable.invokeForEach(l -> l.preDeprovisioned(transferProcess));
     }
 
     private StateProcessorImpl<TransferProcess> processTransfersInState(TransferProcessStates state, Function<TransferProcess, Boolean> function) {
@@ -430,7 +430,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
     private void transitionToCompleted(TransferProcess process) {
         process.transitionCompleted();
         monitor.debug("Process " + process.getId() + " is now " + COMPLETED);
-        updateTransferProcess(process, l -> l.completed(process));
+        updateTransferProcess(process, l -> l.preCompleted(process));
     }
 
     private void transitionToError(String id, Throwable throwable, String message) {
@@ -442,7 +442,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
 
         monitor.severe(message, throwable);
         transferProcess.transitionError(format("%s: %s", message, throwable.getLocalizedMessage()));
-        updateTransferProcess(transferProcess, l -> l.error(transferProcess));
+        updateTransferProcess(transferProcess, l -> l.preError(transferProcess));
     }
 
     private void processProviderRequest(TransferProcess process, DataRequest dataRequest) {
@@ -452,16 +452,16 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
         var response = dataFlowManager.initiate(dataRequest, policy);
         if (response.succeeded()) {
             process.transitionInProgressOrStreaming();
-            updateTransferProcess(process, l -> l.inProgress(process));
+            updateTransferProcess(process, l -> l.preInProgress(process));
         } else {
             if (ResponseStatus.ERROR_RETRY == response.getFailure().status()) {
                 monitor.severe("Error processing transfer request. Setting to retry: " + process.getId());
                 process.transitionProvisioned();
-                updateTransferProcess(process, l -> l.provisioned(process));
+                updateTransferProcess(process, l -> l.preProvisioned(process));
             } else {
                 monitor.severe(format("Fatal error processing transfer request: %s. Error details: %s", process.getId(), String.join(", ", response.getFailureMessages())));
                 process.transitionError(response.getFailureMessages().stream().findFirst().orElse(""));
-                updateTransferProcess(process, l -> l.error(process));
+                updateTransferProcess(process, l -> l.preError(process));
             }
         }
     }
@@ -478,7 +478,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
 
                     transferProcess.transitionRequested();
                     transferProcessStore.update(transferProcess);
-                    observable.invokeForEach(l -> l.requested(transferProcess));
+                    observable.invokeForEach(l -> l.preRequested(transferProcess));
                     return result;
                 })
                 .whenComplete((o, throwable) -> {
@@ -492,7 +492,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
                         }
 
                         transferProcess.transitionInProgressOrStreaming();
-                        updateTransferProcess(transferProcess, l -> l.inProgress(transferProcess));
+                        updateTransferProcess(transferProcess, l -> l.preInProgress(transferProcess));
                     }
                 });
     }

--- a/extensions/azure/events/src/main/java/org/eclipse/dataspaceconnector/events/azure/AzureEventGridPublisher.java
+++ b/extensions/azure/events/src/main/java/org/eclipse/dataspaceconnector/events/azure/AzureEventGridPublisher.java
@@ -40,7 +40,7 @@ class AzureEventGridPublisher implements TransferProcessListener {
     }
 
     @Override
-    public void created(TransferProcess process) {
+    public void preCreated(TransferProcess process) {
         var dto = createTransferProcessDto(process);
         if (process.getType() == TransferProcess.Type.CONSUMER) {
             sendEvent("createdConsumer", eventTypeTransferprocess, dto).subscribe(new LoggingSubscriber<>("Transfer process created"));
@@ -50,25 +50,25 @@ class AzureEventGridPublisher implements TransferProcessListener {
     }
 
     @Override
-    public void completed(TransferProcess process) {
+    public void preCompleted(TransferProcess process) {
         sendEvent("completed", eventTypeTransferprocess, createTransferProcessDto(process)).subscribe(new LoggingSubscriber<>("Transfer process completed"));
     }
 
 
     @Override
-    public void deprovisioned(TransferProcess process) {
+    public void preDeprovisioned(TransferProcess process) {
         sendEvent("deprovisioned", eventTypeTransferprocess, createTransferProcessDto(process)).subscribe(new LoggingSubscriber<>("Transfer process resources deprovisioned"));
 
     }
 
     @Override
-    public void ended(TransferProcess process) {
+    public void preEnded(TransferProcess process) {
         sendEvent("ended", eventTypeTransferprocess, createTransferProcessDto(process)).subscribe(new LoggingSubscriber<>("Transfer process ended"));
 
     }
 
     @Override
-    public void error(TransferProcess process) {
+    public void preError(TransferProcess process) {
         sendEvent("error", eventTypeTransferprocess, createTransferProcessDto(process)).subscribe(new LoggingSubscriber<>("Transfer process errored!"));
 
     }

--- a/samples/04.1-file-transfer-listener/listener/src/main/java/org/eclipse/dataspaceconnector/extensions/listener/MarkerFileCreator.java
+++ b/samples/04.1-file-transfer-listener/listener/src/main/java/org/eclipse/dataspaceconnector/extensions/listener/MarkerFileCreator.java
@@ -19,12 +19,12 @@ public class MarkerFileCreator implements TransferProcessListener {
     }
 
     /**
-     * Callback invoked by the EDC framework when a transfer has completed.
+     * Callback invoked by the EDC framework when a transfer is about to be completed.
      *
-     * @param process the transfer process that has completed.
+     * @param process the transfer process that is about to be completed.
      */
     @Override
-    public void completed(final TransferProcess process) {
+    public void preCompleted(final TransferProcess process) {
         Path path = Path.of(process.getDataRequest().getDataDestination().getProperty("path"));
         if (!Files.isDirectory(path)) {
             path = path.getParent();

--- a/samples/other/run-from-junit/src/test/java/org/eclipse/dataspaceconnector/junit/ConsumerRunner.java
+++ b/samples/other/run-from-junit/src/test/java/org/eclipse/dataspaceconnector/junit/ConsumerRunner.java
@@ -83,7 +83,7 @@ public class ConsumerRunner {
             TransferInitiateResult response = processManager.initiateConsumerRequest(usOrEuRequest);
             observable.registerListener(new TransferProcessListener() {
                 @Override
-                public void completed(TransferProcess process) {
+                public void preCompleted(TransferProcess process) {
                     if (process.getId().equals(response.getContent())) {
                         return;
                     }
@@ -98,7 +98,7 @@ public class ConsumerRunner {
                 }
 
                 @Override
-                public void deprovisioned(TransferProcess process) {
+                public void preDeprovisioned(TransferProcess process) {
                     if (process.getId().equals(response.getContent())) {
                         return;
                     }
@@ -139,7 +139,7 @@ public class ConsumerRunner {
             TransferInitiateResult response = processManager.initiateConsumerRequest(usOrEuRequest);
             observable.registerListener(new TransferProcessListener() {
                 @Override
-                public void completed(TransferProcess process) {
+                public void preCompleted(TransferProcess process) {
                     if (process.getId().equals(response.getContent())) {
                         return;
                     }
@@ -154,7 +154,7 @@ public class ConsumerRunner {
                 }
 
                 @Override
-                public void deprovisioned(TransferProcess process) {
+                public void preDeprovisioned(TransferProcess process) {
                     if (!process.getId().equals(response.getContent())) {
                         return;
                     }
@@ -192,7 +192,7 @@ public class ConsumerRunner {
             TransferInitiateResult response = processManager.initiateConsumerRequest(usOrEuRequest);
             observable.registerListener(new TransferProcessListener() {
                 @Override
-                public void completed(TransferProcess process) {
+                public void preCompleted(TransferProcess process) {
                     if (process.getId().equals(response.getContent())) {
                         return;
                     }
@@ -207,7 +207,7 @@ public class ConsumerRunner {
                 }
 
                 @Override
-                public void deprovisioned(TransferProcess process) {
+                public void preDeprovisioned(TransferProcess process) {
                     if (process.getId().equals(response.getContent())) {
                         return;
                     }

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/observe/ContractNegotiationListener.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/observe/ContractNegotiationListener.java
@@ -21,9 +21,9 @@ import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.Cont
  * Interface implemented by listeners registered to observe contract negotiation state changes
  * via {@link Observable#registerListener}.
  * <p>
- * Note that the listener is not guaranteed to be called after a state change, in case
- * the application restarts. That is relevant when using a persistent contract negotiation
- * store implementation.
+ * Note that the listener is called before state changes are persisted.
+ * Therefore, when using a persistent contract negotiation store implementation, it
+ * is guaranteed to be called at least once.
  */
 public interface ContractNegotiationListener {
     
@@ -125,7 +125,16 @@ public interface ContractNegotiationListener {
      */
     default void confirming(ContractNegotiation negotiation) {
     }
-    
+
+    /**
+     * Called after a {@link ContractNegotiation} has moved to state
+     * {@link ContractNegotiationStates#CONFIRMING_SENT}.
+     *
+     * @param negotiation the contract negotiation whose state has changed.
+     */
+    default void confirmingSent(ContractNegotiation negotiation) {
+    }
+
     /**
      * Called after a {@link ContractNegotiation} has moved to state
      * {@link ContractNegotiationStates#CONFIRMED}.
@@ -134,7 +143,7 @@ public interface ContractNegotiationListener {
      */
     default void confirmed(ContractNegotiation negotiation) {
     }
-    
+
     /**
      * Called after a {@link ContractNegotiation} has moved to state
      * {@link ContractNegotiationStates#ERROR}.
@@ -143,5 +152,4 @@ public interface ContractNegotiationListener {
      */
     default void error(ContractNegotiation negotiation) {
     }
-    
 }

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/observe/ContractNegotiationListener.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/observe/ContractNegotiationListener.java
@@ -29,127 +29,118 @@ public interface ContractNegotiationListener {
     
     /**
      * Called after a {@link ContractNegotiation} has moved to state
-     * {@link ContractNegotiationStates#REQUESTING}.
+     * {@link ContractNegotiationStates#REQUESTING}, but before the change is persisted.
      *
      * @param negotiation the contract negotiation whose state has changed.
      */
-    default void requesting(ContractNegotiation negotiation) {
+    default void preRequesting(ContractNegotiation negotiation) {
     }
     
     /**
      * Called after a {@link ContractNegotiation} has moved to state
-     * {@link ContractNegotiationStates#REQUESTED}.
+     * {@link ContractNegotiationStates#REQUESTED}, but before the change is persisted.
      *
      * @param negotiation the contract negotiation whose state has changed.
      */
-    default void requested(ContractNegotiation negotiation) {
+    default void preRequested(ContractNegotiation negotiation) {
     }
     
     /**
      * Called after a {@link ContractNegotiation} has moved to state
-     * {@link ContractNegotiationStates#PROVIDER_OFFERING}.
+     * {@link ContractNegotiationStates#PROVIDER_OFFERING}, but before the change is persisted.
      *
      * @param negotiation the contract negotiation whose state has changed.
      */
-    default void providerOffering(ContractNegotiation negotiation) {
+    default void preProviderOffering(ContractNegotiation negotiation) {
     }
     
     /**
      * Called after a {@link ContractNegotiation} has moved to state
-     * {@link ContractNegotiationStates#PROVIDER_OFFERED}.
+     * {@link ContractNegotiationStates#PROVIDER_OFFERED}, but before the change is persisted.
      *
      * @param negotiation the contract negotiation whose state has changed.
      */
-    default void providerOffered(ContractNegotiation negotiation) {
+    default void preProviderOffered(ContractNegotiation negotiation) {
     }
     
     /**
      * Called after a {@link ContractNegotiation} has moved to state
-     * {@link ContractNegotiationStates#CONSUMER_OFFERING}.
+     * {@link ContractNegotiationStates#CONSUMER_OFFERING}, but before the change is persisted.
      *
      * @param negotiation the contract negotiation whose state has changed.
      */
-    default void consumerOffering(ContractNegotiation negotiation) {
+    default void preConsumerOffering(ContractNegotiation negotiation) {
     }
     
     /**
      * Called after a {@link ContractNegotiation} has moved to state
-     * {@link ContractNegotiationStates#CONSUMER_OFFERED}.
+     * {@link ContractNegotiationStates#CONSUMER_OFFERED}, but before the change is persisted.
      *
      * @param negotiation the contract negotiation whose state has changed.
      */
-    default void consumerOffered(ContractNegotiation negotiation) {
+    default void preConsumerOffered(ContractNegotiation negotiation) {
     }
     
     /**
      * Called after a {@link ContractNegotiation} has moved to state
-     * {@link ContractNegotiationStates#CONSUMER_APPROVING}.
+     * {@link ContractNegotiationStates#CONSUMER_APPROVING}, but before the change is persisted.
      *
      * @param negotiation the contract negotiation whose state has changed.
      */
-    default void consumerApproving(ContractNegotiation negotiation) {
+    default void preConsumerApproving(ContractNegotiation negotiation) {
     }
     
     /**
      * Called after a {@link ContractNegotiation} has moved to state
-     * {@link ContractNegotiationStates#CONSUMER_APPROVED}.
+     * {@link ContractNegotiationStates#CONSUMER_APPROVED}, but before the change is persisted.
      *
      * @param negotiation the contract negotiation whose state has changed.
      */
-    default void consumerApproved(ContractNegotiation negotiation) {
+    default void preConsumerApproved(ContractNegotiation negotiation) {
     }
     
     /**
      * Called after a {@link ContractNegotiation} has moved to state
-     * {@link ContractNegotiationStates#DECLINING}.
+     * {@link ContractNegotiationStates#DECLINING}, but before the change is persisted.
      *
      * @param negotiation the contract negotiation whose state has changed.
      */
-    default void declining(ContractNegotiation negotiation) {
+    default void preDeclining(ContractNegotiation negotiation) {
     }
     
     /**
      * Called after a {@link ContractNegotiation} has moved to state
-     * {@link ContractNegotiationStates#DECLINED}.
+     * {@link ContractNegotiationStates#DECLINED}, but before the change is persisted.
      *
      * @param negotiation the contract negotiation whose state has changed.
      */
-    default void declined(ContractNegotiation negotiation) {
+    default void preDeclined(ContractNegotiation negotiation) {
     }
     
     /**
      * Called after a {@link ContractNegotiation} has moved to state
-     * {@link ContractNegotiationStates#CONFIRMING}.
+     * {@link ContractNegotiationStates#CONFIRMING}, but before the change is persisted.
      *
      * @param negotiation the contract negotiation whose state has changed.
      */
-    default void confirming(ContractNegotiation negotiation) {
+    default void preConfirming(ContractNegotiation negotiation) {
     }
 
     /**
      * Called after a {@link ContractNegotiation} has moved to state
-     * {@link ContractNegotiationStates#CONFIRMING_SENT}.
+     * {@link ContractNegotiationStates#CONFIRMED}, but before the change is persisted.
      *
      * @param negotiation the contract negotiation whose state has changed.
      */
-    default void confirmingSent(ContractNegotiation negotiation) {
+    default void preConfirmed(ContractNegotiation negotiation) {
     }
 
     /**
      * Called after a {@link ContractNegotiation} has moved to state
-     * {@link ContractNegotiationStates#CONFIRMED}.
+     * {@link ContractNegotiationStates#ERROR}, but before the change is persisted.
      *
      * @param negotiation the contract negotiation whose state has changed.
      */
-    default void confirmed(ContractNegotiation negotiation) {
-    }
-
-    /**
-     * Called after a {@link ContractNegotiation} has moved to state
-     * {@link ContractNegotiationStates#ERROR}.
-     *
-     * @param negotiation the contract negotiation whose state has changed.
-     */
-    default void error(ContractNegotiation negotiation) {
+    default void preError(ContractNegotiation negotiation) {
     }
 }

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/observe/TransferProcessListener.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/observe/TransferProcessListener.java
@@ -22,9 +22,9 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessS
  * Interface implemented by listeners registered to observe transfer process
  * state changes via {@link Observable#registerListener}.
  * <p>
- * Note that the listener is not guaranteed to be called after a state change, in case
- * the application restarts. That is relevant when using a persistent transfer
- * store implementation.
+ * Note that the listener is called before state changes are persisted.
+ * Therefore, when using a persistent transfer store implementation, it
+ * is guaranteed to be called at least once.
  */
 public interface TransferProcessListener {
     /**

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/observe/TransferProcessListener.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/observe/TransferProcessListener.java
@@ -29,101 +29,101 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessS
 public interface TransferProcessListener {
     /**
      * Called after a {@link TransferProcess} has moved to state
-     * {@link TransferProcessStates#INITIAL INITIAL}.
+     * {@link TransferProcessStates#INITIAL INITIAL}, but before the change is persisted.
      *
      * @param process the transfer process whose state has changed.
      */
-    default void created(TransferProcess process) {
+    default void preCreated(TransferProcess process) {
     }
 
     /**
      * Called after a {@link TransferProcess} has moved to state
-     * {@link TransferProcessStates#PROVISIONING PROVISIONING}.
+     * {@link TransferProcessStates#PROVISIONING PROVISIONING}, but before the change is persisted.
      *
      * @param process the transfer process whose state has changed.
      */
-    default void provisioning(TransferProcess process) {
+    default void preProvisioning(TransferProcess process) {
     }
 
     /**
      * Called after a {@link TransferProcess} has moved to state
-     * {@link TransferProcessStates#PROVISIONED PROVISIONED}.
+     * {@link TransferProcessStates#PROVISIONED PROVISIONED}, but before the change is persisted.
      *
      * @param process the transfer process whose state has changed.
      */
-    default void provisioned(TransferProcess process) {
+    default void preProvisioned(TransferProcess process) {
     }
 
     /**
      * Called after a {@link TransferProcess} has moved to state
-     * {@link TransferProcessStates#REQUESTING REQUESTING}.
+     * {@link TransferProcessStates#REQUESTING REQUESTING}, but before the change is persisted.
      *
      * @param process the transfer process whose state has changed.
      */
-    default void requesting(TransferProcess process) {
+    default void preRequesting(TransferProcess process) {
     }
 
     /**
      * Called after a {@link TransferProcess} has moved to state
-     * {@link TransferProcessStates#REQUESTED REQUESTED}.
+     * {@link TransferProcessStates#REQUESTED REQUESTED}, but before the change is persisted.
      *
      * @param process the transfer process whose state has changed.
      */
-    default void requested(TransferProcess process) {
+    default void preRequested(TransferProcess process) {
     }
 
     /**
      * Called after a {@link TransferProcess} has moved to state
-     * {@link TransferProcessStates#IN_PROGRESS IN_PROGRESS}.
+     * {@link TransferProcessStates#IN_PROGRESS IN_PROGRESS}, but before the change is persisted.
      *
      * @param process the transfer process whose state has changed.
      */
-    default void inProgress(TransferProcess process) {
+    default void preInProgress(TransferProcess process) {
     }
 
     /**
      * Called after a {@link TransferProcess} has moved to state
-     * {@link TransferProcessStates#COMPLETED COMPLETED}.
+     * {@link TransferProcessStates#COMPLETED COMPLETED}, but before the change is persisted.
      *
      * @param process the transfer process whose state has changed.
      */
-    default void completed(TransferProcess process) {
+    default void preCompleted(TransferProcess process) {
     }
 
     /**
      * Called after a {@link TransferProcess} has moved to state
-     * {@link TransferProcessStates#DEPROVISIONING DEPROVISIONING}.
+     * {@link TransferProcessStates#DEPROVISIONING DEPROVISIONING}, but before the change is persisted.
      *
      * @param process the transfer process whose state has changed.
      */
-    default void deprovisioning(TransferProcess process) {
+    default void preDeprovisioning(TransferProcess process) {
     }
 
     /**
      * Called after a {@link TransferProcess} has moved to state
-     * {@link TransferProcessStates#DEPROVISIONED DEPROVISIONED}.
+     * {@link TransferProcessStates#DEPROVISIONED DEPROVISIONED}, but before the change is persisted.
      *
      * @param process the transfer process whose state has changed.
      */
-    default void deprovisioned(TransferProcess process) {
+    default void preDeprovisioned(TransferProcess process) {
     }
 
     /**
      * Called after a {@link TransferProcess} has moved to state
-     * {@link TransferProcessStates#ENDED ENDED}.
+     * {@link TransferProcessStates#ENDED ENDED}, but before the change is persisted.
      *
      * @param process the transfer process whose state has changed.
      */
-    default void ended(TransferProcess process) {
+    default void preEnded(TransferProcess process) {
     }
 
     /**
      * Called after a {@link TransferProcess} has moved to state
-     * {@link TransferProcessStates#ERROR ERROR}.
+     * {@link TransferProcessStates#ERROR ERROR}, but before the change is persisted.
      *
      * @param process the transfer process whose state has changed.
      */
-    default void error(TransferProcess process) {
+    default void preError(TransferProcess process) {
     }
 
 }


### PR DESCRIPTION
## What this PR changes/adds

- Call the listeners before the state transition is persisted.
- Add  _confirmingSent_ method to ContractNegotiationListener

## Why it does that

A custom extension may need to perform custom processing after a data transfer has reached a certain stage.

Triggering custom logic on TransferProcess state changes requires registering a TransferProcessListener. However listeners are not guaranteed to be called, e.g. if the instance crashes after persisting the state change but before invoking the listener. Custom logic in the listener can be crucial for the functioning of client applications, thus EDC needs to guarantee that these are called before advancing a transfer process to the next state is made durable.

## Further notes

- calling observable (_observable.invokeForEach(observe)_) and saving negotiation/transferProcess were grouped in one method to reduce code duplication

## Linked Issue(s)

Closes #434 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
