### PR TITLE
refactor: Simplify CatalogService and ConnectorService interfaces

### DIFF
--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/controller/MultipartController.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/controller/MultipartController.java
@@ -124,13 +124,14 @@ public class MultipartController {
             return Response.ok(createFormDataMultiPart(notAuthenticated(header, connectorId))).build();
         }
 
-        MultipartRequest multipartRequest = MultipartRequest.Builder.newInstance()
+        var claimToken = verificationResult.getContent();
+        var multipartRequest = MultipartRequest.Builder.newInstance()
                 .header(header)
                 .payload(payload)
-                .verificationResult(verificationResult)
+                .claimToken(claimToken)
                 .build();
 
-        Handler handler = multipartHandlers.stream()
+        var handler = multipartHandlers.stream()
                 .filter(h -> h.canHandle(multipartRequest))
                 .findFirst()
                 .orElse(null);
@@ -138,7 +139,7 @@ public class MultipartController {
             return Response.ok(createFormDataMultiPart(messageTypeNotSupported(header, connectorId))).build();
         }
 
-        MultipartResponse multipartResponse = handler.handleRequest(multipartRequest, verificationResult);
+        MultipartResponse multipartResponse = handler.handleRequest(multipartRequest, claimToken);
         if (multipartResponse != null) {
             return Response.ok(createFormDataMultiPart(multipartResponse)).build();
         }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ArtifactRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ArtifactRequestHandler.java
@@ -28,7 +28,6 @@ import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNeg
 import org.eclipse.dataspaceconnector.spi.contract.validation.ContractValidationService;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
@@ -79,9 +78,9 @@ public class ArtifactRequestHandler implements Handler {
     }
 
     @Override
-    public @Nullable MultipartResponse handleRequest(@NotNull MultipartRequest multipartRequest, @NotNull Result<ClaimToken> verificationResult) {
+    public @Nullable MultipartResponse handleRequest(@NotNull MultipartRequest multipartRequest, @NotNull ClaimToken claimToken) {
         Objects.requireNonNull(multipartRequest);
-        Objects.requireNonNull(verificationResult);
+        Objects.requireNonNull(claimToken);
 
         var artifactRequestMessage = (ArtifactRequestMessage) multipartRequest.getHeader();
 
@@ -105,7 +104,7 @@ public class ArtifactRequestHandler implements Handler {
             return createBadParametersErrorMultipartResponse(multipartRequest.getHeader());
         }
 
-        var isContractValid = contractValidationService.validate(verificationResult.getContent(), contractAgreement);
+        var isContractValid = contractValidationService.validate(claimToken, contractAgreement);
         if (!isContractValid) {
             monitor.info("ArtifactRequestHandler: Contract Validation Invalid");
             return createBadParametersErrorMultipartResponse(multipartRequest.getHeader());

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ContractAgreementHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ContractAgreementHandler.java
@@ -74,9 +74,9 @@ public class ContractAgreementHandler implements Handler {
     }
 
     @Override
-    public @Nullable MultipartResponse handleRequest(@NotNull MultipartRequest multipartRequest, @NotNull Result<ClaimToken> verificationResult) {
+    public @Nullable MultipartResponse handleRequest(@NotNull MultipartRequest multipartRequest, @NotNull ClaimToken claimToken) {
         Objects.requireNonNull(multipartRequest);
-        Objects.requireNonNull(verificationResult);
+        Objects.requireNonNull(claimToken);
 
         var message = (ContractAgreementMessage) multipartRequest.getHeader();
 
@@ -121,7 +121,7 @@ public class ContractAgreementHandler implements Handler {
         // TODO get hash from message
         var agreement = result.getContent();
         var processId = message.getTransferContract();
-        var negotiationResponse = negotiationManager.confirmed(verificationResult.getContent(),
+        var negotiationResponse = negotiationManager.confirmed(claimToken,
                 String.valueOf(processId), agreement, null);
         if (negotiationResponse.failed() && negotiationResponse.getStatus() == NegotiationResult.Status.FATAL_ERROR) {
             monitor.debug("ContractAgreementHandler: Could not process contract agreement");
@@ -139,10 +139,4 @@ public class ContractAgreementHandler implements Handler {
                 .build();
     }
 
-    private MultipartResponse createBadParametersErrorMultipartResponse(Message message, String payload) {
-        return MultipartResponse.Builder.newInstance()
-                .header(badParameters(message, connectorId))
-                .payload(payload)
-                .build();
-    }
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ContractOfferHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ContractOfferHandler.java
@@ -65,9 +65,9 @@ public class ContractOfferHandler implements Handler {
     }
 
     @Override
-    public @Nullable MultipartResponse handleRequest(@NotNull MultipartRequest multipartRequest, @NotNull Result<ClaimToken> verificationResult) {
+    public @Nullable MultipartResponse handleRequest(@NotNull MultipartRequest multipartRequest, @NotNull ClaimToken claimToken) {
         Objects.requireNonNull(multipartRequest);
-        Objects.requireNonNull(verificationResult);
+        Objects.requireNonNull(claimToken);
 
         var message = (ContractOfferMessage) multipartRequest.getHeader();
 

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ContractRejectionHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ContractRejectionHandler.java
@@ -23,7 +23,6 @@ import org.eclipse.dataspaceconnector.spi.contract.negotiation.ProviderContractN
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.response.NegotiationResult;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -60,9 +59,9 @@ public class ContractRejectionHandler implements Handler {
     }
 
     @Override
-    public @Nullable MultipartResponse handleRequest(@NotNull MultipartRequest multipartRequest, @NotNull Result<ClaimToken> verificationResult) {
+    public @Nullable MultipartResponse handleRequest(@NotNull MultipartRequest multipartRequest, @NotNull ClaimToken claimToken) {
         Objects.requireNonNull(multipartRequest);
-        Objects.requireNonNull(verificationResult);
+        Objects.requireNonNull(claimToken);
 
         var message = (ContractRejectionMessage) multipartRequest.getHeader();
         var correlationMessageId = message.getCorrelationMessage(); // TODO correlation msg missing
@@ -77,10 +76,9 @@ public class ContractRejectionHandler implements Handler {
         }
 
         // abort negotiation process (one of them can handle this process by id)
-        var token = verificationResult.getContent();
-        var result = providerNegotiationManager.declined(token, String.valueOf(correlationId));
+        var result = providerNegotiationManager.declined(claimToken, String.valueOf(correlationId));
         if (result.failed() && result.getStatus() == NegotiationResult.Status.FATAL_ERROR) {
-            result = consumerNegotiationManager.declined(token, String.valueOf(correlationId));
+            result = consumerNegotiationManager.declined(claimToken, String.valueOf(correlationId));
         }
 
         if (result.failed() && result.getStatus() == NegotiationResult.Status.FATAL_ERROR) {

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ContractRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ContractRequestHandler.java
@@ -75,9 +75,9 @@ public class ContractRequestHandler implements Handler {
     }
 
     @Override
-    public @Nullable MultipartResponse handleRequest(@NotNull MultipartRequest multipartRequest, @NotNull Result<ClaimToken> verificationResult) {
+    public @Nullable MultipartResponse handleRequest(@NotNull MultipartRequest multipartRequest, @NotNull ClaimToken claimToken) {
         Objects.requireNonNull(multipartRequest);
-        Objects.requireNonNull(verificationResult);
+        Objects.requireNonNull(claimToken);
 
         var message = (ContractRequestMessage) multipartRequest.getHeader();
 
@@ -142,7 +142,7 @@ public class ContractRequestHandler implements Handler {
                 .build();
 
         // Start negotiation process
-        negotiationManager.requested(verificationResult.getContent(), requestObj);
+        negotiationManager.requested(claimToken, requestObj);
 
         return MultipartResponse.Builder.newInstance()
                 .header(ResponseMessageUtil.createRequestInProcessMessage(connectorId, message))

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/EndpointDataReferenceHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/EndpointDataReferenceHandler.java
@@ -68,7 +68,7 @@ public class EndpointDataReferenceHandler implements Handler {
      * - finally apply {@link EndpointDataReferenceReceiver} to the resulting EDR to dispatch it into the consumer environment.
      */
     @Override
-    public @Nullable MultipartResponse handleRequest(@NotNull MultipartRequest multipartRequest, @NotNull Result<ClaimToken> verificationResult) {
+    public @Nullable MultipartResponse handleRequest(@NotNull MultipartRequest multipartRequest, @NotNull ClaimToken claimToken) {
         var edr = typeManager.readValue(multipartRequest.getPayload(), EndpointDataReference.class);
         var transformationResult = transformer.transform(edr);
         if (transformationResult.failed()) {

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/Handler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/Handler.java
@@ -37,5 +37,5 @@ public interface Handler {
      * @param multipartRequest from another connector
      * @return {@link MultipartResponse} or null, if the request cannot be handled (e.g. when content missing)
      */
-    @Nullable MultipartResponse handleRequest(@NotNull MultipartRequest multipartRequest, @NotNull Result<ClaimToken> verificationResult);
+    @Nullable MultipartResponse handleRequest(@NotNull MultipartRequest multipartRequest, @NotNull ClaimToken claimToken);
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/NotificationMessageHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/NotificationMessageHandler.java
@@ -51,13 +51,13 @@ public class NotificationMessageHandler implements Handler {
      * Delegate the processing of the request to the first {@link Handler} in the registry that accepts this kind of request, if any.
      */
     @Override
-    public @Nullable MultipartResponse handleRequest(@NotNull MultipartRequest multipartRequest, @NotNull Result<ClaimToken> verificationResult) {
+    public @Nullable MultipartResponse handleRequest(@NotNull MultipartRequest multipartRequest, @NotNull ClaimToken claimToken) {
         var notification = (NotificationMessage) multipartRequest.getHeader();
         var subhandler = subhandlers.getHandler(notification.getClass());
         if (subhandler == null) {
             return createErrorMultipartResponse(multipartRequest.getHeader());
         }
-        return subhandler.handleRequest(multipartRequest, verificationResult);
+        return subhandler.handleRequest(multipartRequest, claimToken);
     }
 
     private MultipartResponse createErrorMultipartResponse(Message message) {

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/AbstractDescriptionRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/AbstractDescriptionRequestHandler.java
@@ -57,7 +57,7 @@ abstract class AbstractDescriptionRequestHandler<T, S> implements DescriptionReq
     @Override
     public final MultipartResponse handle(
             @NotNull DescriptionRequestMessage descriptionRequestMessage,
-            @NotNull Result<ClaimToken> verificationResult,
+            @NotNull ClaimToken claimToken,
             @Nullable String payload) {
         Objects.requireNonNull(descriptionRequestMessage);
 
@@ -82,7 +82,7 @@ abstract class AbstractDescriptionRequestHandler<T, S> implements DescriptionReq
             return createBadParametersErrorMultipartResponse(connectorId, descriptionRequestMessage);
         }
 
-        T retrievedObject = retrieveObject(idsId, verificationResult);
+        T retrievedObject = retrieveObject(idsId, claimToken);
         if (retrievedObject == null) {
             return createNotFoundErrorMultipartResponse(connectorId, descriptionRequestMessage);
         }
@@ -110,5 +110,5 @@ abstract class AbstractDescriptionRequestHandler<T, S> implements DescriptionReq
                 .build();
     }
 
-    protected abstract T retrieveObject(@NotNull IdsId idsId, @NotNull Result<ClaimToken> verificationResult);
+    protected abstract T retrieveObject(@NotNull IdsId idsId, @NotNull ClaimToken verificationResult);
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/ArtifactDescriptionRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/ArtifactDescriptionRequestHandler.java
@@ -46,7 +46,7 @@ public class ArtifactDescriptionRequestHandler extends AbstractDescriptionReques
     }
 
     @Override
-    protected Asset retrieveObject(@NotNull IdsId idsId, @NotNull Result<ClaimToken> verificationResult) {
+    protected Asset retrieveObject(@NotNull IdsId idsId, @NotNull ClaimToken claimToken) {
         return assetIndex.findById(idsId.getValue());
     }
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/ConnectorDescriptionRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/ConnectorDescriptionRequestHandler.java
@@ -16,7 +16,6 @@ package org.eclipse.dataspaceconnector.ids.api.multipart.handler.description;
 
 import de.fraunhofer.iais.eis.Connector;
 import de.fraunhofer.iais.eis.DescriptionRequestMessage;
-import de.fraunhofer.iais.eis.DescriptionResponseMessage;
 import org.eclipse.dataspaceconnector.ids.api.multipart.message.MultipartResponse;
 import org.eclipse.dataspaceconnector.ids.spi.IdsIdParser;
 import org.eclipse.dataspaceconnector.ids.spi.IdsType;
@@ -24,7 +23,6 @@ import org.eclipse.dataspaceconnector.ids.spi.service.ConnectorService;
 import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTransformerRegistry;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -54,18 +52,18 @@ public class ConnectorDescriptionRequestHandler implements DescriptionRequestHan
 
     @Override
     public MultipartResponse handle(@NotNull DescriptionRequestMessage descriptionRequestMessage,
-                                    @NotNull Result<ClaimToken> verificationResult,
+                                    @NotNull ClaimToken claimToken,
                                     @Nullable String payload) {
-        Objects.requireNonNull(verificationResult);
+        Objects.requireNonNull(claimToken);
         Objects.requireNonNull(descriptionRequestMessage);
 
         if (!isRequestingCurrentConnectorsDescription(descriptionRequestMessage)) {
             return createErrorMultipartResponse(connectorId, descriptionRequestMessage);
         }
 
-        DescriptionResponseMessage descriptionResponseMessage = createDescriptionResponseMessage(connectorId, descriptionRequestMessage);
+        var descriptionResponseMessage = createDescriptionResponseMessage(connectorId, descriptionRequestMessage);
 
-        Result<Connector> transformResult = transformerRegistry.transform(connectorService.getConnector(verificationResult), Connector.class);
+        var transformResult = transformerRegistry.transform(connectorService.getConnector(claimToken), Connector.class);
         if (transformResult.failed()) {
             monitor.warning(
                     String.format(

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/DataCatalogDescriptionRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/DataCatalogDescriptionRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021 Daimler TSS GmbH
+ *  Copyright (c) 2021 - 2022 Daimler TSS GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 
@@ -44,7 +45,7 @@ public class DataCatalogDescriptionRequestHandler extends AbstractDescriptionReq
     }
 
     @Override
-    protected Catalog retrieveObject(@NotNull IdsId idsId, @NotNull Result<ClaimToken> verificationResult) {
-        return dataCatalogService.getDataCatalog(verificationResult);
+    protected Catalog retrieveObject(@NotNull IdsId idsId, @NotNull ClaimToken claimToken) {
+        return dataCatalogService.getDataCatalog(claimToken);
     }
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/DescriptionRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/DescriptionRequestHandler.java
@@ -27,6 +27,6 @@ public interface DescriptionRequestHandler {
     @Nullable
     MultipartResponse handle(
             @NotNull DescriptionRequestMessage descriptionRequestMessage,
-            @NotNull Result<ClaimToken> verificationResult,
+            @NotNull ClaimToken claimToken,
             @Nullable String payload);
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/RepresentationDescriptionRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/RepresentationDescriptionRequestHandler.java
@@ -46,7 +46,7 @@ public class RepresentationDescriptionRequestHandler extends AbstractDescription
     }
 
     @Override
-    protected Asset retrieveObject(@NotNull IdsId idsId, @NotNull Result<ClaimToken> verificationResult) {
+    protected Asset retrieveObject(@NotNull IdsId idsId, @NotNull ClaimToken claimToken) {
         return assetIndex.findById(idsId.getValue());
     }
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/ResourceDescriptionRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/ResourceDescriptionRequestHandler.java
@@ -57,7 +57,7 @@ public class ResourceDescriptionRequestHandler extends AbstractDescriptionReques
     }
 
     @Override
-    protected OfferedAsset retrieveObject(@NotNull IdsId idsId, @NotNull Result<ClaimToken> verificationResult) {
+    protected OfferedAsset retrieveObject(@NotNull IdsId idsId, @NotNull ClaimToken claimToken) {
         String assetId = idsId.getValue();
         Asset asset = assetIndex.findById(assetId);
         if (asset == null) {
@@ -65,7 +65,7 @@ public class ResourceDescriptionRequestHandler extends AbstractDescriptionReques
         }
 
         ContractOfferQuery contractOfferQuery = ContractOfferQuery.Builder.newInstance()
-                .claimToken(verificationResult.getContent())
+                .claimToken(claimToken)
                 .criterion(new Criterion(Asset.PROPERTY_ID, "=", assetId))
                 .build();
 

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/message/MultipartRequest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/message/MultipartRequest.java
@@ -26,12 +26,12 @@ public class MultipartRequest {
 
     private final Message header;
     private final String payload;
-    private final Result<ClaimToken> verificationResult;
+    private final ClaimToken claimToken;
 
-    private MultipartRequest(@NotNull Message header, @Nullable String payload, @Nullable Result<ClaimToken> verificationResult) {
+    private MultipartRequest(@NotNull Message header, @Nullable String payload, ClaimToken claimToken) {
         this.header = Objects.requireNonNull(header);
         this.payload = payload;
-        this.verificationResult = verificationResult;
+        this.claimToken = claimToken;
     }
 
     @NotNull
@@ -45,15 +45,15 @@ public class MultipartRequest {
     }
 
     @Nullable
-    public Result<ClaimToken> getVerificationResult() {
-        return verificationResult;
+    public ClaimToken getClaimToken() {
+        return claimToken;
     }
 
     public static class Builder {
 
         private Message header;
         private String payload;
-        private Result<ClaimToken> verificationResult;
+        private ClaimToken claimToken;
 
         private Builder() {
         }
@@ -72,13 +72,13 @@ public class MultipartRequest {
             return this;
         }
 
-        public Builder verificationResult(@Nullable Result<ClaimToken> verificationResult) {
-            this.verificationResult = verificationResult;
+        public Builder claimToken(ClaimToken claimToken) {
+            this.claimToken = claimToken;
             return this;
         }
 
         public MultipartRequest build() {
-            return new MultipartRequest(header, payload, verificationResult);
+            return new MultipartRequest(header, payload, claimToken);
         }
     }
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ArtifactRequestHandlerTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ArtifactRequestHandlerTest.java
@@ -80,14 +80,14 @@ class ArtifactRequestHandlerTest {
         var multipartRequest = createMultipartRequest(destination, artifactRequestId, artifactId, contractId);
         var header = (ArtifactRequestMessage) multipartRequest.getHeader();
         var agreement = createContractAgreement();
-        var verificationResult = ClaimToken.Builder.newInstance().build();
+        var claimToken = ClaimToken.Builder.newInstance().build();
 
         var drCapture = ArgumentCaptor.forClass(DataRequest.class);
         when(transferProcessManager.initiateProviderRequest(drCapture.capture())).thenReturn(TransferInitiateResult.success("Transfer success"));
         when(contractNegotiationStore.findContractAgreement(contractId)).thenReturn(agreement);
-        when(contractValidationService.validate(verificationResult, agreement)).thenReturn(true);
+        when(contractValidationService.validate(claimToken, agreement)).thenReturn(true);
 
-        handler.handleRequest(multipartRequest, Result.success(verificationResult));
+        handler.handleRequest(multipartRequest, claimToken);
 
         verify(transferProcessManager).initiateProviderRequest(drCapture.capture());
 

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/EndpointDataReferenceHandlerTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/EndpointDataReferenceHandlerTest.java
@@ -88,7 +88,7 @@ class EndpointDataReferenceHandlerTest {
         when(receiver.send(edr)).thenReturn(CompletableFuture.completedFuture(Result.success()));
         when(receiverRegistry.getAll()).thenReturn(List.of(receiver));
 
-        var response = handler.handleRequest(request, createSuccessClaimToken());
+        var response = handler.handleRequest(request, createClaimToken());
 
         verify(transformer, times(1)).transform(edrCapture.capture());
 
@@ -112,7 +112,7 @@ class EndpointDataReferenceHandlerTest {
 
         when(transformer.transform(any())).thenReturn(Result.failure("error"));
 
-        var response = handler.handleRequest(request, createSuccessClaimToken());
+        var response = handler.handleRequest(request, createClaimToken());
 
         assertThat(response)
                 .isNotNull()
@@ -129,7 +129,7 @@ class EndpointDataReferenceHandlerTest {
         when(receiver.send(edr)).thenReturn(CompletableFuture.completedFuture(Result.failure("error")));
         when(receiverRegistry.getAll()).thenReturn(List.of(receiver));
 
-        var response = handler.handleRequest(request, createSuccessClaimToken());
+        var response = handler.handleRequest(request, createClaimToken());
 
         assertThat(response)
                 .isNotNull()
@@ -146,7 +146,7 @@ class EndpointDataReferenceHandlerTest {
         when(receiver.send(edr)).thenReturn(CompletableFuture.failedFuture(new RuntimeException("error")));
         when(receiverRegistry.getAll()).thenReturn(List.of(receiver));
 
-        var response = handler.handleRequest(request, createSuccessClaimToken());
+        var response = handler.handleRequest(request, createClaimToken());
 
         assertThat(response)
                 .isNotNull()
@@ -170,7 +170,7 @@ class EndpointDataReferenceHandlerTest {
                 .build();
     }
 
-    private static Result<ClaimToken> createSuccessClaimToken() {
-        return Result.success(ClaimToken.Builder.newInstance().build());
+    private static ClaimToken createClaimToken() {
+        return ClaimToken.Builder.newInstance().build();
     }
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/NotificationMessageHandlerTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/NotificationMessageHandlerTest.java
@@ -66,7 +66,7 @@ class NotificationMessageHandlerTest {
     void delegateToSubHandler_subHandlerNotFound_shouldReturnRejectionMessage() {
         var request = createMultipartRequest(new ParticipantCertificateGrantedMessageBuilder().build());
 
-        var response = handler.handleRequest(request, createSuccessClaimToken());
+        var response = handler.handleRequest(request, createClaimToken());
 
         assertThat(response)
                 .isNotNull()
@@ -78,7 +78,7 @@ class NotificationMessageHandlerTest {
     @Test
     void delegateToSubHandler_shouldReturnResultFromSubHandler() {
         var request = createMultipartRequest(new ParticipantUpdateMessageBuilder().build());
-        var verificationResult = createSuccessClaimToken();
+        var verificationResult = createClaimToken();
         var subHandlerResponse = MultipartResponse.Builder.newInstance().header(new MessageProcessedNotificationMessageBuilder().build()).build();
         when(subHandler.handleRequest(request, verificationResult)).thenReturn(subHandlerResponse);
 
@@ -94,7 +94,7 @@ class NotificationMessageHandlerTest {
         return MultipartRequest.Builder.newInstance().header(message).build();
     }
 
-    private static Result<ClaimToken> createSuccessClaimToken() {
-        return Result.success(ClaimToken.Builder.newInstance().build());
+    private static ClaimToken createClaimToken() {
+        return ClaimToken.Builder.newInstance().build();
     }
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/DescriptionHandlerTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/DescriptionHandlerTest.java
@@ -101,16 +101,16 @@ class DescriptionHandlerTest {
         MultipartRequest multipartRequest = MultipartRequest.Builder.newInstance()
                 .header(requestHeader)
                 .build();
-        var verificationResult = Result.success(ClaimToken.Builder.newInstance().build());
+        var claimToken = ClaimToken.Builder.newInstance().build();
 
-        when(connectorDescriptionRequestHandler.handle(requestHeader, verificationResult, multipartRequest.getPayload())).thenReturn(response);
+        when(connectorDescriptionRequestHandler.handle(requestHeader, claimToken, multipartRequest.getPayload())).thenReturn(response);
 
 
-        var result = descriptionHandler.handleRequest(multipartRequest, verificationResult);
+        var result = descriptionHandler.handleRequest(multipartRequest, claimToken);
 
         assertThat(result).isNotNull();
         assertThat(result).extracting(MultipartResponse::getHeader).isEqualTo(responseHeader);
-        verify(connectorDescriptionRequestHandler).handle(requestHeader, verificationResult, multipartRequest.getPayload());
+        verify(connectorDescriptionRequestHandler).handle(requestHeader, claimToken, multipartRequest.getPayload());
     }
 
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/RepresentationDescriptionRequestHandlerTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/RepresentationDescriptionRequestHandlerTest.java
@@ -85,8 +85,9 @@ public class RepresentationDescriptionRequestHandlerTest {
 
     @Test
     public void testSimpleSuccessPath() {
-        var verificationResult = Result.success(ClaimToken.Builder.newInstance().build());
-        var result = representationDescriptionRequestHandler.handle(descriptionRequestMessage, verificationResult, null);
+        var claimToken = ClaimToken.Builder.newInstance().build();
+
+        var result = representationDescriptionRequestHandler.handle(descriptionRequestMessage, claimToken, null);
 
         assertNotNull(result);
         assertNotNull(result.getHeader());

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/ResourceDescriptionRequestHandlerTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/ResourceDescriptionRequestHandlerTest.java
@@ -59,7 +59,6 @@ public class ResourceDescriptionRequestHandlerTest {
     private AssetIndex assetIndex;
     private Resource resource;
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @BeforeEach
     public void setup() throws URISyntaxException {
         monitor = mock(Monitor.class);
@@ -91,13 +90,13 @@ public class ResourceDescriptionRequestHandlerTest {
 
     @Test
     public void testSimpleSuccessPath() {
-        var verificationResult = Result.success(ClaimToken.Builder.newInstance().build());
+        var claimToken = ClaimToken.Builder.newInstance().build();
         when(assetIndex.findById(anyString())).thenReturn(Asset.Builder.newInstance().build());
         var resourceResult = Result.success(resource);
         when(transformerRegistry.transform(isA(OfferedAsset.class), eq(Resource.class))).thenReturn(resourceResult);
         when(contractOfferService.queryContractOffers(isA(ContractOfferQuery.class))).thenReturn(Stream.empty());
 
-        var result = resourceDescriptionRequestHandler.handle(descriptionRequestMessage, verificationResult, null);
+        var result = resourceDescriptionRequestHandler.handle(descriptionRequestMessage, claimToken, null);
 
         assertNotNull(result);
         assertNotNull(result.getHeader());

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImpl.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021 Daimler TSS GmbH
+ *  Copyright (c) 2021 - 2022 Daimler TSS GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 
@@ -21,8 +22,10 @@ import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
 import java.util.Objects;
 
 import static java.util.stream.Collectors.toList;
@@ -48,10 +51,11 @@ public class CatalogServiceImpl implements CatalogService {
      */
     @Override
     @NotNull
-    public Catalog getDataCatalog(Result<ClaimToken> verificationResult) {
-        var query = ContractOfferQuery.Builder.newInstance().claimToken(verificationResult.getContent()).build();
-        var offerStream = contractOfferService.queryContractOffers(query);
+    public Catalog getDataCatalog(ClaimToken claimToken) {
+        var query = ContractOfferQuery.Builder.newInstance().claimToken(claimToken).build();
 
-        return Catalog.Builder.newInstance().id(dataCatalogId).contractOffers(offerStream.collect(toList())).build();
+        var offers = contractOfferService.queryContractOffers(query).collect(toList());
+
+        return Catalog.Builder.newInstance().id(dataCatalogId).contractOffers(offers).build();
     }
 }

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImpl.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021 Daimler TSS GmbH
+ *  Copyright (c) 2021 - 2022 Daimler TSS GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 
@@ -45,10 +46,11 @@ public class ConnectorServiceImpl implements ConnectorService {
     }
 
     @NotNull
-    public Connector getConnector(@NotNull Result<ClaimToken> verificationResult) {
-        Objects.requireNonNull(verificationResult);
+    @Override
+    public Connector getConnector(@NotNull ClaimToken claimToken) {
+        Objects.requireNonNull(claimToken);
 
-        Catalog catalog = dataCatalogService.getDataCatalog(verificationResult);
+        Catalog catalog = dataCatalogService.getDataCatalog(claimToken);
 
         return Connector.Builder
                 .newInstance()

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImplTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImplTest.java
@@ -35,19 +35,17 @@ import static org.mockito.Mockito.when;
 class CatalogServiceImplTest {
     private static final String CATALOG_ID = "catalogId";
 
+    private final ContractOfferService contractOfferService = mock(ContractOfferService.class);
     private CatalogServiceImpl dataCatalogService;
-    private ContractOfferService contractOfferService;
 
     @BeforeEach
     void setUp() {
-        Monitor monitor = mock(Monitor.class);
-        contractOfferService = mock(ContractOfferService.class);
-        dataCatalogService = new CatalogServiceImpl(monitor, CATALOG_ID, contractOfferService);
+        dataCatalogService = new CatalogServiceImpl(mock(Monitor.class), CATALOG_ID, contractOfferService);
     }
 
     @Test
     void getDataCatalog() {
-        var verificationResult = Result.success(ClaimToken.Builder.newInstance().build());
+        var claimToken = ClaimToken.Builder.newInstance().build();
 
         var offers = Arrays.asList(
                 ContractOffer.Builder.newInstance()
@@ -60,7 +58,7 @@ class CatalogServiceImplTest {
                         .build());
         when(contractOfferService.queryContractOffers(any(ContractOfferQuery.class))).thenReturn(offers.stream());
 
-        var result = dataCatalogService.getDataCatalog(verificationResult);
+        var result = dataCatalogService.getDataCatalog(claimToken);
 
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(CATALOG_ID);

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImplTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImplTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021 Daimler TSS GmbH
+ *  Copyright (c) 2021 - 2022 Daimler TSS GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 
@@ -41,21 +42,15 @@ class ConnectorServiceImplTest {
     private static final URI CONNECTOR_MAINTAINER = URI.create("https://example.com/connector/maintainer");
     private static final URI CONNECTOR_CURATOR = URI.create("https://example.com/connector/curator");
     private static final String CONNECTOR_VERSION = "connectorVersion";
+    private final ConnectorServiceSettings connectorServiceSettings = mock(ConnectorServiceSettings.class);
+    private final ConnectorVersionProvider connectorVersionProvider = mock(ConnectorVersionProvider.class);
+    private final CatalogService dataCatalogService = mock(CatalogService.class);
 
     private ConnectorServiceImpl connectorService;
 
-    private ConnectorServiceSettings connectorServiceSettings;
-    private ConnectorVersionProvider connectorVersionProvider;
-    private CatalogService dataCatalogService;
-
     @BeforeEach
     void setUp() {
-        Monitor monitor = mock(Monitor.class);
-        connectorServiceSettings = mock(ConnectorServiceSettings.class);
-        connectorVersionProvider = mock(ConnectorVersionProvider.class);
-        dataCatalogService = mock(CatalogService.class);
-
-        connectorService = new ConnectorServiceImpl(monitor, connectorServiceSettings, connectorVersionProvider, dataCatalogService);
+        connectorService = new ConnectorServiceImpl(mock(Monitor.class), connectorServiceSettings, connectorVersionProvider, dataCatalogService);
     }
 
     @Test
@@ -69,8 +64,9 @@ class ConnectorServiceImplTest {
         when(connectorServiceSettings.getMaintainer()).thenReturn(CONNECTOR_MAINTAINER);
         when(connectorServiceSettings.getCurator()).thenReturn(CONNECTOR_CURATOR);
         when(connectorVersionProvider.getVersion()).thenReturn(CONNECTOR_VERSION);
+        var claimToken = ClaimToken.Builder.newInstance().build();
 
-        var result = connectorService.getConnector(Result.success(ClaimToken.Builder.newInstance().build()));
+        var result = connectorService.getConnector(claimToken);
 
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(CONNECTOR_ID);

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/CatalogService.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/CatalogService.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ */
+
 package org.eclipse.dataspaceconnector.ids.spi.service;
 
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
@@ -16,5 +30,5 @@ public interface CatalogService {
      * @return data catalog
      */
     @NotNull
-    Catalog getDataCatalog(Result<ClaimToken> verificationResult);
+    Catalog getDataCatalog(ClaimToken claimToken);
 }

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/ConnectorService.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/ConnectorService.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 
@@ -31,5 +32,5 @@ public interface ConnectorService {
      * @return connector description
      */
     @NotNull
-    Connector getConnector(@NotNull Result<ClaimToken> verificationResult);
+    Connector getConnector(@NotNull ClaimToken claimToken);
 }


### PR DESCRIPTION
## What this PR changes/adds

Simplify interfaces of `CatalogService` and `ConnectorService` passing a `ClaimToken` object instead of a wrapping `Result`.

## Why it does that

It's a simple refactor that simplifies things, and avoids to carry around a `Result` object after it has already been evaluated.

## Further notes

*

## Linked Issue(s)

Closes #373

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
