### PR TITLE
fix maven artifactId transport-spi

### DIFF
--- a/spi/transport-spi/build.gradle.kts
+++ b/spi/transport-spi/build.gradle.kts
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       SAP SE - Minor fix
  *
  */
 
@@ -23,8 +24,8 @@ dependencies {
 
 publishing {
     publications {
-        create<MavenPublication>("web-spi") {
-            artifactId = "web-spi"
+        create<MavenPublication>("transport-spi") {
+            artifactId = "transport-spi"
             from(components["java"])
         }
     }


### PR DESCRIPTION
Fix cut and paste error in gradle file. Correct artifactId is transport-spi.

## Linked Issue(s)

Closes #945 

