### PR TITLE
doc(decision): document use of "story" issues

### DIFF
--- a/docs/developer/decision-records/2022-03-11-story-issues/README.md
+++ b/docs/developer/decision-records/2022-03-11-story-issues/README.md
@@ -7,7 +7,7 @@ we'll name "story issues". Every story issues has several sub-issues a.k.a sub-t
 
 ## Rationale
 
-There is no clear limit or rule the specifies the size at which issues need to be broken into sub-issues, rather, 
+There is no clear limit or rule that specifies the size at which issues need to be broken into sub-issues, rather, 
 this should be done by intuition. Developers are expected to have an intrinsic understanding of the natural boundaries
 of features. In case of doubt it is better to create several small issues and list them in an overarching
 story issue. 

--- a/docs/developer/decision-records/2022-03-11-story-issues/README.md
+++ b/docs/developer/decision-records/2022-03-11-story-issues/README.md
@@ -36,9 +36,8 @@ indicator on overview pages. More information can be found in the [documentation
 
 For example, a story to add an API endpoint to the codebase could be split into the following sub-tasks:
 - add endpoint + swagger doc to controller
-- add service implementation + unit tests
-- add method to backing store + unit tests + integration tests
-- add integration tests to controller
+- add service implementation + tests
+- add method to backing store + tests
 - add documentation
 
 Generally speaking there should be one PR per sub-issue.

--- a/docs/developer/decision-records/2022-03-11-story-issues/README.md
+++ b/docs/developer/decision-records/2022-03-11-story-issues/README.md
@@ -34,10 +34,9 @@ The overarching story issues should contain a bulleted list with references to a
 This will cause GitHub to automatically track the sub-issues in the overarching story issue, and it will display a progress
 indicator on overview pages. More information can be found in the [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists).
 
-For example, a story to add an API endpoint to the codebase could be split into the following sub-tasks:
-- add endpoint + swagger doc to controller
-- add service implementation + tests
-- add method to backing store + tests
-- add documentation
+For example, imagine a story that requires some lib analysis or evaluation before the lib is adopted into the code base could be split into the following sub-tasks:
+- evaluate lib X, lib Y and lib Z, create ADR
+- implement adapter for lib
+- add overall system-test 
 
 Generally speaking there should be one PR per sub-issue.

--- a/docs/developer/decision-records/2022-03-11-story-issues/README.md
+++ b/docs/developer/decision-records/2022-03-11-story-issues/README.md
@@ -31,6 +31,8 @@ The overarching story issues should contain a bulleted list with references to a
 ...
 ```
 
+Please add the `"story"` label to the overarching story issue.
+
 This will cause GitHub to automatically track the sub-issues in the overarching story issue, and it will display a progress
 indicator on overview pages. More information can be found in the [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists).
 

--- a/docs/developer/decision-records/2022-03-11-umbrella-issues/README.md
+++ b/docs/developer/decision-records/2022-03-11-umbrella-issues/README.md
@@ -1,0 +1,44 @@
+# Creating "story" issues
+
+## Decision
+
+For larger features, for which it seems reasonable to create more than one issue, we will create overarching issues which 
+we'll name "story issues". Every story issues has several sub-issues a.k.a sub-tasks.
+
+## Rationale
+
+There is no clear limit or rule the specifies the size at which issues need to be broken into sub-issues, rather, 
+this should be done by intuition. Developers are expected to have an intrinsic understanding of the natural boundaries
+of features. In case of doubt it is better to create several small issues and list them in an overarching
+story issue. 
+
+Sub-issues may initially just be placeholders. That shows readers how the story is intended to be implemented and 
+which aspects have been taken into account, even if certain details might still be missing.
+
+Finally, having small, focused issues and PRs makes them more digestible, which in turn will benefit the review process.  
+
+## Approach
+
+Issues should be broken up if
+- there is more than one area of code involved (e.g. API, store,...)
+- work streams can be parallelized
+- there are orthogonal concerns
+
+The overarching story issues should contain a bulleted list with references to all sub-issues, for example:
+```markdown
+- [ ] #123
+- [ ] #456
+...
+```
+
+This will cause GitHub to automatically track the sub-issues in the overarching story issue, and it will display a progress
+indicator on overview pages. More information can be found in the [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists).
+
+For example, a story to add an API endpoint to the codebase could be split into the following sub-tasks:
+- add endpoint + swagger doc to controller
+- add service implementation + unit tests
+- add method to backing store + unit tests + integration tests
+- add integration tests to controller
+- add documentation
+
+Generally speaking there should be one PR per sub-issue.


### PR DESCRIPTION
## What this PR changes/adds

Adds a decision-record about the use of "story" issues, a.k.a. umbrella issues.

## Why it does that

A decision was made to use task lists in issues, which greatly improves the structure of work, keeps PRs clean and succinct and makes code reviews easier and more easily digestible.

## Further notes
n/a

## Linked Issue(s)

n/a

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [x] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
