### PR TITLE
sample 4: update permission

### DIFF
--- a/samples/04.0-file-transfer/transfer-file/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferExtension.java
+++ b/samples/04.0-file-transfer/transfer-file/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferExtension.java
@@ -69,7 +69,8 @@ public class FileTransferExtension implements ServiceExtension {
     private Policy createPolicy() {
 
         var usePermission = Permission.Builder.newInstance()
-                .action(Action.Builder.newInstance().type("idsc:USE").build())
+                .action(Action.Builder.newInstance().type("USE").build())
+                .target("test-document")
                 .build();
 
         return Policy.Builder.newInstance()


### PR DESCRIPTION
## What this PR changes/adds

It updates the permission in the `transfer-file` module of sample 04.0. It changes the permission's action from `idsc:USE` to `USE` and adds a permission target.

## Why it does that

Currently, upon description request the transformer throws an error when transforming the permission from sample 4 due to a missing target and an unknown action type. While the description request is not required for sample 4 to run successfully, people might look at this sample and define their policies in the same way, which would then lead to these errors.
