### PR TITLE
feature:content addresses

### DIFF
--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
@@ -16,6 +16,7 @@
 package org.eclipse.dataspaceconnector.transfer.core;
 
 import org.eclipse.dataspaceconnector.spi.EdcSetting;
+import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
 import org.eclipse.dataspaceconnector.spi.command.BoundedCommandQueue;
 import org.eclipse.dataspaceconnector.spi.command.CommandHandlerRegistry;
 import org.eclipse.dataspaceconnector.spi.command.CommandRunner;
@@ -57,9 +58,9 @@ import org.eclipse.dataspaceconnector.transfer.core.transfer.TransferProcessMana
  * Provides core data transfer services to the system.
  */
 @CoreExtension
-@Provides({ StatusCheckerRegistry.class, ResourceManifestGenerator.class, TransferProcessManager.class,
+@Provides({StatusCheckerRegistry.class, ResourceManifestGenerator.class, TransferProcessManager.class,
         TransferProcessObservable.class, DataOperatorRegistry.class, DataFlowManager.class, ProvisionManager.class,
-        EndpointDataReferenceReceiverRegistry.class, EndpointDataReferenceTransformer.class })
+        EndpointDataReferenceReceiverRegistry.class, EndpointDataReferenceTransformer.class})
 public class CoreTransferExtension implements ServiceExtension {
     private static final long DEFAULT_ITERATION_WAIT = 5000; // millis
 
@@ -68,10 +69,15 @@ public class CoreTransferExtension implements ServiceExtension {
 
     @Inject
     private TransferProcessStore transferProcessStore;
+
     @Inject
     private CommandHandlerRegistry registry;
+
     @Inject
     private RemoteMessageDispatcherRegistry dispatcherRegistry;
+
+    @Inject
+    private DataAddressResolver addressResolver;
 
     private TransferProcessManagerImpl processManager;
 
@@ -137,6 +143,7 @@ public class CoreTransferExtension implements ServiceExtension {
                 .observable(observable)
                 .store(transferProcessStore)
                 .batchSize(context.getSetting(TRANSFER_STATE_MACHINE_BATCH_SIZE, 5))
+                .addressResolver(addressResolver)
                 .build();
 
         context.registerService(TransferProcessManager.class, processManager);

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
@@ -41,6 +41,7 @@ import org.eclipse.dataspaceconnector.spi.transfer.retry.TransferWaitStrategy;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedContentResource;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.StatusCheckerRegistry;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.command.TransferProcessCommand;
 import org.eclipse.dataspaceconnector.transfer.core.command.handlers.AddProvisionedResourceCommandHandler;
@@ -165,5 +166,6 @@ public class CoreTransferExtension implements ServiceExtension {
 
     private void registerTypes(TypeManager typeManager) {
         typeManager.registerTypes(DataRequest.class);
+        typeManager.registerTypes(ProvisionedContentResource.class);
     }
 }

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/provision/ResourceManifestGeneratorImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/provision/ResourceManifestGeneratorImpl.java
@@ -15,65 +15,54 @@
 package org.eclipse.dataspaceconnector.transfer.core.provision;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
-import org.eclipse.dataspaceconnector.spi.transfer.provision.ResourceDefinitionGenerator;
+import org.eclipse.dataspaceconnector.spi.transfer.provision.ConsumerResourceDefinitionGenerator;
+import org.eclipse.dataspaceconnector.spi.transfer.provision.ProducerResourceDefinitionGenerator;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ResourceManifestGenerator;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceManifest;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.emptyList;
-import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess.Type.CONSUMER;
-
 /**
  * Default implementation.
  */
 public class ResourceManifestGeneratorImpl implements ResourceManifestGenerator {
-    private final List<ResourceDefinitionGenerator> consumerGenerators = new ArrayList<>();
-    private final List<ResourceDefinitionGenerator> providerGenerators = new ArrayList<>();
+    private final List<ConsumerResourceDefinitionGenerator> consumerGenerators = new ArrayList<>();
+    private final List<ProducerResourceDefinitionGenerator> providerGenerators = new ArrayList<>();
 
     @Override
-    public void registerConsumerGenerator(ResourceDefinitionGenerator generator) {
+    public void registerGenerator(ConsumerResourceDefinitionGenerator generator) {
         consumerGenerators.add(generator);
     }
 
     @Override
-    public void registerProviderGenerator(ResourceDefinitionGenerator generator) {
+    public void registerGenerator(ProducerResourceDefinitionGenerator generator) {
         providerGenerators.add(generator);
     }
 
     @Override
-    public ResourceManifest generateResourceManifest(TransferProcess process, Policy policy) {
-        var definitions = generateDefinitions(process, policy);
+    public ResourceManifest generateConsumerResourceManifest(DataRequest dataRequest, Policy policy) {
+        if (!dataRequest.isManagedResources()) {
+            return ResourceManifest.Builder.newInstance().build();
+        }
+        var definitions = consumerGenerators.stream()
+                .map(generator -> generator.generate(dataRequest, policy))
+                .filter(Objects::nonNull).collect(Collectors.toList());
+
         return ResourceManifest.Builder.newInstance().definitions(definitions).build();
     }
 
-    @NotNull
-    private List<ResourceDefinition> generateDefinitions(TransferProcess process, Policy policy) {
-        var dataRequest = process.getDataRequest();
-        if (process.getType() == CONSUMER) {
-            return dataRequest.isManagedResources() ? generateConsumerDefinitions(process, policy) : emptyList();
-        } else {
-            return generateProviderDefinitions(process, policy);
-        }
+    @Override
+    public ResourceManifest generateProviderResourceManifest(DataRequest dataRequest, DataAddress assetAddress, Policy policy) {
+        var definitions = providerGenerators.stream()
+                .map(generator -> generator.generate(dataRequest, assetAddress, policy))
+                .filter(Objects::nonNull).collect(Collectors.toList());
+
+        return ResourceManifest.Builder.newInstance().definitions(definitions).build();
     }
 
-    @NotNull
-    private List<ResourceDefinition> generateConsumerDefinitions(TransferProcess process, Policy policy) {
-        return consumerGenerators.stream()
-                .map(generator -> generator.generate(process, policy))
-                .filter(Objects::nonNull).collect(Collectors.toList());
-    }
-
-    @NotNull
-    private List<ResourceDefinition> generateProviderDefinitions(TransferProcess process, Policy policy) {
-        return providerGenerators.stream()
-                .map(generator -> generator.generate(process, policy))
-                .filter(Objects::nonNull).collect(Collectors.toList());
-    }
 }

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/provision/ResourceManifestGeneratorImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/provision/ResourceManifestGeneratorImpl.java
@@ -16,7 +16,7 @@ package org.eclipse.dataspaceconnector.transfer.core.provision;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ConsumerResourceDefinitionGenerator;
-import org.eclipse.dataspaceconnector.spi.transfer.provision.ProducerResourceDefinitionGenerator;
+import org.eclipse.dataspaceconnector.spi.transfer.provision.ProviderResourceDefinitionGenerator;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ResourceManifestGenerator;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
  */
 public class ResourceManifestGeneratorImpl implements ResourceManifestGenerator {
     private final List<ConsumerResourceDefinitionGenerator> consumerGenerators = new ArrayList<>();
-    private final List<ProducerResourceDefinitionGenerator> providerGenerators = new ArrayList<>();
+    private final List<ProviderResourceDefinitionGenerator> providerGenerators = new ArrayList<>();
 
     @Override
     public void registerGenerator(ConsumerResourceDefinitionGenerator generator) {
@@ -40,7 +40,7 @@ public class ResourceManifestGeneratorImpl implements ResourceManifestGenerator 
     }
 
     @Override
-    public void registerGenerator(ProducerResourceDefinitionGenerator generator) {
+    public void registerGenerator(ProviderResourceDefinitionGenerator generator) {
         providerGenerators.add(generator);
     }
 

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
@@ -40,9 +40,9 @@ import org.eclipse.dataspaceconnector.spi.transfer.provision.ProvisionManager;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ResourceManifestGenerator;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
-import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionResponse;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedContentResource;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedDataDestinationResource;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedResource;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceManifest;
@@ -174,23 +174,33 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
 
         responses.stream()
                 .map(response -> {
-                    var destinationResource = response.getResource();
+                    var provisionedResource = response.getResource();
                     var secretToken = response.getSecretToken();
 
-                    if (destinationResource instanceof ProvisionedDataDestinationResource) {
-                        var dataDestinationResource = (ProvisionedDataDestinationResource) destinationResource;
-                        DataAddress dataDestination = dataDestinationResource.createDataDestination();
+                    if (provisionedResource instanceof ProvisionedDataDestinationResource) {
+                        // a data destination was provisioned by a consumer
+                        var dataDestinationResource = (ProvisionedDataDestinationResource) provisionedResource;
+                        var dataDestination = dataDestinationResource.createDataDestination();
 
                         if (secretToken != null) {
-                            String keyName = dataDestinationResource.getResourceName();
+                            var keyName = dataDestinationResource.getResourceName();
                             vault.storeSecret(keyName, typeManager.writeValueAsString(secretToken));
                             dataDestination.setKeyName(keyName);
                         }
-
                         transferProcess.getDataRequest().updateDestination(dataDestination);
+                    } else if (provisionedResource instanceof ProvisionedContentResource) {
+                        // content for the data transfer was provisioned by the provider
+                        var contentResource = (ProvisionedContentResource) provisionedResource;
+                        var contentAddress = contentResource.getContentDataAddress();
+                        if (secretToken != null) {
+                            var keyName = contentResource.getResourceName();
+                            vault.storeSecret(keyName, typeManager.writeValueAsString(secretToken));
+                            contentAddress.setKeyName(keyName);
+                        }
+                        transferProcess.addContentDataAddress(contentAddress);
                     }
 
-                    return destinationResource;
+                    return provisionedResource;
                 })
                 .forEach(transferProcess::addProvisionedResource);
 
@@ -243,6 +253,8 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
                 process.transitionError("Asset not found: " + assetId);
                 updateTransferProcess(process, l -> l.preError(process));
             }
+            // default the content address to the asset address; this may be overridden during provisioning
+            process.addContentDataAddress(dataAddress);
             manifest = manifestGenerator.generateProviderResourceManifest(dataRequest, dataAddress, policy);
         }
 

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/provision/ResourceManifestGeneratorImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/provision/ResourceManifestGeneratorImplTest.java
@@ -2,7 +2,7 @@ package org.eclipse.dataspaceconnector.transfer.core.provision;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ConsumerResourceDefinitionGenerator;
-import org.eclipse.dataspaceconnector.spi.transfer.provision.ProducerResourceDefinitionGenerator;
+import org.eclipse.dataspaceconnector.spi.transfer.provision.ProviderResourceDefinitionGenerator;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.transfer.core.TestResourceDefinition;
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.when;
 class ResourceManifestGeneratorImplTest {
 
     private final ConsumerResourceDefinitionGenerator consumerGenerator = mock(ConsumerResourceDefinitionGenerator.class);
-    private final ProducerResourceDefinitionGenerator providerGenerator = mock(ProducerResourceDefinitionGenerator.class);
+    private final ProviderResourceDefinitionGenerator providerGenerator = mock(ProviderResourceDefinitionGenerator.class);
     private final ResourceManifestGeneratorImpl generator = new ResourceManifestGeneratorImpl();
     private Policy policy;
     private DataAddress dataAddress;

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/provision/ResourceManifestGeneratorImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/provision/ResourceManifestGeneratorImplTest.java
@@ -1,10 +1,10 @@
 package org.eclipse.dataspaceconnector.transfer.core.provision;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
-import org.eclipse.dataspaceconnector.spi.transfer.provision.ResourceDefinitionGenerator;
+import org.eclipse.dataspaceconnector.spi.transfer.provision.ConsumerResourceDefinitionGenerator;
+import org.eclipse.dataspaceconnector.spi.transfer.provision.ProducerResourceDefinitionGenerator;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.eclipse.dataspaceconnector.transfer.core.TestResourceDefinition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,8 +12,6 @@ import org.junit.jupiter.api.Test;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess.Type.CONSUMER;
-import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess.Type.PROVIDER;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -21,25 +19,27 @@ import static org.mockito.Mockito.when;
 
 class ResourceManifestGeneratorImplTest {
 
-    private final ResourceDefinitionGenerator consumerGenerator = mock(ResourceDefinitionGenerator.class);
-    private final ResourceDefinitionGenerator providerGenerator = mock(ResourceDefinitionGenerator.class);
+    private final ConsumerResourceDefinitionGenerator consumerGenerator = mock(ConsumerResourceDefinitionGenerator.class);
+    private final ProducerResourceDefinitionGenerator providerGenerator = mock(ProducerResourceDefinitionGenerator.class);
     private final ResourceManifestGeneratorImpl generator = new ResourceManifestGeneratorImpl();
     private Policy policy;
+    private DataAddress dataAddress;
 
     @BeforeEach
     void setUp() {
-        generator.registerConsumerGenerator(consumerGenerator);
-        generator.registerProviderGenerator(providerGenerator);
+        generator.registerGenerator(consumerGenerator);
+        generator.registerGenerator(providerGenerator);
         policy = Policy.Builder.newInstance().build();
+        dataAddress = DataAddress.Builder.newInstance().type("test").build();
     }
 
     @Test
     void shouldGenerateResourceManifestForConsumerManagedTransferProcess() {
-        var process = createTransferProcess(CONSUMER, true);
+        var dataRequest = createDataRequest(true);
         var resourceDefinition = TestResourceDefinition.Builder.newInstance().id(UUID.randomUUID().toString()).build();
         when(consumerGenerator.generate(any(), any())).thenReturn(resourceDefinition);
 
-        var resourceManifest = generator.generateResourceManifest(process, policy);
+        var resourceManifest = generator.generateConsumerResourceManifest(dataRequest, policy);
 
         assertThat(resourceManifest.getDefinitions()).hasSize(1).containsExactly(resourceDefinition);
         verifyNoInteractions(providerGenerator);
@@ -47,9 +47,9 @@ class ResourceManifestGeneratorImplTest {
 
     @Test
     void shouldGenerateEmptyResourceManifestForEmptyConsumerNotManagedTransferProcess() {
-        var process = createTransferProcess(CONSUMER, false);
+        var dataRequest = createDataRequest(false);
 
-        var resourceManifest = generator.generateResourceManifest(process, policy);
+        var resourceManifest = generator.generateConsumerResourceManifest(dataRequest, policy);
 
         assertThat(resourceManifest.getDefinitions()).isEmpty();
         verifyNoInteractions(consumerGenerator);
@@ -58,19 +58,18 @@ class ResourceManifestGeneratorImplTest {
 
     @Test
     void shouldGenerateResourceManifestForProviderTransferProcess() {
-        var process = createTransferProcess(PROVIDER, false);
+        var process = createDataRequest(false);
         var resourceDefinition = TestResourceDefinition.Builder.newInstance().id(UUID.randomUUID().toString()).build();
-        when(providerGenerator.generate(any(), any())).thenReturn(resourceDefinition);
+        when(providerGenerator.generate(any(), any(), any())).thenReturn(resourceDefinition);
 
-        var resourceManifest = generator.generateResourceManifest(process, policy);
+        var resourceManifest = generator.generateProviderResourceManifest(process, dataAddress, policy);
 
         assertThat(resourceManifest.getDefinitions()).hasSize(1).containsExactly(resourceDefinition);
         verifyNoInteractions(consumerGenerator);
     }
 
-    private TransferProcess createTransferProcess(TransferProcess.Type type, boolean managedResources) {
+    private DataRequest createDataRequest(boolean managedResources) {
         var destination = DataAddress.Builder.newInstance().type("any").build();
-        var dataRequest = DataRequest.Builder.newInstance().managedResources(managedResources).dataDestination(destination).build();
-        return TransferProcess.Builder.newInstance().id(UUID.randomUUID().toString()).dataRequest(dataRequest).type(type).build();
+        return DataRequest.Builder.newInstance().managedResources(managedResources).dataDestination(destination).build();
     }
 }

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplIntegrationTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplIntegrationTest.java
@@ -1,6 +1,7 @@
 package org.eclipse.dataspaceconnector.transfer.core.transfer;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
 import org.eclipse.dataspaceconnector.spi.command.CommandQueue;
 import org.eclipse.dataspaceconnector.spi.command.CommandRunner;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
@@ -54,7 +55,7 @@ class TransferProcessManagerImplIntegrationTest {
     @BeforeEach
     void setup() {
         var resourceManifest = ResourceManifest.Builder.newInstance().definitions(List.of(new TestResourceDefinition())).build();
-        when(manifestGenerator.generateResourceManifest(any(TransferProcess.class), any(Policy.class))).thenReturn(resourceManifest);
+        when(manifestGenerator.generateConsumerResourceManifest(any(DataRequest.class), any(Policy.class))).thenReturn(resourceManifest);
 
         transferProcessManager = TransferProcessManagerImpl.Builder.newInstance()
                 .provisionManager(provisionManager)
@@ -70,6 +71,7 @@ class TransferProcessManagerImplIntegrationTest {
                 .statusCheckerRegistry(mock(StatusCheckerRegistry.class))
                 .observable(mock(TransferProcessObservable.class))
                 .store(store)
+                .addressResolver(mock(DataAddressResolver.class))
                 .build();
     }
 

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.transfer.core.transfer;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
 import org.eclipse.dataspaceconnector.spi.command.CommandQueue;
 import org.eclipse.dataspaceconnector.spi.command.CommandRunner;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
@@ -114,6 +115,7 @@ class TransferProcessManagerImplTest {
                 .statusCheckerRegistry(statusCheckerRegistry)
                 .observable(mock(TransferProcessObservable.class))
                 .store(store)
+                .addressResolver(mock(DataAddressResolver.class))
                 .build();
     }
 
@@ -139,7 +141,7 @@ class TransferProcessManagerImplTest {
         var process = createTransferProcess(INITIAL);
         when(store.nextForState(eq(INITIAL.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
         var resourceManifest = ResourceManifest.Builder.newInstance().definitions(List.of(new TestResourceDefinition())).build();
-        when(manifestGenerator.generateResourceManifest(any(TransferProcess.class), any(Policy.class))).thenReturn(resourceManifest);
+        when(manifestGenerator.generateConsumerResourceManifest(any(DataRequest.class), any(Policy.class))).thenReturn(resourceManifest);
         var latch = countDownOnUpdateLatch();
 
         manager.start();

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
@@ -30,9 +30,11 @@ import org.eclipse.dataspaceconnector.spi.transfer.provision.ProvisionManager;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ResourceManifestGenerator;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DeprovisionResponse;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionResponse;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedContentResource;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedDataDestinationResource;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedResourceSet;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceManifest;
@@ -152,13 +154,44 @@ class TransferProcessManagerImplTest {
     }
 
     @Test
-    void provisioning_shouldTransitionToProvisioned() throws InterruptedException {
+    void provisioning_shouldTransitionToProvisionedOnDataDestination() throws InterruptedException {
         var process = createTransferProcess(PROVISIONING).toBuilder()
                 .resourceManifest(ResourceManifest.Builder.newInstance().definitions(List.of(new TestResourceDefinition())).build())
                 .build();
         var provisionResponse = ProvisionResponse.Builder.newInstance()
                 .resource(provisionedDataDestinationResource())
                 .build();
+        when(provisionManager.provision(any(TransferProcess.class), isA(Policy.class))).thenReturn(completedFuture(List.of(provisionResponse)));
+        when(store.nextForState(eq(PROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
+        when(store.find(process.getId())).thenReturn(process);
+        var latch = countDownOnUpdateLatch();
+
+        manager.start();
+
+        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
+        verify(store).update(argThat(p -> p.getState() == PROVISIONED.code()));
+    }
+
+    @Test
+    void provisioning_shouldTransitionToProvisionedOnContentAddress() throws InterruptedException {
+        var resourceDefinition = TestResourceDefinition.Builder.newInstance().id("3").build();
+
+        var process = createTransferProcess(PROVISIONING).toBuilder()
+                .resourceManifest(ResourceManifest.Builder.newInstance().definitions(List.of(resourceDefinition)).build())
+                .build();
+
+        var resource = ProvisionedContentResource.Builder.newInstance()
+                .resourceName("test")
+                .id("1")
+                .transferProcessId("2")
+                .resourceDefinitionId("3")
+                .contentDataAddress(DataAddress.Builder.newInstance().type("test").build())
+                .build();
+
+        var provisionResponse = ProvisionResponse.Builder.newInstance()
+                .resource(resource)
+                .build();
+
         when(provisionManager.provision(any(TransferProcess.class), isA(Policy.class))).thenReturn(completedFuture(List.of(provisionResponse)));
         when(store.nextForState(eq(PROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
         when(store.find(process.getId())).thenReturn(process);

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/build.gradle.kts
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     testImplementation(testFixtures(project(":launchers:junit")))
     testImplementation(testFixtures(project(":common:util")))
     testImplementation(project(":core:transfer"))
+    testImplementation(project(":extensions:in-memory:assetindex-memory"))
     testImplementation(project(":data-protocols:ids:ids-api-multipart-endpoint-v1"))
     testImplementation(project(":extensions:in-memory:negotiation-store-memory"))
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/MultipartControllerIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/MultipartControllerIntegrationTest.java
@@ -39,7 +39,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.getFreePort;
 import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
 
 public class MultipartControllerIntegrationTest extends AbstractMultipartControllerIntegrationTest {

--- a/extensions/aws/s3/s3-provision/src/main/java/org/eclipse/dataspaceconnector/aws/s3/provision/AwsProvisionExtension.java
+++ b/extensions/aws/s3/s3-provision/src/main/java/org/eclipse/dataspaceconnector/aws/s3/provision/AwsProvisionExtension.java
@@ -79,7 +79,7 @@ public class AwsProvisionExtension implements ServiceExtension {
 
         // register the generator
         var manifestGenerator = context.getService(ResourceManifestGenerator.class);
-        manifestGenerator.registerConsumerGenerator(new S3ResourceDefinitionConsumerGenerator());
+        manifestGenerator.registerGenerator(new S3ConsumerResourceDefinitionGenerator());
 
         var statusCheckerReg = context.getService(StatusCheckerRegistry.class);
         statusCheckerReg.register(S3BucketSchema.TYPE, new S3StatusChecker(clientProvider, retryPolicy));

--- a/extensions/aws/s3/s3-provision/src/main/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3ConsumerResourceDefinitionGenerator.java
+++ b/extensions/aws/s3/s3-provision/src/main/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3ConsumerResourceDefinitionGenerator.java
@@ -16,10 +16,9 @@ package org.eclipse.dataspaceconnector.aws.s3.provision;
 
 import org.eclipse.dataspaceconnector.aws.s3.core.S3BucketSchema;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
-import org.eclipse.dataspaceconnector.spi.transfer.provision.ResourceDefinitionGenerator;
-import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.eclipse.dataspaceconnector.spi.transfer.provision.ConsumerResourceDefinitionGenerator;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import software.amazon.awssdk.regions.Region;
 
 import static java.util.UUID.randomUUID;
@@ -27,23 +26,22 @@ import static java.util.UUID.randomUUID;
 /**
  * Generates S3 buckets on the consumer (requesting connector) that serve as data destinations.
  */
-public class S3ResourceDefinitionConsumerGenerator implements ResourceDefinitionGenerator {
+public class S3ConsumerResourceDefinitionGenerator implements ConsumerResourceDefinitionGenerator {
 
     @Override
-    public ResourceDefinition generate(TransferProcess process, Policy policy) {
-        var request = process.getDataRequest();
-        if (request.getDestinationType() != null) {
-            if (!S3BucketSchema.TYPE.equals(request.getDestinationType())) {
+    public ResourceDefinition generate(DataRequest dataRequest, Policy policy) {
+        if (dataRequest.getDestinationType() != null) {
+            if (!S3BucketSchema.TYPE.equals(dataRequest.getDestinationType())) {
                 return null;
             }
             // FIXME generate region from policy engine
-            return S3BucketResourceDefinition.Builder.newInstance().id(randomUUID().toString()).bucketName(process.getId()).regionId(Region.US_EAST_1.id()).build();
+            return S3BucketResourceDefinition.Builder.newInstance().id(randomUUID().toString()).bucketName(dataRequest.getProcessId()).regionId(Region.US_EAST_1.id()).build();
 
-        } else if (request.getDataDestination() == null || !(request.getDataDestination().getType().equals(S3BucketSchema.TYPE))) {
+        } else if (dataRequest.getDataDestination() == null || !(dataRequest.getDataDestination().getType().equals(S3BucketSchema.TYPE))) {
             return null;
         }
-        DataAddress destination = request.getDataDestination();
-        String id = randomUUID().toString();
+        var destination = dataRequest.getDataDestination();
+        var id = randomUUID().toString();
         return S3BucketResourceDefinition.Builder.newInstance().id(id).bucketName(destination.getProperty(S3BucketSchema.BUCKET_NAME)).regionId(destination.getProperty(S3BucketSchema.REGION)).build();
     }
 }

--- a/extensions/azure/blobstorage/blob-provision/src/main/java/org/eclipse/dataspaceconnector/provision/azure/AzureProvisionExtension.java
+++ b/extensions/azure/blobstorage/blob-provision/src/main/java/org/eclipse/dataspaceconnector/provision/azure/AzureProvisionExtension.java
@@ -20,7 +20,7 @@ import org.eclipse.dataspaceconnector.azure.blob.core.AzureSasToken;
 import org.eclipse.dataspaceconnector.azure.blob.core.api.BlobStoreApi;
 import org.eclipse.dataspaceconnector.provision.azure.blob.ObjectContainerProvisionedResource;
 import org.eclipse.dataspaceconnector.provision.azure.blob.ObjectContainerStatusChecker;
-import org.eclipse.dataspaceconnector.provision.azure.blob.ObjectStorageDefinitionConsumerGenerator;
+import org.eclipse.dataspaceconnector.provision.azure.blob.ObjectStorageConsumerResourceDefinitionGenerator;
 import org.eclipse.dataspaceconnector.provision.azure.blob.ObjectStorageProvisioner;
 import org.eclipse.dataspaceconnector.provision.azure.blob.ObjectStorageResourceDefinition;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
@@ -55,7 +55,7 @@ public class AzureProvisionExtension implements ServiceExtension {
 
         // register the generator
         var manifestGenerator = context.getService(ResourceManifestGenerator.class);
-        manifestGenerator.registerConsumerGenerator(new ObjectStorageDefinitionConsumerGenerator());
+        manifestGenerator.registerGenerator(new ObjectStorageConsumerResourceDefinitionGenerator());
 
         var statusCheckerReg = context.getService(StatusCheckerRegistry.class);
         statusCheckerReg.register(AzureBlobStoreSchema.TYPE, new ObjectContainerStatusChecker(blobStoreApi, retryPolicy));

--- a/extensions/azure/blobstorage/blob-provision/src/main/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageConsumerResourceDefinitionGenerator.java
+++ b/extensions/azure/blobstorage/blob-provision/src/main/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageConsumerResourceDefinitionGenerator.java
@@ -16,25 +16,23 @@ package org.eclipse.dataspaceconnector.provision.azure.blob;
 
 import org.eclipse.dataspaceconnector.azure.blob.core.AzureBlobStoreSchema;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
-import org.eclipse.dataspaceconnector.spi.transfer.provision.ResourceDefinitionGenerator;
-import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.eclipse.dataspaceconnector.spi.transfer.provision.ConsumerResourceDefinitionGenerator;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.jetbrains.annotations.Nullable;
 
 import static java.util.UUID.randomUUID;
 
-public class ObjectStorageDefinitionConsumerGenerator implements ResourceDefinitionGenerator {
+public class ObjectStorageConsumerResourceDefinitionGenerator implements ConsumerResourceDefinitionGenerator {
 
     @Override
-    public @Nullable ResourceDefinition generate(TransferProcess process, Policy policy) {
-        var request = process.getDataRequest();
-        if (request.getDataDestination() == null || request.getDestinationType() == null || !AzureBlobStoreSchema.TYPE.equals(request.getDestinationType())) {
+    public @Nullable ResourceDefinition generate(DataRequest dataRequest, Policy policy) {
+        if (dataRequest.getDataDestination() == null || dataRequest.getDestinationType() == null || !AzureBlobStoreSchema.TYPE.equals(dataRequest.getDestinationType())) {
             return null;
         }
 
-        DataAddress destination = request.getDataDestination();
-        String id = randomUUID().toString();
+        var destination = dataRequest.getDataDestination();
+        var id = randomUUID().toString();
         var account = destination.getProperty(AzureBlobStoreSchema.ACCOUNT_NAME);
         var container = destination.getProperty(AzureBlobStoreSchema.CONTAINER_NAME);
         if (container == null) {

--- a/extensions/azure/blobstorage/blob-provision/src/test/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageConsumerResourceDefinitionGeneratorTest.java
+++ b/extensions/azure/blobstorage/blob-provision/src/test/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageConsumerResourceDefinitionGeneratorTest.java
@@ -19,24 +19,21 @@ import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.regex.Pattern;
 
-import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ObjectStorageDefinitionConsumerGeneratorTest {
+class ObjectStorageConsumerResourceDefinitionGeneratorTest {
 
     private final Pattern regexPattern = Pattern.compile("([a-f0-9]{8}(-[a-f0-9]{4}){4}[a-f0-9]{8})");
-    private ObjectStorageDefinitionConsumerGenerator generator;
+    private ObjectStorageConsumerResourceDefinitionGenerator generator;
 
     @BeforeEach
     void setUp() {
-        generator = new ObjectStorageDefinitionConsumerGenerator();
+        generator = new ObjectStorageConsumerResourceDefinitionGenerator();
     }
 
     @Test
@@ -47,13 +44,12 @@ class ObjectStorageDefinitionConsumerGeneratorTest {
                 .build();
         var asset = Asset.Builder.newInstance().build();
         var dr = DataRequest.Builder.newInstance().dataDestination(destination).assetId(asset.getId()).build();
-        var tp = TransferProcess.Builder.newInstance().dataRequest(dr).id(randomUUID().toString()).build();
         var policy = Policy.Builder.newInstance().build();
 
-        ResourceDefinition def = generator.generate(tp, policy);
+        var definition = generator.generate(dr, policy);
 
-        assertThat(def).isInstanceOf(ObjectStorageResourceDefinition.class);
-        var objectDef = (ObjectStorageResourceDefinition) def;
+        assertThat(definition).isInstanceOf(ObjectStorageResourceDefinition.class);
+        var objectDef = (ObjectStorageResourceDefinition) definition;
         assertThat(objectDef.getAccountName()).isEqualTo("test-account");
         assertThat(objectDef.getContainerName()).isEqualTo("test-container");
         assertThat(objectDef.getId()).matches(regexPattern);
@@ -66,12 +62,11 @@ class ObjectStorageDefinitionConsumerGeneratorTest {
                 .build();
         var asset = Asset.Builder.newInstance().build();
         var dataRequest = DataRequest.Builder.newInstance().dataDestination(destination).assetId(asset.getId()).build();
-        var tp = TransferProcess.Builder.newInstance().dataRequest(dataRequest).id(randomUUID().toString()).build();
         var policy = Policy.Builder.newInstance().build();
 
-        ResourceDefinition def = generator.generate(tp, policy);
-        assertThat(def).isNotNull();
-        assertThat(((ObjectStorageResourceDefinition) def).getContainerName()).matches(
+        var definition = generator.generate(dataRequest, policy);
+        assertThat(definition).isNotNull();
+        assertThat(((ObjectStorageResourceDefinition) definition).getContainerName()).matches(
                 regexPattern);
     }
 }

--- a/samples/other/run-from-junit/src/test/java/org/eclipse/dataspaceconnector/junit/EndToEndTest.java
+++ b/samples/other/run-from-junit/src/test/java/org/eclipse/dataspaceconnector/junit/EndToEndTest.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.dataspaceconnector.junit;
 
+import org.eclipse.dataspaceconnector.dataloading.AssetLoader;
 import org.eclipse.dataspaceconnector.ids.spi.Protocols;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
@@ -34,6 +35,7 @@ import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowController;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowInitiateResult;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowManager;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.message.RemoteMessage;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
@@ -86,7 +88,7 @@ public class EndToEndTest {
     }
 
     @Test
-    void processProviderRequest(TransferProcessManager processManager, DataFlowManager dataFlowManager) throws InterruptedException {
+    void processProviderRequest(TransferProcessManager processManager, DataFlowManager dataFlowManager, AssetLoader loader) throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(1);
 
         DataFlowController controllerMock = mock(DataFlowController.class);
@@ -103,6 +105,10 @@ public class EndToEndTest {
         var connectorId = "https://test";
 
         var asset = Asset.Builder.newInstance().id(artifactId).build();
+
+        loader.accept(asset, DataAddress.Builder.newInstance().type("test").build());
+
+
         var request = DataRequest.Builder.newInstance().protocol(Protocols.IDS_MULTIPART).assetId(asset.getId())
                 .connectorId(connectorId).connectorAddress(connectorId).destinationType("S3").id(UUID.randomUUID().toString()).build();
 

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ConsumerResourceDefinitionGenerator.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ConsumerResourceDefinitionGenerator.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.transfer.provision;
+
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Generates a resource definition for a data transfer request on a consumer.
+ */
+public interface ConsumerResourceDefinitionGenerator {
+
+    /**
+     * Generates a resource definition. If no resource definition is generated, return null.
+     *
+     * @param dataRequest the data request associated with transfer process
+     * @param policy the contract agreement usage policy for the asset being transferred
+     */
+    @Nullable
+    ResourceDefinition generate(DataRequest dataRequest, Policy policy);
+
+}

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ProducerResourceDefinitionGenerator.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ProducerResourceDefinitionGenerator.java
@@ -15,22 +15,24 @@
 package org.eclipse.dataspaceconnector.spi.transfer.provision;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Generates a resource definition for a data transfer request.
+ * Generates a resource definition for a data transfer request on a provider.
  */
-public interface ResourceDefinitionGenerator {
+public interface ProducerResourceDefinitionGenerator {
 
     /**
      * Generates a resource definition. If no resource definition is generated, return null.
      *
-     * @param process the transfer process to generate the definition for
+     * @param dataRequest the data request associated with transfer process
+     * @param assetAddress the asset data address
      * @param policy the contract agreement usage policy for the asset being transferred
      */
     @Nullable
-    ResourceDefinition generate(TransferProcess process, Policy policy);
+    ResourceDefinition generate(DataRequest dataRequest, DataAddress assetAddress, Policy policy);
 
 }

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ProviderResourceDefinitionGenerator.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ProviderResourceDefinitionGenerator.java
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Generates a resource definition for a data transfer request on a provider.
  */
-public interface ProducerResourceDefinitionGenerator {
+public interface ProviderResourceDefinitionGenerator {
 
     /**
      * Generates a resource definition. If no resource definition is generated, return null.

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ResourceManifestGenerator.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ResourceManifestGenerator.java
@@ -21,7 +21,7 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceManifest;
 
 /**
- * Generates resource manifests for data transfer requests. Implementations are responsible for enforcing policy contraints associated with transfer requests.
+ * Generates resource manifests for data transfer requests. Implementations are responsible for enforcing policy constraints associated with transfer requests.
  */
 @Feature("edc:core:transfer:provision:resourcemanifest-generator")
 public interface ResourceManifestGenerator {

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ResourceManifestGenerator.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ResourceManifestGenerator.java
@@ -16,8 +16,9 @@ package org.eclipse.dataspaceconnector.spi.transfer.provision;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.system.Feature;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceManifest;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 
 /**
  * Generates resource manifests for data transfer requests. Implementations are responsible for enforcing policy contraints associated with transfer requests.
@@ -25,15 +26,34 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 @Feature("edc:core:transfer:provision:resourcemanifest-generator")
 public interface ResourceManifestGenerator {
 
-    void registerConsumerGenerator(ResourceDefinitionGenerator generator);
-
-    void registerProviderGenerator(ResourceDefinitionGenerator generator);
+    /**
+     * Registers a generator for consumer-side generation.
+     *
+     * @param generator the generator
+     */
+    void registerGenerator(ConsumerResourceDefinitionGenerator generator);
 
     /**
-     * Generates a resource manifest for a data request on a connector. Operations should be idempotent.
+     * Registers a generator for producer-side generation.
      *
-     * @param process the transfer process to generate the definition for
+     * @param generator the generator
+     */
+    void registerGenerator(ProducerResourceDefinitionGenerator generator);
+
+    /**
+     * Generates a resource manifest for a consumer-side data request. Operations must be idempotent.
+     *
+     * @param dataRequest the data request associated with transfer process
      * @param policy the contract agreement usage policy for the asset being transferred
      */
-    ResourceManifest generateResourceManifest(TransferProcess process, Policy policy);
+    ResourceManifest generateConsumerResourceManifest(DataRequest dataRequest, Policy policy);
+
+    /**
+     * Generates a resource manifest for a provider-side data request. Operations must be idempotent.
+     *
+     * @param dataRequest the data request associated with transfer process
+     * @param assetAddress the asset data address
+     * @param policy the contract agreement usage policy for the asset being transferred
+     */
+    ResourceManifest generateProviderResourceManifest(DataRequest dataRequest, DataAddress assetAddress, Policy policy);
 }

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ResourceManifestGenerator.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ResourceManifestGenerator.java
@@ -38,7 +38,7 @@ public interface ResourceManifestGenerator {
      *
      * @param generator the generator
      */
-    void registerGenerator(ProducerResourceDefinitionGenerator generator);
+    void registerGenerator(ProviderResourceDefinitionGenerator generator);
 
     /**
      * Generates a resource manifest for a consumer-side data request. Operations must be idempotent.

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionedContentResource.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionedContentResource.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2020, 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.types.domain.transfer;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+
+import java.util.Objects;
+
+/**
+ * A provisioned resource that is a content data address.
+ *
+ * This resource type is created when a provider's backend system provisions data as part of a data transfer.
+ */
+@JsonTypeName("dataspaceconnector:provisioneddcontentresource")
+@JsonDeserialize(builder = ProvisionedContentResource.Builder.class)
+public class ProvisionedContentResource extends ProvisionedResource {
+    private String resourceName;
+    private DataAddress contentDataAddress;
+
+    public String getResourceName() {
+        return resourceName;
+    }
+
+    public DataAddress getContentDataAddress() {
+        return contentDataAddress;
+    }
+
+    private ProvisionedContentResource() {
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ProvisionedResource.Builder<ProvisionedContentResource, Builder> {
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder resourceName(String name) {
+            provisionedResource.resourceName = name;
+            return this;
+        }
+
+        public Builder contentDataAddress(DataAddress dataAddress) {
+            provisionedResource.contentDataAddress = dataAddress;
+            return this;
+        }
+
+        @Override
+        protected void verify() {
+            Objects.requireNonNull(provisionedResource.resourceName, "resourceName");
+        }
+
+        private Builder() {
+            super(new ProvisionedContentResource());
+        }
+
+    }
+}

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcess.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcess.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.dataspaceconnector.spi.telemetry.TraceCarrier;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.Instant;
@@ -100,6 +101,7 @@ public class TransferProcess implements TraceCarrier {
     private Map<String, String> traceContext = new HashMap<>();
     private String errorDetail;
     private DataRequest dataRequest;
+    private DataAddress contentDataAddress;
     private ResourceManifest resourceManifest;
     private ProvisionedResourceSet provisionedResourceSet;
 
@@ -142,6 +144,10 @@ public class TransferProcess implements TraceCarrier {
         return provisionedResourceSet;
     }
 
+    public DataAddress getContentDataAddress() {
+        return contentDataAddress;
+    }
+
     public String getErrorDetail() {
         return errorDetail;
     }
@@ -161,6 +167,10 @@ public class TransferProcess implements TraceCarrier {
             provisionedResourceSet = ProvisionedResourceSet.Builder.newInstance().transferProcessId(id).build();
         }
         provisionedResourceSet.addResource(resource);
+    }
+
+    public void addContentDataAddress(DataAddress dataAddress) {
+        contentDataAddress = dataAddress;
     }
 
     public boolean provisioningComplete() {
@@ -275,8 +285,19 @@ public class TransferProcess implements TraceCarrier {
     }
 
     public TransferProcess copy() {
-        return Builder.newInstance().id(id).state(state).stateTimestamp(stateTimestamp).stateCount(stateCount).resourceManifest(resourceManifest).dataRequest(dataRequest)
-                .provisionedResourceSet(provisionedResourceSet).traceContext(traceContext).type(type).errorDetail(errorDetail).build();
+        return Builder.newInstance()
+                .id(id)
+                .state(state)
+                .stateTimestamp(stateTimestamp)
+                .stateCount(stateCount)
+                .resourceManifest(resourceManifest)
+                .dataRequest(dataRequest)
+                .provisionedResourceSet(provisionedResourceSet)
+                .contentDataAddress(contentDataAddress)
+                .traceContext(traceContext)
+                .type(type)
+                .errorDetail(errorDetail)
+                .build();
     }
 
     public Builder toBuilder() {
@@ -376,6 +397,11 @@ public class TransferProcess implements TraceCarrier {
 
         public Builder resourceManifest(ResourceManifest manifest) {
             process.resourceManifest = manifest;
+            return this;
+        }
+
+        public Builder contentDataAddress(DataAddress dataAddress) {
+            process.contentDataAddress = dataAddress;
             return this;
         }
 

--- a/spi/transfer-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionedContentResourceTest.java
+++ b/spi/transfer-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionedContentResourceTest.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.spi.types.domain.transfer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ *
+ */
+class ProvisionedContentResourceTest {
+
+    @Test
+    void verifySerializeDeserialize() throws JsonProcessingException {
+        var dataAddress = DataAddress.Builder.newInstance().type("test").build();
+        var resource = ProvisionedContentResource.Builder.newInstance()
+                .resourceName("test")
+                .contentDataAddress(dataAddress)
+                .id("1")
+                .transferProcessId("2")
+                .resourceDefinitionId("12")
+                .build();
+        var mapper = new ObjectMapper();
+        var serialized = mapper.writeValueAsString(resource);
+        var deserialized = mapper.readValue(serialized, ProvisionedContentResource.class);
+
+        assertThat(deserialized).isNotNull();
+        assertThat(deserialized.getContentDataAddress()).isNotNull();
+        assertThat(deserialized.getResourceName()).isEqualTo("test");
+        assertThat(deserialized.getId()).isEqualTo("1");
+        assertThat(deserialized.getTransferProcessId()).isEqualTo("2");
+        assertThat(deserialized.getResourceDefinitionId()).isEqualTo("12");
+    }
+}

--- a/spi/transfer-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionedContentResourceTest.java
+++ b/spi/transfer-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionedContentResourceTest.java
@@ -20,9 +20,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- *
- */
 class ProvisionedContentResourceTest {
 
     @Test

--- a/spi/transfer-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcessTest.java
+++ b/spi/transfer-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcessTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.spi.types.domain.transfer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -30,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.INITIAL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -51,13 +53,23 @@ class TransferProcessTest {
 
     @Test
     void verifyCopy() {
-        TransferProcess process = TransferProcess.Builder.newInstance().id(UUID.randomUUID().toString()).type(TransferProcess.Type.PROVIDER).state(TransferProcessStates.COMPLETED.code()).stateCount(1).stateTimestamp(1).build();
+        TransferProcess process = TransferProcess.Builder
+                .newInstance()
+                .id(UUID.randomUUID().toString())
+                .type(TransferProcess.Type.PROVIDER)
+                .state(TransferProcessStates.COMPLETED.code())
+                .contentDataAddress(DataAddress.Builder.newInstance().type("test").build())
+                .stateCount(1)
+                .stateTimestamp(1)
+                .build();
+
         TransferProcess copy = process.copy();
 
         assertEquals(process.getState(), copy.getState());
         assertEquals(process.getType(), copy.getType());
         assertEquals(process.getStateCount(), copy.getStateCount());
         assertEquals(process.getStateTimestamp(), copy.getStateTimestamp());
+        assertNotNull(process.getContentDataAddress());
 
         assertEquals(process, copy);
     }
@@ -143,7 +155,7 @@ class TransferProcessTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = TransferProcessStates.class, names = { "COMPLETED", "ENDED", "ERROR" }, mode = EnumSource.Mode.EXCLUDE)
+    @EnumSource(value = TransferProcessStates.class, names = {"COMPLETED", "ENDED", "ERROR"}, mode = EnumSource.Mode.EXCLUDE)
     void verifyCancel_validStates(TransferProcessStates state) {
         TransferProcess.Builder builder = TransferProcess.Builder.newInstance().id(UUID.randomUUID().toString());
         builder.state(state.code());
@@ -154,7 +166,7 @@ class TransferProcessTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = TransferProcessStates.class, names = { "COMPLETED", "ENDED", "ERROR" }, mode = EnumSource.Mode.INCLUDE)
+    @EnumSource(value = TransferProcessStates.class, names = {"COMPLETED", "ENDED", "ERROR"}, mode = EnumSource.Mode.INCLUDE)
     void verifyCancel_invalidStates(TransferProcessStates state) {
         TransferProcess.Builder builder = TransferProcess.Builder.newInstance().id(UUID.randomUUID().toString());
         builder.state(state.code());


### PR DESCRIPTION
In order to support HTTP-based data provisioning (https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/963), it must be possible for the provisioner to supply the EDC control plane with a data address to resolve generated data. This backend-supplied data address is a Content Data Address as described in https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/pull/976.

## What this PR changes/adds

See #977

## Linked Issue(s)


Closes #977 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
