### PR TITLE
Dataloading extension: Add deleteById to AssetLoader.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ the detailed section referring to by linking pull requests or issues.
 * Add public Api to DPF and make `HttpDataSource` more generic (#699)
 * Add an in-memory data plane store (#705)
 * Introduce extensions for synchronous data transfer using data plane (#711)
-* Add a deleteById method to the AssetLoader interface (#?)
+* Add a deleteById method to the AssetLoader interface (#880)
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ the detailed section referring to by linking pull requests or issues.
 * Add public Api to DPF and make `HttpDataSource` more generic (#699)
 * Add an in-memory data plane store (#705)
 * Introduce extensions for synchronous data transfer using data plane (#711)
+* Add a deleteById method to the AssetLoader interface (#?)
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ the detailed section referring to by linking pull requests or issues.
 * Add okhttp client timeouts (#735)
 * Unit test framework for Dependency Injection (#843)
 * Implemented S3BucketReader (#675)
+* Add a deleteById method to the AssetLoader interface (#880)
 
 #### Changed
 
@@ -90,7 +91,6 @@ the detailed section referring to by linking pull requests or issues.
 * Add public Api to DPF and make `HttpDataSource` more generic (#699)
 * Add an in-memory data plane store (#705)
 * Introduce extensions for synchronous data transfer using data plane (#711)
-* Add a deleteById method to the AssetLoader interface (#880)
 
 #### Changed
 

--- a/extensions/azure/cosmos/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndex.java
+++ b/extensions/azure/cosmos/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndex.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.assetindex.azure;
 
+import com.azure.cosmos.implementation.NotFoundException;
 import com.azure.cosmos.models.SqlQuerySpec;
 import net.jodah.failsafe.RetryPolicy;
 import org.eclipse.dataspaceconnector.assetindex.azure.model.AssetDocument;
@@ -23,6 +24,7 @@ import org.eclipse.dataspaceconnector.dataloading.AssetLoader;
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
@@ -42,6 +44,7 @@ public class CosmosAssetIndex implements AssetIndex, DataAddressResolver, AssetL
     private final TypeManager typeManager;
     private final RetryPolicy<Object> retryPolicy;
     private final CosmosAssetQueryBuilder queryBuilder;
+    private final Monitor monitor;
 
     /**
      * Creates a new instance of the CosmosDB-based for Asset storage.
@@ -51,11 +54,12 @@ public class CosmosAssetIndex implements AssetIndex, DataAddressResolver, AssetL
      * @param typeManager  The {@link TypeManager} that's used for serialization and deserialization.
      * @param retryPolicy  Retry policy if query to CosmosDB fails.
      */
-    public CosmosAssetIndex(CosmosDbApi assetDb, String partitionKey, TypeManager typeManager, RetryPolicy<Object> retryPolicy) {
+    public CosmosAssetIndex(CosmosDbApi assetDb, String partitionKey, TypeManager typeManager, RetryPolicy<Object> retryPolicy, Monitor monitor) {
         this.assetDb = Objects.requireNonNull(assetDb);
         this.partitionKey = partitionKey;
         this.typeManager = Objects.requireNonNull(typeManager);
         this.retryPolicy = Objects.requireNonNull(retryPolicy);
+        this.monitor = monitor;
         queryBuilder = new CosmosAssetQueryBuilder();
     }
 
@@ -103,6 +107,17 @@ public class CosmosAssetIndex implements AssetIndex, DataAddressResolver, AssetL
     public void accept(Asset asset, DataAddress dataAddress) {
         var assetDocument = new AssetDocument(asset, partitionKey, dataAddress);
         assetDb.saveItem(assetDocument);
+    }
+
+    @Override
+    public Asset deleteById(String assetId) {
+        try {
+            var deletedItem = assetDb.deleteItem(assetId);
+            return convertObject(deletedItem).getWrappedAsset();
+        } catch (NotFoundException notFoundException) {
+            monitor.debug(() -> String.format("Asset with id %s not found", assetId));
+            return null;
+        }
     }
 
     @Override

--- a/extensions/azure/cosmos/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexExtension.java
+++ b/extensions/azure/cosmos/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexExtension.java
@@ -43,7 +43,7 @@ public class CosmosAssetIndexExtension implements ServiceExtension {
         Vault vault = context.getService(Vault.class);
 
         var cosmosDbApi = new CosmosDbApiImpl(vault, configuration);
-        var assetIndex = new CosmosAssetIndex(cosmosDbApi, configuration.getPartitionKey(), context.getTypeManager(), context.getService(RetryPolicy.class));
+        var assetIndex = new CosmosAssetIndex(cosmosDbApi, configuration.getPartitionKey(), context.getTypeManager(), context.getService(RetryPolicy.class), context.getMonitor());
         context.registerService(AssetIndex.class, assetIndex);
         context.registerService(AssetLoader.class, assetIndex);
         context.registerService(DataAddressResolver.class, assetIndex);

--- a/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexIntegrationTest.java
+++ b/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexIntegrationTest.java
@@ -372,7 +372,7 @@ class CosmosAssetIndexIntegrationTest {
 
     @Test
     void deleteById_whenMissing_returnsNull() {
-        assertThat(assetIndex.deleteById(UUID.randomUUID().toString())).isNull();
+        assertThat(assetIndex.deleteById("not-exists")).isNull();
     }
 
     private Asset createAsset(String id, String somePropertyKey, String somePropertyValue) {

--- a/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexTest.java
+++ b/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.assetindex.azure;
 
+import com.azure.cosmos.implementation.NotFoundException;
 import com.azure.cosmos.models.SqlQuerySpec;
 import net.jodah.failsafe.RetryPolicy;
 import org.eclipse.dataspaceconnector.assetindex.azure.model.AssetDocument;
@@ -21,6 +22,8 @@ import org.eclipse.dataspaceconnector.azure.cosmos.CosmosDbApi;
 import org.eclipse.dataspaceconnector.common.matchers.PredicateMatcher;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
+import org.eclipse.dataspaceconnector.spi.monitor.ConsoleMonitor;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
@@ -49,6 +52,7 @@ import static org.mockito.Mockito.when;
 class CosmosAssetIndexTest {
 
     private static final String TEST_PARTITION_KEY = "test-partition-key";
+    private static final String TEST_ID = "id-test";
     private CosmosDbApi api;
     private TypeManager typeManager;
     private RetryPolicy<Object> retryPolicy;
@@ -64,34 +68,34 @@ class CosmosAssetIndexTest {
         typeManager.registerTypes(AssetDocument.class, Asset.class);
         retryPolicy = new RetryPolicy<>().withMaxRetries(1);
         api = mock(CosmosDbApi.class);
-        assetIndex = new CosmosAssetIndex(api, TEST_PARTITION_KEY, typeManager, retryPolicy);
+        assetIndex = new CosmosAssetIndex(api, TEST_PARTITION_KEY, typeManager, retryPolicy, mock(Monitor.class));
     }
 
     @Test
     void inputValidation() {
         // null cosmos api
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> new CosmosAssetIndex(null, TEST_PARTITION_KEY, null, retryPolicy));
+                .isThrownBy(() -> new CosmosAssetIndex(null, TEST_PARTITION_KEY, null, retryPolicy, mock(Monitor.class)));
 
         // type manager is null
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> new CosmosAssetIndex(api, TEST_PARTITION_KEY, null, retryPolicy));
+                .isThrownBy(() -> new CosmosAssetIndex(api, TEST_PARTITION_KEY, null, retryPolicy, mock(Monitor.class)));
 
         // retry policy is null
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> new CosmosAssetIndex(api, TEST_PARTITION_KEY, typeManager, null));
+                .isThrownBy(() -> new CosmosAssetIndex(api, TEST_PARTITION_KEY, typeManager, null, mock(Monitor.class)));
     }
 
     @Test
     void findById() {
-        String id = "id-test";
-        AssetDocument document = createDocument(id);
-        when(api.queryItemById(eq(id))).thenReturn(document);
 
-        Asset actualAsset = assetIndex.findById(id);
+        AssetDocument document = createDocument(TEST_ID);
+        when(api.queryItemById(TEST_ID)).thenReturn(document);
+
+        Asset actualAsset = assetIndex.findById(TEST_ID);
 
         assertThat(actualAsset.getProperties()).isEqualTo(document.getWrappedAsset().getProperties());
-        verify(api).queryItemById(eq(id));
+        verify(api).queryItemById(TEST_ID);
     }
 
     @Test
@@ -162,7 +166,7 @@ class CosmosAssetIndexTest {
         // let's verify that the query actually contains the proper WHERE clause
         var queryCapture = ArgumentCaptor.forClass(SqlQuerySpec.class);
         when(api.queryItems(queryCapture.capture())).thenReturn(Stream.of(createDocument(id1), createDocument(id2)));
-        CosmosAssetIndex assetIndex = new CosmosAssetIndex(api, TEST_PARTITION_KEY, typeManager, retryPolicy);
+        CosmosAssetIndex assetIndex = new CosmosAssetIndex(api, TEST_PARTITION_KEY, typeManager, retryPolicy, mock(ConsoleMonitor.class));
         var selectByName = AssetSelectorExpression.Builder.newInstance().whenEquals(Asset.PROPERTY_NAME, "somename").build();
 
         var assets = assetIndex.queryAssets(selectByName);
@@ -177,8 +181,7 @@ class CosmosAssetIndexTest {
 
     @Test
     void findAll_noQuerySpec() {
-        String id = "id-test";
-        AssetDocument document = createDocument(id);
+        AssetDocument document = createDocument(TEST_ID);
         var expectedQuery = "SELECT * FROM AssetDocument OFFSET 0 LIMIT 50";
         when(api.queryItems(argThat(queryMatches(expectedQuery)))).thenReturn(Stream.of(document));
 
@@ -191,8 +194,7 @@ class CosmosAssetIndexTest {
 
     @Test
     void findAll_withPaging_SortingDesc() {
-        String id = "id-test";
-        AssetDocument document = createDocument(id);
+        AssetDocument document = createDocument(TEST_ID);
         var expectedQuery = "SELECT * FROM AssetDocument ORDER BY AssetDocument.wrappedInstance.anyField DESC OFFSET 5 LIMIT 100";
         when(api.queryItems(argThat(queryMatches(expectedQuery)))).thenReturn(Stream.of(document));
 
@@ -211,8 +213,7 @@ class CosmosAssetIndexTest {
 
     @Test
     void findAll_withPaging_SortingAsc() {
-        String id = "id-test";
-        AssetDocument document = createDocument(id);
+        AssetDocument document = createDocument(TEST_ID);
         var expectedQuery = "SELECT * FROM AssetDocument ORDER BY AssetDocument.wrappedInstance.anyField ASC OFFSET 5 LIMIT 100";
         when(api.queryItems(argThat(queryMatches(expectedQuery)))).thenReturn(Stream.of(document));
 
@@ -231,8 +232,7 @@ class CosmosAssetIndexTest {
 
     @Test
     void findAll_withFiltering() {
-        String id = "id-test";
-        AssetDocument document = createDocument(id);
+        AssetDocument document = createDocument(TEST_ID);
         var expectedQuery = "SELECT * FROM AssetDocument WHERE AssetDocument.wrappedInstance.someField = @someField OFFSET 5 LIMIT 100";
         when(api.queryItems(argThat(queryMatches(expectedQuery)))).thenReturn(Stream.of(document));
 
@@ -246,6 +246,22 @@ class CosmosAssetIndexTest {
         assertThat(assets).hasSize(1).extracting(Asset::getId).containsExactly(document.getWrappedAsset().getId());
         assertThat(assets).extracting(Asset::getProperties).allSatisfy(m -> assertThat(m).containsAllEntriesOf(document.getWrappedAsset().getProperties()));
         verify(api).queryItems(any(SqlQuerySpec.class));
+    }
+
+    @Test
+    void deleteById_whenPresent_deletesItem() {
+        AssetDocument document = createDocument(TEST_ID);
+        when(api.deleteItem(TEST_ID)).thenReturn(document);
+
+        var deletedAsset = assetIndex.deleteById(TEST_ID);
+        assertThat(deletedAsset.getProperties()).isEqualTo(document.getWrappedAsset().getProperties());
+        verify(api).deleteItem(TEST_ID);
+    }
+
+    @Test
+    void deleteById_whenMissing_returnsNull() {
+        when(api.deleteItem(TEST_ID)).thenThrow(new NotFoundException());
+        assertThat(assetIndex.deleteById(TEST_ID)).isNull();
     }
 
     @NotNull

--- a/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexTest.java
+++ b/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexTest.java
@@ -260,8 +260,9 @@ class CosmosAssetIndexTest {
 
     @Test
     void deleteById_whenMissing_returnsNull() {
-        when(api.deleteItem(TEST_ID)).thenThrow(new NotFoundException());
-        assertThat(assetIndex.deleteById(TEST_ID)).isNull();
+        var id = "not-exists";
+        when(api.deleteItem(id)).thenThrow(new NotFoundException());
+        assertThat(assetIndex.deleteById(id)).isNull();
     }
 
     @NotNull

--- a/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/CosmosDbApi.java
+++ b/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/CosmosDbApi.java
@@ -28,7 +28,7 @@ public interface CosmosDbApi extends ReadinessProvider {
 
     void saveItems(Collection<CosmosDocument<?>> definitions);
 
-    void deleteItem(String id);
+    Object deleteItem(String id);
 
     @Nullable Object queryItemById(String id);
 

--- a/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/CosmosDbApiImpl.java
+++ b/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/CosmosDbApiImpl.java
@@ -129,7 +129,7 @@ public class CosmosDbApiImpl implements CosmosDbApi {
             throw new NotFoundException("An object with the ID " + id + " could not be found!");
         }
         try {
-            container.deleteItem(item, itemRequestOptions).getItem();
+            container.deleteItem(item, itemRequestOptions);
         } catch (CosmosException e) {
             throw new EdcPersistenceException(e);
         }

--- a/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/CosmosDbApiImpl.java
+++ b/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/CosmosDbApiImpl.java
@@ -32,6 +32,7 @@ import com.azure.cosmos.models.SqlParameter;
 import com.azure.cosmos.models.SqlQuerySpec;
 import org.eclipse.dataspaceconnector.common.string.StringUtils;
 import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.persistence.EdcPersistenceException;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.system.health.HealthCheckResult;
 import org.jetbrains.annotations.NotNull;
@@ -120,7 +121,7 @@ public class CosmosDbApiImpl implements CosmosDbApi {
     }
 
     @Override
-    public void deleteItem(String id) {
+    public Object deleteItem(String id) {
 
         // we need to query the item first, because delete-by-id requires a partition key, which we might not have available here
         var item = queryItemById(id);
@@ -130,8 +131,9 @@ public class CosmosDbApiImpl implements CosmosDbApi {
         try {
             container.deleteItem(item, itemRequestOptions).getItem();
         } catch (CosmosException e) {
-            throw new EdcException(e);
+            throw new EdcPersistenceException(e);
         }
+        return item;
     }
 
     @Override

--- a/extensions/azure/cosmos/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/cosmos/azure/CosmosDbApiImplIntegrationTest.java
+++ b/extensions/azure/cosmos/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/cosmos/azure/CosmosDbApiImplIntegrationTest.java
@@ -152,7 +152,7 @@ class CosmosDbApiImplIntegrationTest {
 
     @Test
     void deleteItem_whenItemMissing_throws() {
-        var id = UUID.randomUUID().toString();
+        var id = "not-exists";
         assertThatThrownBy(() -> cosmosDbApi.deleteItem(id))
                 .hasMessageContaining(String.format("An object with the ID %s could not be found!", id))
                 .isInstanceOf(NotFoundException.class);

--- a/extensions/azure/cosmos/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/cosmos/azure/CosmosDbApiImplIntegrationTest.java
+++ b/extensions/azure/cosmos/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/cosmos/azure/CosmosDbApiImplIntegrationTest.java
@@ -2,10 +2,12 @@ package org.eclipse.dataspaceconnector.cosmos.azure;
 
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosDatabase;
+import com.azure.cosmos.implementation.NotFoundException;
 import com.azure.cosmos.models.CosmosContainerResponse;
 import com.azure.cosmos.models.CosmosDatabaseResponse;
 import com.azure.cosmos.models.CosmosItemRequestOptions;
 import com.azure.cosmos.models.PartitionKey;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.eclipse.dataspaceconnector.azure.cosmos.CosmosDbApiImpl;
 import org.eclipse.dataspaceconnector.azure.testfixtures.CosmosTestClient;
 import org.eclipse.dataspaceconnector.common.annotations.IntegrationTest;
@@ -16,10 +18,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @IntegrationTest
 class CosmosDbApiImplIntegrationTest {
@@ -80,9 +82,10 @@ class CosmosDbApiImplIntegrationTest {
         record.add(testItem);
 
         var queryResult = cosmosDbApi.queryItemById(testItem.getId());
-        assertThat(queryResult).isNotNull().isInstanceOf(LinkedHashMap.class);
 
-        assertThat((LinkedHashMap) queryResult).containsEntry("id", testItem.getId())
+        assertThat(queryResult)
+                .asInstanceOf(InstanceOfAssertFactories.MAP)
+                .containsEntry("id", testItem.getId())
                 .containsEntry("partitionKey", PARTITION_KEY)
                 .containsEntry("wrappedInstance", "payload");
 
@@ -100,9 +103,10 @@ class CosmosDbApiImplIntegrationTest {
 
         assertThat(cosmosDbApi.queryAllItems()).hasSize(2)
                 .allSatisfy(o -> {
-                    assertThat(o).isInstanceOf(LinkedHashMap.class);
-                    assertThat((LinkedHashMap) o).containsEntry("wrappedInstance", "payload");
-                    assertThat(((LinkedHashMap) o).get("id")).isIn(testItem.getId(), testItem2.getId());
+                    assertThat(o)
+                            .asInstanceOf(InstanceOfAssertFactories.MAP)
+                            .containsEntry("wrappedInstance", "payload")
+                            .hasEntrySatisfying("id", id -> assertThat(id).isIn(testItem.getId(), testItem2.getId()));
                 });
     }
 
@@ -130,6 +134,28 @@ class CosmosDbApiImplIntegrationTest {
         var query = "SELECT * FROM t WHERE t.wrappedInstance='payload-two'";
         var result = cosmosDbApi.queryItems(query);
         assertThat(result).hasSize(2);
+    }
+
+    @Test
+    void deleteItem_whenItemPresent_deletes() {
+        var testItem = new TestCosmosDocument("payload", PARTITION_KEY);
+        container.createItem(testItem);
+
+        var deletedItem = cosmosDbApi.deleteItem(testItem.getId());
+
+        assertThat(deletedItem)
+                .asInstanceOf(InstanceOfAssertFactories.MAP)
+                .containsEntry("id", testItem.getId())
+                .containsEntry("partitionKey", PARTITION_KEY)
+                .containsEntry("wrappedInstance", "payload");
+    }
+
+    @Test
+    void deleteItem_whenItemMissing_throws() {
+        var id = UUID.randomUUID().toString();
+        assertThatThrownBy(() -> cosmosDbApi.deleteItem(id))
+                .hasMessageContaining(String.format("An object with the ID %s could not be found!", id))
+                .isInstanceOf(NotFoundException.class);
     }
 
 }

--- a/extensions/dataloading/src/main/java/org/eclipse/dataspaceconnector/dataloading/AssetLoader.java
+++ b/extensions/dataloading/src/main/java/org/eclipse/dataspaceconnector/dataloading/AssetLoader.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.dataspaceconnector.dataloading;
 
+import org.eclipse.dataspaceconnector.spi.persistence.EdcPersistenceException;
 import org.eclipse.dataspaceconnector.spi.system.Feature;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
@@ -28,6 +29,7 @@ public interface AssetLoader extends DataSink<AssetEntry> {
      *
      * @param assetId Id of the asset to be deleted.
      * @return Deleted Asset or null if asset did not exist.
+     * @throws EdcPersistenceException if something goes wrong.
      */
     Asset deleteById(String assetId);
 

--- a/extensions/dataloading/src/main/java/org/eclipse/dataspaceconnector/dataloading/AssetLoader.java
+++ b/extensions/dataloading/src/main/java/org/eclipse/dataspaceconnector/dataloading/AssetLoader.java
@@ -22,4 +22,13 @@ public interface AssetLoader extends DataSink<AssetEntry> {
     String FEATURE = "edc:asset:assetindex:loader";
 
     void accept(Asset asset, DataAddress dataAddress);
+
+    /**
+     * Deletes an asset.
+     *
+     * @param assetId Id of the asset to be deleted.
+     * @return Deleted Asset or null if asset did not exist.
+     */
+    Asset deleteById(String assetId);
+
 }

--- a/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetIndexTest.java
+++ b/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetIndexTest.java
@@ -267,7 +267,7 @@ class InMemoryAssetIndexTest {
 
     @Test
     void deleteById_whenMissing_returnsNull() {
-        assertThat(index.deleteById(UUID.randomUUID().toString())).isNull();
+        assertThat(index.deleteById("not-exists")).isNull();
     }
 
     @NotNull

--- a/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetIndexTest.java
+++ b/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetIndexTest.java
@@ -253,6 +253,23 @@ class InMemoryAssetIndexTest {
         assertThat(index.queryAssets(spec)).containsAll(assets);
     }
 
+    @Test
+    void deleteById_whenPresent_deletes() {
+        var asset = createAsset("foobar");
+        index.accept(asset, createDataAddress(asset));
+        var deletedAsset = index.deleteById(asset.getId());
+
+        assertThat(deletedAsset).isEqualTo(asset);
+        var assetSelector = AssetSelectorExpression.Builder.newInstance().whenEquals(Asset.PROPERTY_NAME, asset.getName()).build();
+        var assets = index.queryAssets(assetSelector);
+        assertThat(assets).isEmpty();
+    }
+
+    @Test
+    void deleteById_whenMissing_returnsNull() {
+        assertThat(index.deleteById(UUID.randomUUID().toString())).isNull();
+    }
+
     @NotNull
     private Asset createAsset(String name) {
         return createAsset(name, UUID.randomUUID().toString());

--- a/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryDataAddressResolverTest.java
+++ b/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryDataAddressResolverTest.java
@@ -1,6 +1,7 @@
 package org.eclipse.dataspaceconnector.metadata.memory;
 
 import org.assertj.core.api.Assertions;
+import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +38,18 @@ class InMemoryDataAddressResolverTest {
         resolver.accept(testAsset, address);
 
         assertThatThrownBy(() -> resolver.resolveForAsset(null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void resolveForAsset_whenAssetDeleted_raisesException() {
+        var testAsset = createAsset("foobar", UUID.randomUUID().toString());
+        var address = createDataAddress(testAsset);
+        resolver.accept(testAsset, address);
+
+        resolver.deleteById(testAsset.getId());
+        assertThatThrownBy(() -> resolver.resolveForAsset(testAsset.getId()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(String.format("No DataAddress found for Asset ID=%s", testAsset.getId()));
     }
 
     private Asset createAsset(String name, String id) {


### PR DESCRIPTION
## What this PR changes/adds

- Added deleteById method in AssetLoader interface
- Implemented method for AssetLoader implementations (inMemory & CosmosDB implementations)

## Why it does that

Part of the issue https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/801. This is needed for the Data Management API.

## Further notes

- Updated contract of CosmosDbApi.deleteItem to return the item, to avoid querying the item twice.
- Added Monitor dependency to CosmoAssetIndex to be able to log when an item is not found.

## Linked Issue(s)

Closes #801

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
