### PR TITLE
core: increase Xmx in order to build "smoothly" with several gradle daemons

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -36,3 +36,5 @@ httpMockServer=5.12.0
 micrometerVersion=1.8.2
 bouncycastleVersion=1.70
 gatlingVersion=3.7.5
+
+org.gradle.jvmargs=-Xmx512m


### PR DESCRIPTION
## What this PR changes/adds

Increase -Xmx in gradle daemons

## Why it does that

Users may have OOM while building.
