### PR TITLE
Data management: fix package names

### DIFF
--- a/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/transformer/DtoTransformerRegistryImpl.java
+++ b/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/transformer/DtoTransformerRegistryImpl.java
@@ -35,12 +35,12 @@ import static java.lang.String.format;
  * and register one otherwise:
  * <pre>
  * \@Inject(required=false)
- * private ApiTransformerRegistry registry;
+ * private DtoTransformerRegistry registry;
  *
  * void initialize(ServiceExtensionContext context){
  *      if(registry == null){
- *          registry= new ApiTransformerRegistryImpl();
- *          context.registerService(ApiTransformerRegistry.class, registry);
+ *          registry= new DtoTransformerRegistryImpl();
+ *          context.registerService(DtoTransformerRegistry.class, registry);
  *      }
  *
  *      var yourController = new YourApiController(..., registry);
@@ -81,7 +81,7 @@ public class DtoTransformerRegistryImpl implements DtoTransformerRegistry {
                 .findFirst().orElse(null);
 
         if (t == null) {
-            throw new EdcException(format("No ApiTransformer registered that can handle %s -> %s", object, outputType));
+            throw new EdcException(format("No DtoTransformer registered that can handle %s -> %s", object, outputType));
         }
         return outputType.cast(((DtoTransformer<INPUT, OUTPUT>) t).transform(object, context));
     }

--- a/extensions/api/api-core/src/test/java/org/eclipse/dataspaceconnector/api/transformer/DtoTransformerRegistryImplTest.java
+++ b/extensions/api/api-core/src/test/java/org/eclipse/dataspaceconnector/api/transformer/DtoTransformerRegistryImplTest.java
@@ -70,7 +70,7 @@ class DtoTransformerRegistryImplTest {
         registry.register(new TestTransformer());
 
         assertThatThrownBy(() -> registry.transform("foo", Integer.class)).isInstanceOf(EdcException.class)
-                .hasMessageStartingWith("No ApiTransformer registered that can handle foo -> " + Integer.class);
+                .hasMessageStartingWith("No DtoTransformer registered that can handle foo -> " + Integer.class);
     }
 
     @Test

--- a/extensions/api/data-management/contractagreement/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApi.java
+++ b/extensions/api/data-management/contractagreement/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApi.java
@@ -11,10 +11,10 @@
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
-package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition;
+package org.eclipse.dataspaceconnector.api.datamanagement.contractagreement;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model.ContractAgreementDto;
+import org.eclipse.dataspaceconnector.api.datamanagement.contractagreement.model.ContractAgreementDto;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 
 import java.util.List;

--- a/extensions/api/data-management/contractagreement/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApiController.java
+++ b/extensions/api/data-management/contractagreement/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApiController.java
@@ -13,7 +13,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition;
+package org.eclipse.dataspaceconnector.api.datamanagement.contractagreement;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
@@ -22,7 +22,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
-import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model.ContractAgreementDto;
+import org.eclipse.dataspaceconnector.api.datamanagement.contractagreement.model.ContractAgreementDto;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;

--- a/extensions/api/data-management/contractagreement/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApiExtension.java
+++ b/extensions/api/data-management/contractagreement/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApiExtension.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition;
+package org.eclipse.dataspaceconnector.api.datamanagement.contractagreement;
 
 import org.eclipse.dataspaceconnector.api.datamanagement.configuration.DataManagementApiConfiguration;
 import org.eclipse.dataspaceconnector.spi.WebService;
@@ -20,15 +20,15 @@ import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
-public class TransferProcessApiExtension implements ServiceExtension {
+public class ContractAgreementApiExtension implements ServiceExtension {
     @Inject
     private WebService webService;
 
     @Inject
-    private DataManagementApiConfiguration configuration;
+    private DataManagementApiConfiguration config;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        webService.registerResource(configuration.getContextAlias(), new TransferProcessApiController(context.getMonitor()));
+        webService.registerResource(config.getContextAlias(), new ContractAgreementApiController(context.getMonitor()));
     }
 }

--- a/extensions/api/data-management/contractagreement/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/model/ContractAgreementDto.java
+++ b/extensions/api/data-management/contractagreement/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/model/ContractAgreementDto.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model;
+package org.eclipse.dataspaceconnector.api.datamanagement.contractagreement.model;
 
 public class ContractAgreementDto {
     private String id;

--- a/extensions/api/data-management/contractagreement/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
+++ b/extensions/api/data-management/contractagreement/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
@@ -12,4 +12,4 @@
 #
 #
 
-org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.ContractAgreementApiExtension
+org.eclipse.dataspaceconnector.api.datamanagement.contractagreement.ContractAgreementApiExtension

--- a/extensions/api/data-management/contractagreement/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/contractagreement/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApiControllerIntegrationTest.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition;
+package org.eclipse.dataspaceconnector.api.datamanagement.contractagreement;
 
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
 import static org.mockito.Mockito.mock;
 
-class TransferProcessApiControllerIntegrationTest {
+public class ContractAgreementApiControllerIntegrationTest {
 
     private static int port;
     private OkHttpClient client;
@@ -49,7 +49,7 @@ class TransferProcessApiControllerIntegrationTest {
         config.portMapping(new PortMapping("data", port, "/api/v1/data"));
         var jetty = new JettyService(config, monitor);
 
-        var ctrl = new TransferProcessApiController(monitor);
+        var ctrl = new ContractAgreementApiController(monitor);
         var jerseyService = new JerseyRestService(jetty, new TypeManager(), mock(CorsFilterConfiguration.class), monitor);
         jetty.start();
         jerseyService.registerResource("data", ctrl);
@@ -62,20 +62,20 @@ class TransferProcessApiControllerIntegrationTest {
     }
 
     @Test
-    void getAllTransferProcesses() throws IOException {
+    void getAllContractAgreements() throws IOException {
         var response = get(basePath());
         assertThat(response.code()).isEqualTo(200);
     }
 
     @Test
-    void getTransferProcesses_withPaging() throws IOException {
+    void getAllContractAgreements_withPaging() throws IOException {
         try (var response = get(basePath() + "?offset=10&limit=15&sort=ASC")) {
             assertThat(response.code()).isEqualTo(200);
         }
     }
 
     @Test
-    void getSingleTransferProcess() throws IOException {
+    void getSingleContractAgreement() throws IOException {
         var id = "test-id";
         try (var response = get(basePath() + "/" + id)) {
             //assertThat(response.code()).isEqualTo(200);
@@ -84,7 +84,7 @@ class TransferProcessApiControllerIntegrationTest {
     }
 
     @Test
-    void getSingleTransferProcess_notFound() throws IOException {
+    void getSingleContractAgreement_notFound() throws IOException {
         try (var response = get(basePath() + "/not-exist")) {
             // assertThat(response.code()).isEqualTo(404);
         }
@@ -93,7 +93,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @NotNull
     private String basePath() {
-        return "http://localhost:" + port + "/api/v1/data/transferprocess";
+        return "http://localhost:" + port + "/api/v1/data/contractagreements";
     }
 
     @NotNull

--- a/extensions/api/data-management/contractagreement/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApiControllerTest.java
+++ b/extensions/api/data-management/contractagreement/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApiControllerTest.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition;
+package org.eclipse.dataspaceconnector.api.datamanagement.contractagreement;
 
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.junit.jupiter.api.BeforeEach;

--- a/extensions/api/data-management/contractagreement/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/model/ContractAgreementDtoTest.java
+++ b/extensions/api/data-management/contractagreement/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/model/ContractAgreementDtoTest.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model;
+package org.eclipse.dataspaceconnector.api.datamanagement.contractagreement.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApi.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApi.java
@@ -12,11 +12,11 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition;
+package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model.TransferProcessDto;
-import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model.TransferRequestDto;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferProcessDto;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferRequestDto;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 
 import java.util.List;

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiController.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiController.java
@@ -13,7 +13,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition;
+package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
@@ -23,8 +23,8 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
-import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model.TransferProcessDto;
-import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model.TransferRequestDto;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferProcessDto;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferRequestDto;
 import org.eclipse.dataspaceconnector.common.string.StringUtils;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiExtension.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiExtension.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition;
+package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess;
 
 import org.eclipse.dataspaceconnector.api.datamanagement.configuration.DataManagementApiConfiguration;
 import org.eclipse.dataspaceconnector.spi.WebService;
@@ -20,15 +20,15 @@ import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
-public class ContractAgreementApiExtension implements ServiceExtension {
+public class TransferProcessApiExtension implements ServiceExtension {
     @Inject
     private WebService webService;
 
     @Inject
-    private DataManagementApiConfiguration config;
+    private DataManagementApiConfiguration configuration;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        webService.registerResource(config.getContextAlias(), new ContractAgreementApiController(context.getMonitor()));
+        webService.registerResource(configuration.getContextAlias(), new TransferProcessApiController(context.getMonitor()));
     }
 }

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/DataRequestDto.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/DataRequestDto.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model;
+package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferProcessDto.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferProcessDto.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model;
+package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferRequestDto.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferRequestDto.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model;
+package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/extensions/api/data-management/transferprocess/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
+++ b/extensions/api/data-management/transferprocess/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
@@ -12,4 +12,4 @@
 #
 #
 
-org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.TransferProcessApiExtension
+org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.TransferProcessApiExtension

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiApiControllerTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiApiControllerTest.java
@@ -1,6 +1,6 @@
-package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition;
+package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess;
 
-import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model.TransferRequestDto;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferRequestDto;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.junit.jupiter.api.BeforeEach;

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerIntegrationTest.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition;
+package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess;
 
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
 import static org.mockito.Mockito.mock;
 
-public class ContractAgreementApiControllerIntegrationTest {
+class TransferProcessApiControllerIntegrationTest {
 
     private static int port;
     private OkHttpClient client;
@@ -49,7 +49,7 @@ public class ContractAgreementApiControllerIntegrationTest {
         config.portMapping(new PortMapping("data", port, "/api/v1/data"));
         var jetty = new JettyService(config, monitor);
 
-        var ctrl = new ContractAgreementApiController(monitor);
+        var ctrl = new TransferProcessApiController(monitor);
         var jerseyService = new JerseyRestService(jetty, new TypeManager(), mock(CorsFilterConfiguration.class), monitor);
         jetty.start();
         jerseyService.registerResource("data", ctrl);
@@ -62,20 +62,20 @@ public class ContractAgreementApiControllerIntegrationTest {
     }
 
     @Test
-    void getAllContractAgreements() throws IOException {
+    void getAllTransferProcesses() throws IOException {
         var response = get(basePath());
         assertThat(response.code()).isEqualTo(200);
     }
 
     @Test
-    void getAllContractAgreements_withPaging() throws IOException {
+    void getTransferProcesses_withPaging() throws IOException {
         try (var response = get(basePath() + "?offset=10&limit=15&sort=ASC")) {
             assertThat(response.code()).isEqualTo(200);
         }
     }
 
     @Test
-    void getSingleContractAgreement() throws IOException {
+    void getSingleTransferProcess() throws IOException {
         var id = "test-id";
         try (var response = get(basePath() + "/" + id)) {
             //assertThat(response.code()).isEqualTo(200);
@@ -84,7 +84,7 @@ public class ContractAgreementApiControllerIntegrationTest {
     }
 
     @Test
-    void getSingleContractAgreement_notFound() throws IOException {
+    void getSingleTransferProcess_notFound() throws IOException {
         try (var response = get(basePath() + "/not-exist")) {
             // assertThat(response.code()).isEqualTo(404);
         }
@@ -93,7 +93,7 @@ public class ContractAgreementApiControllerIntegrationTest {
 
     @NotNull
     private String basePath() {
-        return "http://localhost:" + port + "/api/v1/data/contractagreements";
+        return "http://localhost:" + port + "/api/v1/data/transferprocess";
     }
 
     @NotNull

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferProcessDtoTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferProcessDtoTest.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model;
+package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;


### PR DESCRIPTION
## What this PR changes/adds

Fix package names as well as class names in comments. Presumably several packages were cookie-cut from "contractdefinition", after which the package name needs to be updated.

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
