### PR TITLE
fix(action): add permissions to pull-request-auto-assign-project.yaml

### DIFF
--- a/.github/workflows/pull-request-auto-assign-project.yaml
+++ b/.github/workflows/pull-request-auto-assign-project.yaml
@@ -9,6 +9,9 @@ env:
 jobs:
   assign-project:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Assign to basic project
         uses: srggrs/assign-one-project-github-action@1.3.1


### PR DESCRIPTION
## What this PR changes/adds

Adds permission to action.

## Why it does that

Currently, the action that should assign a new PR to a project fails:
```
{
  "message": "Resource not accessible by integration",
  "documentation_url": "https://docs.github.com/rest/reference/projects#create-a-project-card"
}
```

## Further notes

This issue seems to be known and a possible solution ist mentioned (https://github.com/actions/first-interaction/issues/10). Worth a try.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
