### PR TITLE
test: fix flaky test

### DIFF
--- a/common/state-machine-lib/src/test/java/org/eclipse/dataspaceconnector/common/statemachine/StateMachineTest.java
+++ b/common/state-machine-lib/src/test/java/org/eclipse/dataspaceconnector/common/statemachine/StateMachineTest.java
@@ -81,7 +81,7 @@ class StateMachineTest {
         doAnswer(i -> {
             latch.countDown();
             return 0L;
-        }).when(waitStrategy).success();
+        }).when(waitStrategy).waitForMillis();
         var stateMachine = StateMachine.Builder.newInstance("test", monitor, instrumentation, waitStrategy)
                 .processor(processor)
                 .build();


### PR DESCRIPTION
## What this PR changes/adds

Fix a flaky test

## Why it does that

After #912 one test of `StateMachineTest` stated breaking randomly, caused by the change of the order of calling `waitStrategy.success` and `waitStrategy.waitForMillis`

## Further notes

-

## Linked Issue(s)

-

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
