### PR TITLE
core: move extension loading logic from ServiceExtensionContext to ExtensionLoader

### DIFF
--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/DefaultServiceExtensionContext.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/DefaultServiceExtensionContext.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2021 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -9,43 +9,26 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 
 package org.eclipse.dataspaceconnector.boot.system;
 
-import org.eclipse.dataspaceconnector.boot.util.TopologicalSort;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.system.BaseExtension;
 import org.eclipse.dataspaceconnector.spi.system.ConfigurationExtension;
-import org.eclipse.dataspaceconnector.spi.system.CoreExtension;
-import org.eclipse.dataspaceconnector.spi.system.Feature;
-import org.eclipse.dataspaceconnector.spi.system.Provides;
-import org.eclipse.dataspaceconnector.spi.system.Requires;
-import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.system.configuration.Config;
 import org.eclipse.dataspaceconnector.spi.system.configuration.ConfigFactory;
-import org.eclipse.dataspaceconnector.spi.system.injection.EdcInjectionException;
-import org.eclipse.dataspaceconnector.spi.system.injection.InjectionContainer;
-import org.eclipse.dataspaceconnector.spi.system.injection.InjectionPoint;
-import org.eclipse.dataspaceconnector.spi.system.injection.InjectionPointScanner;
 import org.eclipse.dataspaceconnector.spi.telemetry.Telemetry;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Base service extension context.
@@ -57,25 +40,18 @@ public class DefaultServiceExtensionContext implements ServiceExtensionContext {
     private final TypeManager typeManager;
 
     private final Map<Class<?>, Object> services = new HashMap<>();
-    private final ServiceLocator serviceLocator;
-    private final InjectionPointScanner injectionPointScanner;
-    private List<ConfigurationExtension> configurationExtensions;
+    private final List<ConfigurationExtension> configurationExtensions;
     private String connectorId;
     private Config config;
 
-    public DefaultServiceExtensionContext(TypeManager typeManager, Monitor monitor, Telemetry telemetry) {
-        this(typeManager, monitor, telemetry, new ServiceLocatorImpl());
-    }
-
-    public DefaultServiceExtensionContext(TypeManager typeManager, Monitor monitor, Telemetry telemetry, ServiceLocator serviceLocator) {
+    public DefaultServiceExtensionContext(TypeManager typeManager, Monitor monitor, Telemetry telemetry, List<ConfigurationExtension> configurationExtensions) {
         this.typeManager = typeManager;
         this.monitor = monitor;
         this.telemetry = telemetry;
-        this.serviceLocator = serviceLocator;
+        this.configurationExtensions = configurationExtensions;
         // register as services
         registerService(TypeManager.class, typeManager);
         registerService(Monitor.class, monitor);
-        injectionPointScanner = new InjectionPointScanner();
     }
 
     @Override
@@ -129,28 +105,7 @@ public class DefaultServiceExtensionContext implements ServiceExtensionContext {
     }
 
     @Override
-    public List<InjectionContainer<ServiceExtension>> loadServiceExtensions() {
-        List<ServiceExtension> serviceExtensions = loadExtensions(ServiceExtension.class, true);
-
-        //the first sort is only to verify that there are no "upward" dependencies from PRIMORDIAL -> DEFAULT
-        var sips = sortExtensions(serviceExtensions);
-
-        return Collections.unmodifiableList(sips);
-    }
-
-    @Override
-    public <T> List<T> loadExtensions(Class<T> type, boolean required) {
-        return serviceLocator.loadImplementors(type, required);
-    }
-
-    @Override
-    public <T> T loadSingletonExtension(Class<T> type, boolean required) {
-        return serviceLocator.loadSingletonImplementor(type, required);
-    }
-
-    @Override
     public void initialize() {
-        configurationExtensions = loadExtensions(ConfigurationExtension.class, false);
         configurationExtensions.forEach(ext -> {
             ext.initialize(monitor);
             monitor.info("Initialized " + ext.name());
@@ -169,86 +124,6 @@ public class DefaultServiceExtensionContext implements ServiceExtensionContext {
         return System.getenv();
     }
 
-    private List<InjectionContainer<ServiceExtension>> sortExtensions(List<ServiceExtension> loadedExtensions) {
-        Map<String, List<ServiceExtension>> dependencyMap = new HashMap<>();
-        addDefaultExtensions(loadedExtensions);
-
-        // add all provided features to the dependency map
-        loadedExtensions.forEach(ext -> getProvidedFeatures(ext).forEach(feature -> dependencyMap.computeIfAbsent(feature, k -> new ArrayList<>()).add(ext)));
-        var sort = new TopologicalSort<ServiceExtension>();
-
-        // check if all injected fields are satisfied, collect missing ones and throw exception otherwise
-        var unsatisfiedInjectionPoints = new ArrayList<InjectionPoint<ServiceExtension>>();
-        var injectionPoints = loadedExtensions.stream().flatMap(ext -> getInjectedFields(ext).stream().peek(injectionPoint -> {
-            List<ServiceExtension> dependencies = dependencyMap.get(injectionPoint.getFeatureName());
-            if (dependencies == null) {
-                if (injectionPoint.isRequired()) {
-                    unsatisfiedInjectionPoints.add(injectionPoint);
-                }
-            } else {
-                dependencies.forEach(dependency -> sort.addDependency(ext, dependency));
-            }
-        })).collect(Collectors.toList());
-
-        if (!unsatisfiedInjectionPoints.isEmpty()) {
-            var string = "The following injected fields were not provided:\n";
-            string += unsatisfiedInjectionPoints.stream().map(InjectionPoint::toString).collect(Collectors.joining("\n"));
-            throw new EdcInjectionException(string);
-        }
-
-        //check that all the @Required features are there
-        var unsatisfiedRequirements = new ArrayList<String>();
-        loadedExtensions.forEach(ext -> {
-            var features = getRequiredFeatures(ext.getClass());
-            features.forEach(feature -> {
-                var dependencies = dependencyMap.get(feature);
-                if (dependencies == null) {
-                    unsatisfiedRequirements.add(feature);
-                } else {
-                    dependencies.forEach(dependency -> sort.addDependency(ext, dependency));
-                }
-            });
-        });
-
-        if (!unsatisfiedRequirements.isEmpty()) {
-            var string = String.format("The following @Require'd features were not provided: [%s]", String.join(", ", unsatisfiedRequirements));
-            throw new EdcException(string);
-        }
-
-        sort.sort(loadedExtensions);
-
-        // todo: should the list of InjectionContainers be generated directly by the flatmap?
-        // convert the sorted list of extensions into an equally sorted list of InjectionContainers
-        return loadedExtensions.stream().map(se -> new InjectionContainer<>(se, injectionPoints.stream().filter(ip -> ip.getInstance() == se).collect(Collectors.toSet()))).collect(Collectors.toList());
-    }
-
-    private Set<String> getRequiredFeatures(Class<?> clazz) {
-        var requiresAnnotation = clazz.getAnnotation(Requires.class);
-        if (requiresAnnotation != null) {
-            var features = requiresAnnotation.value();
-            return Stream.of(features).map(this::getFeatureValue).collect(Collectors.toSet());
-        }
-        return Collections.emptySet();
-    }
-
-    /**
-     * Handles core-, transfer- and contract-extensions and inserts them at the beginning of the list so that
-     * explicit @Requires annotations are not necessary
-     */
-    private void addDefaultExtensions(List<ServiceExtension> loadedExtensions) {
-        var baseDependencies = loadedExtensions.stream().filter(e -> e.getClass().getAnnotation(BaseExtension.class) != null).collect(Collectors.toList());
-        if (baseDependencies.isEmpty()) {
-            throw new EdcException("No base dependencies were found on the classpath. Please add the \"core:base\" module to your classpath!");
-        }
-        var coreDependencies = loadedExtensions.stream().filter(e -> e.getClass().getAnnotation(CoreExtension.class) != null).collect(Collectors.toList());
-
-        //make sure the core- and transfer-dependencies are ALWAYS ordered first
-        loadedExtensions.removeAll(baseDependencies);
-        loadedExtensions.removeAll(coreDependencies);
-        coreDependencies.forEach(se -> loadedExtensions.add(0, se));
-        baseDependencies.forEach(se -> loadedExtensions.add(0, se));
-    }
-
     private Config loadConfig() {
         var config = configurationExtensions.stream()
                 .map(ConfigurationExtension::getConfig)
@@ -261,38 +136,5 @@ public class DefaultServiceExtensionContext implements ServiceExtensionContext {
 
         return config.merge(environmentConfig).merge(systemPropertyConfig);
     }
-
-    /**
-     * Obtains all features a specific extension provides as strings
-     */
-    private Set<InjectionPoint<ServiceExtension>> getInjectedFields(ServiceExtension ext) {
-        // initialize with legacy list
-
-        return injectionPointScanner.getInjectionPoints(ext);
-
-    }
-
-    /**
-     * Obtains all features a specific extension requires as strings
-     */
-    private Set<String> getProvidedFeatures(ServiceExtension ext) {
-        var allProvides = new HashSet<String>();
-
-        var providesAnnotation = ext.getClass().getAnnotation(Provides.class);
-        if (providesAnnotation != null) {
-            var featureStrings = Arrays.stream(providesAnnotation.value()).map(this::getFeatureValue).collect(Collectors.toSet());
-            allProvides.addAll(featureStrings);
-        }
-        return allProvides;
-    }
-
-    private String getFeatureValue(Class<?> featureClass) {
-        var annotation = featureClass.getAnnotation(Feature.class);
-        if (annotation == null) {
-            return featureClass.getName();
-        }
-        return annotation.value();
-    }
-
 
 }

--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoader.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoader.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2021 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 
@@ -17,31 +18,54 @@ package org.eclipse.dataspaceconnector.boot.system;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import org.eclipse.dataspaceconnector.boot.system.injection.InjectorImpl;
+import org.eclipse.dataspaceconnector.boot.util.TopologicalSort;
+import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.monitor.ConsoleMonitor;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.monitor.MultiplexingMonitor;
 import org.eclipse.dataspaceconnector.spi.security.CertificateResolver;
 import org.eclipse.dataspaceconnector.spi.security.PrivateKeyResolver;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
+import org.eclipse.dataspaceconnector.spi.system.BaseExtension;
+import org.eclipse.dataspaceconnector.spi.system.CoreExtension;
+import org.eclipse.dataspaceconnector.spi.system.Feature;
 import org.eclipse.dataspaceconnector.spi.system.MonitorExtension;
 import org.eclipse.dataspaceconnector.spi.system.NullVaultExtension;
+import org.eclipse.dataspaceconnector.spi.system.Provides;
+import org.eclipse.dataspaceconnector.spi.system.Requires;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.system.VaultExtension;
+import org.eclipse.dataspaceconnector.spi.system.injection.EdcInjectionException;
 import org.eclipse.dataspaceconnector.spi.system.injection.InjectionContainer;
-import org.eclipse.dataspaceconnector.spi.system.injection.Injector;
+import org.eclipse.dataspaceconnector.spi.system.injection.InjectionPoint;
+import org.eclipse.dataspaceconnector.spi.system.injection.InjectionPointScanner;
 import org.eclipse.dataspaceconnector.spi.telemetry.Telemetry;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.lang.String.format;
 
 public class ExtensionLoader {
 
-    private ExtensionLoader() {
+    private final InjectionPointScanner injectionPointScanner = new InjectionPointScanner();
+    private final ServiceLocator serviceLocator;
+
+    public ExtensionLoader(ServiceLocator serviceLocator) {
+        this.serviceLocator = serviceLocator;
     }
 
     /**
@@ -49,9 +73,10 @@ public class ExtensionLoader {
      */
     public static void bootServiceExtensions(List<InjectionContainer<ServiceExtension>> containers, ServiceExtensionContext context) {
         var monitor = context.getMonitor();
+        var injector = new InjectorImpl();
 
         containers.forEach(container -> {
-            getInjector().inject(container, context);
+            injector.inject(container, context);
             container.getInjectionTarget().initialize(context);
             //todo: add verification here, that every @Provides corresponds to a .registerService call
             var result = container.validate(context);
@@ -67,15 +92,11 @@ public class ExtensionLoader {
         });
     }
 
-    private static Injector getInjector() {
-        return new InjectorImpl();
-    }
-
     /**
      * Loads a vault extension.
      */
-    public static void loadVault(ServiceExtensionContext context) {
-        VaultExtension vaultExtension = context.loadSingletonExtension(VaultExtension.class, false);
+    public static void loadVault(ServiceExtensionContext context, ExtensionLoader loader) {
+        VaultExtension vaultExtension = loader.loadSingletonExtension(VaultExtension.class, false);
         if (vaultExtension == null) {
             vaultExtension = new NullVaultExtension();
             context.getMonitor().info("Secrets vault not configured. Defaulting to null vault.");
@@ -116,5 +137,144 @@ public class ExtensionLoader {
             throw new IllegalStateException(String.format("Found %s OpenTelemetry implementations. Please provide only one OpenTelemetry service provider.", openTelemetries.size()));
         }
         return openTelemetries.isEmpty() ? GlobalOpenTelemetry.get() : openTelemetries.get(0);
+    }
+
+    /**
+     * Loads and orders the service extensions.
+     */
+    public List<InjectionContainer<ServiceExtension>> loadServiceExtensions() {
+        List<ServiceExtension> serviceExtensions = loadExtensions(ServiceExtension.class, true);
+
+        //the first sort is only to verify that there are no "upward" dependencies from PRIMORDIAL -> DEFAULT
+        var sips = sortExtensions(serviceExtensions);
+
+        return Collections.unmodifiableList(sips);
+    }
+
+    /**
+     * Loads multiple extensions, raising an exception if at least one is not found.
+     */
+    public <T> List<T> loadExtensions(Class<T> type, boolean required) {
+        return serviceLocator.loadImplementors(type, required);
+    }
+
+    /**
+     * Loads a single extension, raising an exception if one is not found.
+     */
+    @Nullable()
+    @Contract("_, true -> !null")
+    public <T> T loadSingletonExtension(Class<T> type, boolean required) {
+        return serviceLocator.loadSingletonImplementor(type, required);
+    }
+
+    private List<InjectionContainer<ServiceExtension>> sortExtensions(List<ServiceExtension> loadedExtensions) {
+        Map<String, List<ServiceExtension>> dependencyMap = new HashMap<>();
+        addDefaultExtensions(loadedExtensions);
+
+        // add all provided features to the dependency map
+        loadedExtensions.forEach(ext -> getProvidedFeatures(ext).forEach(feature -> dependencyMap.computeIfAbsent(feature, k -> new ArrayList<>()).add(ext)));
+        var sort = new TopologicalSort<ServiceExtension>();
+
+        // check if all injected fields are satisfied, collect missing ones and throw exception otherwise
+        var unsatisfiedInjectionPoints = new ArrayList<InjectionPoint<ServiceExtension>>();
+        var injectionPoints = loadedExtensions.stream().flatMap(ext -> getInjectedFields(ext).stream().peek(injectionPoint -> {
+            List<ServiceExtension> dependencies = dependencyMap.get(injectionPoint.getFeatureName());
+            if (dependencies == null) {
+                if (injectionPoint.isRequired()) {
+                    unsatisfiedInjectionPoints.add(injectionPoint);
+                }
+            } else {
+                dependencies.forEach(dependency -> sort.addDependency(ext, dependency));
+            }
+        })).collect(Collectors.toList());
+
+        if (!unsatisfiedInjectionPoints.isEmpty()) {
+            var string = "The following injected fields were not provided:\n";
+            string += unsatisfiedInjectionPoints.stream().map(InjectionPoint::toString).collect(Collectors.joining("\n"));
+            throw new EdcInjectionException(string);
+        }
+
+        //check that all the @Required features are there
+        var unsatisfiedRequirements = new ArrayList<String>();
+        loadedExtensions.forEach(ext -> {
+            var features = getRequiredFeatures(ext.getClass());
+            features.forEach(feature -> {
+                var dependencies = dependencyMap.get(feature);
+                if (dependencies == null) {
+                    unsatisfiedRequirements.add(feature);
+                } else {
+                    dependencies.forEach(dependency -> sort.addDependency(ext, dependency));
+                }
+            });
+        });
+
+        if (!unsatisfiedRequirements.isEmpty()) {
+            var string = String.format("The following @Require'd features were not provided: [%s]", String.join(", ", unsatisfiedRequirements));
+            throw new EdcException(string);
+        }
+
+        sort.sort(loadedExtensions);
+
+        // todo: should the list of InjectionContainers be generated directly by the flatmap?
+        // convert the sorted list of extensions into an equally sorted list of InjectionContainers
+        return loadedExtensions.stream().map(se -> new InjectionContainer<>(se, injectionPoints.stream().filter(ip -> ip.getInstance() == se).collect(Collectors.toSet()))).collect(Collectors.toList());
+    }
+
+    private Set<String> getRequiredFeatures(Class<?> clazz) {
+        var requiresAnnotation = clazz.getAnnotation(Requires.class);
+        if (requiresAnnotation != null) {
+            var features = requiresAnnotation.value();
+            return Stream.of(features).map(this::getFeatureValue).collect(Collectors.toSet());
+        }
+        return Collections.emptySet();
+    }
+
+    /**
+     * Obtains all features a specific extension requires as strings
+     */
+    private Set<String> getProvidedFeatures(ServiceExtension ext) {
+        var allProvides = new HashSet<String>();
+
+        var providesAnnotation = ext.getClass().getAnnotation(Provides.class);
+        if (providesAnnotation != null) {
+            var featureStrings = Arrays.stream(providesAnnotation.value()).map(this::getFeatureValue).collect(Collectors.toSet());
+            allProvides.addAll(featureStrings);
+        }
+        return allProvides;
+    }
+
+    private String getFeatureValue(Class<?> featureClass) {
+        var annotation = featureClass.getAnnotation(Feature.class);
+        if (annotation == null) {
+            return featureClass.getName();
+        }
+        return annotation.value();
+    }
+
+    /**
+     * Obtains all features a specific extension provides as strings
+     */
+    private Set<InjectionPoint<ServiceExtension>> getInjectedFields(ServiceExtension ext) {
+        // initialize with legacy list
+
+        return injectionPointScanner.getInjectionPoints(ext);
+    }
+
+    /**
+     * Handles core-, transfer- and contract-extensions and inserts them at the beginning of the list so that
+     * explicit @Requires annotations are not necessary
+     */
+    private void addDefaultExtensions(List<ServiceExtension> loadedExtensions) {
+        var baseDependencies = loadedExtensions.stream().filter(e -> e.getClass().getAnnotation(BaseExtension.class) != null).collect(Collectors.toList());
+        if (baseDependencies.isEmpty()) {
+            throw new EdcException("No base dependencies were found on the classpath. Please add the \"core:base\" module to your classpath!");
+        }
+        var coreDependencies = loadedExtensions.stream().filter(e -> e.getClass().getAnnotation(CoreExtension.class) != null).collect(Collectors.toList());
+
+        //make sure the core- and transfer-dependencies are ALWAYS ordered first
+        loadedExtensions.removeAll(baseDependencies);
+        loadedExtensions.removeAll(coreDependencies);
+        coreDependencies.forEach(se -> loadedExtensions.add(0, se));
+        baseDependencies.forEach(se -> loadedExtensions.add(0, se));
     }
 }

--- a/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/DefaultServiceExtensionContextTest.java
+++ b/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/DefaultServiceExtensionContextTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2021 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -9,24 +9,16 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 
 package org.eclipse.dataspaceconnector.boot.system;
 
-import org.eclipse.dataspaceconnector.boot.util.CyclicDependencyException;
-import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.system.BaseExtension;
 import org.eclipse.dataspaceconnector.spi.system.ConfigurationExtension;
-import org.eclipse.dataspaceconnector.spi.system.Inject;
-import org.eclipse.dataspaceconnector.spi.system.Provides;
-import org.eclipse.dataspaceconnector.spi.system.Requires;
-import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.configuration.Config;
 import org.eclipse.dataspaceconnector.spi.system.configuration.ConfigFactory;
-import org.eclipse.dataspaceconnector.spi.system.injection.EdcInjectionException;
-import org.eclipse.dataspaceconnector.spi.system.injection.InjectionContainer;
 import org.eclipse.dataspaceconnector.spi.telemetry.Telemetry;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,41 +26,32 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class DefaultServiceExtensionContextTest {
 
-    private final ServiceExtension coreExtension = new TestCoreExtension();
     private DefaultServiceExtensionContext context;
-    private ServiceLocator serviceLocatorMock;
+    private final ConfigurationExtension configuration = mock(ConfigurationExtension.class);
 
     @BeforeEach
     void setUp() {
         TypeManager typeManager = new TypeManager();
         Monitor monitor = mock(Monitor.class);
         Telemetry telemetry = new Telemetry();
-        serviceLocatorMock = mock(ServiceLocator.class);
-        context = new DefaultServiceExtensionContext(typeManager, monitor, telemetry, serviceLocatorMock);
+        context = new DefaultServiceExtensionContext(typeManager, monitor, telemetry, List.of(configuration));
     }
 
     @Test
     void getConfig_onlyFromConfig() {
         var path = "edc.test";
 
-        var configExtMock = mock(ConfigurationExtension.class);
         Config extensionConfig = ConfigFactory.fromMap(Map.of("edc.test.entry1", "value1", "edc.test.entry2", "value2"));
-        when(configExtMock.getConfig()).thenReturn(extensionConfig);
-        when(serviceLocatorMock.loadImplementors(eq(ConfigurationExtension.class), anyBoolean())).thenReturn(List.of(configExtMock));
+        when(configuration.getConfig()).thenReturn(extensionConfig);
         context.initialize();
 
         var config = context.getConfig(path);
@@ -81,10 +64,8 @@ class DefaultServiceExtensionContextTest {
     void getConfig_withOtherProperties() {
         var path = "edc.test";
 
-        var configExtMock = mock(ConfigurationExtension.class);
         Config extensionConfig = ConfigFactory.fromMap(Map.of("edc.test.entry1", "value1", "edc.test.entry2", "value2"));
-        when(configExtMock.getConfig()).thenReturn(extensionConfig);
-        when(serviceLocatorMock.loadImplementors(eq(ConfigurationExtension.class), anyBoolean())).thenReturn(List.of(configExtMock));
+        when(configuration.getConfig()).thenReturn(extensionConfig);
         System.setProperty("edc.test.entry3", "foo");
 
         context.initialize();
@@ -103,10 +84,8 @@ class DefaultServiceExtensionContextTest {
     void getConfig_withOtherPropertiesOverlapping() {
         var path = "edc.test";
 
-        var configExtMock = mock(ConfigurationExtension.class);
         Config extensionConfig = ConfigFactory.fromMap(Map.of("edc.test.entry1", "value1", "edc.test.entry2", "value2"));
-        when(configExtMock.getConfig()).thenReturn(extensionConfig);
-        when(serviceLocatorMock.loadImplementors(eq(ConfigurationExtension.class), anyBoolean())).thenReturn(List.of(configExtMock));
+        when(configuration.getConfig()).thenReturn(extensionConfig);
         System.setProperty("edc.test.entry2", "foo");
 
         context.initialize();
@@ -122,175 +101,8 @@ class DefaultServiceExtensionContextTest {
     }
 
     @Test
-    @DisplayName("No dependencies between service extensions")
-    void loadServiceExtensions_noDependencies() {
-
-        var service1 = new ServiceExtension() {
-        };
-        when(serviceLocatorMock.loadImplementors(eq(ServiceExtension.class), anyBoolean())).thenReturn(mutableListOf(service1, coreExtension));
-
-        var list = context.loadServiceExtensions();
-
-        assertThat(list).hasSize(2);
-        assertThat(list).extracting(InjectionContainer::getInjectionTarget).contains(service1);
-        verify(serviceLocatorMock).loadImplementors(eq(ServiceExtension.class), anyBoolean());
-    }
-
-    @Test
-    @DisplayName("Locating two service extensions for the same service class ")
-    void loadServiceExtensions_whenMultipleServices() {
-        var service1 = new ServiceExtension() {
-        };
-        var service2 = new ServiceExtension() {
-        };
-
-        when(serviceLocatorMock.loadImplementors(eq(ServiceExtension.class), anyBoolean())).thenReturn(mutableListOf(service1, service2, coreExtension));
-
-        var list = context.loadServiceExtensions();
-        assertThat(list).hasSize(3);
-        assertThat(list).extracting(InjectionContainer::getInjectionTarget).containsExactlyInAnyOrder(service1, service2, coreExtension);
-        verify(serviceLocatorMock).loadImplementors(eq(ServiceExtension.class), anyBoolean());
-    }
-
-    @Test
-    @DisplayName("A DEFAULT service extension depends on a PRIMORDIAL one")
-    void loadServiceExtensions_withBackwardsDependency() {
-        var depending = new DependingExtension();
-        var someExtension = new SomeExtension();
-        var providing = new ProvidingExtension();
-
-        when(serviceLocatorMock.loadImplementors(eq(ServiceExtension.class), anyBoolean())).thenReturn(mutableListOf(providing, depending, someExtension, coreExtension));
-
-        var services = context.loadServiceExtensions();
-        assertThat(services).extracting(InjectionContainer::getInjectionTarget).containsExactly(coreExtension, providing, depending, someExtension);
-        verify(serviceLocatorMock).loadImplementors(eq(ServiceExtension.class), anyBoolean());
-    }
-
-
-    @Test
-    @DisplayName("A service extension has a dependency on another one of the same loading stage")
-    void loadServiceExtensions_withEqualDependency() {
-        var depending = new DependingExtension() {
-        };
-        var coreService = new SomeExtension() {
-        };
-
-        var thirdService = new ServiceExtension() {
-        };
-
-        when(serviceLocatorMock.loadImplementors(eq(ServiceExtension.class), anyBoolean())).thenReturn(mutableListOf(depending, thirdService, coreService, coreExtension));
-
-        var services = context.loadServiceExtensions();
-        assertThat(services).extracting(InjectionContainer::getInjectionTarget).containsExactlyInAnyOrder(coreService, depending, thirdService, coreExtension);
-        verify(serviceLocatorMock).loadImplementors(eq(ServiceExtension.class), anyBoolean());
-    }
-
-    @Test
-    @DisplayName("Two service extensions have a circular dependency")
-    void loadServiceExtensions_withCircularDependency() {
-        var s1 = new TestProvidingExtension2();
-        var s2 = new TestProvidingExtension();
-
-        when(serviceLocatorMock.loadImplementors(eq(ServiceExtension.class), anyBoolean())).thenReturn(mutableListOf(s1, s2, coreExtension));
-
-        assertThatThrownBy(() -> context.loadServiceExtensions()).isInstanceOf(CyclicDependencyException.class);
-        verify(serviceLocatorMock).loadImplementors(eq(ServiceExtension.class), anyBoolean());
-    }
-
-    @Test
-    @DisplayName("A service extension has an unsatisfied dependency")
-    void loadServiceExtensions_dependencyNotSatisfied() {
-        var depending = new DependingExtension();
-        var someExtension = new SomeExtension();
-
-        when(serviceLocatorMock.loadImplementors(eq(ServiceExtension.class), anyBoolean())).thenReturn(mutableListOf(depending, someExtension, coreExtension));
-
-        assertThatThrownBy(() -> context.loadServiceExtensions()).isInstanceOf(EdcException.class).hasMessageContaining("The following injected fields were not provided:\nField \"someService\" of type ");
-        verify(serviceLocatorMock).loadImplementors(eq(ServiceExtension.class), anyBoolean());
-    }
-
-    @Test
-    @DisplayName("Services extensions are sorted by dependency order")
-    void loadServiceExtensions_dependenciesAreSorted() {
-        var depending = new DependingExtension();
-        var providingExtension = new ProvidingExtension();
-
-
-        when(serviceLocatorMock.loadImplementors(eq(ServiceExtension.class), anyBoolean())).thenReturn(mutableListOf(depending, providingExtension, coreExtension));
-
-        var services = context.loadServiceExtensions();
-        assertThat(services).extracting(InjectionContainer::getInjectionTarget).containsExactly(coreExtension, providingExtension, depending);
-        verify(serviceLocatorMock).loadImplementors(eq(ServiceExtension.class), anyBoolean());
-    }
-
-    @Test
-    @DisplayName("Should throw exception when no core dependency found")
-    void noCoreDependency_shouldThrowException() {
-        var depending = new DependingExtension();
-        var coreService = new SomeExtension();
-
-        when(serviceLocatorMock.loadImplementors(eq(ServiceExtension.class), anyBoolean())).thenReturn(mutableListOf(depending, coreService));
-
-        assertThatThrownBy(() -> context.loadServiceExtensions()).isInstanceOf(EdcException.class);
-
-    }
-
-    @Test
-    @DisplayName("Requires annotation influences ordering")
-    void loadServiceExtensions_withAnnotation() {
-        var depending = new DependingExtension();
-        var providingExtension = new ProvidingExtension();
-        var annotatedExtension = new AnnotatedExtension();
-
-        when(serviceLocatorMock.loadImplementors(eq(ServiceExtension.class), anyBoolean())).thenReturn(mutableListOf(depending, annotatedExtension, providingExtension, coreExtension));
-
-        var services = context.loadServiceExtensions();
-        assertThat(services).extracting(InjectionContainer::getInjectionTarget).containsExactly(coreExtension, providingExtension, depending, annotatedExtension);
-        verify(serviceLocatorMock).loadImplementors(eq(ServiceExtension.class), anyBoolean());
-    }
-
-    @Test
-    @DisplayName("Requires annotation not satisfied")
-    void loadServiceExtensions_withAnnotation_notSatisfied() {
-        var annotatedExtension = new AnnotatedExtension();
-
-        when(serviceLocatorMock.loadImplementors(eq(ServiceExtension.class), anyBoolean())).thenReturn(mutableListOf(annotatedExtension, coreExtension));
-
-        assertThatThrownBy(() -> context.loadServiceExtensions()).isNotInstanceOf(EdcInjectionException.class).isInstanceOf(EdcException.class);
-        verify(serviceLocatorMock).loadImplementors(eq(ServiceExtension.class), anyBoolean());
-    }
-
-    @Test
-    @DisplayName("Mixed requirement features work")
-    void loadServiceExtensions_withMixedInjectAndAnnotation() {
-        var providingExtension = new ProvidingExtension(); // provides SomeObject
-        var anotherProvidingExt = new AnotherProvidingExtension(); //provides AnotherObject
-        var mixedAnnotation = new MixedAnnotation();
-
-        when(serviceLocatorMock.loadImplementors(eq(ServiceExtension.class), anyBoolean())).thenReturn(mutableListOf(mixedAnnotation, providingExtension, coreExtension, anotherProvidingExt));
-
-        var services = context.loadServiceExtensions();
-        assertThat(services).extracting(InjectionContainer::getInjectionTarget).containsExactly(coreExtension, providingExtension, anotherProvidingExt, mixedAnnotation);
-        verify(serviceLocatorMock).loadImplementors(eq(ServiceExtension.class), anyBoolean());
-    }
-
-    @Test
-    @DisplayName("Mixed requirement features introducing circular dependency")
-    void loadServiceExtensions_withMixedInjectAndAnnotation_withCircDependency() {
-        var s1 = new TestProvidingExtension3();
-        var s2 = new TestProvidingExtension();
-
-        when(serviceLocatorMock.loadImplementors(eq(ServiceExtension.class), anyBoolean())).thenReturn(mutableListOf(s1, s2, coreExtension));
-
-        assertThatThrownBy(() -> context.loadServiceExtensions()).isInstanceOf(CyclicDependencyException.class);
-        verify(serviceLocatorMock).loadImplementors(eq(ServiceExtension.class), anyBoolean());
-    }
-
-    @Test
     void get_setting_returns_the_setting_from_the_configuration_extension() {
-        var configuration = mock(ConfigurationExtension.class);
         when(configuration.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of("key", "value")));
-        when(serviceLocatorMock.loadImplementors(ConfigurationExtension.class, false)).thenReturn(List.of(configuration));
         context.initialize();
 
         var setting = context.getSetting("key", "default");
@@ -300,9 +112,7 @@ class DefaultServiceExtensionContextTest {
 
     @Test
     void get_setting_returns_default_value_if_setting_is_not_found() {
-        var configuration = mock(ConfigurationExtension.class);
         when(configuration.getConfig()).thenReturn(ConfigFactory.empty());
-        when(serviceLocatorMock.loadImplementors(ConfigurationExtension.class, false)).thenReturn(List.of(configuration));
         context.initialize();
 
         var setting = context.getSetting("key", "default");
@@ -313,9 +123,7 @@ class DefaultServiceExtensionContextTest {
     @Test
     @DisplayName("An environment variable in UPPER_SNAKE_CASE gets converted to dot-notation")
     void loadConfig_mapsSystemPropertyToJavaPropertyFormat() {
-        var configuration = mock(ConfigurationExtension.class);
         when(configuration.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of("key", "value")));
-        when(serviceLocatorMock.loadImplementors(ConfigurationExtension.class, false)).thenReturn(List.of(configuration));
         context = Mockito.spy(context);
         when(context.getEnvironmentVariables()).thenReturn(Map.of("SOME_KEY", "env-val"));
         context.initialize();
@@ -330,9 +138,7 @@ class DefaultServiceExtensionContextTest {
     @Test
     @DisplayName("An environment variable in UPPER_SNAKE_CASE should overwrite app config in dot-notation")
     void loadConfig_envOverwritesAppConfig() {
-        var configuration = mock(ConfigurationExtension.class);
         when(configuration.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of("some.key", "value1")));
-        when(serviceLocatorMock.loadImplementors(ConfigurationExtension.class, false)).thenReturn(List.of(configuration));
         context = Mockito.spy(context);
         when(context.getEnvironmentVariables()).thenReturn(Map.of("SOME_KEY", "value2"));
         context.initialize();
@@ -347,9 +153,7 @@ class DefaultServiceExtensionContextTest {
     void loadConfig_systemPropOverwritesEnvVar() {
 
         System.setProperty("some.key", "value3");
-        var configuration = mock(ConfigurationExtension.class);
         when(configuration.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of("some.key", "value1")));
-        when(serviceLocatorMock.loadImplementors(ConfigurationExtension.class, false)).thenReturn(List.of(configuration));
         context = Mockito.spy(context);
         when(context.getEnvironmentVariables()).thenReturn(Map.of("SOME_KEY", "value2"));
         context.initialize();
@@ -363,62 +167,4 @@ class DefaultServiceExtensionContextTest {
         }
     }
 
-    @SafeVarargs
-    private <T> List<T> mutableListOf(T... elements) {
-        return new ArrayList<>(List.of(elements));
-    }
-
-    private static class DependingExtension implements ServiceExtension {
-        @Inject
-        private SomeObject someService;
-    }
-
-    private static class SomeExtension implements ServiceExtension {
-    }
-
-    @Provides({ SomeObject.class })
-    private static class ProvidingExtension implements ServiceExtension {
-    }
-
-    @Provides(AnotherObject.class)
-    private static class AnotherProvidingExtension implements ServiceExtension {
-    }
-
-    @Provides({ SomeObject.class })
-    private static class TestProvidingExtension implements ServiceExtension {
-        @Inject
-        AnotherObject obj;
-    }
-
-    @Provides({ AnotherObject.class })
-    private static class TestProvidingExtension2 implements ServiceExtension {
-        @Inject
-        SomeObject obj;
-    }
-
-    @Provides({ AnotherObject.class })
-    @Requires({ SomeObject.class })
-    private static class TestProvidingExtension3 implements ServiceExtension {
-    }
-
-    @Requires(SomeObject.class)
-    private static class AnnotatedExtension implements ServiceExtension {
-    }
-
-    @Requires(SomeObject.class)
-    private static class MixedAnnotation implements ServiceExtension {
-        @Inject
-        private AnotherObject obj;
-    }
-
-    private static class SomeObject {
-    }
-
-    private static class AnotherObject {
-    }
-
-    @BaseExtension
-    private static class TestCoreExtension implements ServiceExtension {
-
-    }
 }

--- a/samples/other/custom-runtime/src/main/java/org/eclipse/dataspaceconnector/demo/runtime/CustomRuntime.java
+++ b/samples/other/custom-runtime/src/main/java/org/eclipse/dataspaceconnector/demo/runtime/CustomRuntime.java
@@ -3,6 +3,7 @@ package org.eclipse.dataspaceconnector.demo.runtime;
 import org.eclipse.dataspaceconnector.boot.system.DefaultServiceExtensionContext;
 import org.eclipse.dataspaceconnector.boot.system.runtime.BaseRuntime;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.system.ConfigurationExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.telemetry.Telemetry;
@@ -10,8 +11,6 @@ import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
-
-import static org.eclipse.dataspaceconnector.boot.system.ExtensionLoader.loadTelemetry;
 
 public class CustomRuntime extends BaseRuntime {
 
@@ -31,7 +30,7 @@ public class CustomRuntime extends BaseRuntime {
     @Override
     protected @NotNull ServiceExtensionContext createContext(TypeManager typeManager, Monitor monitor, Telemetry telemetry) {
         //override the default service extension context with a super customized one
-        return new SuperCustomExtensionContext(typeManager, monitor, telemetry);
+        return new SuperCustomExtensionContext(typeManager, monitor, telemetry, loadConfigurationExtensions());
     }
 
     @Override
@@ -43,8 +42,8 @@ public class CustomRuntime extends BaseRuntime {
     }
 
     private static class SuperCustomExtensionContext extends DefaultServiceExtensionContext {
-        public SuperCustomExtensionContext(TypeManager typeManager, Monitor monitor, Telemetry telemetry) {
-            super(typeManager, monitor, telemetry);
+        public SuperCustomExtensionContext(TypeManager typeManager, Monitor monitor, Telemetry telemetry, List<ConfigurationExtension> configurationExtensions) {
+            super(typeManager, monitor, telemetry, configurationExtensions);
         }
     }
 }

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ServiceExtensionContext.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ServiceExtensionContext.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2021 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 
@@ -73,23 +74,6 @@ public interface ServiceExtensionContext extends SettingResolver {
      */
     default <T> void registerService(Class<T> type, T service) {
     }
-
-    /**
-     * Loads and orders the service extensions.
-     */
-    List<InjectionContainer<ServiceExtension>> loadServiceExtensions();
-
-    /**
-     * Loads multiple extensions, raising an exception if at least one is not found.
-     */
-    <T> List<T> loadExtensions(Class<T> type, boolean required);
-
-    /**
-     * Loads a single extension, raising an exception if one is not found.
-     */
-    @Nullable()
-    @Contract("_, true -> !null")
-    <T> T loadSingletonExtension(Class<T> type, boolean required);
 
     /**
      * Initializes the service context. This should be used to perform tasks like service registrations, etc.


### PR DESCRIPTION
## What this PR changes/adds

Moves the extension loading logic from the `DefaultServiceExtensionContext` to `ExtensionLoader`

## Why it does that

Currently `DefaultServiceExtensionContext` do a lot of things, and it's not clear why it has to load extension too. On the other hand, the `ExtensionLoader` is just a static methods container, and it seems the best place to put this kind of logic.

## Further notes

* had to put a pair of class cast on `EdcRuntime` because it has no other way to know that it has a `MultiSourceServiceLocator` service locator instance. Adding a generic class parameter to `BaseRuntime` seems a bit too much, but feedback is welcome.

## Linked Issue(s)

-

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
