### PR TITLE
Feature: adds `execute` method with result to the `TransactionContext`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ the detailed section referring to by linking pull requests or issues.
 * Extract interfaces for every api controller class to improve swagger documentation (#891)
 * Instrument executors with metrics (#912)
 * Call the listeners before the state transition is persisted. (#876)
+* Added an overload to `TransactionContext#execute()` (#968)
 * Run CosmosDB integration tests on cloud in CI (#964)
 
 #### Removed

--- a/extensions/sql/contract-definition/store/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionStore.java
+++ b/extensions/sql/contract-definition/store/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionStore.java
@@ -33,7 +33,6 @@ import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import javax.sql.DataSource;
 
@@ -91,36 +90,40 @@ public class SqlContractDefinitionStore implements ContractDefinitionStore {
 
     @Override
     public @NotNull Collection<ContractDefinition> findAll() {
-        try (var connection = getConnection()) {
-            return executeQuery(
-                    connection,
-                    this::mapResultSet,
-                    String.format(SQL_FIND_CLAUSE_TEMPLATE, CONTRACT_DEFINITION_TABLE));
-        } catch (Exception exception) {
-            throw new EdcPersistenceException(exception);
-        }
+        return transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                return executeQuery(
+                        connection,
+                        this::mapResultSet,
+                        String.format(SQL_FIND_CLAUSE_TEMPLATE, CONTRACT_DEFINITION_TABLE));
+            } catch (Exception exception) {
+                throw new EdcPersistenceException(exception);
+            }
+        });
     }
 
     @Override
     public @NotNull Stream<ContractDefinition> findAll(QuerySpec spec) {
-        Objects.requireNonNull(spec);
+        return transactionContext.execute(() -> {
+            Objects.requireNonNull(spec);
 
-        var limit = Limit.Builder.newInstance()
-                .limit(spec.getLimit())
-                .offset(spec.getOffset())
-                .build();
+            var limit = Limit.Builder.newInstance()
+                    .limit(spec.getLimit())
+                    .offset(spec.getOffset())
+                    .build();
 
-        var query = SQL_FIND_CLAUSE_TEMPLATE + " " + limit.getStatement();
+            var query = SQL_FIND_CLAUSE_TEMPLATE + " " + limit.getStatement();
 
-        try (var connection = getConnection()) {
-            var definitions = executeQuery(
-                    connection,
-                    this::mapResultSet,
-                    String.format(query, CONTRACT_DEFINITION_TABLE));
-            return definitions.stream();
-        } catch (Exception exception) {
-            throw new EdcPersistenceException(exception);
-        }
+            try (var connection = getConnection()) {
+                var definitions = executeQuery(
+                        connection,
+                        this::mapResultSet,
+                        String.format(query, CONTRACT_DEFINITION_TABLE));
+                return definitions.stream();
+            } catch (Exception exception) {
+                throw new EdcPersistenceException(exception);
+            }
+        });
     }
 
     @Override
@@ -150,12 +153,12 @@ public class SqlContractDefinitionStore implements ContractDefinitionStore {
     @Override
     public void update(ContractDefinition definition) {
         Objects.requireNonNull(definition);
+        transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                if (existsById(definition.getId(), connection)) {
+                    throw new EdcPersistenceException(String.format("Cannot update. Contract Definition with ID '%s' does not exist.", definition.getId()));
+                }
 
-        try (var connection = getConnection()) {
-            if (existsById(definition.getId(), connection)) {
-                throw new EdcPersistenceException(String.format("Cannot update. Contract Definition with ID '%s' does not exist.", definition.getId()));
-            }
-            transactionContext.execute(() -> {
                 try {
                     executeQuery(connection, SQL_UPDATE_CLAUSE_TEMPLATE,
                             definition.getId(),
@@ -166,34 +169,30 @@ public class SqlContractDefinitionStore implements ContractDefinitionStore {
                 } catch (JsonProcessingException e) {
                     throw new EdcPersistenceException(e);
                 }
-            });
-        } catch (Exception e) {
-            if (e instanceof EdcPersistenceException) {
-                throw (EdcPersistenceException) e;
+
+            } catch (Exception e) {
+                if (e instanceof EdcPersistenceException) {
+                    throw (EdcPersistenceException) e;
+                }
+                throw new EdcPersistenceException(e.getMessage(), e);
             }
-            throw new EdcPersistenceException(e.getMessage(), e);
-        }
+        });
     }
 
     @Override
     public ContractDefinition deleteById(String id) {
         Objects.requireNonNull(id);
-
-        AtomicReference<ContractDefinition> atomicRef = new AtomicReference<>();
-
-        transactionContext.execute(() -> {
+        return transactionContext.execute(() -> {
             try (var connection = getConnection()) {
                 var entity = findById(connection, id);
                 if (entity != null) {
-                    atomicRef.set(entity);
                     executeQuery(connection, SQL_DELETE_CLAUSE_TEMPLATE, id);
                 }
+                return entity;
             } catch (Exception e) {
                 throw new EdcPersistenceException(e.getMessage(), e);
             }
         });
-
-        return atomicRef.get();
     }
 
     private boolean existsById(String definitionId, Connection connection) {

--- a/extensions/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/AtomikosTransactionContext.java
+++ b/extensions/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/AtomikosTransactionContext.java
@@ -31,8 +31,8 @@ import static javax.transaction.Status.STATUS_MARKED_ROLLBACK;
  * An implementation backed by the Atomikos transaction manager.
  */
 public class AtomikosTransactionContext implements TransactionContext {
+    private final Monitor monitor;
     private TransactionManager transactionManager;
-    private Monitor monitor;
 
     public AtomikosTransactionContext(Monitor monitor) {
         this.monitor = monitor;
@@ -44,6 +44,14 @@ public class AtomikosTransactionContext implements TransactionContext {
 
     @Override
     public void execute(TransactionBlock block) {
+        execute((ResultTransactionBlock<Void>) () -> {
+            block.execute();
+            return null;
+        });
+    }
+
+    @Override
+    public <T> T execute(ResultTransactionBlock<T> block) {
         var startedTransaction = false;
         Transaction transaction = null;
         try {
@@ -54,7 +62,7 @@ public class AtomikosTransactionContext implements TransactionContext {
                 startedTransaction = true;
             }
 
-            block.execute();
+            return block.execute();
 
         } catch (Exception e) {
             try {
@@ -80,4 +88,5 @@ public class AtomikosTransactionContext implements TransactionContext {
             }
         }
     }
+
 }

--- a/extensions/transaction/transaction-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transaction/NoopTransactionContext.java
+++ b/extensions/transaction/transaction-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transaction/NoopTransactionContext.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.transaction;
 
 /**
@@ -7,5 +21,10 @@ public class NoopTransactionContext implements TransactionContext {
     @Override
     public void execute(TransactionBlock block) {
         block.execute();
+    }
+
+    @Override
+    public <T> T execute(ResultTransactionBlock<T> block) {
+        return block.execute();
     }
 }

--- a/extensions/transaction/transaction-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transaction/TransactionContext.java
+++ b/extensions/transaction/transaction-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transaction/TransactionContext.java
@@ -18,9 +18,9 @@ package org.eclipse.dataspaceconnector.spi.transaction;
  * Implementations execute code within a transactional boundary. A {@code TransactionContext} provides a consistent programming model for local and global (e.g. JTA) transaction
  * infrastructure. Specifically, client code executes transactional code in the same way whether the context is backed by a local resource such as a single JDBC connection pool
  * or a JTA transaction manager with enlisted resources.
- *
+ * <p>
  * Implementations must support joining existing transactions. Nested executions will therefore join the transactional context of their parent.
- *
+ * <p>
  * Transactional semantics will vary by implementation. For example, an implementation may only support atomicity when a single resource is enlisted in a transaction.
  */
 public interface TransactionContext {
@@ -29,6 +29,11 @@ public interface TransactionContext {
      * Executes the code within a transaction.
      */
     void execute(TransactionBlock block);
+
+    /**
+     * Executes the code within a transaction producing a result
+     */
+    <T> T execute(ResultTransactionBlock<T> block);
 
     /**
      * Defines a block of transactional code.
@@ -41,5 +46,13 @@ public interface TransactionContext {
          */
         void execute();
 
+    }
+
+    /**
+     * Defines a block of transactional code producing a result
+     */
+    @FunctionalInterface
+    interface ResultTransactionBlock<T> {
+        T execute();
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

overloads the `TransactionContext#execute()` method to be able to return a result. 

## Why it does that

This is useful when wrapping read-calls in transactions, because it gets rid of having to declare an `AtomicReference`.

## Further notes

An explicit functional interface `ResultTransactionBlock` was also declared to maintain consistency.

## Linked Issue(s)

none

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
