### PR TITLE
spi: Return the deleted ContractDefinition when deleting ContractDefinition.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ the detailed section referring to by linking pull requests or issues.
 * Add public Api to DPF and make `HttpDataSource` more generic (#699)
 * Add an in-memory data plane store (#705)
 * Introduce extensions for synchronous data transfer using data plane (#711)
+* Add a deleteById method to the AssetLoader interface (#?)
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,6 @@ the detailed section referring to by linking pull requests or issues.
 * Add public Api to DPF and make `HttpDataSource` more generic (#699)
 * Add an in-memory data plane store (#705)
 * Introduce extensions for synchronous data transfer using data plane (#711)
-* Add a deleteById method to the AssetLoader interface (#?)
 
 #### Changed
 

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
@@ -263,7 +263,7 @@ class IdsApiMultipartDispatcherV1IntegrationTestServiceExtension implements Serv
         }
 
         @Override
-        public void delete(String id) {
+        public ContractDefinition deleteById(String id) {
             throw new NotImplementedError();
         }
 

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
@@ -262,7 +262,7 @@ class IdsApiMultipartEndpointV1IntegrationTestServiceExtension implements Servic
         }
 
         @Override
-        public void delete(String id) {
+        public ContractDefinition deleteById(String id) {
             throw new NotImplementedError();
         }
 

--- a/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexIntegrationTest.java
+++ b/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexIntegrationTest.java
@@ -26,7 +26,6 @@ import org.eclipse.dataspaceconnector.azure.cosmos.CosmosDbApiImpl;
 import org.eclipse.dataspaceconnector.azure.testfixtures.CosmosTestClient;
 import org.eclipse.dataspaceconnector.azure.testfixtures.annotations.AzureCosmosDbIntegrationTest;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
-import org.eclipse.dataspaceconnector.spi.monitor.ConsoleMonitor;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStore.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStore.java
@@ -125,8 +125,9 @@ public class CosmosContractDefinitionStore implements ContractDefinitionStore {
     }
 
     @Override
-    public void delete(String id) {
-        cosmosDbApi.deleteItem(id);
+    public ContractDefinition deleteById(String id) {
+        var deletedItem = cosmosDbApi.deleteItem(id);
+        return deletedItem == null ? null : convert(deletedItem);
     }
 
     @Override

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreIntegrationTest.java
@@ -203,19 +203,21 @@ public class CosmosContractDefinitionStoreIntegrationTest {
 
     @Test
     void delete() {
-        var doc1 = generateDocument(TEST_PARTITION_KEY);
-        container.createItem(doc1);
+        var document = generateDocument(TEST_PARTITION_KEY);
+        container.createItem(document);
 
-        store.delete(doc1.getId());
+        var contractDefinition = convert(document);
+        var deletedContractDefinition = store.deleteById(document.getId());
+        assertThat(deletedContractDefinition).isEqualTo(contractDefinition);
 
-        assertThat(container.readAllItems(new PartitionKey(doc1.getPartitionKey()), Object.class)).isEmpty();
+        assertThat(container.readAllItems(new PartitionKey(document.getPartitionKey()), Object.class)).isEmpty();
     }
 
     @Test
     void delete_notExist() {
-        assertThatThrownBy(() -> store.delete("not-exist-id"))
+        assertThatThrownBy(() -> store.deleteById("not-exists"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessageContaining("An object with the ID not-exist-id could not be found!");
+                .hasMessageContaining("An object with the ID not-exists could not be found!");
     }
 
     @Test

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FccTestExtension.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FccTestExtension.java
@@ -204,7 +204,7 @@ public class FccTestExtension implements ServiceExtension {
         }
 
         @Override
-        public void delete(String id) {
+        public ContractDefinition deleteById(String id) {
             throw new NotImplementedError();
         }
 

--- a/extensions/in-memory/contractdefinition-store-memory/src/main/java/org/eclipse/dataspaceconnector/contractdefinition/store/memory/InMemoryContractDefinitionStore.java
+++ b/extensions/in-memory/contractdefinition-store-memory/src/main/java/org/eclipse/dataspaceconnector/contractdefinition/store/memory/InMemoryContractDefinitionStore.java
@@ -82,8 +82,8 @@ public class InMemoryContractDefinitionStore implements ContractDefinitionStore 
     }
 
     @Override
-    public void delete(String id) {
-        cache.remove(id);
+    public ContractDefinition deleteById(String id) {
+        return cache.remove(id);
     }
 
     @Override

--- a/extensions/in-memory/contractdefinition-store-memory/src/test/java/org/eclipse/dataspaceconnector/contractdefinition/store/memory/InMemoryContractDefinitionStoreTest.java
+++ b/extensions/in-memory/contractdefinition-store-memory/src/test/java/org/eclipse/dataspaceconnector/contractdefinition/store/memory/InMemoryContractDefinitionStoreTest.java
@@ -43,8 +43,14 @@ class InMemoryContractDefinitionStoreTest {
         store.save(List.of(definition2));
         assertThat(store.findAll()).contains(definition1);
 
-        store.delete(definition1.getId());
+        var deletedDefinition = store.deleteById(definition1.getId());
+        assertThat(deletedDefinition).isEqualTo(definition1);
         assertThat(store.findAll()).doesNotContain(definition1);
+    }
+
+    @Test
+    void deleteById_whenContractDefinitionMissing_returnsNull() {
+        assertThat(store.deleteById("not-exists")).isNull();
     }
 
     @Test

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/store/ContractDefinitionStore.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/store/ContractDefinitionStore.java
@@ -62,7 +62,7 @@ public interface ContractDefinitionStore {
     /**
      * Deletes the definition with the given id.
      */
-    void delete(String id);
+    ContractDefinition deleteById(String id);
 
     /**
      * Signals the store should reload its internal cache if updates were may. If the implementation does not implement caching, this method will do nothing.


### PR DESCRIPTION
## What this PR changes/adds

- Updated the contract of ContractDefinitionStore.delete to return the deleted ContractDefinition.
- Updated the name of the method `delete` to `deleteById` for consistency with other service and correspond to the story definition.

## Why it does that

Part of task #802.

## Further notes


## Linked Issue(s)

Closes #802

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
