### PR TITLE
gradle: remove workers configuration settings

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,3 @@
-#org.gradle.console=rich
-org.gradle.parallel=true
-org.gradle.workers.max=32
-
 javaVersion=11
 
 infoModelVersion=4.2.7


### PR DESCRIPTION
## What this PR changes/adds

Removes the gradle workers settings

## Why it does that

These settings are raising problems on different developers machines

## Further notes

* Seems like the build time without the parameters is pretty much the same as with (on my repo the `Test Code` task took 15m, that's pretty much the average time it took with the parameters set. parallelism is not always a solution :) )

## Linked Issue(s)

Closes #958
Superseds #897 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
