### PR TITLE
Proposal: technical concept for a `ContractNegotiationStore` based on SQL

### DIFF
--- a/extensions/sql/contract-negotiation/ddl.sql
+++ b/extensions/sql/contract-negotiation/ddl.sql
@@ -1,0 +1,60 @@
+create table if not exists contract_agreement
+(
+    id                varchar not null
+        constraint contract_agreement_pk
+            primary key,
+    provider_agent_id varchar,
+    consumer_agent_id varchar,
+    signing_date      bigint,
+    start_date        bigint,
+    end_date          integer,
+    asset_id          varchar not null,
+    policy_id         varchar
+);
+
+alter table contract_agreement
+    owner to "user";
+
+create table if not exists contract_negotiation
+(
+    id                    varchar                                            not null
+        constraint contract_negotiation_pk
+            primary key,
+    correlation_id        varchar                                            not null,
+    counterparty_id       varchar                                            not null,
+    counterparty_address  varchar                                            not null,
+    protocol              varchar default 'ids-multipart'::character varying not null,
+    type                  integer default 0                                  not null,
+    state                 integer default 0                                  not null,
+    state_count           integer default 0,
+    state_timestamp       bigint,
+    error_detail          varchar,
+    contract_agreement_id varchar
+        constraint contract_negotiation_contract_agreement_id_fk
+            references contract_agreement,
+    contract_offers       varchar,
+    trace_context         varchar,
+    lease_id              varchar
+        constraint contract_negotiation_lease_lease_id_fk
+            references lease
+            on delete set null
+);
+
+comment on column contract_negotiation.contract_agreement_id is 'ContractAgreement serialized as JSON';
+
+comment on column contract_negotiation.contract_offers is 'List<ContractOffer> serialized as JSON';
+
+comment on column contract_negotiation.trace_context is 'Map<String,String> serialized as JSON';
+
+alter table contract_negotiation
+    owner to "user";
+
+create index if not exists contract_negotiation_correlationid_index
+    on contract_negotiation (correlation_id);
+
+create unique index if not exists contract_negotiation_id_uindex
+    on contract_negotiation (id);
+
+create unique index if not exists contract_agreement_id_uindex
+    on contract_agreement (id);
+

--- a/extensions/sql/contract-negotiation/dml.sql
+++ b/extensions/sql/contract-negotiation/dml.sql
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+-- insert
+INSERT INTO contract_negotiation (id, correlation_id, counterparty_id, counterparty_address)
+VALUES ('test-cn1', 'corr1', 'other-id', 'http://other.com')
+
+-- find by ID
+SELECT *
+FROM contract_negotiation
+WHERE id = 'test-cn1'
+  AND (lease_id IS NULL OR lease_id IN (SELECT lease_id FROM lease WHERE (NOW > (leased_at + lease.lease_duration)));
+
+
+-- find for correlation id
+SELECT *
+FROM contract_negotiation
+WHERE correlation_id = 'corr1';
+
+
+-- find contract agreement
+SELECT *
+FROM contract_agreement
+WHERE id = 'contract1';
+
+
+-- delete - only if no contract
+DELETE
+FROM contract_negotiation
+WHERE id = 'test-cn1'
+  AND contract_agreement_id IS NULL;
+
+-- acquire lease
+-- 1. create lease
+INSERT INTO lease (lease_id, leased_by, leased_at, lease_duration)
+VALUES ('lease-1', 'yomama', NOW, default);
+
+-- 2. update contract negotiation
+UPDATE contract_negotiation
+SET lease_id='lease-1'
+WHERE id IN ('test-cn1');
+--could be list of IDs
+
+-- break lease
+DELETE
+FROM lease
+WHERE lease_id = (SELECT lease_id from contract_negotiation WHERE id = 'test-cn1');
+
+
+-- update
+UPDATE contract_negotiation
+SET state=200,
+    state_count=3,
+    state_timestamp=12345,
+    error_detail=NULL,
+    contract_offers='{}',
+    trace_context='{}'
+WHERE id = 'test-cn1';
+
+
+-- select next for state
+SELECT *
+FROM contract_negotiation
+WHERE state = 200
+  AND (lease_id IS NULL OR
+       lease_id IN (SELECT lease_id FROM lease WHERE (60000 + 12345 > (leased_at + lease.lease_duration))))
+LIMIT 5;

--- a/extensions/sql/contract-negotiation/proposal.md
+++ b/extensions/sql/contract-negotiation/proposal.md
@@ -1,0 +1,88 @@
+# SQL-based `ContractNegotiationStore` - technical proposal
+
+## 1. Table schema
+see [ddl.sql](ddl.sql).
+
+As an alternative to storing `ContractAgreement`s in a dedicated table, it could also be serialized and stored as column 
+in the `contract_negotiation` table. However, we will need to be able to list all contract agreements at some point, so it 
+seemed more future-proof to have it separate.
+
+## 2. Translating the `ContractNegotiationStore` into SQL statements
+
+see [dml.sql](dml.sql)
+
+### `find`
+
+```sql
+SELECT *
+FROM contract_negotiation
+WHERE id = 'test-cn1';
+
+```
+
+### `findForCorrelationId`
+```sql
+SELECT *
+FROM contract_negotiation
+WHERE correlation_id = 'corr1';
+```
+
+### `findContractAgreement`
+```sql
+SELECT *
+FROM contract_agreement
+WHERE id = 'contract1';
+```
+
+### `save`
+Saving an entity will have "upsert" semantics, and break the lease if updated.
+
+```sql
+-- if not exist create
+INSERT INTO contract_negotiation (id, correlation_id, counterparty_id, counterparty_address)
+VALUES ('test-cn1', 'corr1', 'other-id', 'http://other.com');
+
+-- if exist update
+DELETE
+FROM lease
+WHERE lease_id = (SELECT lease_id FROM contract_negotiation WHERE id = 'test-cn2');
+
+UPDATE contract_negotiation
+SET state=200, state_count=3, state_timestamp=12345, error_detail=NULL, contract_offers='{}', trace_context='{}'
+WHERE id='test-cn1';
+
+```
+
+### `delete`
+Will only delete if there is no contract yet.
+```sql
+DELETE
+FROM contract_negotiation
+WHERE id = 'test-cn1'
+  AND contract_agreement_id IS NULL;
+```
+
+### `queryNegotiations`
+For the sake of simplicity we'll only consider `QuerySpec#limit` and `QuerySpec#offset` for now. Filtering and sorting
+will be implemented later.
+
+
+### `nextForState`
+The semantics of this is to select a number of rows and immediately "lease" them, i.e. create an entry in the `lease` table
+and update the `lease_id` column in `contract_negotiations:
+```sql
+-- 1. select 
+SELECT * FROM contract_negotiation
+WHERE state=200
+  AND (lease_id IS NULL OR lease_id IN (SELECT lease_id FROM lease WHERE (NOW > (leased_at + lease.lease_duration))))
+LIMIT 5;
+
+-- 2. insert lease
+INSERT INTO lease (lease_id, leased_by, leased_at, lease_duration)
+VALUES ('lease-1', 'yomama', NOW, default);
+
+-- 3. update contract_negotiation
+UPDATE contract_negotiation
+SET lease_id='lease-1'
+WHERE id IN ('test-cn1');
+```


### PR DESCRIPTION
## What this PR changes/adds

Adds a technical concept for table schema and DML/DQL statements. No implementation.

## Why it does that

Before the implementation of #864 can start, there needs to be a vetted proposal in place.

## Further notes

Concept document currently resided in `extensions/sql/contract-negotiation/proposal.md` and will be renamed to `README.md` once the proposal is accepted.

## Linked Issue(s)

Closes #864 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
