### PR TITLE
system-tests: avoid system-tests failure when runtimes are not fully built

### DIFF
--- a/system-tests/e2e-transfer-test/runner/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/runner/build.gradle.kts
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 

--- a/system-tests/tests/build.gradle.kts
+++ b/system-tests/tests/build.gradle.kts
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 


### PR DESCRIPTION
## What this PR changes/adds

Makes the `EdcRuntimeExtension` load the resources of an "extension runtime" from the `main` folder.

## Why it does that

Currently, there are two way of handling extension runtime dependencies: 
- not define them into the "runner/tests" module as dependency (as it's done by the `system-tests:end-to-end-transfer:runner` module)
- define them as `testRuntimeOnly` (as it's done by the `system-tests:tests` module)

both of them are wrong, for these reasons:
- the first because it does not define a "build" order for the modules, so you must have every extension runtime module built by the test run, otherwise the extension runtimes will not be loaded.
- the second because it loads all the dependencies of the extension runtimes into the common class loader, and so every extension runtime will have the union of the dependencies of every runtime, and that is wrong, because every runtime should have its dependencies (e.g. control-plane dependencies are different from the data-plane one)

I found out that the best way is to use `testCompileOnly`, that takes the best from the used approaches.
The only issue is that the `testCompile` task happens before the `processResources`, so after that happens no resources are built into the module `build` directory. To resolve this, I made the `EdcRuntimeExtension.resolveClassPathEntry` to replace the "built" path with the "src" path on the resource entry. This works and saves lots of headaches.

## Further notes

-

## Linked Issue(s)

-

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
