### PR TITLE
ContractNegotiationService: refactor signature of DTO and method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ the detailed section referring to by linking pull requests or issues.
 * Call the listeners before the state transition is persisted. (#876)
 * Add an overload to `TransactionContext#execute()` (#968)
 * Run CosmosDB integration tests on cloud in CI (#964)
+* Updated the ContractNegotiation service for DataManagementApi (#985)
 * Set policy and rule target dynamically when generating contract offers (#609)
 * Add SQL-AssetIndex to support `QuerySpec` (#1014)
 * Improve provision signalling and align deprovisioning to handle error conditions (#992)

--- a/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiController.java
+++ b/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiController.java
@@ -169,14 +169,18 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
     }
 
     private boolean isValid(NegotiationInitiateRequestDto initiateDto) {
-        return StringUtils.isNoneBlank(initiateDto.getConnectorId(), initiateDto.getConnectorAddress(), initiateDto.getProtocol(), initiateDto.getOfferId());
+        return StringUtils.isNoneBlank(initiateDto.getConnectorId(), initiateDto.getConnectorAddress(), initiateDto.getProtocol(),
+                initiateDto.getOffer().getOfferId(), initiateDto.getOffer().getAssetId(), initiateDto.getOffer().getPolicyId());
     }
 
     private void handleFailedResult(ServiceResult<ContractNegotiation> result, String id) {
         switch (result.reason()) {
-            case NOT_FOUND: throw new ObjectNotFoundException(ContractNegotiation.class, id);
-            case CONFLICT: throw new ObjectExistsException(ContractNegotiation.class, id);
-            default: throw new EdcException("unexpected error");
+            case NOT_FOUND:
+                throw new ObjectNotFoundException(ContractNegotiation.class, id);
+            case CONFLICT:
+                throw new ObjectExistsException(ContractNegotiation.class, id);
+            default:
+                throw new EdcException("unexpected error");
         }
     }
 }

--- a/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiExtension.java
+++ b/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiExtension.java
@@ -35,22 +35,22 @@ import static java.util.Optional.ofNullable;
 public class ContractNegotiationApiExtension implements ServiceExtension {
 
     @Inject
-    WebService webService;
+    private WebService webService;
 
     @Inject
-    DataManagementApiConfiguration config;
+    private DataManagementApiConfiguration config;
 
     @Inject
-    DtoTransformerRegistry transformerRegistry;
+    private DtoTransformerRegistry transformerRegistry;
 
     @Inject
-    ContractNegotiationStore store;
+    private ContractNegotiationStore store;
 
     @Inject
-    ConsumerContractNegotiationManager manager;
+    private ConsumerContractNegotiationManager manager;
 
     @Inject(required = false)
-    TransactionContext transactionContext;
+    private TransactionContext transactionContext;
 
     @Override
     public void initialize(ServiceExtensionContext context) {

--- a/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/model/ContractOfferDescription.java
+++ b/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/model/ContractOfferDescription.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ContractOfferDescription {
+    private final String offerId;
+    private final String assetId;
+    private final String policyId;
+
+    @JsonCreator
+    public ContractOfferDescription(@JsonProperty("offerId") String offerId,
+                                    @JsonProperty("assetId") String assetId,
+                                    @JsonProperty("policyId") String policyId) {
+        this.offerId = offerId;
+        this.assetId = assetId;
+        this.policyId = policyId;
+    }
+
+    public String getOfferId() {
+        return offerId;
+    }
+
+    public String getAssetId() {
+        return assetId;
+    }
+
+    public String getPolicyId() {
+        return policyId;
+    }
+}

--- a/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/model/NegotiationInitiateRequestDto.java
+++ b/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/model/NegotiationInitiateRequestDto.java
@@ -14,12 +14,14 @@
 
 package org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.model;
 
+import org.jetbrains.annotations.NotNull;
+
 public class NegotiationInitiateRequestDto {
 
     private String connectorAddress;
     private String protocol = "ids-multipart";
     private String connectorId;
-    private String offerId;
+    private ContractOfferDescription offer;
 
     private NegotiationInitiateRequestDto() {
 
@@ -37,8 +39,8 @@ public class NegotiationInitiateRequestDto {
         return connectorId;
     }
 
-    public String getOfferId() {
-        return offerId;
+    public @NotNull ContractOfferDescription getOffer() {
+        return offer;
     }
 
 
@@ -68,8 +70,8 @@ public class NegotiationInitiateRequestDto {
             return this;
         }
 
-        public Builder offerId(String offerId) {
-            dto.offerId = offerId;
+        public Builder offerId(ContractOfferDescription offerId) {
+            dto.offer = offerId;
             return this;
         }
 

--- a/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformer.java
+++ b/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformer.java
@@ -18,9 +18,9 @@ import org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.mod
 import org.eclipse.dataspaceconnector.api.transformer.DtoTransformer;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractOfferRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -38,7 +38,10 @@ public class NegotiationInitiateRequestDtoToDataRequestTransformer implements Dt
     @Override
     public @Nullable ContractOfferRequest transform(@Nullable NegotiationInitiateRequestDto object, @NotNull TransformerContext context) {
         // TODO: ContractOfferRequest should contain only the contractOfferId and the contract offer should be retrieved from the catalog. Ref #985
-        var contractOffer = ContractOffer.Builder.newInstance().id(object.getOfferId()).policy(Policy.Builder.newInstance().build()).build();
+        var contractOffer = ContractOffer.Builder.newInstance()
+                .id(object.getOffer().getOfferId())
+                .asset(Asset.Builder.newInstance().id(object.getOffer().getAssetId()).build())
+                .policy(Policy.Builder.newInstance().id(object.getOffer().getPolicyId()).build()).build();
         return ContractOfferRequest.Builder.newInstance()
                 .connectorId(object.getConnectorId())
                 .connectorAddress(object.getConnectorAddress())

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.CompletableFuture;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.TestFunctions.createOffer;
 import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.getFreePort;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.REQUESTED;
 import static org.hamcrest.Matchers.is;
@@ -147,7 +148,7 @@ class ContractNegotiationApiControllerIntegrationTest {
                 .connectorId("connector")
                 .protocol(TestRemoteMessageDispatcher.TEST_PROTOCOL)
                 .connectorAddress("connectorAddress")
-                .offerId(UUID.randomUUID().toString())
+                .offerId(createOffer())
                 .build();
 
         var result = baseRequest()

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerTest.java
@@ -48,6 +48,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.TestFunctions.createOffer;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.REQUESTED;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -177,7 +178,7 @@ class ContractNegotiationApiControllerTest {
                 .connectorId("connectorId")
                 .connectorAddress("connectorAddress")
                 .protocol("protocol")
-                .offerId("offerId")
+                .offerId(createOffer("offerId"))
                 .build();
 
         var negotiationId = controller.initiateContractNegotiation(request);
@@ -192,7 +193,7 @@ class ContractNegotiationApiControllerTest {
                 .connectorId("connectorId")
                 .connectorAddress("connectorAddress")
                 .protocol("protocol")
-                .offerId("offerId")
+                .offerId(createOffer("offerId"))
                 .build();
         when(transformerRegistry.transform(any(), any())).thenReturn(Result.failure("failure"));
 
@@ -254,7 +255,7 @@ class ContractNegotiationApiControllerTest {
                 .connectorAddress(connectorAddress)
                 .connectorId(connectorId)
                 .protocol(protocol)
-                .offerId(offerId)
+                .offerId(createOffer(offerId))
                 .build();
         assertThatThrownBy(() -> controller.initiateContractNegotiation(rq)).isInstanceOf(IllegalArgumentException.class);
     }

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/TestFunctions.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/TestFunctions.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation;
+
+import org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.model.ContractOfferDescription;
+
+import java.util.UUID;
+
+public class TestFunctions {
+    public static ContractOfferDescription createOffer(String offerId, String assetId, String policyId) {
+        return new ContractOfferDescription(offerId, assetId, policyId);
+    }
+
+    public static ContractOfferDescription createOffer(String offerId) {
+        return createOffer(offerId, UUID.randomUUID().toString(), UUID.randomUUID().toString());
+    }
+
+    public static ContractOfferDescription createOffer() {
+        return createOffer(UUID.randomUUID().toString(), UUID.randomUUID().toString(), UUID.randomUUID().toString());
+    }
+}

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformerTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformerTest.java
@@ -19,6 +19,7 @@ import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.TestFunctions.createOffer;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractOfferRequest.Type.INITIAL;
 import static org.mockito.Mockito.mock;
 
@@ -39,7 +40,7 @@ class NegotiationInitiateRequestDtoToDataRequestTransformerTest {
                 .connectorId("connectorId")
                 .connectorAddress("address")
                 .protocol("protocol")
-                .offerId("offerId")
+                .offerId(createOffer("offerId"))
                 .build();
 
         var request = transformer.transform(dto, context);

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -1044,6 +1044,15 @@ components:
         contractEnd:
           type: string
           format: date-time
+    ContractOfferDescription:
+      type: object
+      properties:
+        offerId:
+          type: string
+        assetId:
+          type: string
+        policyId:
+          type: string
     ContractOfferRequest:
       type: object
       properties:
@@ -1178,8 +1187,8 @@ components:
           type: string
         connectorId:
           type: string
-        offerId:
-          type: string
+        offer:
+          $ref: '#/components/schemas/ContractOfferDescription'
     Permission:
       type: object
       properties:

--- a/resources/openapi/yaml/contractnegotiation.yaml
+++ b/resources/openapi/yaml/contractnegotiation.yaml
@@ -172,6 +172,15 @@ components:
           enum:
           - CONSUMER
           - PROVIDER
+    ContractOfferDescription:
+      type: object
+      properties:
+        offerId:
+          type: string
+        assetId:
+          type: string
+        policyId:
+          type: string
     NegotiationInitiateRequestDto:
       type: object
       properties:
@@ -181,5 +190,5 @@ components:
           type: string
         connectorId:
           type: string
-        offerId:
-          type: string
+        offer:
+          $ref: '#/components/schemas/ContractOfferDescription'

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/offer/ContractOffer.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/offer/ContractOffer.java
@@ -35,24 +35,35 @@ public class ContractOffer {
 
     /**
      * The policy that describes the usage conditions of the assets
+     * Must be mutually exclusive with {@link ContractOffer#getPolicyId()}
      */
     private Policy policy;
 
     /**
      * The offered asset
+     * Must be mutually exclusive with {@link ContractOffer#getAssetId()} ()}
      */
     private Asset asset;
-
+    /**
+     * Refers to the policy which should be involved in the negotiation. This is only used when <em>initiating</em>
+     * a negotiation and indicates, that an existing policy is to be used.
+     * Must be mutually exclusive with {@link ContractOffer#getPolicy()}
+     */
+    private String policyId;
+    /**
+     * Refers to the asset that is offered. Note that this is only to be used during the actual negotiation and cannot be
+     * used in the initial offer from the provider to the consumer.
+     * Must be mutually exclusive with {@link ContractOffer#getAsset()}
+     */
+    private String assetId;
     /**
      * The participant who provides the offered data
      */
     private URI provider;
-
     /**
      * The participant consuming the offered data
      */
     private URI consumer;
-
     /**
      * Timestamp defining the start time when the offer becomes effective
      */
@@ -61,7 +72,6 @@ public class ContractOffer {
      * Timestamp defining the end date when the offer becomes ineffective
      */
     private ZonedDateTime offerEnd;
-
     /**
      * Timestamp defining the start date when the contract becomes effective
      */
@@ -70,6 +80,16 @@ public class ContractOffer {
      * Timestamp defining the end date when the contract becomes terminated
      */
     private ZonedDateTime contractEnd;
+
+    @Nullable
+    public String getPolicyId() {
+        return policyId;
+    }
+
+    @Nullable
+    public String getAssetId() {
+        return assetId;
+    }
 
     @NotNull
     public String getId() {
@@ -117,11 +137,6 @@ public class ContractOffer {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(id, policy, asset, provider, consumer, offerStart, offerEnd, contractStart, contractEnd);
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -135,6 +150,11 @@ public class ContractOffer {
                 Objects.equals(contractStart, that.contractStart) && Objects.equals(contractEnd, that.contractEnd);
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, policy, asset, provider, consumer, offerStart, offerEnd, contractStart, contractEnd);
+    }
+
     @JsonPOJOBuilder(withPrefix = "")
     public static final class Builder {
         private Asset asset;
@@ -146,6 +166,8 @@ public class ContractOffer {
         private ZonedDateTime offerEnd;
         private ZonedDateTime contractStart;
         private ZonedDateTime contractEnd;
+        private String assetId;
+        private String policyId;
 
         private Builder() {
         }
@@ -200,20 +222,46 @@ public class ContractOffer {
             return this;
         }
 
+        public Builder policyId(String policyId) {
+            this.policyId = policyId;
+            return this;
+        }
+
+        public Builder assetId(String assetId) {
+            this.assetId = assetId;
+            return this;
+        }
+
         public ContractOffer build() {
-            Objects.requireNonNull(policy);
             Objects.requireNonNull(id);
 
+            // check mutual exclusivity
+            if (policyId != null && policy != null) {
+                throw new IllegalArgumentException("policy and policyId are mutually exclusive");
+            }
+            if (assetId != null && asset != null) {
+                throw new IllegalArgumentException("asset and assetId are mutually exclusive");
+            }
+
+            if (policy == null && policyId == null) {
+                throw new IllegalArgumentException("either policy or policyId must be set");
+            }
+            if (asset == null && assetId == null) {
+                throw new IllegalArgumentException("either asset or assetId must be set");
+            }
+
             ContractOffer offer = new ContractOffer();
-            offer.id = this.id;
-            offer.policy = this.policy;
-            offer.asset = this.asset;
-            offer.provider = this.provider;
-            offer.consumer = this.consumer;
-            offer.offerStart = this.offerStart;
-            offer.offerEnd = this.offerEnd;
-            offer.contractStart = this.contractStart;
-            offer.contractEnd = this.contractEnd;
+            offer.id = id;
+            offer.policy = policy;
+            offer.asset = asset;
+            offer.provider = provider;
+            offer.consumer = consumer;
+            offer.offerStart = offerStart;
+            offer.offerEnd = offerEnd;
+            offer.contractStart = contractStart;
+            offer.contractEnd = contractEnd;
+            offer.assetId = assetId;
+            offer.policyId = policyId;
             return offer;
         }
     }

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/offer/ContractOffer.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/offer/ContractOffer.java
@@ -246,9 +246,6 @@ public class ContractOffer {
             if (policy == null && policyId == null) {
                 throw new IllegalArgumentException("either policy or policyId must be set");
             }
-            if (asset == null && assetId == null) {
-                throw new IllegalArgumentException("either asset or assetId must be set");
-            }
 
             ContractOffer offer = new ContractOffer();
             offer.id = id;

--- a/spi/contract-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/offer/ContractOfferTest.java
+++ b/spi/contract-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/offer/ContractOfferTest.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.types.domain.contract.offer;
+
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ContractOfferTest {
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Test
+    void verifyMutualExclusivity() {
+        var p = ContractOffer.Builder.newInstance().id("test-offer");
+
+        assertThatThrownBy(() -> p.asset(Asset.Builder.newInstance().id("test-asset").build())
+                .assetId("another-asset").build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("asset and assetId are mutually exclusive");
+
+        assertThatThrownBy(() -> p.policy(Policy.Builder.newInstance().build())
+                .policyId("some-policy").build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("policy and policyId are mutually exclusive");
+    }
+
+    @Test
+    void verifyRequiredFields() {
+        assertThatThrownBy(() -> ContractOffer.Builder.newInstance().build()).isInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> ContractOffer.Builder.newInstance().id("some-id")
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("either policy or policyId must be set");
+
+        assertThatThrownBy(() -> ContractOffer.Builder.newInstance().id("some-id")
+                .policyId("test-policyId")
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("either asset or assetId must be set");
+
+        assertThatThrownBy(() -> ContractOffer.Builder.newInstance().id("some-id")
+                .assetId("test-assetId")
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("either policy or policyId must be set");
+    }
+}

--- a/spi/contract-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/offer/ContractOfferTest.java
+++ b/spi/contract-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/offer/ContractOfferTest.java
@@ -52,12 +52,6 @@ class ContractOfferTest {
                 .hasMessage("either policy or policyId must be set");
 
         assertThatThrownBy(() -> ContractOffer.Builder.newInstance().id("some-id")
-                .policyId("test-policyId")
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("either asset or assetId must be set");
-
-        assertThatThrownBy(() -> ContractOffer.Builder.newInstance().id("some-id")
                 .assetId("test-assetId")
                 .build())
                 .isInstanceOf(IllegalArgumentException.class)


### PR DESCRIPTION
## What this PR changes/adds

Replaced the `String offerId` property in `NegotiationInitiateDto` with a new object called `ContractOfferDescription`, which is essentially a wrapper around the offer id, asset id and policy id.

## Why it does that

The IDS communication requires an `Asset` and a `Policy` to be present on a `ContractOffer`, even when sending from consumer to provider.

To avoid having a dependency onto the catalog's query endpoint, I put a shim in that creates a sparsely populated (=empty except the ID) Asset and Policy.

## Further notes

- This changes the REST API

## Linked Issue(s)

Closes #985 
## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
