### PR TITLE
Samples: fixed Observability Sample, added instructions for Azure Application Insights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ the detailed section referring to by linking pull requests or issues.
 * Implement Asset service for Data Management API (#931)
 * Added embedded and remote DPF Selector (#832)
 * Pass path information into http data source through DPF public API (#929)
+* Add instructions for observability sample with Azure Application Insights (#928)
 
 #### Changed
 

--- a/samples/04.3-open-telemetry/README.md
+++ b/samples/04.3-open-telemetry/README.md
@@ -22,14 +22,14 @@ In addition, the [Jaeger exporter](https://github.com/open-telemetry/opentelemet
 To run the consumer, the provider, and Jaeger execute the following commands in the project root folder:
 
 ```bash
-./gradlew samples:04.3-open-telemetry:consumer:build samples:04.0-file-transfer:provider:build
+./gradlew samples:04.3-open-telemetry:consumer:build samples:04.3-open-telemetry:provider:build
 docker-compose -f samples/04.3-open-telemetry/docker-compose.yaml up --abort-on-container-exit
 ```
 
 Once the consumer and provider are up, start a contract negotiation by executing:
 
 ```bash
-curl -X POST -H "Content-Type: application/json" -d @samples/04.0-file-transfer/contractoffer.json "http://localhost:9191/api/negotiation?connectorAddress=http://provider:8181/api/v1/ids/data"
+curl -X POST -H "Content-Type: application/json" -d @samples/04.0-file-transfer/contractoffer.json "http://localhost:9191/api/negotiation?connectorAddress=http://provider:8282/api/v1/ids/data"
 ```
 
 The contract negotiation causes an HTTP request sent from the consumer to the provider connector, followed by another message from the provider to the consumer connector.
@@ -45,7 +45,7 @@ Click the globe icon near the top right corner (Metrics Explorer) and select a m
 
 ## Using another monitoring backend
 
-Other monitoring backends can be plugged in easily with OpenTelemetry. For instance, if you want to use Azure Application Insights instead of Jaeger, you can replace the OpenTelemetry Java Agent by the [Application Insights Java Agent](https://docs.microsoft.com/en-us/azure/azure-monitor/app/java-in-process-agent#download-the-jar-file) instead, which has to be stored in the root folder of this sample as well. The only additional configuration required are the `APPLICATIONINSIGHTS_CONNECTION_STRING` and `APPLICATIONINSIGHTS_ROLE_NAME` env variables:
+Other monitoring backends can be plugged in easily with OpenTelemetry. For instance, if you want to use Azure Application Insights instead of Jaeger, you can replace the OpenTelemetry Java Agent with the [Application Insights Java Agent](https://docs.microsoft.com/azure/azure-monitor/app/java-in-process-agent#download-the-jar-file), which has to be stored in the root folder of this sample as well. The only additional configuration required are the `APPLICATIONINSIGHTS_CONNECTION_STRING` and `APPLICATIONINSIGHTS_ROLE_NAME` env variables:
 
 ```yaml
   consumer:
@@ -53,13 +53,22 @@ Other monitoring backends can be plugged in easily with OpenTelemetry. For insta
     environment:
       APPLICATIONINSIGHTS_CONNECTION_STRING: <your-connection-string>
       APPLICATIONINSIGHTS_ROLE_NAME: consumer
-      edc.api.control.auth.apikey.value: password
-      ids.webhook.address: http://consumer:8181
+      # optional: increase log verbosity (default level is INFO)
+      APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL: DEBUG
+      WEB_HTTP_PORT: 8181
+      WEB_HTTP_PATH: /api
+      WEB_HTTP_DATA_PORT: 8182
+      WEB_HTTP_DATA_PATH: /api/v1/data
+      IDS_WEBHOOK_ADDRESS: http://consumer:8181
     volumes:
       - ../:/samples
     ports:
       - 9191:8181
-    entrypoint: java -javaagent:/samples/04.3-open-telemetry/applicationinsights-agent-3.2.5.jar -jar /samples/04.3-open-telemetry/consumer/build/libs/consumer.jar
+      - 9192:8182
+    entrypoint: java
+      -javaagent:/samples/04.3-open-telemetry/applicationinsights-agent-3.2.8.jar
+      -Djava.util.logging.config.file=/samples/04.3-open-telemetry/logging.properties
+      -jar /samples/04.3-open-telemetry/consumer/build/libs/consumer.jar
 ```
 
 The Application Insights Java agent will automatically collect metrics from Micrometer, without any configuration needed.

--- a/samples/04.3-open-telemetry/docker-compose.yaml
+++ b/samples/04.3-open-telemetry/docker-compose.yaml
@@ -9,16 +9,21 @@ services:
       OTEL_TRACES_EXPORTER: jaeger
       OTEL_EXPORTER_JAEGER_ENDPOINT: http://jaeger:14250
       OTEL_METRICS_EXPORTER: prometheus
-      edc.api.control.auth.apikey.value: password
-      ids.webhook.address: http://consumer:8181
+      WEB_HTTP_PORT: 9191
+      WEB_HTTP_PATH: /api
+      WEB_HTTP_DATA_PORT: 9192
+      WEB_HTTP_DATA_PATH: /api/v1/data
+      WEB_HTTP_IDS_PORT: 9292
+      WEB_HTTP_IDS_PATH: /api/v1/ids
+      IDS_WEBHOOK_ADDRESS: http://consumer:9292
     volumes:
       - ../:/samples
     ports:
-      - 9191:8181
-      - 9192:8182
+      - "9191:9191"
+      - "9192:9292"
     entrypoint: java
       -javaagent:/samples/04.3-open-telemetry/opentelemetry-javaagent.jar
-      -Dedc.fs.config=/samples/04.3-open-telemetry/consumer/config.properties
+      -Djava.util.logging.config.file=/samples/04.3-open-telemetry/logging.properties
       -jar /samples/04.3-open-telemetry/consumer/build/libs/consumer.jar
 
   provider:
@@ -27,16 +32,21 @@ services:
       OTEL_SERVICE_NAME: provider
       OTEL_TRACES_EXPORTER: jaeger
       OTEL_EXPORTER_JAEGER_ENDPOINT: http://jaeger:14250
-      ids.webhook.address: http://provider:8181
+      WEB_HTTP_PORT: 8181
+      WEB_HTTP_PATH: /api
+      WEB_HTTP_DATA_PORT: 8182
+      WEB_HTTP_DATA_PATH: /api/v1/data
+      IDS_WEBHOOK_ADDRESS: http://provider:8282
     volumes:
       - ../:/samples
     ports:
-      - 8181:8181
-      - 8182:8182
+      - "8181:8181"
+      - "8182:8182"
+      - "8282:8282"
     entrypoint: java
       -javaagent:/samples/04.3-open-telemetry/opentelemetry-javaagent.jar
-      -Dedc.fs.config=/samples/04.0-file-transfer/provider/config.properties
-      -jar /samples/04.0-file-transfer/provider/build/libs/provider.jar
+      -Djava.util.logging.config.file=/samples/04.3-open-telemetry/logging.properties
+      -jar /samples/04.3-open-telemetry/provider/build/libs/provider.jar
 
   jaeger:
     image: jaegertracing/all-in-one

--- a/samples/04.3-open-telemetry/logging.properties
+++ b/samples/04.3-open-telemetry/logging.properties
@@ -1,0 +1,5 @@
+handlers = java.util.logging.ConsoleHandler
+.level = FINE
+java.util.logging.ConsoleHandler.level = ALL
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format = %1$tF %1$tT %4$s : %5$s %n

--- a/samples/04.3-open-telemetry/provider/build.gradle.kts
+++ b/samples/04.3-open-telemetry/provider/build.gradle.kts
@@ -8,8 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Microsoft Corporation - initial API and implementation
- *       ZF Friedrichshafen AG - add dependency
+ *       Microsoft Corporation - initial implementation
  *
  */
 
@@ -24,25 +23,23 @@ val rsApi: String by project
 
 dependencies {
     implementation(project(":core"))
-    implementation(project(":core:micrometer"))
 
     implementation(project(":extensions:in-memory:assetindex-memory"))
     implementation(project(":extensions:in-memory:transfer-store-memory"))
-    implementation(project(":extensions:in-memory:assetindex-memory"))
     implementation(project(":extensions:in-memory:negotiation-store-memory"))
     implementation(project(":extensions:in-memory:contractdefinition-store-memory"))
+
+    implementation(project(":extensions:api:observability"))
 
     implementation(project(":extensions:filesystem:configuration-fs"))
     implementation(project(":extensions:iam:iam-mock"))
 
-    implementation(project(":extensions:api:control"))
     implementation(project(":extensions:api:data-management"))
 
     implementation(project(":data-protocols:ids"))
-    runtimeOnly(project(":extensions:http:jersey-micrometer"))
-    runtimeOnly(project(":extensions:http:jetty-micrometer"))
+
+    implementation(project(":samples:04.0-file-transfer:transfer-file"))
     runtimeOnly(project(":extensions:jdk-logger-monitor"))
-    implementation(project(":samples:04.0-file-transfer:api"))
 }
 
 application {
@@ -52,5 +49,5 @@ application {
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     exclude("**/pom.properties", "**/pom.xm")
     mergeServiceFiles()
-    archiveFileName.set("consumer.jar")
+    archiveFileName.set("provider.jar")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -189,6 +189,7 @@ include(":samples:04.2-modify-transferprocess:simulator")
 
 include(":samples:04.3-open-telemetry:micrometer")
 include(":samples:04.3-open-telemetry:consumer")
+include(":samples:04.3-open-telemetry:provider")
 
 include(":samples:05-file-transfer-cloud:consumer")
 include(":samples:05-file-transfer-cloud:provider")


### PR DESCRIPTION
## What this PR changes/adds

- Fixed sample 04.3 that was broken (env variables should now be in UPPER_CASE; issue with ports/API Key configuration)
- Fixed instructions for using Application Insights with the sample
- Used `jdk-logger-monitor` in the sample so that monitor logs are exported to java.util.logging, and from there captured by the Application Insights agent if used

## Why it does that

- Sample was broken
- Azure users need a sample for Application Insights

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #861 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
