### PR TITLE
extensions: implement ContractDefinition Data Management Api 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,11 +29,12 @@ the detailed section referring to by linking pull requests or issues.
 * Implement S3BucketReader (#675)
 * Add configuration setting for state machine batch size (#872)
 * Add Jetty context alias for IDS API (#815)
-* Implement Asset service for Data Management API (#931)
-* Added embedded and remote DPF Selector (#832)
+* Add embedded and remote DPF Selector (#832)
 * Pass path information into http data source through DPF public API (#929)
 * Add instructions for observability sample with Azure Application Insights (#928)
 * Add interface `WebServer` to `web-spi` (#921)
+* Implement Asset service for Data Management API (#931)
+* Implement ContractDefinition service for Data Management API (#940)
 
 #### Changed
 

--- a/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/exception/ObjectExistsException.java
+++ b/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/exception/ObjectExistsException.java
@@ -18,11 +18,7 @@ import static java.lang.String.format;
 
 public class ObjectExistsException extends EdcApiException {
 
-    public ObjectExistsException(String objectId, String objectType) {
-        super(format("Object of type %s already exists with ID = %s", objectType, objectId));
-    }
-
     public ObjectExistsException(Class<?> objectType, String objectId) {
-        this(objectType.getSimpleName(), objectId);
+        super(format("Object of type %s already exists with ID = %s", objectType.getSimpleName(), objectId));
     }
 }

--- a/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/exception/ObjectNotFoundException.java
+++ b/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/exception/ObjectNotFoundException.java
@@ -17,11 +17,8 @@ package org.eclipse.dataspaceconnector.api.exception;
 import static java.lang.String.format;
 
 public class ObjectNotFoundException extends EdcApiException {
-    public ObjectNotFoundException(String objectType, String objectId) {
-        super(format("Object of type %s with ID=%s was not found", objectType, objectId));
-    }
 
     public ObjectNotFoundException(Class<?> objectType, String objectId) {
-        this(objectType.getSimpleName(), objectId);
+        super(format("Object of type %s with ID=%s was not found", objectType.getSimpleName(), objectId));
     }
 }

--- a/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/transformer/DtoTransformer.java
+++ b/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/transformer/DtoTransformer.java
@@ -9,13 +9,13 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 
 package org.eclipse.dataspaceconnector.api.transformer;
 
 import org.eclipse.dataspaceconnector.spi.transformer.TypeTransformer;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Marker interface to group transformers which are intended for use in API controllers, i.e. converting business objects
@@ -25,12 +25,4 @@ import org.jetbrains.annotations.NotNull;
  * @param <OUTPUT> the type that the input gets converted into. Usually this is a DTO.
  */
 public interface DtoTransformer<INPUT, OUTPUT> extends TypeTransformer<INPUT, OUTPUT> {
-    /**
-     * Determines whether a transformer can handle a particular pair.
-     *
-     * @param object     Source object
-     * @param outputType desired target type.
-     * @return true if can handle, false otherwise.
-     */
-    boolean canHandle(@NotNull Object object, @NotNull Class<?> outputType);
 }

--- a/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/transformer/DtoTransformerRegistryImpl.java
+++ b/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/transformer/DtoTransformerRegistryImpl.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 
@@ -77,7 +78,8 @@ public class DtoTransformerRegistryImpl implements DtoTransformerRegistry {
     private <INPUT, OUTPUT> OUTPUT transform(INPUT object, Class<OUTPUT> outputType, TransformerContext context) {
         Objects.requireNonNull(object);
 
-        var t = transformers.stream().filter(tr -> tr.canHandle(object, outputType))
+        var t = transformers.stream()
+                .filter(tr -> tr.getInputType().isInstance(object) && tr.getOutputType().equals(outputType))
                 .findFirst().orElse(null);
 
         if (t == null) {

--- a/extensions/api/api-core/src/test/java/org/eclipse/dataspaceconnector/api/exception/mappers/EdcApiExceptionMapperTest.java
+++ b/extensions/api/api-core/src/test/java/org/eclipse/dataspaceconnector/api/exception/mappers/EdcApiExceptionMapperTest.java
@@ -36,8 +36,8 @@ class EdcApiExceptionMapperTest {
     public static Stream<Arguments> getArgs() {
         return Stream.of(Arguments.of(new ObjectNotModifiableException("1234", "test-type"), 423),
                 Arguments.of(new AuthenticationFailedException(), 401),
-                Arguments.of(new ObjectExistsException("test-id", "test-object-type"), 409),
-                Arguments.of(new ObjectNotFoundException("test-object-id", "test-object-type"), 404),
+                Arguments.of(new ObjectExistsException(Object.class, "test-object-id"), 409),
+                Arguments.of(new ObjectNotFoundException(Object.class, "test-object-id"), 404),
                 Arguments.of(new IllegalStateException("foo"), 503),
                 Arguments.of(new IllegalArgumentException("foo"), 400),
                 Arguments.of(new UnsupportedOperationException("foo"), 501),

--- a/extensions/api/api-core/src/test/java/org/eclipse/dataspaceconnector/api/transformer/DtoTransformerRegistryImplTest.java
+++ b/extensions/api/api-core/src/test/java/org/eclipse/dataspaceconnector/api/transformer/DtoTransformerRegistryImplTest.java
@@ -86,10 +86,6 @@ class DtoTransformerRegistryImplTest {
     }
 
     private static class TestTransformer implements DtoTransformer<String, String> {
-        @Override
-        public boolean canHandle(@NotNull Object object, @NotNull Class<?> outputType) {
-            return object instanceof String && outputType == String.class;
-        }
 
         @Override
         public Class<String> getInputType() {

--- a/extensions/api/data-management/asset/build.gradle.kts
+++ b/extensions/api/data-management/asset/build.gradle.kts
@@ -12,9 +12,6 @@
  *    Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  */
 
-val infoModelVersion: String by project
-val jerseyVersion: String by project
-val okHttpVersion: String by project
 val restAssured: String by project
 val rsApi: String by project
 
@@ -35,7 +32,6 @@ dependencies {
     testImplementation(project(":extensions:http"))
     testImplementation(project(":extensions:in-memory:assetindex-memory"))
     testImplementation(project(":extensions:in-memory:negotiation-store-memory"))
-    testImplementation(project(":extensions:transaction:transaction-local"))
     testImplementation(testFixtures(project(":common:util")))
     testImplementation(testFixtures(project(":launchers:junit")))
     testImplementation("io.rest-assured:rest-assured:${restAssured}")

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiController.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiController.java
@@ -112,7 +112,7 @@ public class AssetApiController implements AssetApi {
     public AssetDto getAsset(@PathParam("id") String id) {
         monitor.debug(format("Attempting to return Asset with id %s", id));
         return Optional.of(id)
-                .map(it -> service.findbyId(id))
+                .map(it -> service.findById(id))
                 .map(it -> transformerRegistry.transform(it, AssetDto.class))
                 .filter(Result::succeeded)
                 .map(Result::getContent)

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetService.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetService.java
@@ -29,7 +29,7 @@ public interface AssetService {
      * @param assetId id of the asset
      * @return the asset, null if it's not found
      */
-    Asset findbyId(String assetId);
+    Asset findById(String assetId);
 
     /**
      * Query assets

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetService.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetService.java
@@ -35,7 +35,7 @@ public interface AssetService {
      * Query assets
      *
      * @param query request
-     * @return the collection of assets that match the query
+     * @return the collection of assets that matches the query
      */
     Collection<Asset> query(QuerySpec query);
 

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImpl.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImpl.java
@@ -44,7 +44,7 @@ public class AssetServiceImpl implements AssetService {
     }
 
     @Override
-    public Asset findbyId(String assetId) {
+    public Asset findById(String assetId) {
         return index.findById(assetId);
     }
 
@@ -84,7 +84,7 @@ public class AssetServiceImpl implements AssetService {
         var result = new AtomicReference<ServiceResult<Asset>>();
 
         transactionContext.execute(() -> {
-            if (findbyId(asset.getId()) == null) {
+            if (findById(asset.getId()) == null) {
                 loader.accept(asset, dataAddress);
                 result.set(ServiceResult.success(asset));
             } else {

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImpl.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImpl.java
@@ -84,7 +84,7 @@ public class AssetServiceImpl implements AssetService {
         var result = new AtomicReference<ServiceResult<Asset>>();
 
         transactionContext.execute(() -> {
-            if (index.findById(asset.getId()) == null) {
+            if (findbyId(asset.getId()) == null) {
                 loader.accept(asset, dataAddress);
                 result.set(ServiceResult.success(asset));
             } else {

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/transform/AssetDtoToAssetTransformer.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/transform/AssetDtoToAssetTransformer.java
@@ -34,11 +34,6 @@ public class AssetDtoToAssetTransformer implements DtoTransformer<AssetDto, Asse
     }
 
     @Override
-    public boolean canHandle(@NotNull Object object, @NotNull Class<?> outputType) {
-        return getInputType().isInstance(object) && outputType.equals(getOutputType());
-    }
-
-    @Override
     public @Nullable Asset transform(@Nullable AssetDto object, @NotNull TransformerContext context) {
         return Asset.Builder.newInstance().properties(object.getProperties()).build();
     }

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/transform/AssetToAssetDtoTransformer.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/transform/AssetToAssetDtoTransformer.java
@@ -34,11 +34,6 @@ public class AssetToAssetDtoTransformer implements DtoTransformer<Asset, AssetDt
     }
 
     @Override
-    public boolean canHandle(@NotNull Object object, @NotNull Class<?> outputType) {
-        return getInputType().isInstance(object) && outputType.equals(getOutputType());
-    }
-
-    @Override
     public @Nullable AssetDto transform(@Nullable Asset object, @NotNull TransformerContext context) {
         return AssetDto.Builder.newInstance().properties(object.getProperties()).build();
     }

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/transform/DataAddressDtoToDataAddressTransformer.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/transform/DataAddressDtoToDataAddressTransformer.java
@@ -21,13 +21,7 @@ import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.xml.crypto.Data;
-
 public class DataAddressDtoToDataAddressTransformer implements DtoTransformer<DataAddressDto, DataAddress> {
-    @Override
-    public boolean canHandle(@NotNull Object object, @NotNull Class<?> outputType) {
-        return getInputType().isInstance(object) && outputType.equals(getOutputType());
-    }
 
     @Override
     public Class<DataAddressDto> getInputType() {

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiControllerTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiControllerTest.java
@@ -133,7 +133,7 @@ public class AssetApiControllerTest {
 
     @Test
     void getAssetById() {
-        when(service.findbyId("id")).thenReturn(Asset.Builder.newInstance().build());
+        when(service.findById("id")).thenReturn(Asset.Builder.newInstance().build());
         when(transformerRegistry.transform(isA(Asset.class), eq(AssetDto.class))).thenReturn(Result.success(AssetDto.Builder.newInstance().build()));
 
         var assetDto = controller.getAsset("id");
@@ -144,14 +144,14 @@ public class AssetApiControllerTest {
 
     @Test
     void getAssetById_notExists() {
-        when(service.findbyId("id")).thenReturn(null);
+        when(service.findById("id")).thenReturn(null);
 
         assertThatThrownBy(() -> controller.getAsset("id")).isInstanceOf(ObjectNotFoundException.class);
     }
 
     @Test
     void getAssetById_notExistsIfTransformFails() {
-        when(service.findbyId("id")).thenReturn(Asset.Builder.newInstance().build());
+        when(service.findById("id")).thenReturn(Asset.Builder.newInstance().build());
         when(transformerRegistry.transform(isA(Asset.class), eq(AssetDto.class))).thenReturn(Result.failure("failure"));
 
         assertThatThrownBy(() -> controller.getAsset("id")).isInstanceOf(ObjectNotFoundException.class);

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImplTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImplTest.java
@@ -1,6 +1,5 @@
-package org.eclipse.dataspaceconnector.api.datamanagement.asset;
+package org.eclipse.dataspaceconnector.api.datamanagement.asset.service;
 
-import org.eclipse.dataspaceconnector.api.datamanagement.asset.service.AssetServiceImpl;
 import org.eclipse.dataspaceconnector.dataloading.AssetLoader;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImplTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImplTest.java
@@ -41,7 +41,7 @@ class AssetServiceImplTest {
     void findById_shouldRelyOnAssetIndex() {
         when(index.findById("assetId")).thenReturn(createAsset("assetId"));
 
-        var asset = service.findbyId("assetId");
+        var asset = service.findById("assetId");
 
         String assetId = "assetId";
         assertThat(asset).isNotNull().matches(hasId(assetId));

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/transform/AssetDtoToAssetTransformerTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/transform/AssetDtoToAssetTransformerTest.java
@@ -16,7 +16,6 @@ package org.eclipse.dataspaceconnector.api.datamanagement.asset.transform;
 
 import org.eclipse.dataspaceconnector.api.datamanagement.asset.model.AssetDto;
 import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
-import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -32,13 +31,6 @@ class AssetDtoToAssetTransformerTest {
     void inputOutputType() {
         assertThat(transformer.getInputType()).isNotNull();
         assertThat(transformer.getOutputType()).isNotNull();
-    }
-
-    @Test
-    void canHandle() {
-        assertThat(transformer.canHandle(AssetDto.Builder.newInstance().build(), Asset.class)).isTrue();
-        assertThat(transformer.canHandle("any other", Asset.class)).isFalse();
-        assertThat(transformer.canHandle(AssetDto.Builder.newInstance().build(), Object.class)).isFalse();
     }
 
     @Test

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/transform/AssetToAssetDtoTransformerTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/transform/AssetToAssetDtoTransformerTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.api.datamanagement.asset.transform;
 
-import org.eclipse.dataspaceconnector.api.datamanagement.asset.model.AssetDto;
 import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.junit.jupiter.api.Test;
@@ -32,13 +31,6 @@ class AssetToAssetDtoTransformerTest {
     void inputOutputType() {
         assertThat(transformer.getInputType()).isNotNull();
         assertThat(transformer.getOutputType()).isNotNull();
-    }
-
-    @Test
-    void canHandle() {
-        assertThat(transformer.canHandle(Asset.Builder.newInstance().build(), AssetDto.class)).isTrue();
-        assertThat(transformer.canHandle("any other", AssetDto.class)).isFalse();
-        assertThat(transformer.canHandle(Asset.Builder.newInstance().build(), Object.class)).isFalse();
     }
 
     @Test

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/transform/DataAddressDtoToDataAddressTransformerTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/transform/DataAddressDtoToDataAddressTransformerTest.java
@@ -16,7 +16,6 @@ package org.eclipse.dataspaceconnector.api.datamanagement.asset.transform;
 
 import org.eclipse.dataspaceconnector.api.datamanagement.asset.model.DataAddressDto;
 import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
-import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -32,13 +31,6 @@ class DataAddressDtoToDataAddressTransformerTest {
     void inputOutputType() {
         assertThat(transformer.getInputType()).isNotNull();
         assertThat(transformer.getOutputType()).isNotNull();
-    }
-
-    @Test
-    void canHandle() {
-        assertThat(transformer.canHandle(DataAddressDto.Builder.newInstance().build(), DataAddress.class)).isTrue();
-        assertThat(transformer.canHandle("any other", DataAddress.class)).isFalse();
-        assertThat(transformer.canHandle(DataAddressDto.Builder.newInstance().build(), Object.class)).isFalse();
     }
 
     @Test

--- a/extensions/api/data-management/contractdefinition/build.gradle.kts
+++ b/extensions/api/data-management/contractdefinition/build.gradle.kts
@@ -34,7 +34,6 @@ dependencies {
     testImplementation(testFixtures(project(":common:util")))
     testImplementation(testFixtures(project(":launchers:junit")))
     testImplementation(project(":extensions:in-memory:contractdefinition-store-memory"))
-    testImplementation(project(":extensions:in-memory:negotiation-store-memory"))
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
 }
 

--- a/extensions/api/data-management/contractdefinition/build.gradle.kts
+++ b/extensions/api/data-management/contractdefinition/build.gradle.kts
@@ -9,13 +9,12 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 
-
-val infoModelVersion: String by project
 val rsApi: String by project
-val okHttpVersion: String by project
+val restAssured: String by project
 
 plugins {
     `java-library`
@@ -23,19 +22,20 @@ plugins {
 }
 
 dependencies {
-    api(project(":spi"))
-    implementation(project(":common:util"))
     implementation(project(":extensions:api:api-core"))
+    implementation(project(":extensions:api:auth-spi"))
     implementation(project(":extensions:api:data-management:api-configuration"))
-
+    implementation(project(":extensions:dataloading"))
+    implementation(project(":extensions:transaction:transaction-spi"))
 
     implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
 
-    testImplementation("com.squareup.okhttp3:okhttp:${okHttpVersion}")
-    testImplementation(testFixtures(project(":launchers:junit")))
-    testImplementation(project(":extensions:in-memory:contractdefinition-store-memory"))
     testImplementation(project(":extensions:http"))
     testImplementation(testFixtures(project(":common:util")))
+    testImplementation(testFixtures(project(":launchers:junit")))
+    testImplementation(project(":extensions:in-memory:contractdefinition-store-memory"))
+    testImplementation(project(":extensions:in-memory:negotiation-store-memory"))
+    testImplementation("io.rest-assured:rest-assured:${restAssured}")
 }
 
 publishing {

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiController.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiController.java
@@ -35,7 +35,6 @@ import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.result.Result;
-import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
 
 import java.util.List;
@@ -87,7 +86,7 @@ public class ContractDefinitionApiController implements ContractDefinitionApi {
         monitor.debug(format("get contract definition with ID %s", id));
 
         return Optional.of(id)
-                .map(service::findbyId)
+                .map(service::findById)
                 .map(it -> transformerRegistry.transform(it, ContractDefinitionDto.class))
                 .filter(Result::succeeded)
                 .map(Result::getContent)

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiController.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiController.java
@@ -25,12 +25,22 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model.ContractDefinitionDto;
+import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.service.ContractDefinitionService;
+import org.eclipse.dataspaceconnector.api.exception.ObjectExistsException;
+import org.eclipse.dataspaceconnector.api.exception.ObjectNotFoundException;
+import org.eclipse.dataspaceconnector.api.result.ServiceResult;
+import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
+import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
+import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
 
-import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 
@@ -39,9 +49,13 @@ import static java.lang.String.format;
 @Path("/contractdefinitions")
 public class ContractDefinitionApiController implements ContractDefinitionApi {
     private final Monitor monitor;
+    private final ContractDefinitionService service;
+    private final DtoTransformerRegistry transformerRegistry;
 
-    public ContractDefinitionApiController(Monitor monitor) {
+    public ContractDefinitionApiController(Monitor monitor, ContractDefinitionService service, DtoTransformerRegistry transformerRegistry) {
         this.monitor = monitor;
+        this.service = service;
+        this.transformerRegistry = transformerRegistry;
     }
 
     @GET
@@ -59,8 +73,11 @@ public class ContractDefinitionApiController implements ContractDefinitionApi {
                 .sortOrder(sortOrder).build();
         monitor.debug(format("get all contract definitions %s", spec));
 
-        return Collections.emptyList();
-
+        return service.query(spec).stream()
+                .map(it -> transformerRegistry.transform(it, ContractDefinitionDto.class))
+                .filter(Result::succeeded)
+                .map(Result::getContent)
+                .collect(Collectors.toList());
     }
 
     @GET
@@ -69,21 +86,52 @@ public class ContractDefinitionApiController implements ContractDefinitionApi {
     public ContractDefinitionDto getContractDefinition(@PathParam("id") String id) {
         monitor.debug(format("get contract definition with ID %s", id));
 
-        return null;
+        return Optional.of(id)
+                .map(service::findbyId)
+                .map(it -> transformerRegistry.transform(it, ContractDefinitionDto.class))
+                .filter(Result::succeeded)
+                .map(Result::getContent)
+                .orElseThrow(() -> new ObjectNotFoundException(ContractDefinition.class, id));
     }
 
     @POST
     @Override
     public void createContractDefinition(ContractDefinitionDto dto) {
         monitor.debug("create new contract definition");
-    }
+        var transformResult = transformerRegistry.transform(dto, ContractDefinition.class);
+        if (transformResult.failed()) {
+            throw new IllegalArgumentException("Request is not well formatted");
+        }
 
+        ContractDefinition contractDefinition = transformResult.getContent();
+
+        var result = service.create(contractDefinition);
+        if (result.succeeded()) {
+            monitor.debug(format("Contract negotiation created %s", result.getContent().getId()));
+        } else {
+            throw new ObjectExistsException(ContractDefinition.class, dto.getId());
+        }
+    }
 
     @DELETE
     @Path("{id}")
     @Override
     public void deleteContractDefinition(@PathParam("id") String id) {
         monitor.debug(format("Attempting to delete contract definition with id %s", id));
+        var result = service.delete(id);
+        if (result.succeeded()) {
+            monitor.debug(format("Contract negotiation deleted %s", result.getContent().getId()));
+        } else {
+            handleFailedResult(result, id);
+        }
+    }
+
+    private void handleFailedResult(ServiceResult<ContractDefinition> result, String id) {
+        switch (result.reason()) {
+            case NOT_FOUND: throw new ObjectNotFoundException(ContractDefinition.class, id);
+            case CONFLICT: throw new ObjectExistsException(ContractDefinition.class, id);
+            default: throw new EdcException("unexpected error");
+        }
     }
 
 }

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiExtension.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiExtension.java
@@ -24,7 +24,6 @@ import org.eclipse.dataspaceconnector.dataloading.ContractDefinitionLoader;
 import org.eclipse.dataspaceconnector.spi.WebService;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
-import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
@@ -47,9 +46,6 @@ public class ContractDefinitionApiExtension implements ServiceExtension {
     ContractDefinitionStore contractDefinitionStore;
 
     @Inject
-    ContractNegotiationStore contractNegotiationStore;
-
-    @Inject
     ContractDefinitionLoader contractDefinitionLoader;
 
     @Inject(required = false)
@@ -67,7 +63,7 @@ public class ContractDefinitionApiExtension implements ServiceExtension {
                     return new NoopTransactionContext();
                 });
 
-        var service = new ContractDefinitionServiceImpl(contractDefinitionStore, contractDefinitionLoader, transactionContextImpl, contractNegotiationStore);
+        var service = new ContractDefinitionServiceImpl(contractDefinitionStore, contractDefinitionLoader, transactionContextImpl);
         webService.registerResource(config.getContextAlias(), new ContractDefinitionApiController(monitor, service, transformerRegistry));
     }
 }

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiExtension.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiExtension.java
@@ -9,26 +9,65 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 
 package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition;
 
 import org.eclipse.dataspaceconnector.api.datamanagement.configuration.DataManagementApiConfiguration;
+import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.service.ContractDefinitionServiceImpl;
+import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.transform.ContractDefinitionDtoToContractDefinitionTransformer;
+import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.transform.ContractDefinitionToContractDefinitionDtoTransformer;
+import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
+import org.eclipse.dataspaceconnector.dataloading.ContractDefinitionLoader;
 import org.eclipse.dataspaceconnector.spi.WebService;
+import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
+import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.transaction.NoopTransactionContext;
+import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
+
+import static java.util.Optional.ofNullable;
 
 public class ContractDefinitionApiExtension implements ServiceExtension {
     @Inject
-    private WebService webService;
+    WebService webService;
 
     @Inject
-    private DataManagementApiConfiguration config;
+    DataManagementApiConfiguration config;
+
+    @Inject
+    DtoTransformerRegistry transformerRegistry;
+
+    @Inject
+    ContractDefinitionStore contractDefinitionStore;
+
+    @Inject
+    ContractNegotiationStore contractNegotiationStore;
+
+    @Inject
+    ContractDefinitionLoader contractDefinitionLoader;
+
+    @Inject(required = false)
+    TransactionContext transactionContext;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        webService.registerResource(config.getContextAlias(), new ContractDefinitionApiController(context.getMonitor()));
+        transformerRegistry.register(new ContractDefinitionToContractDefinitionDtoTransformer());
+        transformerRegistry.register(new ContractDefinitionDtoToContractDefinitionTransformer());
+
+        var monitor = context.getMonitor();
+        var transactionContextImpl = ofNullable(transactionContext)
+                .orElseGet(() -> {
+                    monitor.warning("No TransactionContext registered, a no-op implementation will be used, not suitable for production environments");
+                    return new NoopTransactionContext();
+                });
+
+        var service = new ContractDefinitionServiceImpl(contractDefinitionStore, contractDefinitionLoader, transactionContextImpl, contractNegotiationStore);
+        webService.registerResource(config.getContextAlias(), new ContractDefinitionApiController(monitor, service, transformerRegistry));
     }
 }

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/ContractDefinitionDto.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/ContractDefinitionDto.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/service/ContractDefinitionService.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/service/ContractDefinitionService.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.service;
+
+import org.eclipse.dataspaceconnector.api.result.ServiceResult;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
+
+import java.util.Collection;
+
+public interface ContractDefinitionService {
+
+    /**
+     * Returns a contract definition by its id
+     *
+     * @param contractDefinitionId id of the contract definition
+     * @return the contract definition, null if it's not found
+     */
+    ContractDefinition findbyId(String contractDefinitionId);
+
+    /**
+     * Query contract definitions
+     *
+     * @param query request
+     * @return the collection of contract definitions that matches the query
+     */
+    Collection<ContractDefinition> query(QuerySpec query);
+
+    /**
+     * Create a contract definition with its related data address
+     *
+     * @param contractDefinition the contract definition
+     * @return successful result if the contract definition is created correctly, failure otherwise
+     */
+    ServiceResult<ContractDefinition> create(ContractDefinition contractDefinition);
+
+    /**
+     * Delete a contract definition
+     *
+     * @param contractDefinitionId the id of the contract definition to be deleted
+     * @return successful result if the contract definition is deleted correctly, failure otherwise
+     */
+    ServiceResult<ContractDefinition> delete(String contractDefinitionId);
+}

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/service/ContractDefinitionService.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/service/ContractDefinitionService.java
@@ -20,6 +20,10 @@ import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDe
 
 import java.util.Collection;
 
+/**
+ * Service that permits actions and queries on ContractDefinition entity.
+ *
+ */
 public interface ContractDefinitionService {
 
     /**
@@ -28,7 +32,7 @@ public interface ContractDefinitionService {
      * @param contractDefinitionId id of the contract definition
      * @return the contract definition, null if it's not found
      */
-    ContractDefinition findbyId(String contractDefinitionId);
+    ContractDefinition findById(String contractDefinitionId);
 
     /**
      * Query contract definitions
@@ -39,7 +43,8 @@ public interface ContractDefinitionService {
     Collection<ContractDefinition> query(QuerySpec query);
 
     /**
-     * Create a contract definition with its related data address
+     * Create a contract definition with its related data address.
+     * If a definition with the same id exists, returns CONFLICT failure.
      *
      * @param contractDefinition the contract definition
      * @return successful result if the contract definition is created correctly, failure otherwise
@@ -47,7 +52,9 @@ public interface ContractDefinitionService {
     ServiceResult<ContractDefinition> create(ContractDefinition contractDefinition);
 
     /**
-     * Delete a contract definition
+     * Delete a contract definition.
+     * If the definition is already referenced by a contract agreement, returns CONFLICT failure.
+     * If the definition does not exist, returns NOT_FOUND failure.
      *
      * @param contractDefinitionId the id of the contract definition to be deleted
      * @return successful result if the contract definition is deleted correctly, failure otherwise

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/service/ContractDefinitionServiceImpl.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/service/ContractDefinitionServiceImpl.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.service;
+
+import org.eclipse.dataspaceconnector.api.result.ServiceResult;
+import org.eclipse.dataspaceconnector.dataloading.ContractDefinitionLoader;
+import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
+import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
+
+public class ContractDefinitionServiceImpl implements ContractDefinitionService {
+    private final ContractDefinitionStore store;
+    private final ContractDefinitionLoader loader;
+    private final TransactionContext transactionContext;
+    private final ContractNegotiationStore contractNegotiationStore;
+
+    public ContractDefinitionServiceImpl(ContractDefinitionStore store, ContractDefinitionLoader loader, TransactionContext transactionContext, ContractNegotiationStore contractNegotiationStore) {
+        this.store = store;
+        this.loader = loader;
+        this.transactionContext = transactionContext;
+        this.contractNegotiationStore = contractNegotiationStore;
+    }
+
+    @Override
+    public ContractDefinition findbyId(String contractDefinitionId) {
+        var querySpec = QuerySpec.Builder.newInstance()
+                .filter(List.of(new Criterion("id", "=", contractDefinitionId)))
+                .build();
+
+        return store.findAll(querySpec).findFirst().orElse(null);
+    }
+
+    @Override
+    public Collection<ContractDefinition> query(QuerySpec query) {
+        return store.findAll(query).collect(toList());
+    }
+
+    @Override
+    public ServiceResult<ContractDefinition> create(ContractDefinition contractDefinition) {
+        var result = new AtomicReference<ServiceResult<ContractDefinition>>();
+
+        transactionContext.execute(() -> {
+            if (findbyId(contractDefinition.getId()) == null) {
+                loader.accept(contractDefinition);
+                result.set(ServiceResult.success(contractDefinition));
+            } else {
+                result.set(ServiceResult.conflict(format("ContractDefinition %s cannot be created because it already exist", contractDefinition.getId())));
+            }
+        });
+
+        return result.get();
+    }
+
+    @Override
+    public ServiceResult<ContractDefinition> delete(String contractDefinitionId) {
+        var result = new AtomicReference<ServiceResult<ContractDefinition>>();
+
+        transactionContext.execute(() -> {
+            var filter = format("contractAgreement.id like %s:%%", contractDefinitionId);
+            var query = QuerySpec.Builder.newInstance().filter(filter).build();
+
+            var negotiationsOnAsset = contractNegotiationStore.queryNegotiations(query);
+            if (negotiationsOnAsset.findAny().isPresent()) {
+                result.set(ServiceResult.conflict(format("ContractDefinition %s cannot be deleted as it is referenced by at least one contract agreement", contractDefinitionId)));
+                return;
+            }
+
+            var deleted = store.deleteById(contractDefinitionId);
+            if (deleted == null) {
+                result.set(ServiceResult.notFound(format("ContractDefinition %s does not exist", contractDefinitionId)));
+                return;
+            }
+
+            result.set(ServiceResult.success(deleted));
+        });
+
+        return result.get();
+    }
+}

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/transform/ContractDefinitionDtoToContractDefinitionTransformer.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/transform/ContractDefinitionDtoToContractDefinitionTransformer.java
@@ -39,8 +39,8 @@ public class ContractDefinitionDtoToContractDefinitionTransformer implements Dto
     public @Nullable ContractDefinition transform(@Nullable ContractDefinitionDto object, @NotNull TransformerContext context) {
         return ContractDefinition.Builder.newInstance()
                 .id(object.getId())
-                .accessPolicy(Policy.Builder.newInstance().id(object.getAccessPolicyId()).build())
-                .contractPolicy(Policy.Builder.newInstance().id(object.getContractPolicyId()).build())
+                .accessPolicy(Policy.Builder.newInstance().id(object.getAccessPolicyId()).build()) // TODO: policy will be replaced by policy id
+                .contractPolicy(Policy.Builder.newInstance().id(object.getContractPolicyId()).build()) // TODO: policy will be replaced by policy id
                 .selectorExpression(AssetSelectorExpression.Builder.newInstance().criteria(object.getCriteria()).build())
                 .build();
     }

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/transform/ContractDefinitionDtoToContractDefinitionTransformer.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/transform/ContractDefinitionDtoToContractDefinitionTransformer.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.transform;
+
+import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model.ContractDefinitionDto;
+import org.eclipse.dataspaceconnector.api.transformer.DtoTransformer;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
+import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class ContractDefinitionDtoToContractDefinitionTransformer implements DtoTransformer<ContractDefinitionDto, ContractDefinition> {
+
+    @Override
+    public Class<ContractDefinitionDto> getInputType() {
+        return ContractDefinitionDto.class;
+    }
+
+    @Override
+    public Class<ContractDefinition> getOutputType() {
+        return ContractDefinition.class;
+    }
+
+    @Override
+    public @Nullable ContractDefinition transform(@Nullable ContractDefinitionDto object, @NotNull TransformerContext context) {
+        return ContractDefinition.Builder.newInstance()
+                .id(object.getId())
+                .accessPolicy(Policy.Builder.newInstance().id(object.getAccessPolicyId()).build())
+                .contractPolicy(Policy.Builder.newInstance().id(object.getContractPolicyId()).build())
+                .selectorExpression(AssetSelectorExpression.Builder.newInstance().criteria(object.getCriteria()).build())
+                .build();
+    }
+}

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/transform/ContractDefinitionToContractDefinitionDtoTransformer.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/transform/ContractDefinitionToContractDefinitionDtoTransformer.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.transform;
+
+import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model.ContractDefinitionDto;
+import org.eclipse.dataspaceconnector.api.transformer.DtoTransformer;
+import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class ContractDefinitionToContractDefinitionDtoTransformer implements DtoTransformer<ContractDefinition, ContractDefinitionDto> {
+
+    @Override
+    public Class<ContractDefinition> getInputType() {
+        return ContractDefinition.class;
+    }
+
+    @Override
+    public Class<ContractDefinitionDto> getOutputType() {
+        return ContractDefinitionDto.class;
+    }
+
+    @Override
+    public @Nullable ContractDefinitionDto transform(@Nullable ContractDefinition object, @NotNull TransformerContext context) {
+        return ContractDefinitionDto.Builder.newInstance()
+                .id(object.getId())
+                .accessPolicyId(object.getAccessPolicy().getUid())
+                .contractPolicyId(object.getContractPolicy().getUid())
+                .criteria(object.getSelectorExpression().getCriteria())
+                .build();
+    }
+}

--- a/extensions/api/data-management/contractdefinition/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
+++ b/extensions/api/data-management/contractdefinition/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
@@ -9,6 +9,7 @@
 #
 #  Contributors:
 #       Microsoft Corporation - initial API and implementation
+#       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 #
 #
 

--- a/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiControllerIntegrationTest.java
@@ -21,18 +21,13 @@ import org.eclipse.dataspaceconnector.dataloading.ContractDefinitionLoader;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
-import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
-import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
-import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
-import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Map;
-import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
@@ -41,7 +36,7 @@ import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.getFr
 import static org.hamcrest.Matchers.is;
 
 @ExtendWith(EdcExtension.class)
-public class ContractDefinitionsApiControllerIntegrationTest {
+public class ContractDefinitionApiControllerIntegrationTest {
 
     private final int port = getFreePort();
     private final String authKey = "123456";
@@ -147,19 +142,6 @@ public class ContractDefinitionsApiControllerIntegrationTest {
                 .statusCode(404);
     }
 
-    @Test
-    void deleteAsset_alreadyReferencedInAgreement(ContractNegotiationStore negotiationStore, ContractDefinitionLoader loader) {
-        var contractDefinition = createContractDefinition("definitionId");
-        loader.accept(contractDefinition);
-        negotiationStore.save(createContractNegotiation(contractDefinition));
-
-        baseRequest()
-                .contentType(JSON)
-                .delete("/contractdefinitions/definitionId")
-                .then()
-                .statusCode(409);
-    }
-
     private ContractDefinition createContractDefinition(String id) {
         return ContractDefinition.Builder.newInstance()
                 .id(id)
@@ -177,23 +159,4 @@ public class ContractDefinitionsApiControllerIntegrationTest {
                 .when();
     }
 
-    private ContractNegotiation createContractNegotiation(ContractDefinition contractDefinition) {
-        return ContractNegotiation.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
-                .counterPartyId(UUID.randomUUID().toString())
-                .counterPartyAddress("address")
-                .protocol("protocol")
-                .contractAgreement(createContractAgreement(contractDefinition))
-                .build();
-    }
-
-    private ContractAgreement createContractAgreement(ContractDefinition contractDefinition) {
-        return ContractAgreement.Builder.newInstance()
-                .id(contractDefinition.getId() + ":" + UUID.randomUUID())
-                .providerAgentId(UUID.randomUUID().toString())
-                .consumerAgentId(UUID.randomUUID().toString())
-                .asset(Asset.Builder.newInstance().build())
-                .policy(Policy.Builder.newInstance().build())
-                .build();
-    }
 }

--- a/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiControllerTest.java
+++ b/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiControllerTest.java
@@ -1,121 +1,185 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ */
+
 package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition;
 
+import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model.ContractDefinitionDto;
+import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.service.ContractDefinitionService;
+import org.eclipse.dataspaceconnector.api.exception.ObjectExistsException;
+import org.eclipse.dataspaceconnector.api.exception.ObjectNotFoundException;
+import org.eclipse.dataspaceconnector.api.result.ServiceResult;
+import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.SortOrder;
+import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.List;
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 class ContractDefinitionApiControllerTest {
+
+    private final DtoTransformerRegistry transformerRegistry = mock(DtoTransformerRegistry.class);
+    private final ContractDefinitionService service = mock(ContractDefinitionService.class);
     private ContractDefinitionApiController controller;
 
     @BeforeEach
     void setup() {
         var monitor = mock(Monitor.class);
-        controller = new ContractDefinitionApiController(monitor);
+        controller = new ContractDefinitionApiController(monitor, service, transformerRegistry);
     }
 
     @Test
-    void getAll_paging_noFilter() {
-        //todo: implement
+    void getAll() {
+        var contractDefinition = createContractDefinition();
+        when(service.query(any())).thenReturn(List.of(contractDefinition));
+        var dto = ContractDefinitionDto.Builder.newInstance().id(contractDefinition.getId()).build();
+        when(transformerRegistry.transform(any(), eq(ContractDefinitionDto.class))).thenReturn(Result.success(dto));
+
+        var allContractDefinitions = controller.getAllContractDefinitions(1, 10, "field=value", SortOrder.ASC, "field");
+
+        assertThat(allContractDefinitions).hasSize(1).first().matches(d -> d.getId().equals(contractDefinition.getId()));
+        verify(transformerRegistry).transform(contractDefinition, ContractDefinitionDto.class);
+        verify(service).query(argThat(s ->
+                s.getOffset() == 1 &&
+                s.getLimit() == 10 &&
+                s.getFilterExpression().size() == 1 &&
+                s.getFilterExpression().get(0).equals(new Criterion("field", "=", "value")) &&
+                s.getSortOrder().equals(SortOrder.ASC) &&
+                s.getSortField().equals("field")
+        ));
     }
 
     @Test
-    void getAll_paging_pageSizeTooLarge() {
-        //todo: implement
-    }
+    void getAll_filtersOutFailedTransforms() {
+        var contractDefinition = createContractDefinition();
+        when(service.query(any())).thenReturn(List.of(contractDefinition));
+        when(transformerRegistry.transform(isA(ContractDefinition.class), eq(ContractDefinitionDto.class))).thenReturn(Result.failure("failure"));
 
-    @Test
-    void getAll_paging_offsetOutOfBounds() {
-        //todo: implement
-    }
+        var allContractDefinitions = controller.getAllContractDefinitions(1, 10, "field=value", SortOrder.ASC, "field");
 
-    @ParameterizedTest
-    @ValueSource(strings = { "id=id1", "id = id1", "id =id1", "id= id1" })
-    void getAll_paging_withValidFilter(String filter) {
-        //todo: implement
-    }
-
-
-    @ParameterizedTest
-    @ValueSource(strings = { "id > id1", "id < id1", "id like id1", "id inside id1" })
-    void getAll_paging_filterWithInvalidOperator(String filter) {
-        //todo: implement
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = { "id>id1", "id<id1" })
-    void getAll_paging_withInvalidFilter(String filter) {
-        //todo: implement
-    }
-
-    @Test
-    void getAll_paging_invalidParams() {
-        //todo: implement
-    }
-
-    @Test
-    void getAll_noPaging() {
-        //todo: implement
+        assertThat(allContractDefinitions).hasSize(0);
+        verify(transformerRegistry).transform(contractDefinition, ContractDefinitionDto.class);
     }
 
     @Test
     void getContractDef_found() {
-        //todo: implement
+        var contractDefinition = createContractDefinition();
+        when(service.findbyId("definitionId")).thenReturn(contractDefinition);
+        var dto = ContractDefinitionDto.Builder.newInstance().id(contractDefinition.getId()).build();
+        when(transformerRegistry.transform(isA(ContractDefinition.class), eq(ContractDefinitionDto.class))).thenReturn(Result.success(dto));
+
+        var retrieved = controller.getContractDefinition("definitionId");
+
+        assertThat(retrieved).isNotNull();
     }
 
     @Test
     void getContractDef_notFound() {
-        assertThat(controller.getContractDefinition("not-exist")).isNull();
+        when(service.findbyId("definitionId")).thenReturn(null);
+
+        assertThatThrownBy(() -> controller.getContractDefinition("nonExistingId")).isInstanceOf(ObjectNotFoundException.class);
+        verifyNoInteractions(transformerRegistry);
+    }
+
+    @Test
+    void getContractDef_notFoundIfTransformationFails() {
+        var contractDefinition = createContractDefinition();
+        when(service.findbyId("definitionId")).thenReturn(contractDefinition);
+        when(transformerRegistry.transform(isA(ContractDefinition.class), eq(ContractDefinitionDto.class))).thenReturn(Result.failure("failure"));
+
+        assertThatThrownBy(() -> controller.getContractDefinition("nonExistingId")).isInstanceOf(ObjectNotFoundException.class);
     }
 
     @Test
     void createContractDefinition_success() {
-        //todo: implement
+        var dto = ContractDefinitionDto.Builder.newInstance().build();
+        var contractDefinition = createContractDefinition();
+        when(transformerRegistry.transform(isA(ContractDefinitionDto.class), eq(ContractDefinition.class))).thenReturn(Result.success(contractDefinition));
+        when(service.create(any())).thenReturn(ServiceResult.success(contractDefinition));
 
+        controller.createContractDefinition(dto);
+
+        verify(service).create(isA(ContractDefinition.class));
+        verify(transformerRegistry).transform(isA(ContractDefinitionDto.class), eq(ContractDefinition.class));
     }
 
     @Test
     void createContractDefinition_alreadyExists() {
-        //todo: implement
+        var dto = ContractDefinitionDto.Builder.newInstance().build();
+        when(transformerRegistry.transform(isA(ContractDefinitionDto.class), eq(ContractDefinition.class))).thenReturn(Result.success(createContractDefinition()));
+        when(service.create(any())).thenReturn(ServiceResult.conflict("already exists"));
+
+        assertThatThrownBy(() -> controller.createContractDefinition(dto)).isInstanceOf(ObjectExistsException.class);
     }
 
     @Test
-    void createContractDefinition_policyNotFound() {
-        //todo: implement
+    void createContractDefinition_transformationFails() {
+        var dto = ContractDefinitionDto.Builder.newInstance().build();
+        when(transformerRegistry.transform(isA(ContractDefinitionDto.class), eq(ContractDefinition.class))).thenReturn(Result.failure("failure"));
 
-    }
-
-    @Test
-    void createContractDefinition_noAssetSelector() {
-        //todo: implement
-    }
-
-    @Test
-    void createContractDefinition_noAccessPolicy() {
-        //todo: implement
-    }
-
-    @Test
-    void createContractDefinition_noContractPolicy() {
-        //todo: implement
+        assertThatThrownBy(() -> controller.createContractDefinition(dto)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void delete() {
-        //todo: implement
+        var contractDefinition = createContractDefinition();
+        when(service.delete("definitionId")).thenReturn(ServiceResult.success(contractDefinition));
+
+        controller.deleteContractDefinition("definitionId");
+
+        verify(service).delete("definitionId");
     }
 
     @Test
     void delete_notFound() {
+        when(service.delete("definitionId")).thenReturn(ServiceResult.notFound("not found"));
 
+        assertThatThrownBy(() -> controller.deleteContractDefinition("definitionId")).isInstanceOf(ObjectNotFoundException.class);
     }
 
     @Test
     void delete_notPossible() {
-        //todo: implement
+        when(service.delete("definitionId")).thenReturn(ServiceResult.conflict("conflict"));
+
+        assertThatThrownBy(() -> controller.deleteContractDefinition("definitionId")).isInstanceOf(ObjectExistsException.class);
+    }
+
+    private ContractDefinition createContractDefinition() {
+        return ContractDefinition.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .accessPolicy(Policy.Builder.newInstance().build())
+                .contractPolicy(Policy.Builder.newInstance().build())
+                .selectorExpression(AssetSelectorExpression.SELECT_ALL)
+                .build();
     }
 }

--- a/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiControllerTest.java
+++ b/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiControllerTest.java
@@ -29,8 +29,6 @@ import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
 import java.util.UUID;
@@ -94,7 +92,7 @@ class ContractDefinitionApiControllerTest {
     @Test
     void getContractDef_found() {
         var contractDefinition = createContractDefinition();
-        when(service.findbyId("definitionId")).thenReturn(contractDefinition);
+        when(service.findById("definitionId")).thenReturn(contractDefinition);
         var dto = ContractDefinitionDto.Builder.newInstance().id(contractDefinition.getId()).build();
         when(transformerRegistry.transform(isA(ContractDefinition.class), eq(ContractDefinitionDto.class))).thenReturn(Result.success(dto));
 
@@ -105,7 +103,7 @@ class ContractDefinitionApiControllerTest {
 
     @Test
     void getContractDef_notFound() {
-        when(service.findbyId("definitionId")).thenReturn(null);
+        when(service.findById("definitionId")).thenReturn(null);
 
         assertThatThrownBy(() -> controller.getContractDefinition("nonExistingId")).isInstanceOf(ObjectNotFoundException.class);
         verifyNoInteractions(transformerRegistry);
@@ -114,7 +112,7 @@ class ContractDefinitionApiControllerTest {
     @Test
     void getContractDef_notFoundIfTransformationFails() {
         var contractDefinition = createContractDefinition();
-        when(service.findbyId("definitionId")).thenReturn(contractDefinition);
+        when(service.findById("definitionId")).thenReturn(contractDefinition);
         when(transformerRegistry.transform(isA(ContractDefinition.class), eq(ContractDefinitionDto.class))).thenReturn(Result.failure("failure"));
 
         assertThatThrownBy(() -> controller.getContractDefinition("nonExistingId")).isInstanceOf(ObjectNotFoundException.class);

--- a/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/ContractDefinitionDtoTest.java
+++ b/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/ContractDefinitionDtoTest.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 

--- a/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/service/ContractDefinitionServiceImplTest.java
+++ b/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/service/ContractDefinitionServiceImplTest.java
@@ -1,0 +1,160 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.service;
+
+import org.eclipse.dataspaceconnector.dataloading.ContractDefinitionLoader;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
+import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
+import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.spi.transaction.NoopTransactionContext;
+import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.api.result.ServiceFailure.Reason.CONFLICT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class ContractDefinitionServiceImplTest {
+
+    private final ContractDefinitionStore store = mock(ContractDefinitionStore.class);
+    private final ContractNegotiationStore contractNegotiationStore = mock(ContractNegotiationStore.class);
+    private final ContractDefinitionLoader loader = mock(ContractDefinitionLoader.class);
+    private final TransactionContext transactionContext = new NoopTransactionContext();
+    private final ContractDefinitionServiceImpl service = new ContractDefinitionServiceImpl(store, loader, transactionContext, contractNegotiationStore);
+
+    @Test
+    void findById_filtersById() {
+        var definition = createContractDefinition();
+        when(store.findAll(isA(QuerySpec.class))).thenReturn(Stream.of(definition));
+
+        var result = service.findbyId(definition.getId());
+
+        assertThat(result).matches(hasId(definition.getId()));
+        verify(store).findAll(argThat(q -> q.getFilterExpression().contains(new Criterion("id", "=", definition.getId()))));
+    }
+
+    @Test
+    void findById_returnsNullIfNotFound() {
+        when(store.findAll(isA(QuerySpec.class))).thenReturn(Stream.empty());
+
+        var result = service.findbyId("any");
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void query() {
+        var definition = createContractDefinition();
+        when(store.findAll(isA(QuerySpec.class))).thenReturn(Stream.of(definition));
+
+        var result = service.query(QuerySpec.none());
+
+        String id = definition.getId();
+        assertThat(result).hasSize(1).first().matches(hasId(id));
+    }
+
+    @Test
+    void create_shouldCreateDefinitionIfItDoesNotAlreadyExist() {
+        var definition = createContractDefinition();
+        when(store.findAll(isA(QuerySpec.class))).thenReturn(Stream.empty());
+
+        var inserted = service.create(definition);
+
+        assertThat(inserted.succeeded()).isTrue();
+        assertThat(inserted.getContent()).matches(hasId(definition.getId()));
+        verify(loader).accept(argThat(it -> definition.getId().equals(it.getId())));
+    }
+
+    @Test
+    void create_shouldNotCreateDefinitionIfItAlreadyExists() {
+        var definition = createContractDefinition();
+        when(store.findAll(isA(QuerySpec.class))).thenReturn(Stream.of(definition));
+
+        var inserted = service.create(definition);
+
+        assertThat(inserted.failed()).isTrue();
+        assertThat(inserted.reason()).isEqualTo(CONFLICT);
+        verifyNoInteractions(loader);
+    }
+
+    @Test
+    void delete_shouldDeleteDefinitionIfItsNotReferencedByAnyAgreement() {
+        var definition = createContractDefinition();
+        when(contractNegotiationStore.queryNegotiations(any())).thenReturn(Stream.empty());
+        when(store.deleteById("assetId")).thenReturn(definition);
+
+        var deleted = service.delete("assetId");
+
+        assertThat(deleted.succeeded()).isTrue();
+        assertThat(deleted.getContent()).matches(hasId(definition.getId()));
+    }
+
+    @Test
+    void delete_shouldNotDeleteIfNegotiationIsAlreadyPartOfAnAgreement() {
+        var contractDefinition = createContractDefinition();
+        when(store.deleteById("assetId")).thenReturn(contractDefinition);
+        ContractNegotiation contractNegotiation = ContractNegotiation.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .counterPartyId(UUID.randomUUID().toString())
+                .counterPartyAddress("address")
+                .protocol("protocol")
+                .contractAgreement(ContractAgreement.Builder.newInstance()
+                        .id(contractDefinition.getId() + ":" + UUID.randomUUID())
+                        .providerAgentId(UUID.randomUUID().toString())
+                        .consumerAgentId(UUID.randomUUID().toString())
+                        .asset(Asset.Builder.newInstance().build())
+                        .policy(Policy.Builder.newInstance().build())
+                        .build())
+                .build();
+        when(contractNegotiationStore.queryNegotiations(any())).thenReturn(Stream.of(contractNegotiation));
+
+        var deleted = service.delete(contractNegotiation.getId());
+
+        assertThat(deleted.failed()).isTrue();
+        assertThat(deleted.getFailure().getReason()).isEqualTo(CONFLICT);
+    }
+
+    @NotNull
+    private Predicate<ContractDefinition> hasId(String id) {
+        return d -> d.getId().equals(id);
+    }
+
+    private ContractDefinition createContractDefinition() {
+        return ContractDefinition.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .accessPolicy(Policy.Builder.newInstance().build())
+                .contractPolicy(Policy.Builder.newInstance().build())
+                .selectorExpression(AssetSelectorExpression.SELECT_ALL)
+                .build();
+    }
+}

--- a/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/transform/ContractDefinitionDtoToContractDefinitionTransformerTest.java
+++ b/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/transform/ContractDefinitionDtoToContractDefinitionTransformerTest.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.transform;
+
+import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model.ContractDefinitionDto;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class ContractDefinitionDtoToContractDefinitionTransformerTest {
+
+    private final ContractDefinitionDtoToContractDefinitionTransformer transformer = new ContractDefinitionDtoToContractDefinitionTransformer();
+
+    @Test
+    void inputOutputType() {
+        assertThat(transformer.getInputType()).isNotNull();
+        assertThat(transformer.getOutputType()).isNotNull();
+    }
+
+    @Test
+    void transform() {
+        var context = mock(TransformerContext.class);
+        var contractDefinitionDto = ContractDefinitionDto.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .accessPolicyId(UUID.randomUUID().toString())
+                .contractPolicyId(UUID.randomUUID().toString())
+                .criteria(List.of(new Criterion("left", "=", "right")))
+                .build();
+
+        var contractDefinition = transformer.transform(contractDefinitionDto, context);
+
+        assertThat(contractDefinition.getId()).isEqualTo(contractDefinitionDto.getId());
+        assertThat(contractDefinition.getAccessPolicy().getUid()).isEqualTo(contractDefinitionDto.getAccessPolicyId());
+        assertThat(contractDefinition.getContractPolicy().getUid()).isEqualTo(contractDefinitionDto.getContractPolicyId());
+        assertThat(contractDefinition.getSelectorExpression().getCriteria()).containsExactlyElementsOf(contractDefinitionDto.getCriteria());
+    }
+
+}

--- a/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/transform/ContractDefinitionToContractDefinitionDtoTransformerTest.java
+++ b/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/transform/ContractDefinitionToContractDefinitionDtoTransformerTest.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.transform;
+
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
+import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class ContractDefinitionToContractDefinitionDtoTransformerTest {
+
+    private final ContractDefinitionToContractDefinitionDtoTransformer transformer = new ContractDefinitionToContractDefinitionDtoTransformer();
+
+    @Test
+    void inputOutputType() {
+        assertThat(transformer.getInputType()).isNotNull();
+        assertThat(transformer.getOutputType()).isNotNull();
+    }
+
+    @Test
+    void transform() {
+        var context = mock(TransformerContext.class);
+        var contractDefinition = ContractDefinition.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .accessPolicy(Policy.Builder.newInstance().id(UUID.randomUUID().toString()).build())
+                .contractPolicy(Policy.Builder.newInstance().id(UUID.randomUUID().toString()).build())
+                .selectorExpression(AssetSelectorExpression.Builder.newInstance().constraint("left", "=", "right").build())
+                .build();
+
+        var dto = transformer.transform(contractDefinition, context);
+
+        assertThat(dto.getId()).isEqualTo(contractDefinition.getId());
+        assertThat(dto.getAccessPolicyId()).isEqualTo(contractDefinition.getAccessPolicy().getUid());
+        assertThat(dto.getContractPolicyId()).isEqualTo(contractDefinition.getContractPolicy().getUid());
+        assertThat(dto.getCriteria()).containsExactlyElementsOf(contractDefinition.getSelectorExpression().getCriteria());
+    }
+
+}

--- a/extensions/in-memory/contractdefinition-store-memory/build.gradle.kts
+++ b/extensions/in-memory/contractdefinition-store-memory/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 }
 
 dependencies {
-    api(project(":spi"))
+    implementation(project(":extensions:dataloading"))
     implementation(project(":common:util"))
 }
 

--- a/extensions/in-memory/contractdefinition-store-memory/src/main/java/org/eclipse/dataspaceconnector/contractdefinition/store/memory/InMemoryContractDefinitionStoreExtension.java
+++ b/extensions/in-memory/contractdefinition-store-memory/src/main/java/org/eclipse/dataspaceconnector/contractdefinition/store/memory/InMemoryContractDefinitionStoreExtension.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.contractdefinition.store.memory;
 
+import org.eclipse.dataspaceconnector.dataloading.ContractDefinitionLoader;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
 import org.eclipse.dataspaceconnector.spi.system.Provides;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
@@ -22,7 +23,7 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 /**
  * Provides an in-memory implementation of the {@link ContractDefinitionStore}.
  */
-@Provides(ContractDefinitionStore.class)
+@Provides({ ContractDefinitionStore.class, ContractDefinitionLoader.class })
 public class InMemoryContractDefinitionStoreExtension implements ServiceExtension {
 
     @Override
@@ -32,6 +33,8 @@ public class InMemoryContractDefinitionStoreExtension implements ServiceExtensio
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        context.registerService(ContractDefinitionStore.class, new InMemoryContractDefinitionStore());
+        var store = new InMemoryContractDefinitionStore();
+        context.registerService(ContractDefinitionStore.class, store);
+        context.registerService(ContractDefinitionLoader.class, store::save);
     }
 }

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/BaseCriterionToPredicateConverter.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/BaseCriterionToPredicateConverter.java
@@ -9,43 +9,38 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 
 package org.eclipse.dataspaceconnector.spi.query;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 /**
  * Converts a {@link Criterion} into a {@link Predicate} of any given type.
- * At this time only "=" and "in" operators are supported.
+ * At this time only "=", "in" and "like" operators are supported.
  *
  * @param <T> The type of object that the Predicate is created for.
  */
 public abstract class BaseCriterionToPredicateConverter<T> implements CriterionConverter<Predicate<T>> {
+
     @Override
     public Predicate<T> convert(Criterion criterion) {
-        if ("=".equals(criterion.getOperator())) {
-            return t -> {
-                Object property = property((String) criterion.getOperandLeft(), t);
-                if (property == null) {
-                    return false; //property does not exist on t
-                }
-                return Objects.equals(property, criterion.getOperandRight());
-            };
-        } else if ("in".equalsIgnoreCase(criterion.getOperator())) {
-            return t -> {
-                String property = property((String) criterion.getOperandLeft(), t);
-                var list = (String) criterion.getOperandRight();
-                // some cleanup needs to happen
-                list = list.replace("(", "").replace(")", "").replace(" ", "");
-                var items = list.split(",");
-                return Arrays.asList(items).contains(property);
-            };
+        var operator = criterion.getOperator().toLowerCase();
+
+        switch (operator) {
+            case "=": return equalPredicate(criterion);
+            case "in": return inPredicate(criterion);
+            case "like": return likePredicate(criterion);
+            default:
+                throw new IllegalArgumentException(String.format("Operator [%s] is not supported by this converter!", criterion.getOperator()));
         }
-        throw new IllegalArgumentException(String.format("Operator [%s] is not supported by this converter!", criterion.getOperator()));
     }
 
     /**
@@ -56,4 +51,46 @@ public abstract class BaseCriterionToPredicateConverter<T> implements CriterionC
      * @param <R>    The type of the field's value
      */
     protected abstract <R> R property(String key, Object object);
+
+    @NotNull
+    private Predicate<T> equalPredicate(Criterion criterion) {
+        return t -> {
+            Object property = property((String) criterion.getOperandLeft(), t);
+            if (property == null) {
+                return false; //property does not exist on t
+            }
+            return Objects.equals(property, criterion.getOperandRight());
+        };
+    }
+
+    @NotNull
+    private Predicate<T> inPredicate(Criterion criterion) {
+        return t -> {
+            String property = property((String) criterion.getOperandLeft(), t);
+            var items = ((String) criterion.getOperandRight())
+                    .replace("(", "")
+                    .replace(")", "")
+                    .replace(" ", "")
+                    .split(",");
+
+            return Arrays.asList(items).contains(property);
+        };
+    }
+
+    @NotNull
+    private Predicate<T> likePredicate(Criterion criterion) {
+        return t -> {
+            Object property = property((String) criterion.getOperandLeft(), t);
+            if (property == null) {
+                return false;
+            }
+
+            String operandRight = (String) criterion.getOperandRight();
+
+            return Pattern.compile("^" + operandRight.replace("%", ".*") + "$")
+                    .matcher(property.toString())
+                    .matches();
+        };
+    }
+
 }

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/BaseCriterionToPredicateConverter.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/BaseCriterionToPredicateConverter.java
@@ -37,7 +37,6 @@ public abstract class BaseCriterionToPredicateConverter<T> implements CriterionC
         switch (operator) {
             case "=": return equalPredicate(criterion);
             case "in": return inPredicate(criterion);
-            case "like": return likePredicate(criterion);
             default:
                 throw new IllegalArgumentException(String.format("Operator [%s] is not supported by this converter!", criterion.getOperator()));
         }
@@ -74,22 +73,6 @@ public abstract class BaseCriterionToPredicateConverter<T> implements CriterionC
                     .split(",");
 
             return Arrays.asList(items).contains(property);
-        };
-    }
-
-    @NotNull
-    private Predicate<T> likePredicate(Criterion criterion) {
-        return t -> {
-            Object property = property((String) criterion.getOperandLeft(), t);
-            if (property == null) {
-                return false;
-            }
-
-            String operandRight = (String) criterion.getOperandRight();
-
-            return Pattern.compile("^" + operandRight.replace("%", ".*") + "$")
-                    .matcher(property.toString())
-                    .matches();
         };
     }
 

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/query/BaseCriterionToPredicateConverterTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/query/BaseCriterionToPredicateConverterTest.java
@@ -1,0 +1,88 @@
+package org.eclipse.dataspaceconnector.spi.query;
+
+import org.eclipse.dataspaceconnector.common.reflection.ReflectionUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BaseCriterionToPredicateConverterTest {
+
+    private TestCriterionToPredicateConverter converter = new TestCriterionToPredicateConverter();
+
+    @Test
+    void convertEqual() {
+        var predicate = converter.convert(new Criterion("value", "=", "any"));
+
+        assertThat(predicate)
+                .accepts(new TestObject("any"))
+                .rejects(new TestObject("other"), new TestObject(""), new TestObject(null));
+    }
+
+    @Test
+    void convertIn() {
+        var predicate = converter.convert(new Criterion("value", "in", "(first, second)"));
+
+        assertThat(predicate)
+                .accepts(new TestObject("first"), new TestObject("second"))
+                .rejects(new TestObject("third"), new TestObject(""), new TestObject(null));
+    }
+
+    @Test
+    void convertLike() {
+        var predicate = converter.convert(new Criterion("value", "like", "any"));
+
+        assertThat(predicate)
+                .accepts(new TestObject("any"))
+                .rejects(new TestObject("other"), new TestObject(""), new TestObject(null));
+    }
+
+    @Test
+    void convertLikePrefix() {
+        var predicate = converter.convert(new Criterion("value", "like", "prefix%"));
+
+        assertThat(predicate)
+                .accepts(new TestObject("prefix"), new TestObject("prefix-suffix"))
+                .rejects(new TestObject("other-prefix"), new TestObject(""), new TestObject(null));
+    }
+
+    @Test
+    void convertLikeSuffix() {
+        var predicate = converter.convert(new Criterion("value", "like", "%suffix"));
+
+        assertThat(predicate)
+                .accepts(new TestObject("suffix"), new TestObject("prefix-suffix"))
+                .rejects(new TestObject("suffix-other"), new TestObject(""), new TestObject(null));
+    }
+
+    @Test
+    void convertLikeContent() {
+        var predicate = converter.convert(new Criterion("value", "like", "%content%"));
+
+        assertThat(predicate)
+                .accepts(new TestObject("content"), new TestObject("prefix-content-suffix"))
+                .rejects(new TestObject("conten"), new TestObject(""), new TestObject(null));
+    }
+
+    private static class TestCriterionToPredicateConverter extends BaseCriterionToPredicateConverter<TestObject> {
+
+        @Override
+        protected <R> R property(String key, Object object) {
+            return ReflectionUtil.getFieldValueSilent(key, object);
+        }
+    }
+
+    private static class TestObject {
+        @Override
+        public String toString() {
+            return "TestObject{" +
+                    "value='" + value + '\'' +
+                    '}';
+        }
+
+        private final String value;
+
+        private TestObject(String value) {
+            this.value = value;
+        }
+    }
+}

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/query/BaseCriterionToPredicateConverterTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/query/BaseCriterionToPredicateConverterTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class BaseCriterionToPredicateConverterTest {
 
-    private TestCriterionToPredicateConverter converter = new TestCriterionToPredicateConverter();
+    private final TestCriterionToPredicateConverter converter = new TestCriterionToPredicateConverter();
 
     @Test
     void convertEqual() {
@@ -25,42 +25,6 @@ class BaseCriterionToPredicateConverterTest {
         assertThat(predicate)
                 .accepts(new TestObject("first"), new TestObject("second"))
                 .rejects(new TestObject("third"), new TestObject(""), new TestObject(null));
-    }
-
-    @Test
-    void convertLike() {
-        var predicate = converter.convert(new Criterion("value", "like", "any"));
-
-        assertThat(predicate)
-                .accepts(new TestObject("any"))
-                .rejects(new TestObject("other"), new TestObject(""), new TestObject(null));
-    }
-
-    @Test
-    void convertLikePrefix() {
-        var predicate = converter.convert(new Criterion("value", "like", "prefix%"));
-
-        assertThat(predicate)
-                .accepts(new TestObject("prefix"), new TestObject("prefix-suffix"))
-                .rejects(new TestObject("other-prefix"), new TestObject(""), new TestObject(null));
-    }
-
-    @Test
-    void convertLikeSuffix() {
-        var predicate = converter.convert(new Criterion("value", "like", "%suffix"));
-
-        assertThat(predicate)
-                .accepts(new TestObject("suffix"), new TestObject("prefix-suffix"))
-                .rejects(new TestObject("suffix-other"), new TestObject(""), new TestObject(null));
-    }
-
-    @Test
-    void convertLikeContent() {
-        var predicate = converter.convert(new Criterion("value", "like", "%content%"));
-
-        assertThat(predicate)
-                .accepts(new TestObject("content"), new TestObject("prefix-content-suffix"))
-                .rejects(new TestObject("conten"), new TestObject(""), new TestObject(null));
     }
 
     private static class TestCriterionToPredicateConverter extends BaseCriterionToPredicateConverter<TestObject> {

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/query/QuerySpecTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/query/QuerySpecTest.java
@@ -83,4 +83,5 @@ class QuerySpecTest {
 
         assertThat(qs.getFilterExpression()).isNotNull().isEmpty();
     }
+
 }


### PR DESCRIPTION
## What this PR changes/adds

Implements ContractDefinition service for Data Management Api.
Depends on #931 

## Why it does that

To expose a clear and RESTful api to operate on ContractDefinition

## Further notes

* Implemented "like" operator in `BaseCriterionToPredicateConverter` to permit filter agreements by definition id.
* Inlined `DtoTransformer.canHandle` method, as its implementation was always the same for every implementor.
* Removed some tests on the controller that verified the `QuerySpec` object construction, but in my opinion those verifications should stay on the `QuerySpec` factory (that, in our case, is the builder object)
* The check for existing agreements on the definition before delete has been removed since it's impossible to do that currently (will be possible after #972)

## Linked Issue(s)

Closes #806

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
