### PR TITLE
web-spi: add WebServer interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ the detailed section referring to by linking pull requests or issues.
 * Added embedded and remote DPF Selector (#832)
 * Pass path information into http data source through DPF public API (#929)
 * Add instructions for observability sample with Azure Application Insights (#928)
+* Add interface `WebServer` to `web-spi` (#921)
 
 #### Changed
 

--- a/data-protocols/ids/ids-api-configuration/build.gradle.kts
+++ b/data-protocols/ids/ids-api-configuration/build.gradle.kts
@@ -18,7 +18,6 @@ plugins {
 
 dependencies {
     implementation(project(":spi"))
-    implementation(project(":extensions:http"))
 }
 
 publishing {

--- a/data-protocols/ids/ids-api-configuration/src/main/java/org/eclipse/dataspaceconnector/ids/api/configuration/IdsApiConfigurationExtension.java
+++ b/data-protocols/ids/ids-api-configuration/src/main/java/org/eclipse/dataspaceconnector/ids/api/configuration/IdsApiConfigurationExtension.java
@@ -14,8 +14,7 @@
 
 package org.eclipse.dataspaceconnector.ids.api.configuration;
 
-import org.eclipse.dataspaceconnector.extension.jetty.JettyService;
-import org.eclipse.dataspaceconnector.extension.jetty.PortMapping;
+import org.eclipse.dataspaceconnector.spi.WebServer;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.Provides;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
@@ -30,13 +29,13 @@ import static java.lang.String.format;
 public class IdsApiConfigurationExtension implements ServiceExtension {
     
     public static final String IDS_API_CONFIG = "web.http.ids";
-    private static final String IDS_API_CONTEXT_ALIAS = "ids";
+    public static final String IDS_API_CONTEXT_ALIAS = "ids";
     
     public static final int DEFAULT_IDS_PORT = 8282;
     public static final String DEFAULT_IDS_API_PATH = "/api/v1/ids";
     
     @Inject
-    private JettyService jettyService;
+    private WebServer webServer;
     
     @Override
     public String name() {
@@ -55,7 +54,7 @@ public class IdsApiConfigurationExtension implements ServiceExtension {
         if (config.getEntries().isEmpty()) {
             monitor.warning(format("Settings for [%s] and/or [%s] were not provided. Using default" +
                     " value(s) instead.", IDS_API_CONFIG + ".path", IDS_API_CONFIG + ".path"));
-            jettyService.addPortMapping(new PortMapping(contextAlias, port, path));
+            webServer.addPortMapping(contextAlias, port, path);
         } else {
             path = config.getString("path", path);
             port = config.getInteger("port", port);

--- a/extensions/http/jetty/build.gradle.kts
+++ b/extensions/http/jetty/build.gradle.kts
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *      Catena-X Consortium - initial API and implementation
+ *      Fraunhofer Institute for Software and Systems Engineering - added dependency
  *
  */
 
@@ -24,6 +25,7 @@ dependencies {
     implementation("org.eclipse.jetty.websocket:websocket-jakarta-server:${jettyVersion}")
 
     api(project(":spi:core-spi"))
+    api(project(":spi:web-spi"))
 
     testImplementation("com.squareup.okhttp3:okhttp:${okHttpVersion}")
     testImplementation("org.glassfish.jersey.core:jersey-server:${jerseyVersion}")

--- a/extensions/http/jetty/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyExtension.java
+++ b/extensions/http/jetty/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyExtension.java
@@ -1,11 +1,12 @@
 package org.eclipse.dataspaceconnector.extension.jetty;
 
 import org.eclipse.dataspaceconnector.spi.EdcSetting;
+import org.eclipse.dataspaceconnector.spi.WebServer;
 import org.eclipse.dataspaceconnector.spi.system.Provides;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
-@Provides({ JettyService.class })
+@Provides({ WebServer.class, JettyService.class })
 public class JettyExtension implements ServiceExtension {
 
 
@@ -30,6 +31,7 @@ public class JettyExtension implements ServiceExtension {
 
         jettyService = new JettyService(configuration, monitor);
         context.registerService(JettyService.class, jettyService);
+        context.registerService(WebServer.class, jettyService);
     }
 
     @Override

--- a/extensions/http/jetty/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyService.java
+++ b/extensions/http/jetty/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyService.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.extension.jetty;
 
 import jakarta.servlet.Servlet;
 import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.WebServer;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
@@ -45,7 +46,7 @@ import static org.eclipse.jetty.servlet.ServletContextHandler.NO_SESSIONS;
 /**
  * Provides HTTP(S) support using Jetty.
  */
-public class JettyService {
+public class JettyService implements WebServer {
 
     public static final String DEFAULT_ROOT_PATH = "/api";
     private static final String LOG_ANNOUNCE = "org.eclipse.jetty.util.log.announce";
@@ -133,9 +134,12 @@ public class JettyService {
      * Allows adding a {@link PortMapping} that is not defined in the configuration. This can only
      * be done before the JettyService is started, i.e. before {@link #start()} is called.
      *
-     * @param portMapping the port mapping.
+     * @param contextName name of the port mapping.
+     * @param port port of the port mapping.
+     * @param path path of the port mapping.
      */
-    public void addPortMapping(PortMapping portMapping) {
+    public void addPortMapping(String contextName, int port, String path) {
+        var portMapping = new PortMapping(contextName, port, path);
         if (server != null && (server.isStarted() || server.isStarting())) {
             return;
         }

--- a/spi/web-spi/src/main/java/org/eclipse/dataspaceconnector/spi/WebServer.java
+++ b/spi/web-spi/src/main/java/org/eclipse/dataspaceconnector/spi/WebServer.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2022 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.spi;
+
+import org.eclipse.dataspaceconnector.spi.system.Feature;
+
+/**
+ * Manages the runtime web (HTTP) server.
+ */
+@Feature("edc:core:base:webserver")
+public interface WebServer {
+    
+    /**
+     * Adds a new port mapping and thus a new API context to this web server.
+     *
+     * @param contextName the name of the API context.
+     * @param port the port of the API context.
+     * @param path the path of the API context.
+     */
+    void addPortMapping(String contextName, int port, String path);
+    
+}


### PR DESCRIPTION
## What this PR changes/adds

It adds an interface `WebServer` to the `web-spi` module. The interface is implemented by the `JettyService`.

## Why it does that

The `ids-api-configuration` module adds an API context, even if it is not defined in the `config.properties`. It therefore needs to access the `JettyService` and currently has a dependency on the `http` extension. Adding the interface allows for removing this dependency, as the API context can now be added via the interface.

## Further notes

Besides the method for adding a new port mapping, the `JettyService` also contains a public method `void registerServlet(String contextName, Servlet servlet)`. It might make sense to move this to the `WebServer` interface, too, but as the second parameter is a `jakarta.servlet.Servlet`, this would require adding a dependency to the `web-spi`'s build file. Therefore, this has been left out for now.

## Linked Issue(s)

Closes #921 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
