### PR TITLE
feature: Propagate policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 # Changelog
 
 All notable changes to this project will be documented in this file - formatted and maintained according to the rules
@@ -54,6 +55,7 @@ the detailed section referring to by linking pull requests or issues.
 
 * Flaky S3 StatusChecker Test (#794)
 * Added missing Data Management Asset controller openapi (#853)
+* Policy deserialization (#898)
 
 ---
 

--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/CoreServicesExtension.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/CoreServicesExtension.java
@@ -26,6 +26,7 @@ import org.eclipse.dataspaceconnector.core.base.policy.ScopeFilter;
 import org.eclipse.dataspaceconnector.core.executor.NoopExecutorInstrumentation;
 import org.eclipse.dataspaceconnector.core.health.HealthCheckServiceConfiguration;
 import org.eclipse.dataspaceconnector.core.health.HealthCheckServiceImpl;
+import org.eclipse.dataspaceconnector.policy.model.RegistrationTypes;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.EdcSetting;
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgentService;
@@ -129,6 +130,9 @@ public class CoreServicesExtension implements ServiceExtension {
         context.registerService(RuleBindingRegistry.class, bindingRegistry);
 
         var scopeFilter = new ScopeFilter(bindingRegistry);
+
+        var typeManager = context.getTypeManager();
+        RegistrationTypes.getRegistrationTypes().forEach(typeManager::registerTypes);
 
         var policyEngine = new PolicyEngineImpl(scopeFilter);
         context.registerService(PolicyEngine.class, policyEngine);

--- a/core/base/src/test/java/org/eclipse/dataspaceconnector/core/CoreServicesExtensionTest.java
+++ b/core/base/src/test/java/org/eclipse/dataspaceconnector/core/CoreServicesExtensionTest.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.core;
+
+import org.eclipse.dataspaceconnector.policy.model.RegistrationTypes;
+import org.eclipse.dataspaceconnector.spi.security.PrivateKeyResolver;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CoreServicesExtensionTest {
+    private CoreServicesExtension extension;
+    private ServiceExtensionContext context;
+    private TypeManager typeManager;
+
+    @Test
+    void verifyPolicyTypesAreRegistered() {
+        extension.initialize(context);
+        RegistrationTypes.getRegistrationTypes().forEach(t -> verify(typeManager).registerTypes(t));
+    }
+
+    @BeforeEach
+    void setUp() {
+        extension = new CoreServicesExtension();
+        typeManager = spy(new TypeManager());
+        context = mock(ServiceExtensionContext.class);
+        when(context.getSetting(eq(CoreServicesExtension.MAX_RETRIES), anyInt())).thenReturn(1);
+        when(context.getSetting(eq(CoreServicesExtension.BACKOFF_MIN_MILLIS), anyInt())).thenReturn(1);
+        when(context.getSetting(eq(CoreServicesExtension.BACKOFF_MAX_MILLIS), anyInt())).thenReturn(2);
+        when(context.getService(eq(PrivateKeyResolver.class))).thenReturn(mock(PrivateKeyResolver.class));
+        when(context.getTypeManager()).thenReturn(typeManager);
+    }
+}

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/flow/DataFlowManagerImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/flow/DataFlowManagerImpl.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.transfer.core.flow;
 
 import io.opentelemetry.extension.annotations.WithSpan;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowController;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowInitiateResult;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowManager;
@@ -41,12 +42,12 @@ public class DataFlowManagerImpl implements DataFlowManager {
 
     @WithSpan
     @Override
-    public @NotNull DataFlowInitiateResult initiate(DataRequest dataRequest) {
+    public @NotNull DataFlowInitiateResult initiate(DataRequest dataRequest, Policy policy) {
         try {
             return controllers.stream()
                     .filter(controller -> controller.canHandle(dataRequest))
                     .findFirst()
-                    .map(controller -> controller.initiateFlow(dataRequest))
+                    .map(controller -> controller.initiateFlow(dataRequest, policy))
                     .orElseGet(() -> failure(FATAL_ERROR, controllerNotFound(dataRequest.getId())));
         } catch (Exception e) {
             return failure(FATAL_ERROR, runtimeException(dataRequest.getId(), e.getLocalizedMessage()));

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/inline/InlineDataFlowController.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/inline/InlineDataFlowController.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.transfer.core.inline;
 
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
@@ -50,7 +51,7 @@ public class InlineDataFlowController implements DataFlowController {
     }
 
     @Override
-    public @NotNull DataFlowInitiateResult initiateFlow(DataRequest dataRequest) {
+    public @NotNull DataFlowInitiateResult initiateFlow(DataRequest dataRequest, Policy policy) {
         var source = dataAddressResolver.resolveForAsset(dataRequest.getAssetId());
         var destinationType = dataRequest.getDestinationType();
         monitor.info(format("Copying data from %s to %s", source.getType(), destinationType));

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/provision/ResourceManifestGeneratorImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/provision/ResourceManifestGeneratorImpl.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.transfer.core.provision;
 
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ResourceDefinitionGenerator;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ResourceManifestGenerator;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
@@ -47,32 +48,32 @@ public class ResourceManifestGeneratorImpl implements ResourceManifestGenerator 
     }
 
     @Override
-    public ResourceManifest generateResourceManifest(TransferProcess process) {
-        var definitions = generateDefinitions(process);
+    public ResourceManifest generateResourceManifest(TransferProcess process, Policy policy) {
+        var definitions = generateDefinitions(process, policy);
         return ResourceManifest.Builder.newInstance().definitions(definitions).build();
     }
 
     @NotNull
-    private List<ResourceDefinition> generateDefinitions(TransferProcess process) {
+    private List<ResourceDefinition> generateDefinitions(TransferProcess process, Policy policy) {
         var dataRequest = process.getDataRequest();
         if (process.getType() == CONSUMER) {
-            return dataRequest.isManagedResources() ? generateConsumerDefinitions(process) : emptyList();
+            return dataRequest.isManagedResources() ? generateConsumerDefinitions(process, policy) : emptyList();
         } else {
-            return generateProviderDefinitions(process);
+            return generateProviderDefinitions(process, policy);
         }
     }
 
     @NotNull
-    private List<ResourceDefinition> generateConsumerDefinitions(TransferProcess process) {
+    private List<ResourceDefinition> generateConsumerDefinitions(TransferProcess process, Policy policy) {
         return consumerGenerators.stream()
-                .map(generator -> generator.generate(process))
+                .map(generator -> generator.generate(process, policy))
                 .filter(Objects::nonNull).collect(Collectors.toList());
     }
 
     @NotNull
-    private List<ResourceDefinition> generateProviderDefinitions(TransferProcess process) {
+    private List<ResourceDefinition> generateProviderDefinitions(TransferProcess process, Policy policy) {
         return providerGenerators.stream()
-                .map(generator -> generator.generate(process))
+                .map(generator -> generator.generate(process, policy))
                 .filter(Objects::nonNull).collect(Collectors.toList());
     }
 }

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
@@ -18,6 +18,7 @@ package org.eclipse.dataspaceconnector.transfer.core.transfer;
 import io.opentelemetry.extension.annotations.WithSpan;
 import org.eclipse.dataspaceconnector.common.statemachine.StateMachine;
 import org.eclipse.dataspaceconnector.common.statemachine.StateProcessorImpl;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.command.CommandProcessor;
 import org.eclipse.dataspaceconnector.spi.command.CommandQueue;
@@ -177,7 +178,10 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
      */
     @WithSpan
     private boolean processInitial(TransferProcess process) {
-        var manifest = manifestGenerator.generateResourceManifest(process);
+        // TODO resolve contract agreement policy from the PolicyStore
+        var policy = Policy.Builder.newInstance().build();
+
+        var manifest = manifestGenerator.generateResourceManifest(process, policy);
         process.transitionProvisioning(manifest);
         transferProcessStore.update(process);
         observable.invokeForEach(l -> l.provisioning(process));
@@ -196,7 +200,9 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
      */
     @WithSpan
     private boolean processProvisioning(TransferProcess process) {
-        provisionManager.provision(process)
+        // TODO resolve contract agreement policy from the PolicyStore
+        var policy = Policy.Builder.newInstance().build();
+        provisionManager.provision(process, policy)
                 .whenComplete((responses, throwable) -> {
                     if (throwable == null) {
                         onProvisionComplete(process.getId(), responses);
@@ -312,8 +318,10 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
      */
     @WithSpan
     private boolean processDeprovisioning(TransferProcess process) {
+        // TODO resolve contract agreement policy from the PolicyStore
+        var policy = Policy.Builder.newInstance().build();
         observable.invokeForEach(l -> l.deprovisioning(process)); // TODO: this is called here since it's not callable from the command handler
-        provisionManager.deprovision(process)
+        provisionManager.deprovision(process, policy)
                 .whenComplete((responses, throwable) -> {
                     if (throwable == null) {
                         onDeprovisionComplete(process.getId());
@@ -438,7 +446,10 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
     }
 
     private void processProviderRequest(TransferProcess process, DataRequest dataRequest) {
-        var response = dataFlowManager.initiate(dataRequest);
+        // TODO resolve contract agreement policy from the PolicyStore
+        var policy = Policy.Builder.newInstance().build();
+
+        var response = dataFlowManager.initiate(dataRequest, policy);
         if (response.succeeded()) {
             process.transitionInProgressOrStreaming();
             transferProcessStore.update(process);

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/flow/DataFlowManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/flow/DataFlowManagerImplTest.java
@@ -1,5 +1,6 @@
 package org.eclipse.dataspaceconnector.transfer.core.flow;
 
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowController;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowInitiateResult;
@@ -19,11 +20,13 @@ class DataFlowManagerImplTest {
         var manager = new DataFlowManagerImpl();
         var controller = mock(DataFlowController.class);
         var dataRequest = DataRequest.Builder.newInstance().destinationType("type").build();
+        var policy = Policy.Builder.newInstance().build();
+
         when(controller.canHandle(any())).thenReturn(true);
-        when(controller.initiateFlow(any())).thenReturn(DataFlowInitiateResult.success("success"));
+        when(controller.initiateFlow(any(), any())).thenReturn(DataFlowInitiateResult.success("success"));
         manager.register(controller);
 
-        var response = manager.initiate(dataRequest);
+        var response = manager.initiate(dataRequest, policy);
 
         assertThat(response.succeeded()).isTrue();
     }
@@ -33,10 +36,12 @@ class DataFlowManagerImplTest {
         var manager = new DataFlowManagerImpl();
         var controller = mock(DataFlowController.class);
         var dataRequest = DataRequest.Builder.newInstance().destinationType("type").build();
+        var policy = Policy.Builder.newInstance().build();
+
         when(controller.canHandle(any())).thenReturn(false);
         manager.register(controller);
 
-        var response = manager.initiate(dataRequest);
+        var response = manager.initiate(dataRequest, policy);
 
         assertThat(response.succeeded()).isFalse();
         assertThat(response.getFailure().status()).isEqualTo(FATAL_ERROR);
@@ -47,11 +52,13 @@ class DataFlowManagerImplTest {
         var manager = new DataFlowManagerImpl();
         var controller = mock(DataFlowController.class);
         var dataRequest = DataRequest.Builder.newInstance().destinationType("type").build();
+        var policy = Policy.Builder.newInstance().build();
+
         when(controller.canHandle(any())).thenReturn(true);
-        when(controller.initiateFlow(any())).thenThrow(new EdcException("error"));
+        when(controller.initiateFlow(any(), any())).thenThrow(new EdcException("error"));
         manager.register(controller);
 
-        var response = manager.initiate(dataRequest);
+        var response = manager.initiate(dataRequest, policy);
 
         assertThat(response.succeeded()).isFalse();
         assertThat(response.getFailure().status()).isEqualTo(FATAL_ERROR);

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/provision/ResourceManifestGeneratorImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/provision/ResourceManifestGeneratorImplTest.java
@@ -1,5 +1,6 @@
 package org.eclipse.dataspaceconnector.transfer.core.provision;
 
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ResourceDefinitionGenerator;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
@@ -23,20 +24,22 @@ class ResourceManifestGeneratorImplTest {
     private final ResourceDefinitionGenerator consumerGenerator = mock(ResourceDefinitionGenerator.class);
     private final ResourceDefinitionGenerator providerGenerator = mock(ResourceDefinitionGenerator.class);
     private final ResourceManifestGeneratorImpl generator = new ResourceManifestGeneratorImpl();
+    private Policy policy;
 
     @BeforeEach
     void setUp() {
         generator.registerConsumerGenerator(consumerGenerator);
         generator.registerProviderGenerator(providerGenerator);
+        policy = Policy.Builder.newInstance().build();
     }
 
     @Test
     void shouldGenerateResourceManifestForConsumerManagedTransferProcess() {
         var process = createTransferProcess(CONSUMER, true);
         var resourceDefinition = TestResourceDefinition.Builder.newInstance().id(UUID.randomUUID().toString()).build();
-        when(consumerGenerator.generate(any())).thenReturn(resourceDefinition);
+        when(consumerGenerator.generate(any(), any())).thenReturn(resourceDefinition);
 
-        var resourceManifest = generator.generateResourceManifest(process);
+        var resourceManifest = generator.generateResourceManifest(process, policy);
 
         assertThat(resourceManifest.getDefinitions()).hasSize(1).containsExactly(resourceDefinition);
         verifyNoInteractions(providerGenerator);
@@ -46,7 +49,7 @@ class ResourceManifestGeneratorImplTest {
     void shouldGenerateEmptyResourceManifestForEmptyConsumerNotManagedTransferProcess() {
         var process = createTransferProcess(CONSUMER, false);
 
-        var resourceManifest = generator.generateResourceManifest(process);
+        var resourceManifest = generator.generateResourceManifest(process, policy);
 
         assertThat(resourceManifest.getDefinitions()).isEmpty();
         verifyNoInteractions(consumerGenerator);
@@ -57,9 +60,9 @@ class ResourceManifestGeneratorImplTest {
     void shouldGenerateResourceManifestForProviderTransferProcess() {
         var process = createTransferProcess(PROVIDER, false);
         var resourceDefinition = TestResourceDefinition.Builder.newInstance().id(UUID.randomUUID().toString()).build();
-        when(providerGenerator.generate(any())).thenReturn(resourceDefinition);
+        when(providerGenerator.generate(any(), any())).thenReturn(resourceDefinition);
 
-        var resourceManifest = generator.generateResourceManifest(process);
+        var resourceManifest = generator.generateResourceManifest(process, policy);
 
         assertThat(resourceManifest.getDefinitions()).hasSize(1).containsExactly(resourceDefinition);
         verifyNoInteractions(consumerGenerator);

--- a/extensions/aws/s3/s3-provision/src/main/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3BucketProvisioner.java
+++ b/extensions/aws/s3/s3-provision/src/main/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3BucketProvisioner.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.aws.s3.provision;
 import net.jodah.failsafe.RetryPolicy;
 import org.eclipse.dataspaceconnector.aws.s3.core.AwsTemporarySecretToken;
 import org.eclipse.dataspaceconnector.aws.s3.core.ClientProvider;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.Provisioner;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DeprovisionResponse;
@@ -59,7 +60,7 @@ public class S3BucketProvisioner implements Provisioner<S3BucketResourceDefiniti
     }
 
     @Override
-    public CompletableFuture<ProvisionResponse> provision(S3BucketResourceDefinition resourceDefinition) {
+    public CompletableFuture<ProvisionResponse> provision(S3BucketResourceDefinition resourceDefinition, Policy policy) {
         return S3ProvisionPipeline.Builder.newInstance(retryPolicy)
                 .clientProvider(clientProvider)
                 .roleMaxSessionDuration(configuration.getRoleMaxSessionDuration())
@@ -70,7 +71,7 @@ public class S3BucketProvisioner implements Provisioner<S3BucketResourceDefiniti
     }
 
     @Override
-    public CompletableFuture<DeprovisionResponse> deprovision(S3BucketProvisionedResource resource) {
+    public CompletableFuture<DeprovisionResponse> deprovision(S3BucketProvisionedResource resource, Policy policy) {
         return S3DeprovisionPipeline.Builder.newInstance(retryPolicy)
                 .clientProvider(clientProvider)
                 .monitor(monitor)

--- a/extensions/aws/s3/s3-provision/src/main/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3ResourceDefinitionConsumerGenerator.java
+++ b/extensions/aws/s3/s3-provision/src/main/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3ResourceDefinitionConsumerGenerator.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.aws.s3.provision;
 
 import org.eclipse.dataspaceconnector.aws.s3.core.S3BucketSchema;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ResourceDefinitionGenerator;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
@@ -29,7 +30,7 @@ import static java.util.UUID.randomUUID;
 public class S3ResourceDefinitionConsumerGenerator implements ResourceDefinitionGenerator {
 
     @Override
-    public ResourceDefinition generate(TransferProcess process) {
+    public ResourceDefinition generate(TransferProcess process, Policy policy) {
         var request = process.getDataRequest();
         if (request.getDestinationType() != null) {
             if (!S3BucketSchema.TYPE.equals(request.getDestinationType())) {

--- a/extensions/aws/s3/s3-provision/src/test/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3BucketProvisionerTest.java
+++ b/extensions/aws/s3/s3-provision/src/test/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3BucketProvisionerTest.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.aws.s3.provision;
 import net.jodah.failsafe.RetryPolicy;
 import org.eclipse.dataspaceconnector.aws.s3.core.AwsTemporarySecretToken;
 import org.eclipse.dataspaceconnector.aws.s3.core.ClientProvider;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
@@ -90,8 +91,9 @@ class S3BucketProvisionerTest {
         when(s3Client.createBucket(isA(CreateBucketRequest.class))).thenReturn(completedFuture(createBucketResponse));
 
         S3BucketResourceDefinition definition = S3BucketResourceDefinition.Builder.newInstance().id("test").regionId(Region.US_EAST_1.id()).bucketName("test").transferProcessId("test").build();
+        var policy = Policy.Builder.newInstance().build();
 
-        var response = provisioner.provision(definition).join();
+        var response = provisioner.provision(definition, policy).join();
 
         assertThat(response.getResource()).isInstanceOfSatisfying(S3BucketProvisionedResource.class, resource -> {
             assertThat(resource.getRole()).isEqualTo("roleName");
@@ -109,7 +111,9 @@ class S3BucketProvisionerTest {
         when(s3Client.createBucket(isA(CreateBucketRequest.class))).thenReturn(failedFuture(new RuntimeException("any")));
         S3BucketResourceDefinition definition = S3BucketResourceDefinition.Builder.newInstance().id("test").regionId(Region.US_EAST_1.id()).bucketName("test").transferProcessId("test").build();
 
-        var response = provisioner.provision(definition);
+        var policy = Policy.Builder.newInstance().build();
+
+        var response = provisioner.provision(definition, policy);
 
         assertThat(response).failsWithin(1, SECONDS);
     }

--- a/extensions/azure/blobstorage/blob-provision/src/main/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageDefinitionConsumerGenerator.java
+++ b/extensions/azure/blobstorage/blob-provision/src/main/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageDefinitionConsumerGenerator.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.provision.azure.blob;
 
 import org.eclipse.dataspaceconnector.azure.blob.core.AzureBlobStoreSchema;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ResourceDefinitionGenerator;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
@@ -24,8 +25,9 @@ import org.jetbrains.annotations.Nullable;
 import static java.util.UUID.randomUUID;
 
 public class ObjectStorageDefinitionConsumerGenerator implements ResourceDefinitionGenerator {
+
     @Override
-    public @Nullable ResourceDefinition generate(TransferProcess process) {
+    public @Nullable ResourceDefinition generate(TransferProcess process, Policy policy) {
         var request = process.getDataRequest();
         if (request.getDataDestination() == null || request.getDestinationType() == null || !AzureBlobStoreSchema.TYPE.equals(request.getDestinationType())) {
             return null;

--- a/extensions/azure/blobstorage/blob-provision/src/main/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageProvisioner.java
+++ b/extensions/azure/blobstorage/blob-provision/src/main/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageProvisioner.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.provision.azure.blob;
 import net.jodah.failsafe.RetryPolicy;
 import org.eclipse.dataspaceconnector.azure.blob.core.AzureSasToken;
 import org.eclipse.dataspaceconnector.azure.blob.core.api.BlobStoreApi;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.Provisioner;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DeprovisionResponse;
@@ -52,7 +53,7 @@ public class ObjectStorageProvisioner implements Provisioner<ObjectStorageResour
     }
 
     @Override
-    public CompletableFuture<ProvisionResponse> provision(ObjectStorageResourceDefinition resourceDefinition) {
+    public CompletableFuture<ProvisionResponse> provision(ObjectStorageResourceDefinition resourceDefinition, Policy policy) {
         String containerName = resourceDefinition.getContainerName();
         String accountName = resourceDefinition.getAccountName();
 
@@ -84,7 +85,7 @@ public class ObjectStorageProvisioner implements Provisioner<ObjectStorageResour
     }
 
     @Override
-    public CompletableFuture<DeprovisionResponse> deprovision(ObjectContainerProvisionedResource provisionedResource) {
+    public CompletableFuture<DeprovisionResponse> deprovision(ObjectContainerProvisionedResource provisionedResource, Policy policy) {
         return with(retryPolicy).runAsync(() -> blobStoreApi.deleteContainer(provisionedResource.getAccountName(), provisionedResource.getContainerName()))
                 //the sas token will expire automatically. there is no way of revoking them other than a stored access policy
                 .thenApply(empty -> DeprovisionResponse.Builder.newInstance().resource(provisionedResource).build());

--- a/extensions/azure/blobstorage/blob-provision/src/test/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageDefinitionConsumerGeneratorTest.java
+++ b/extensions/azure/blobstorage/blob-provision/src/test/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageDefinitionConsumerGeneratorTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.provision.azure.blob;
 
 import org.eclipse.dataspaceconnector.azure.blob.core.AzureBlobStoreSchema;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
@@ -47,9 +48,9 @@ class ObjectStorageDefinitionConsumerGeneratorTest {
         var asset = Asset.Builder.newInstance().build();
         var dr = DataRequest.Builder.newInstance().dataDestination(destination).assetId(asset.getId()).build();
         var tp = TransferProcess.Builder.newInstance().dataRequest(dr).id(randomUUID().toString()).build();
+        var policy = Policy.Builder.newInstance().build();
 
-
-        ResourceDefinition def = generator.generate(tp);
+        ResourceDefinition def = generator.generate(tp, policy);
 
         assertThat(def).isInstanceOf(ObjectStorageResourceDefinition.class);
         var objectDef = (ObjectStorageResourceDefinition) def;
@@ -66,8 +67,9 @@ class ObjectStorageDefinitionConsumerGeneratorTest {
         var asset = Asset.Builder.newInstance().build();
         var dataRequest = DataRequest.Builder.newInstance().dataDestination(destination).assetId(asset.getId()).build();
         var tp = TransferProcess.Builder.newInstance().dataRequest(dataRequest).id(randomUUID().toString()).build();
+        var policy = Policy.Builder.newInstance().build();
 
-        ResourceDefinition def = generator.generate(tp);
+        ResourceDefinition def = generator.generate(tp, policy);
         assertThat(def).isNotNull();
         assertThat(((ObjectStorageResourceDefinition) def).getContainerName()).matches(
                 regexPattern);

--- a/extensions/data-plane-transfer/data-plane-transfer-sync/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/flow/ProviderDataPlaneProxyDataFlowController.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-sync/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/flow/ProviderDataPlaneProxyDataFlowController.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.transfer.dataplane.sync.flow;
 
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
@@ -50,7 +51,7 @@ public class ProviderDataPlaneProxyDataFlowController implements DataFlowControl
     }
 
     @Override
-    public @NotNull DataFlowInitiateResult initiateFlow(DataRequest dataRequest) {
+    public @NotNull DataFlowInitiateResult initiateFlow(DataRequest dataRequest, Policy policy) {
         var address = resolver.resolveForAsset(dataRequest.getAssetId());
         var proxyCreationRequest = DataPlaneProxyCreationRequest.Builder.newInstance()
                 .id(dataRequest.getId())

--- a/extensions/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/flow/ProviderDataPlaneProxyDataFlowControllerTest.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/flow/ProviderDataPlaneProxyDataFlowControllerTest.java
@@ -1,5 +1,6 @@
 package org.eclipse.dataspaceconnector.transfer.dataplane.sync.flow;
 
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
 import org.eclipse.dataspaceconnector.spi.message.MessageContext;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
@@ -52,6 +53,7 @@ class ProviderDataPlaneProxyDataFlowControllerTest {
     @Test
     void verifyInitiateFlowSuccess() {
         var request = createDataRequest("HttpProxy");
+        var policy = Policy.Builder.newInstance().build();
         var dataAddress = testDataAddress();
         var edr = createEndpointDataReference();
 
@@ -62,7 +64,7 @@ class ProviderDataPlaneProxyDataFlowControllerTest {
         when(proxyManagerMock.createProxy(any())).thenReturn(Result.success(edr));
         when(dataAddressResolverMock.resolveForAsset(request.getAssetId())).thenReturn(dataAddress);
 
-        var result = controller.initiateFlow(request);
+        var result = controller.initiateFlow(request, policy);
 
         verify(proxyManagerMock, times(1)).createProxy(proxyCreationRequestCaptor.capture());
         verify(dataAddressResolverMock, times(1)).resolveForAsset(request.getAssetId());
@@ -86,13 +88,14 @@ class ProviderDataPlaneProxyDataFlowControllerTest {
     @Test
     void proxyCreationFails_shouldReturnFailedResult() {
         var request = createDataRequest("HttpProxy");
+        var policy = Policy.Builder.newInstance().build();
         var dataAddress = testDataAddress();
         var edr = createEndpointDataReference();
 
         when(dataAddressResolverMock.resolveForAsset(request.getAssetId())).thenReturn(dataAddress);
         when(proxyManagerMock.createProxy(any())).thenReturn(Result.failure("error"));
 
-        var result = controller.initiateFlow(request);
+        var result = controller.initiateFlow(request, policy);
 
         assertThat(result.failed()).isTrue();
         assertThat(result.getFailureMessages()).containsExactly("Failed to generate proxy: error");

--- a/extensions/transfer-functions/transfer-functions-core/src/main/java/org/eclipse/dataspaceconnector/transfer/functions/core/flow/http/HttpDataFlowController.java
+++ b/extensions/transfer-functions/transfer-functions-core/src/main/java/org/eclipse/dataspaceconnector/transfer/functions/core/flow/http/HttpDataFlowController.java
@@ -17,6 +17,7 @@ import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowController;
@@ -65,7 +66,7 @@ public class HttpDataFlowController implements DataFlowController {
     }
 
     @Override
-    public @NotNull DataFlowInitiateResult initiateFlow(DataRequest dataRequest) {
+    public @NotNull DataFlowInitiateResult initiateFlow(DataRequest dataRequest, Policy policy) {
         var dataFlowRequest = createRequest(dataRequest);
         var requestBody = RequestBody.create(typeManager.writeValueAsString(dataFlowRequest), JSON);
         var request = new Request.Builder().url(transferEndpoint).post(requestBody).build();

--- a/extensions/transfer-functions/transfer-functions-core/src/test/java/org/eclipse/dataspaceconnector/transfer/functions/core/flow/http/HttpDataFlowControllerTest.java
+++ b/extensions/transfer-functions/transfer-functions-core/src/test/java/org/eclipse/dataspaceconnector/transfer/functions/core/flow/http/HttpDataFlowControllerTest.java
@@ -18,6 +18,7 @@ import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
@@ -68,8 +69,9 @@ class HttpDataFlowControllerTest {
         httpClient = testOkHttpClient().newBuilder().addInterceptor(delegate).build();
 
         var dataRequest = createDataRequest();
+        var policy = Policy.Builder.newInstance().build();
 
-        assertThat(flowController.initiateFlow(dataRequest).succeeded()).isTrue();
+        assertThat(flowController.initiateFlow(dataRequest, policy).succeeded()).isTrue();
     }
 
     @Test
@@ -83,8 +85,9 @@ class HttpDataFlowControllerTest {
         httpClient = testOkHttpClient().newBuilder().addInterceptor(delegate).build();
 
         var dataRequest = createDataRequest();
+        var policy = Policy.Builder.newInstance().build();
 
-        assertEquals(ERROR_RETRY, flowController.initiateFlow(dataRequest).getFailure().status());
+        assertEquals(ERROR_RETRY, flowController.initiateFlow(dataRequest, policy).getFailure().status());
     }
 
     @Test
@@ -98,8 +101,9 @@ class HttpDataFlowControllerTest {
         httpClient = testOkHttpClient().newBuilder().addInterceptor(delegate).build();
 
         var dataRequest = createDataRequest();
+        var policy = Policy.Builder.newInstance().build();
 
-        assertEquals(FATAL_ERROR, flowController.initiateFlow(dataRequest).getFailure().status());
+        assertEquals(FATAL_ERROR, flowController.initiateFlow(dataRequest, policy).getFailure().status());
     }
 
     private DataRequest createDataRequest() {

--- a/samples/other/run-from-junit/src/test/java/org/eclipse/dataspaceconnector/junit/EndToEndTest.java
+++ b/samples/other/run-from-junit/src/test/java/org/eclipse/dataspaceconnector/junit/EndToEndTest.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.junit;
 
 import org.eclipse.dataspaceconnector.ids.spi.Protocols;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
 import org.eclipse.dataspaceconnector.spi.iam.TokenRepresentation;
@@ -91,7 +92,7 @@ public class EndToEndTest {
         DataFlowController controllerMock = mock(DataFlowController.class);
 
         when(controllerMock.canHandle(isA(DataRequest.class))).thenReturn(true);
-        when(controllerMock.initiateFlow(isA(DataRequest.class))).thenAnswer(i -> {
+        when(controllerMock.initiateFlow(isA(DataRequest.class), isA(Policy.class))).thenAnswer(i -> {
             latch.countDown();
             return DataFlowInitiateResult.success("");
         });
@@ -109,7 +110,7 @@ public class EndToEndTest {
 
         assertThat(latch.await(1, TimeUnit.MINUTES)).isTrue();
         verify(controllerMock).canHandle(isA(DataRequest.class));
-        verify(controllerMock).initiateFlow(isA(DataRequest.class));
+        verify(controllerMock).initiateFlow(isA(DataRequest.class), isA(Policy.class));
     }
 
     @BeforeEach

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/flow/DataFlowController.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/flow/DataFlowController.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.spi.transfer.flow;
 
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.jetbrains.annotations.NotNull;
@@ -30,12 +31,14 @@ public interface DataFlowController {
 
     /**
      * Initiate a data flow.
-     * <p>Implementations should not throw exceptions. If an unexpected exception occurs and the flow should be re-attempted,
-     * set {@link ResponseStatus#ERROR_RETRY} in the response.
-     * If an exception occurs and re-tries should not be re-attempted, set
-     * {@link ResponseStatus#FATAL_ERROR} in the response. </p>
+     *
+     * <p>Implementations should not throw exceptions. If an unexpected exception occurs and the flow should be re-attempted, set {@link ResponseStatus#ERROR_RETRY} in the
+     * response. If an exception occurs and re-tries should not be re-attempted, set {@link ResponseStatus#FATAL_ERROR} in the response. </p>
+     *
+     * @param dataRequest the request
+     * @param policy the contract agreement usage policy for the asset being transferred
      */
     @NotNull
-    DataFlowInitiateResult initiateFlow(DataRequest dataRequest);
+    DataFlowInitiateResult initiateFlow(DataRequest dataRequest, Policy policy);
 
 }

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/flow/DataFlowManager.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/flow/DataFlowManager.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.spi.transfer.flow;
 
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.jetbrains.annotations.NotNull;
 
@@ -31,7 +32,8 @@ public interface DataFlowManager {
      * Initiates a data flow.
      *
      * @param dataRequest the data to transfer
+     * @param policy the contract agreement usage policy for the asset being transferred
      */
     @NotNull
-    DataFlowInitiateResult initiate(DataRequest dataRequest);
+    DataFlowInitiateResult initiate(DataRequest dataRequest, Policy policy);
 }

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ProvisionManager.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ProvisionManager.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.spi.transfer.provision;
 
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DeprovisionResponse;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionResponse;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedResource;
@@ -36,10 +37,10 @@ public interface ProvisionManager {
     /**
      * Provisions resources required to perform the data transfer. This operation is idempotent.
      */
-    CompletableFuture<List<ProvisionResponse>> provision(TransferProcess process);
+    CompletableFuture<List<ProvisionResponse>> provision(TransferProcess process, Policy policy);
 
     /**
      * Removes ephemeral resources associated with the data transfer. this operation is idempotent.
      */
-    CompletableFuture<List<DeprovisionResponse>> deprovision(TransferProcess process);
+    CompletableFuture<List<DeprovisionResponse>> deprovision(TransferProcess process, Policy policy);
 }

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/Provisioner.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/Provisioner.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.spi.transfer.provision;
 
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DeprovisionResponse;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionResponse;
@@ -45,15 +46,21 @@ public interface Provisioner<RD extends ResourceDefinition, PR extends Provision
      * Implementations should not throw exceptions. If an unexpected exception occurs and the flow should be re-attempted, return
      * {@link ResponseStatus#ERROR_RETRY}. If an exception occurs and re-tries should not be re-attempted, return
      * {@link ResponseStatus#FATAL_ERROR}.
+     *
+     * @param resourceDefinition that contains metadata associated with the provision operation
+     * @param policy the contract agreement usage policy for the asset being transferred
      */
-    CompletableFuture<ProvisionResponse> provision(RD resourceDefinition);
+    CompletableFuture<ProvisionResponse> provision(RD resourceDefinition, Policy policy);
 
     /**
      * Removes ephemeral resources of a specific type associated with the data transfer. Implements must be idempotent.
      * Implementations should not throw exceptions. If an unexpected exception occurs and the flow should be re-attempted, return
      * {@link ResponseStatus#ERROR_RETRY}. If an exception occurs and re-tries should not be re-attempted, return
      * {@link ResponseStatus#FATAL_ERROR}.
+     *
+     * @param provisionedResource that contains metadata associated with the provisioned resource
+     * @param policy the contract agreement usage policy for the asset being transferred
      */
-    CompletableFuture<DeprovisionResponse> deprovision(PR provisionedResource);
+    CompletableFuture<DeprovisionResponse> deprovision(PR provisionedResource, Policy policy);
 
 }

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ResourceDefinitionGenerator.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ResourceDefinitionGenerator.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.spi.transfer.provision;
 
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.jetbrains.annotations.Nullable;
@@ -25,8 +26,11 @@ public interface ResourceDefinitionGenerator {
 
     /**
      * Generates a resource definition. If no resource definition is generated, return null.
+     *
+     * @param process the transfer process to generate the definition for
+     * @param policy the contract agreement usage policy for the asset being transferred
      */
     @Nullable
-    ResourceDefinition generate(TransferProcess process);
+    ResourceDefinition generate(TransferProcess process, Policy policy);
 
 }

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ResourceManifestGenerator.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ResourceManifestGenerator.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.spi.transfer.provision;
 
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.system.Feature;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceManifest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
@@ -30,6 +31,9 @@ public interface ResourceManifestGenerator {
 
     /**
      * Generates a resource manifest for a data request on a connector. Operations should be idempotent.
+     *
+     * @param process the transfer process to generate the definition for
+     * @param policy the contract agreement usage policy for the asset being transferred
      */
-    ResourceManifest generateResourceManifest(TransferProcess process);
+    ResourceManifest generateResourceManifest(TransferProcess process, Policy policy);
 }


### PR DESCRIPTION
## What this PR changes/adds

This PR starts work related to #857. As an added bonus, it also fixes #898 since the same code area is modified.  

This PR propagates the current transfer policy during different stages of the transfer process. Note that the actual policy still needs to be resolved from the `PolicyStore` once #930 is merged.

## Why it does that

See the PR.

## Further notes

## Linked Issue(s)

Closes #898 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
