### PR TITLE
CI: checkstyle rule for Java file headers: fix existing source files

### DIFF
--- a/common/util/src/main/java/org/eclipse/dataspaceconnector/common/collection/LruCache.java
+++ b/common/util/src/main/java/org/eclipse/dataspaceconnector/common/collection/LruCache.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.common.collection;
 
 import java.util.LinkedHashMap;

--- a/common/util/src/main/java/org/eclipse/dataspaceconnector/common/concurrency/LockException.java
+++ b/common/util/src/main/java/org/eclipse/dataspaceconnector/common/concurrency/LockException.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.common.concurrency;
 
 /**

--- a/common/util/src/main/java/org/eclipse/dataspaceconnector/common/concurrency/LockManager.java
+++ b/common/util/src/main/java/org/eclipse/dataspaceconnector/common/concurrency/LockManager.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.common.concurrency;
 
 import java.util.concurrent.TimeUnit;

--- a/common/util/src/main/java/org/eclipse/dataspaceconnector/common/stream/PartitionIterator.java
+++ b/common/util/src/main/java/org/eclipse/dataspaceconnector/common/stream/PartitionIterator.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.common.stream;
 
 import java.util.ArrayList;

--- a/common/util/src/test/java/org/eclipse/dataspaceconnector/common/collection/LruCacheTest.java
+++ b/common/util/src/test/java/org/eclipse/dataspaceconnector/common/collection/LruCacheTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.common.collection;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/common/util/src/test/java/org/eclipse/dataspaceconnector/common/concurrency/LockManagerTest.java
+++ b/common/util/src/test/java/org/eclipse/dataspaceconnector/common/concurrency/LockManagerTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.common.concurrency;
 
 import org.junit.jupiter.api.Test;

--- a/common/util/src/test/java/org/eclipse/dataspaceconnector/common/stream/PartitionIteratorTest.java
+++ b/common/util/src/test/java/org/eclipse/dataspaceconnector/common/stream/PartitionIteratorTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.common.stream;
 
 import org.junit.jupiter.api.Test;

--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/CommandHandlerRegistryImpl.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/CommandHandlerRegistryImpl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020-2022 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,6 +12,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - refactored
  *
  */
+
 package org.eclipse.dataspaceconnector.core.base;
 
 import org.eclipse.dataspaceconnector.spi.command.Command;

--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/agent/ParticipantAgentServiceImpl.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/agent/ParticipantAgentServiceImpl.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.core.base.agent;
 
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgent;

--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/policy/PolicyContextImpl.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/policy/PolicyContextImpl.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.core.base.policy;
 
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgent;

--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/policy/PolicyEngineImpl.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/policy/PolicyEngineImpl.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.core.base.policy;
 
 import org.eclipse.dataspaceconnector.policy.engine.PolicyEvaluator;

--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/policy/RuleBindingRegistryImpl.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/policy/RuleBindingRegistryImpl.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.core.base.policy;
 
 import org.eclipse.dataspaceconnector.spi.policy.RuleBindingRegistry;

--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/policy/ScopeFilter.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/policy/ScopeFilter.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.core.base.policy;
 
 import org.eclipse.dataspaceconnector.policy.model.AtomicConstraint;

--- a/core/base/src/test/java/org/eclipse/dataspaceconnector/core/CoreServicesExtensionTest.java
+++ b/core/base/src/test/java/org/eclipse/dataspaceconnector/core/CoreServicesExtensionTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.core;
 
 import org.eclipse.dataspaceconnector.policy.model.PolicyRegistrationTypes;

--- a/core/base/src/test/java/org/eclipse/dataspaceconnector/core/base/agent/ParticipantAgentServiceImplTest.java
+++ b/core/base/src/test/java/org/eclipse/dataspaceconnector/core/base/agent/ParticipantAgentServiceImplTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.core.base.agent;
 
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgentServiceExtension;

--- a/core/base/src/test/java/org/eclipse/dataspaceconnector/core/base/policy/PolicyEngineImplTest.java
+++ b/core/base/src/test/java/org/eclipse/dataspaceconnector/core/base/policy/PolicyEngineImplTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.core.base.policy;
 
 import org.eclipse.dataspaceconnector.policy.model.Action;

--- a/core/base/src/test/java/org/eclipse/dataspaceconnector/core/base/policy/RuleBindingRegistryImplTest.java
+++ b/core/base/src/test/java/org/eclipse/dataspaceconnector/core/base/policy/RuleBindingRegistryImplTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.core.base.policy;
 
 import org.eclipse.dataspaceconnector.spi.policy.PolicyEngine;

--- a/core/base/src/test/java/org/eclipse/dataspaceconnector/core/base/policy/ScopeFilterTest.java
+++ b/core/base/src/test/java/org/eclipse/dataspaceconnector/core/base/policy/ScopeFilterTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.core.base.policy;
 
 import org.eclipse.dataspaceconnector.policy.model.Action;

--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/injection/InjectorImpl.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/injection/InjectorImpl.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.boot.system.injection;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/injection/ReflectiveObjectFactory.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/injection/ReflectiveObjectFactory.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.boot.system.injection;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/util/CyclicDependencyException.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/util/CyclicDependencyException.java
@@ -31,6 +31,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.boot.util;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/util/TopologicalSort.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/util/TopologicalSort.java
@@ -31,6 +31,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.boot.util;
 
 import java.util.ArrayList;

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractNegotiationCommandExtension.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractNegotiationCommandExtension.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021-2022 Fraunhofer Institute for Software and Systems Engineering
+ *  Copyright (c) 2021 - 2022 Fraunhofer Institute for Software and Systems Engineering
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -11,6 +11,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.contract;
 
 import org.eclipse.dataspaceconnector.contract.negotiation.command.handlers.CancelNegotiationCommandHandler;

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
@@ -10,8 +10,9 @@
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
  *       Fraunhofer Institute for Software and Systems Engineering - add contract negotiation functionality
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
- *       Microsoft Corporation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
+ *       Microsoft Corporation - improvements
+ *
  */
 
 package org.eclipse.dataspaceconnector.contract;

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/NullAssetIndex.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/NullAssetIndex.java
@@ -11,6 +11,7 @@
  *       Daimler TSS GmbH - Initial API and Implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.contract;
 
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/common/ContractId.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/common/ContractId.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.contract.common;
 
 import org.jetbrains.annotations.NotNull;

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/AbstractContractNegotiationManager.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/AbstractContractNegotiationManager.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/command/commands/CancelNegotiationCommand.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/command/commands/CancelNegotiationCommand.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021-2022 Fraunhofer Institute for Software and Systems Engineering
+ *  Copyright (c) 2021 - 2022 Fraunhofer Institute for Software and Systems Engineering
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -11,6 +11,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.contract.negotiation.command.commands;
 
 /**

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/command/commands/SingleContractNegotiationCommand.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/command/commands/SingleContractNegotiationCommand.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021-2022 Fraunhofer Institute for Software and Systems Engineering
+ *  Copyright (c) 2021 - 2022 Fraunhofer Institute for Software and Systems Engineering
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -11,6 +11,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.contract.negotiation.command.commands;
 
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.command.ContractNegotiationCommand;

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/command/handlers/CancelNegotiationCommandHandler.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/command/handlers/CancelNegotiationCommandHandler.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021-2022 Fraunhofer Institute for Software and Systems Engineering
+ *  Copyright (c) 2021 - 2022 Fraunhofer Institute for Software and Systems Engineering
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -11,6 +11,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.contract.negotiation.command.handlers;
 
 import org.eclipse.dataspaceconnector.contract.negotiation.command.commands.CancelNegotiationCommand;

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/command/handlers/SingleContractNegotiationCommandHandler.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/command/handlers/SingleContractNegotiationCommandHandler.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021-2022 Fraunhofer Institute for Software and Systems Engineering
+ *  Copyright (c) 2021 - 2022 Fraunhofer Institute for Software and Systems Engineering
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -11,6 +11,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.contract.negotiation.command.handlers;
 
 import org.eclipse.dataspaceconnector.contract.negotiation.command.commands.SingleContractNegotiationCommand;

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractDefinitionServiceImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractDefinitionServiceImpl.java
@@ -10,7 +10,9 @@
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
  *       Microsoft Corporation - Refactoring
+ *
  */
+
 package org.eclipse.dataspaceconnector.contract.offer;
 
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgent;

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImpl.java
@@ -13,6 +13,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - extended method implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.contract.offer;
 
 import org.eclipse.dataspaceconnector.contract.common.ContractId;

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImpl.java
@@ -9,9 +9,10 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Fraunhofer Institute for Software and Systems Engineering
+ *       Fraunhofer Institute for Software and Systems Engineering - improvements
  *
  */
+
 package org.eclipse.dataspaceconnector.contract.validation;
 
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgentService;

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/common/ContractIdTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/common/ContractIdTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.contract.common;
 
 import org.junit.jupiter.api.Test;

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/AbstractContractNegotiationIntegrationTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/AbstractContractNegotiationIntegrationTest.java
@@ -11,6 +11,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.contract.negotiation;
 
 import org.eclipse.dataspaceconnector.contract.common.ContractId;

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -1,9 +1,5 @@
 /*
-<<<<<<< HEAD
- *  Copyright (c) 2021-2022 Fraunhofer Institute for Software and Systems Engineering
-=======
  *  Copyright (c) 2021 - 2022 Fraunhofer Institute for Software and Systems Engineering
->>>>>>> 9d998cb09 (core: add configuration setting to set state machine batch sizes)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -13,9 +9,10 @@
  *
  *  Contributors:
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
+
 package org.eclipse.dataspaceconnector.contract.negotiation;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -11,6 +11,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.contract.negotiation;
 
 import org.eclipse.dataspaceconnector.spi.result.Result;

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -1,9 +1,5 @@
 /*
-<<<<<<< HEAD
- *  Copyright (c) 2021-2022 Fraunhofer Institute for Software and Systems Engineering
-=======
  *  Copyright (c) 2021 - 2022 Fraunhofer Institute for Software and Systems Engineering
->>>>>>> 9d998cb09 (core: add configuration setting to set state machine batch sizes)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -13,9 +9,10 @@
  *
  *  Contributors:
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
+
 package org.eclipse.dataspaceconnector.contract.negotiation;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/command/ContractNegotiationCommandQueueIntegrationTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/command/ContractNegotiationCommandQueueIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021-2022 Fraunhofer Institute for Software and Systems Engineering
+ *  Copyright (c) 2021 - 2022 Fraunhofer Institute for Software and Systems Engineering
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -11,6 +11,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.contract.negotiation.command;
 
 import org.eclipse.dataspaceconnector.contract.negotiation.ConsumerContractNegotiationManagerImpl;

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/command/handlers/CancelNegotiationCommandHandlerTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/command/handlers/CancelNegotiationCommandHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021-2022 Fraunhofer Institute for Software and Systems Engineering
+ *  Copyright (c) 2021 - 2022 Fraunhofer Institute for Software and Systems Engineering
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -11,6 +11,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.contract.negotiation.command.handlers;
 
 import org.eclipse.dataspaceconnector.contract.negotiation.command.commands.CancelNegotiationCommand;

--- a/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/PolicyRegistrationTypes.java
+++ b/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/PolicyRegistrationTypes.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.policy.model;
 
 import java.util.List;

--- a/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/RuleFunction.java
+++ b/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/RuleFunction.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.policy.model;
 
 /**

--- a/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/ActionTest.java
+++ b/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/ActionTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.policy.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/AndConstraintTest.java
+++ b/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/AndConstraintTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.policy.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/AtomicConstraintTest.java
+++ b/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/AtomicConstraintTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.policy.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/DutyTest.java
+++ b/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/DutyTest.java
@@ -12,6 +12,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - added test
  *
  */
+
 package org.eclipse.dataspaceconnector.policy.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/LiteralExpressionTest.java
+++ b/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/LiteralExpressionTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.policy.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/OrConstraintTest.java
+++ b/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/OrConstraintTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.policy.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/PermissionTest.java
+++ b/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/PermissionTest.java
@@ -12,6 +12,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - added test
  *
  */
+
 package org.eclipse.dataspaceconnector.policy.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/PolicyTest.java
+++ b/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/PolicyTest.java
@@ -12,6 +12,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - added test
  *
  */
+
 package org.eclipse.dataspaceconnector.policy.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/PolicyTypeTest.java
+++ b/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/PolicyTypeTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.policy.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/XoneConstraintTest.java
+++ b/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/XoneConstraintTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.policy.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/TransferProcessCommandExtension.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/TransferProcessCommandExtension.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020-2022 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.core;
 
 import org.eclipse.dataspaceconnector.spi.command.CommandHandlerRegistry;

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/AddProvisionedResourceCommandHandler.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/AddProvisionedResourceCommandHandler.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.core.command.handlers;
 
 import org.eclipse.dataspaceconnector.spi.command.CommandHandler;

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/CancelTransferCommandHandler.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/CancelTransferCommandHandler.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020-2022 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,6 +12,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - refactored
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.core.command.handlers;
 
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/DeprovisionRequestHandler.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/DeprovisionRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020-2022 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,6 +12,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - refactored
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.core.command.handlers;
 
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/SingleTransferProcessCommandHandler.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/SingleTransferProcessCommandHandler.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020-2022 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,6 +12,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - refactored
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.core.command.handlers;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/TestProvisionedDataDestinationResource.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/TestProvisionedDataDestinationResource.java
@@ -12,6 +12,7 @@
  *       Microsoft Corporation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.core;
 
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/CancelTransferCommandHandlerTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/CancelTransferCommandHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020-2022 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.core.command.handlers;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/DeprovisionCommandHandlerTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/DeprovisionCommandHandlerTest.java
@@ -1,6 +1,6 @@
 
 /*
- *  Copyright (c) 2020-2022 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,6 +12,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.core.command.handlers;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplIntegrationTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplIntegrationTest.java
@@ -13,6 +13,7 @@
  *       Microsoft Corporation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.core.transfer;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/IdsMultipartParts.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/IdsMultipartParts.java
@@ -12,7 +12,6 @@
  *
  */
 
-
 package org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender;
 
 import org.jetbrains.annotations.NotNull;

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsMultipartApiServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsMultipartApiServiceExtension.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
- *       Fraunhofer Institute for Software and Systems Engineering
+ *       Fraunhofer Institute for Software and Systems Engineering - Improvements
  *       Daimler TSS GmbH - introduce factory to create RequestInProcessMessage
  *
  */

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/controller/MultipartController.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/controller/MultipartController.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
- *       Fraunhofer Institute for Software and Systems Engineering
+ *       Fraunhofer Institute for Software and Systems Engineering - Improvements
  *
  */
 

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ContractOfferHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ContractOfferHandler.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021-2022 Fraunhofer Institute for Software and Systems Engineering, Daimler TSS GmbH
+ *  Copyright (c) 2021 - 2022 Fraunhofer Institute for Software and Systems Engineering, Daimler TSS GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/DataCatalogDescriptionRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/DataCatalogDescriptionRequestHandler.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/AbstractMultipartControllerIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/AbstractMultipartControllerIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021-2022 Daimler TSS GmbH, Fraunhofer Institute for Software and Systems Engineering
+ *  Copyright (c) 2021 - 2022 Daimler TSS GmbH, Fraunhofer Institute for Software and Systems Engineering
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/MultipartControllerIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/MultipartControllerIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021-2022 Daimler TSS GmbH, Fraunhofer Institute for Software and Systems Engineering
+ *  Copyright (c) 2021 - 2022 Daimler TSS GmbH, Fraunhofer Institute for Software and Systems Engineering
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/policy/CustomIdsConstraintDeserializer.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/policy/CustomIdsConstraintDeserializer.java
@@ -11,6 +11,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.ids.core.policy;
 
 import com.fasterxml.jackson.core.JsonParser;

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/policy/IdsConstraintBuilder.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/policy/IdsConstraintBuilder.java
@@ -11,6 +11,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.ids.core.policy;
 
 import de.fraunhofer.iais.eis.BinaryOperator;

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/policy/IdsConstraintImpl.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/policy/IdsConstraintImpl.java
@@ -11,6 +11,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.ids.core.policy;
 
 import com.fasterxml.jackson.annotation.JsonAlias;

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImpl.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImpl.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImpl.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImpl.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/transform/IdsTransformerRegistryImpl.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/transform/IdsTransformerRegistryImpl.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.ids.core.transform;
 
 import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTransformerRegistry;

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/policy/IdsConstraintTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/policy/IdsConstraintTest.java
@@ -11,6 +11,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.ids.core.policy;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImplTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImplTest.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/transform/IdsTransformerRegistryImplTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/transform/IdsTransformerRegistryImplTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.ids.core.transform;
 
 import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTypeTransformer;

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/CatalogService.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/CatalogService.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/ConnectorService.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/ConnectorService.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/transform/IdsTransformerRegistry.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/transform/IdsTransformerRegistry.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.ids.spi.transform;
 
 import org.eclipse.dataspaceconnector.spi.transformer.TypeTransformerRegistry;

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/transform/IdsTypeTransformer.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/transform/IdsTypeTransformer.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.ids.spi.transform;
 
 import org.eclipse.dataspaceconnector.spi.transformer.TypeTransformer;

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/types/SecurityProfile.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/types/SecurityProfile.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
- *       Fraunhofer Institute for Software and Systems Engineering
+ *       Fraunhofer Institute for Software and Systems Engineering - Improvements
  *
  */
 

--- a/data-protocols/ids/ids-spi/src/test/java/org/eclipse/dataspaceconnector/ids/spi/types/SecurityProfileTest.java
+++ b/data-protocols/ids/ids-spi/src/test/java/org/eclipse/dataspaceconnector/ids/spi/types/SecurityProfileTest.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *      Fraunhofer Institute for Software and Systems Engineering - Initial Implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - Initial Implementation
  *
  */
 

--- a/data-protocols/ids/ids-token-validation/src/main/java/org/eclipse/dataspaceconnector/ids/token/validation/IdsTokenValidationServiceExtension.java
+++ b/data-protocols/ids/ids-token-validation/src/main/java/org/eclipse/dataspaceconnector/ids/token/validation/IdsTokenValidationServiceExtension.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Fraunhofer Institute for Software and Systems Engineering
+ *       Fraunhofer Institute for Software and Systems Engineering - Initial Implementation
  *
  */
 

--- a/data-protocols/ids/ids-token-validation/src/main/java/org/eclipse/dataspaceconnector/ids/token/validation/rule/IdsValidationRule.java
+++ b/data-protocols/ids/ids-token-validation/src/main/java/org/eclipse/dataspaceconnector/ids/token/validation/rule/IdsValidationRule.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Fraunhofer Institute for Software and Systems Engineering
+ *       Fraunhofer Institute for Software and Systems Engineering - Initial Implementation
  *
  */
 

--- a/data-protocols/ids/ids-token-validation/src/test/java/org/eclipse/dataspaceconnector/ids/token/validation/rule/IdsValidationRuleTest.java
+++ b/data-protocols/ids/ids-token-validation/src/test/java/org/eclipse/dataspaceconnector/ids/token/validation/rule/IdsValidationRuleTest.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Fraunhofer Institute for Software and Systems Engineering
+ *       Fraunhofer Institute for Software and Systems Engineering - Initial Implementation
  *
  */
 

--- a/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/dataspaceconnector/ids/transform/ContractAgreementToIdsContractAgreementTransformer.java
+++ b/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/dataspaceconnector/ids/transform/ContractAgreementToIdsContractAgreementTransformer.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) Fraunhofer Institute for Software and Systems Engineering
+ *  Copyright (c) 2020 - 2022 Fraunhofer Institute for Software and Systems Engineering
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at

--- a/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/dataspaceconnector/ids/transform/ConstraintToIdsLogicalConstraintTransformerTest.java
+++ b/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/dataspaceconnector/ids/transform/ConstraintToIdsLogicalConstraintTransformerTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.ids.transform;
 
 import de.fraunhofer.iais.eis.LogicalConstraint;

--- a/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/dataspaceconnector/ids/transform/IdsLogicalConstraintToConstraintTransformerTest.java
+++ b/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/dataspaceconnector/ids/transform/IdsLogicalConstraintToConstraintTransformerTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.ids.transform;
 
 import de.fraunhofer.iais.eis.BinaryOperator;

--- a/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/transformer/DtoTransformer.java
+++ b/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/transformer/DtoTransformer.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/transformer/DtoTransformerRegistryImpl.java
+++ b/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/transformer/DtoTransformerRegistryImpl.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/ClientApi.java
+++ b/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/ClientApi.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/ClientControlCatalogApi.java
+++ b/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/ClientControlCatalogApi.java
@@ -8,9 +8,10 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
+
 package org.eclipse.dataspaceconnector.api.control;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;

--- a/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/ClientControlCatalogApiController.java
+++ b/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/ClientControlCatalogApiController.java
@@ -8,9 +8,10 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
+
 package org.eclipse.dataspaceconnector.api.control;
 
 import jakarta.ws.rs.Consumes;

--- a/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/ClientController.java
+++ b/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/ClientController.java
@@ -10,7 +10,7 @@
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
  *       Fraunhofer Institute for Software and Systems Engineering - add negotiation endpoint
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiController.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiController.java
@@ -1,16 +1,17 @@
 /*
- * Copyright (c) 2022 ZF Friedrichshafen AG
+ *  Copyright (c) 2022 ZF Friedrichshafen AG
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * Contributors:
- *    ZF Friedrichshafen AG - Initial API and Implementation
- *    Microsoft Corporation - Added initiate-transfer endpoint
- *    Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial API and Implementation
+ *       Microsoft Corporation - Added initiate-transfer endpoint
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
+ *
  */
 
 package org.eclipse.dataspaceconnector.api.datamanagement.asset;

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiExtension.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiExtension.java
@@ -1,16 +1,17 @@
 /*
- * Copyright (c) 2022 ZF Friedrichshafen AG
+ *  Copyright (c) 2022 ZF Friedrichshafen AG
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * Contributors:
- *    ZF Friedrichshafen AG - Initial API and Implementation
- *    Microsoft Corporation - name refactoring
- *    Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial API and Implementation
+ *       Microsoft Corporation - name refactoring
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
+ *
  */
 
 package org.eclipse.dataspaceconnector.api.datamanagement.asset;

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/model/AssetDto.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/model/AssetDto.java
@@ -1,14 +1,15 @@
 /*
- * Copyright (c) 2022 ZF Friedrichshafen AG
+ *  Copyright (c) 2022 ZF Friedrichshafen AG
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * Contributors:
- *    ZF Friedrichshafen AG - Initial API and Implementation
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial API and Implementation
+ *
  */
 
 package org.eclipse.dataspaceconnector.api.datamanagement.asset.model;

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/model/AssetEntryDto.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/model/AssetEntryDto.java
@@ -1,14 +1,15 @@
 /*
- * Copyright (c) 2022 ZF Friedrichshafen AG
+ *  Copyright (c) 2022 ZF Friedrichshafen AG
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * Contributors:
- *    ZF Friedrichshafen AG - Initial API and Implementation
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial API and Implementation
+ *
  */
 
 package org.eclipse.dataspaceconnector.api.datamanagement.asset.model;

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/model/DataAddressDto.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/model/DataAddressDto.java
@@ -1,14 +1,15 @@
 /*
- * Copyright (c) 2022 ZF Friedrichshafen AG
+ *  Copyright (c) 2022 ZF Friedrichshafen AG
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * Contributors:
- *    ZF Friedrichshafen AG - Initial API and Implementation
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial API and Implementation
+ *
  */
 
 package org.eclipse.dataspaceconnector.api.datamanagement.asset.model;

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiControllerTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiControllerTest.java
@@ -1,16 +1,17 @@
 /*
- * Copyright (c) 2022 ZF Friedrichshafen AG
+ *  Copyright (c) 2022 ZF Friedrichshafen AG
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * Contributors:
- *    ZF Friedrichshafen AG - Initial API and Implementation
- *    Microsoft Corporation - Added initiate-transfer endpoint tests
- *    Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial API and Implementation
+ *       Microsoft Corporation - Added initiate-transfer endpoint tests
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Improvements
+ *
  */
 
 package org.eclipse.dataspaceconnector.api.datamanagement.asset;

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/TestFunctions.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/TestFunctions.java
@@ -1,14 +1,15 @@
 /*
- * Copyright (c) 2022 ZF Friedrichshafen AG
+ *  Copyright (c) 2022 ZF Friedrichshafen AG
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * Contributors:
- *    ZF Friedrichshafen AG - Initial API and Implementation
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial API and Implementation
+ *
  */
 
 package org.eclipse.dataspaceconnector.api.datamanagement.asset;

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/model/AssetDtoTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/model/AssetDtoTest.java
@@ -1,14 +1,15 @@
 /*
- * Copyright (c) 2022 ZF Friedrichshafen AG
+ *  Copyright (c) 2022 ZF Friedrichshafen AG
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * Contributors:
- *    ZF Friedrichshafen AG - Initial API and Implementation
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial API and Implementation
+ *
  */
 
 package org.eclipse.dataspaceconnector.api.datamanagement.asset.model;

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/model/AssetEntryDtoTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/model/AssetEntryDtoTest.java
@@ -1,14 +1,15 @@
 /*
- * Copyright (c) 2022 ZF Friedrichshafen AG
+ *  Copyright (c) 2022 ZF Friedrichshafen AG
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * Contributors:
- *    ZF Friedrichshafen AG - Initial API and Implementation
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial API and Implementation
+ *
  */
 
 package org.eclipse.dataspaceconnector.api.datamanagement.asset.model;

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/model/DataAddressDtoTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/model/DataAddressDtoTest.java
@@ -1,14 +1,15 @@
 /*
- * Copyright (c) 2022 ZF Friedrichshafen AG
+ *  Copyright (c) 2022 ZF Friedrichshafen AG
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * Contributors:
- *    ZF Friedrichshafen AG - Initial API and Implementation
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial API and Implementation
+ *
  */
 
 package org.eclipse.dataspaceconnector.api.datamanagement.asset.model;

--- a/extensions/api/data-management/contractagreement/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApi.java
+++ b/extensions/api/data-management/contractagreement/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApi.java
@@ -8,9 +8,10 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
+
 package org.eclipse.dataspaceconnector.api.datamanagement.contractagreement;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;

--- a/extensions/api/data-management/contractagreement/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApiController.java
+++ b/extensions/api/data-management/contractagreement/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApiController.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApi.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApi.java
@@ -8,9 +8,10 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
+
 package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiController.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiController.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiExtension.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiExtension.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/ContractDefinitionDto.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/ContractDefinitionDto.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/service/ContractDefinitionServiceImpl.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/service/ContractDefinitionServiceImpl.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/transform/ContractDefinitionDtoToContractDefinitionTransformer.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/transform/ContractDefinitionDtoToContractDefinitionTransformer.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/transform/ContractDefinitionToContractDefinitionDtoTransformer.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/transform/ContractDefinitionToContractDefinitionDtoTransformer.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiControllerIntegrationTest.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiControllerTest.java
+++ b/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiControllerTest.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/ContractDefinitionDtoTest.java
+++ b/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/ContractDefinitionDtoTest.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/service/ContractDefinitionServiceImplTest.java
+++ b/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/service/ContractDefinitionServiceImplTest.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/transform/ContractDefinitionDtoToContractDefinitionTransformerTest.java
+++ b/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/transform/ContractDefinitionDtoToContractDefinitionTransformerTest.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/transform/ContractDefinitionToContractDefinitionDtoTransformerTest.java
+++ b/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/transform/ContractDefinitionToContractDefinitionDtoTransformerTest.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApi.java
+++ b/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApi.java
@@ -8,9 +8,10 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
+
 package org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;

--- a/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiController.java
+++ b/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiController.java
@@ -1,16 +1,17 @@
 /*
- * Copyright (c) 2022 ZF Friedrichshafen AG
+ *  Copyright (c) 2022 ZF Friedrichshafen AG
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * Contributors:
- *    ZF Friedrichshafen AG - Initial API and Implementation
- *    Microsoft Corporation - Added initiate-negotiation endpoint
- *    Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial API and Implementation
+ *       Microsoft Corporation - Added initiate-negotiation endpoint
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Improvements
+ *
  */
 
 package org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation;

--- a/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiExtension.java
+++ b/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiExtension.java
@@ -1,15 +1,16 @@
 /*
- * Copyright (c) 2022 ZF Friedrichshafen AG
+ *  Copyright (c) 2022 ZF Friedrichshafen AG
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * Contributors:
- *    ZF Friedrichshafen AG - Initial API and Implementation
- *    Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial API and Implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
  */
 
 package org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation;

--- a/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/model/ContractNegotiationDto.java
+++ b/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/model/ContractNegotiationDto.java
@@ -1,14 +1,15 @@
 /*
- * Copyright (c) 2022 ZF Friedrichshafen AG
+ *  Copyright (c) 2022 ZF Friedrichshafen AG
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * Contributors:
- *   ZF Friedrichshafen AG - Initial API and Implementation
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial API and Implementation
+ *
  */
 
 package org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.model;

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/model/ContractNegotiationDtoTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/model/ContractNegotiationDtoTest.java
@@ -1,14 +1,15 @@
 /*
- * Copyright (c) 2022 ZF Friedrichshafen AG
+ *  Copyright (c) 2022 ZF Friedrichshafen AG
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * Contributors:
- *   ZF Friedrichshafen AG - Initial API and Implementation
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial API and Implementation
+ *
  */
 
 package org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.model;

--- a/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyApi.java
+++ b/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyApi.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyApiController.java
+++ b/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyApiController.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApi.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApi.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiController.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiController.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessService.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessService.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.service;
 
 import org.eclipse.dataspaceconnector.api.result.ServiceResult;

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImpl.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImpl.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.service;
 
 import org.eclipse.dataspaceconnector.api.result.ServiceResult;

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/DataRequestToDataRequestDtoTransformer.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/DataRequestToDataRequestDtoTransformer.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform;
 
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.DataRequestDto;

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessToTransferProcessDtoTransformer.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessToTransferProcessDtoTransformer.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform;
 
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.DataRequestDto;

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImplTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImplTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.service;
 
 import com.github.javafaker.Faker;

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/DataRequestToDataRequestDtoTransformerTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/DataRequestToDataRequestDtoTransformerTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform;
 
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.DataRequestDto;

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/DataRequestTransformerTestData.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/DataRequestTransformerTestData.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform;
 
 import com.github.javafaker.Faker;

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessToTransferProcessDtoTransformerTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessToTransferProcessDtoTransformerTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform;
 
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.DataRequestDto;

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessTransformerTestData.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessTransformerTestData.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform;
 
 import com.github.javafaker.Faker;

--- a/extensions/api/observability/src/main/java/org/eclipse/dataspaceconnector/api/observability/ObservabilityApi.java
+++ b/extensions/api/observability/src/main/java/org/eclipse/dataspaceconnector/api/observability/ObservabilityApi.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/extensions/api/observability/src/main/java/org/eclipse/dataspaceconnector/api/observability/ObservabilityApiController.java
+++ b/extensions/api/observability/src/main/java/org/eclipse/dataspaceconnector/api/observability/ObservabilityApiController.java
@@ -10,10 +10,9 @@
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
  *       Fraunhofer Institute for Software and Systems Engineering - add negotiation endpoint
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
-
 
 package org.eclipse.dataspaceconnector.api.observability;
 

--- a/extensions/azure/data-plane/common/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/validator/AzureStorageValidator.java
+++ b/extensions/azure/data-plane/common/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/validator/AzureStorageValidator.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.validator;
 
 

--- a/extensions/azure/data-plane/common/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/validator/AzureStorageValidatorTest.java
+++ b/extensions/azure/data-plane/common/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/validator/AzureStorageValidatorTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.validator;
 
 import org.junit.jupiter.params.ParameterizedTest;

--- a/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/DataPlaneAzureStorageExtension.java
+++ b/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/DataPlaneAzureStorageExtension.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage;
 
 import net.jodah.failsafe.RetryPolicy;

--- a/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/adapter/BlobAdapter.java
+++ b/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/adapter/BlobAdapter.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.adapter;
 
 import com.azure.storage.blob.specialized.BlockBlobClient;

--- a/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/adapter/BlobAdapterFactory.java
+++ b/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/adapter/BlobAdapterFactory.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.adapter;
 
 import com.azure.storage.blob.BlobServiceClientBuilder;

--- a/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/adapter/DefaultBlobAdapter.java
+++ b/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/adapter/DefaultBlobAdapter.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.adapter;
 
 import com.azure.storage.blob.specialized.BlockBlobClient;

--- a/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSink.java
+++ b/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSink.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline;
 
 import org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.adapter.BlobAdapterFactory;

--- a/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSinkFactory.java
+++ b/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSinkFactory.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline;
 
 import org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.adapter.BlobAdapterFactory;

--- a/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSource.java
+++ b/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSource.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline;
 
 

--- a/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSourceFactory.java
+++ b/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSourceFactory.java
@@ -3,7 +3,7 @@
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
- *  ~s://www.apache.org/licenses/LICENSE-2.0
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
  *  SPDX-License-Identifier: Apache-2.0
  *
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline;
 
 import net.jodah.failsafe.RetryPolicy;

--- a/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureDataSourceToDataSinkTest.java
+++ b/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureDataSourceToDataSinkTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline;
 
 import com.github.javafaker.Faker;

--- a/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSinkFactoryTest.java
+++ b/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSinkFactoryTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline;
 
 import com.github.javafaker.Faker;

--- a/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSourceFactoryTest.java
+++ b/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSourceFactoryTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline;
 
 import com.github.javafaker.Faker;

--- a/extensions/azure/data-plane/storage/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageTestFixtures.java
+++ b/extensions/azure/data-plane/storage/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageTestFixtures.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline;
 
 import com.github.javafaker.Faker;

--- a/extensions/azure/events/src/main/java/org/eclipse/dataspaceconnector/events/azure/AzureEventExtension.java
+++ b/extensions/azure/events/src/main/java/org/eclipse/dataspaceconnector/events/azure/AzureEventExtension.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.events.azure;
 
 import com.azure.core.credential.AzureKeyCredential;

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/CacheQueryAdapterImpl.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/CacheQueryAdapterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Microsoft Corporation
+ *  Copyright (c) 2021 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,8 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *      Microsoft Corporation - initial API and implementation
- *
+ *       Microsoft Corporation - initial API and implementation
  *
  */
 

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/QueryException.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/QueryException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Microsoft Corporation
+ *  Copyright (c) 2021 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,8 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *      Microsoft Corporation - initial API and implementation
- *
+ *       Microsoft Corporation - initial API and implementation
  *
  */
 

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/QueryNotAcceptedException.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/QueryNotAcceptedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Microsoft Corporation
+ *  Copyright (c) 2021 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,8 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *      Microsoft Corporation - initial API and implementation
- *
+ *       Microsoft Corporation - initial API and implementation
  *
  */
 

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/query/InMemoryFccQueryAdapterRegistryTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/query/InMemoryFccQueryAdapterRegistryTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.catalog.cache.query;
 
 import org.eclipse.dataspaceconnector.catalog.spi.CacheQueryAdapter;

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/QueryResponse.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/QueryResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Microsoft Corporation
+ *  Copyright (c) 2021 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,8 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *      Microsoft Corporation - initial API and implementation
- *
+ *       Microsoft Corporation - initial API and implementation
  *
  */
 

--- a/extensions/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/DataPlaneTransferClientExtension.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/DataPlaneTransferClientExtension.java
@@ -1,5 +1,6 @@
 /*
  *  Copyright (c) 2022 Amadeus
+ *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
  *  https://www.apache.org/licenses/LICENSE-2.0

--- a/extensions/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/client/DataPlaneTransferClient.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/client/DataPlaneTransferClient.java
@@ -1,5 +1,6 @@
 /*
  *  Copyright (c) 2022 Amadeus
+ *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
  *  https://www.apache.org/licenses/LICENSE-2.0

--- a/extensions/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/client/EmbeddedDataPlaneTransferClient.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/client/EmbeddedDataPlaneTransferClient.java
@@ -1,5 +1,6 @@
 /*
  *  Copyright (c) 2022 Amadeus
+ *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
  *  https://www.apache.org/licenses/LICENSE-2.0

--- a/extensions/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/client/RemoteDataPlaneTransferClient.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/client/RemoteDataPlaneTransferClient.java
@@ -1,5 +1,6 @@
 /*
  *  Copyright (c) 2022 Amadeus
+ *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
  *  https://www.apache.org/licenses/LICENSE-2.0

--- a/extensions/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/flow/DataPlaneTransferFlowController.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/flow/DataPlaneTransferFlowController.java
@@ -1,5 +1,6 @@
 /*
  *  Copyright (c) 2022 Amadeus
+ *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
  *  https://www.apache.org/licenses/LICENSE-2.0

--- a/extensions/data-plane-transfer/data-plane-transfer-client/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/TestFixtures.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-client/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/TestFixtures.java
@@ -1,5 +1,6 @@
 /*
  *  Copyright (c) 2022 Amadeus
+ *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
  *  https://www.apache.org/licenses/LICENSE-2.0

--- a/extensions/data-plane-transfer/data-plane-transfer-client/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/client/EmbeddedDataPlaneTransferClientTest.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-client/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/client/EmbeddedDataPlaneTransferClientTest.java
@@ -1,5 +1,6 @@
 /*
  *  Copyright (c) 2022 Amadeus
+ *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
  *  https://www.apache.org/licenses/LICENSE-2.0

--- a/extensions/data-plane-transfer/data-plane-transfer-client/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/client/RemoteDataPlaneTransferClientTest.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-client/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/client/RemoteDataPlaneTransferClientTest.java
@@ -1,5 +1,6 @@
 /*
  *  Copyright (c) 2022 Amadeus
+ *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
  *  https://www.apache.org/licenses/LICENSE-2.0

--- a/extensions/data-plane-transfer/data-plane-transfer-client/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/flow/DataPlaneTransferFlowControllerTest.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-client/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/flow/DataPlaneTransferFlowControllerTest.java
@@ -1,5 +1,6 @@
 /*
  *  Copyright (c) 2022 Amadeus
+ *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
  *  https://www.apache.org/licenses/LICENSE-2.0

--- a/extensions/data-plane/data-plane-api/src/main/java/org/eclipse/dataspaceconnector/dataplane/api/DataPlaneApiExtension.java
+++ b/extensions/data-plane/data-plane-api/src/main/java/org/eclipse/dataspaceconnector/dataplane/api/DataPlaneApiExtension.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.api;
 
 import okhttp3.OkHttpClient;

--- a/extensions/data-plane/data-plane-api/src/main/java/org/eclipse/dataspaceconnector/dataplane/api/response/ResponseFunctions.java
+++ b/extensions/data-plane/data-plane-api/src/main/java/org/eclipse/dataspaceconnector/dataplane/api/response/ResponseFunctions.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.api.response;
 
 import jakarta.ws.rs.core.Response;

--- a/extensions/data-plane/data-plane-api/src/test/java/org/eclipse/dataspaceconnector/dataplane/api/controller/DataPlaneTransferControllerTest.java
+++ b/extensions/data-plane/data-plane-api/src/test/java/org/eclipse/dataspaceconnector/dataplane/api/controller/DataPlaneTransferControllerTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.api.controller;
 
 import org.eclipse.dataspaceconnector.dataplane.spi.manager.DataPlaneManager;

--- a/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneFrameworkExtension.java
+++ b/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneFrameworkExtension.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.framework;
 
 import org.eclipse.dataspaceconnector.dataplane.framework.manager.DataPlaneManagerImpl;

--- a/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/manager/DataPlaneManagerImpl.java
+++ b/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/manager/DataPlaneManagerImpl.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.framework.manager;
 
 import org.eclipse.dataspaceconnector.dataplane.spi.manager.DataPlaneManager;

--- a/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/pipeline/PipelineServiceImpl.java
+++ b/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/pipeline/PipelineServiceImpl.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.framework.pipeline;
 
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSink;

--- a/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/pipeline/PipelineServiceTransferServiceImpl.java
+++ b/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/pipeline/PipelineServiceTransferServiceImpl.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.framework.pipeline;
 
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.PipelineService;

--- a/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/registry/TransferServiceRegistryImpl.java
+++ b/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/registry/TransferServiceRegistryImpl.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.framework.registry;
 
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.TransferService;

--- a/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/store/InMemoryDataPlaneStore.java
+++ b/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/store/InMemoryDataPlaneStore.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.framework.store;
 
 import org.eclipse.dataspaceconnector.common.collection.LruCache;

--- a/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneFrameworkExtensionTest.java
+++ b/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneFrameworkExtensionTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.framework;
 
 import org.eclipse.dataspaceconnector.dataplane.framework.pipeline.PipelineServiceImpl;

--- a/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/e2e/EndToEndTest.java
+++ b/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/e2e/EndToEndTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.framework.e2e;
 
 import org.eclipse.dataspaceconnector.dataplane.framework.manager.DataPlaneManagerImpl;

--- a/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/manager/DataPlaneManagerImplTest.java
+++ b/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/manager/DataPlaneManagerImplTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.framework.manager;
 
 import org.eclipse.dataspaceconnector.dataplane.framework.store.InMemoryDataPlaneStore;

--- a/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/registry/TransferServiceRegistryImplTest.java
+++ b/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/registry/TransferServiceRegistryImplTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.framework.registry;
 
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.TransferService;

--- a/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/registry/TransferServiceSelectionStrategyTest.java
+++ b/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/registry/TransferServiceSelectionStrategyTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.framework.registry;
 
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.TransferService;

--- a/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/store/InMemoryDataPlaneStoreTest.java
+++ b/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/store/InMemoryDataPlaneStoreTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.framework.store;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/dataspaceconnector/dataplane/http/DataPlaneHttpExtension.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/dataspaceconnector/dataplane/http/DataPlaneHttpExtension.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.http;
 
 import net.jodah.failsafe.RetryPolicy;

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpDataSink.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpDataSink.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.http.pipeline;
 
 import okhttp3.OkHttpClient;

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpDataSinkFactory.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpDataSinkFactory.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.http.pipeline;
 
 import okhttp3.OkHttpClient;

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpDataSource.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpDataSource.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.http.pipeline;
 
 

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpDataSourceFactory.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpDataSourceFactory.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.http.pipeline;
 
 import net.jodah.failsafe.RetryPolicy;

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/StreamingRequestBody.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/StreamingRequestBody.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.http.pipeline;
 
 import okhttp3.MediaType;

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/DataSourceToDataSinkTests.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/DataSourceToDataSinkTests.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.http.pipeline;
 
 import net.jodah.failsafe.RetryPolicy;

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpDataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpDataSinkFactoryTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.http.pipeline;
 
 import okhttp3.Call;

--- a/extensions/data-plane/data-plane-http/src/testFixtures/java/org/eclipse/dataspaceconnector/dataplane/http/HttpTestFixtures.java
+++ b/extensions/data-plane/data-plane-http/src/testFixtures/java/org/eclipse/dataspaceconnector/dataplane/http/HttpTestFixtures.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.http;
 
 import com.github.javafaker.Faker;

--- a/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/DataPlaneConstants.java
+++ b/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/DataPlaneConstants.java
@@ -12,7 +12,6 @@
  *
  */
 
-
 package org.eclipse.dataspaceconnector.dataplane.spi;
 
 public interface DataPlaneConstants {

--- a/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/manager/DataPlaneManager.java
+++ b/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/manager/DataPlaneManager.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.spi.manager;
 
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSink;

--- a/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/DataSink.java
+++ b/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/DataSink.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.spi.pipeline;
 
 import org.eclipse.dataspaceconnector.dataplane.spi.result.TransferResult;

--- a/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/DataSinkFactory.java
+++ b/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/DataSinkFactory.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.spi.pipeline;
 
 import org.eclipse.dataspaceconnector.spi.result.Result;

--- a/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/DataSource.java
+++ b/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/DataSource.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.spi.pipeline;
 
 import java.io.InputStream;

--- a/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/DataSourceFactory.java
+++ b/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/DataSourceFactory.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.spi.pipeline;
 
 import org.eclipse.dataspaceconnector.spi.result.Result;

--- a/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/InputStreamDataSource.java
+++ b/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/InputStreamDataSource.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.spi.pipeline;
 
 import java.io.InputStream;

--- a/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/OutputStreamDataSink.java
+++ b/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/OutputStreamDataSink.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.spi.pipeline;
 
 import org.eclipse.dataspaceconnector.dataplane.spi.result.TransferResult;

--- a/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSink.java
+++ b/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSink.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.spi.pipeline;
 
 import org.eclipse.dataspaceconnector.common.stream.PartitionIterator;

--- a/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/PipelineService.java
+++ b/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/PipelineService.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.spi.pipeline;
 
 import org.eclipse.dataspaceconnector.dataplane.spi.result.TransferResult;

--- a/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/TransferService.java
+++ b/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/TransferService.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.spi.pipeline;
 
 import org.eclipse.dataspaceconnector.dataplane.spi.result.TransferResult;

--- a/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/registry/TransferServiceRegistry.java
+++ b/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/registry/TransferServiceRegistry.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.spi.registry;
 
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.TransferService;

--- a/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/result/TransferResult.java
+++ b/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/result/TransferResult.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.spi.result;
 
 import org.eclipse.dataspaceconnector.spi.response.ResponseFailure;

--- a/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/store/DataPlaneStore.java
+++ b/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/store/DataPlaneStore.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.spi.store;
 
 /**

--- a/extensions/data-plane/data-plane-spi/src/test/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/InputStreamDataSourceTest.java
+++ b/extensions/data-plane/data-plane-spi/src/test/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/InputStreamDataSourceTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.spi.pipeline;
 
 import org.junit.jupiter.api.Test;

--- a/extensions/data-plane/data-plane-spi/src/test/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/OutputStreamDataSinkTest.java
+++ b/extensions/data-plane/data-plane-spi/src/test/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/OutputStreamDataSinkTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.spi.pipeline;
 
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;

--- a/extensions/dataloading/src/main/java/org/eclipse/dataspaceconnector/dataloading/AssetEntry.java
+++ b/extensions/dataloading/src/main/java/org/eclipse/dataspaceconnector/dataloading/AssetEntry.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataloading;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/extensions/dataloading/src/main/java/org/eclipse/dataspaceconnector/dataloading/AssetLoader.java
+++ b/extensions/dataloading/src/main/java/org/eclipse/dataspaceconnector/dataloading/AssetLoader.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataloading;
 
 import org.eclipse.dataspaceconnector.spi.persistence.EdcPersistenceException;

--- a/extensions/dataloading/src/main/java/org/eclipse/dataspaceconnector/dataloading/ContractDefinitionLoader.java
+++ b/extensions/dataloading/src/main/java/org/eclipse/dataspaceconnector/dataloading/ContractDefinitionLoader.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataloading;
 
 import org.eclipse.dataspaceconnector.spi.system.Feature;

--- a/extensions/dataloading/src/main/java/org/eclipse/dataspaceconnector/dataloading/DataLoader.java
+++ b/extensions/dataloading/src/main/java/org/eclipse/dataspaceconnector/dataloading/DataLoader.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataloading;
 
 

--- a/extensions/dataloading/src/main/java/org/eclipse/dataspaceconnector/dataloading/DataSink.java
+++ b/extensions/dataloading/src/main/java/org/eclipse/dataspaceconnector/dataloading/DataSink.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataloading;
 
 /**

--- a/extensions/dataloading/src/main/java/org/eclipse/dataspaceconnector/dataloading/ValidationException.java
+++ b/extensions/dataloading/src/main/java/org/eclipse/dataspaceconnector/dataloading/ValidationException.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataloading;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/extensions/dataloading/src/test/java/org/eclipse/dataspaceconnector/dataloading/DataLoaderTest.java
+++ b/extensions/dataloading/src/test/java/org/eclipse/dataspaceconnector/dataloading/DataLoaderTest.java
@@ -12,6 +12,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataloading;
 
 import org.eclipse.dataspaceconnector.spi.result.Result;

--- a/extensions/dataloading/src/test/java/org/eclipse/dataspaceconnector/dataloading/TestEntity.java
+++ b/extensions/dataloading/src/test/java/org/eclipse/dataspaceconnector/dataloading/TestEntity.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataloading;
 
 class TestEntity {

--- a/extensions/dataloading/src/test/java/org/eclipse/dataspaceconnector/dataloading/TestEntitySink.java
+++ b/extensions/dataloading/src/test/java/org/eclipse/dataspaceconnector/dataloading/TestEntitySink.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataloading;
 
 interface TestEntitySink extends DataSink<TestEntity> {

--- a/extensions/filesystem/vault-fs/src/main/java/org/eclipse/dataspaceconnector/core/security/fs/FsPrivateKeyResolver.java
+++ b/extensions/filesystem/vault-fs/src/main/java/org/eclipse/dataspaceconnector/core/security/fs/FsPrivateKeyResolver.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Fraunhofer Institute for Software and Systems Engineering
+ *       Fraunhofer Institute for Software and Systems Engineering - Improvements
  *
  */
 

--- a/extensions/filesystem/vault-fs/src/test/java/org/eclipse/dataspaceconnector/core/security/fs/FsRsaPrivateKeyResolverTest.java
+++ b/extensions/filesystem/vault-fs/src/test/java/org/eclipse/dataspaceconnector/core/security/fs/FsRsaPrivateKeyResolverTest.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Fraunhofer Institute for Software and Systems Engineering
+ *       Fraunhofer Institute for Software and Systems Engineering - Improvements
  *
  */
 

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/AbstractHttpResourceDefinition.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/AbstractHttpResourceDefinition.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.provision.http;
 
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/ConfigParser.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/ConfigParser.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.provision.http;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderProvisioner.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderProvisioner.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.provision.http;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderResourceDefinition.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderResourceDefinition.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.provision.http;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderResourceDefinitionGenerator.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderResourceDefinitionGenerator.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.provision.http;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionedContentResource.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionedContentResource.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.provision.http;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerExtension.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerExtension.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.provision.http;
 
 import okhttp3.OkHttpClient;

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerRequest.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerRequest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.provision.http;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/ProvisionerConfiguration.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/ProvisionerConfiguration.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.provision.http;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/ConfigParserTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/ConfigParserTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.provision.http;
 
 import org.eclipse.dataspaceconnector.spi.system.configuration.ConfigFactory;

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderProvisionerTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderProvisionerTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.provision.http;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderResourceDefinitionGeneratorTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderResourceDefinitionGeneratorTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.provision.http;
 
 

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderResourceDefinitionTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderResourceDefinitionTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.provision.http;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerExtensionEndToEndTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerExtensionEndToEndTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.provision.http;
 
 import okhttp3.Interceptor;

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerFixtures.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerFixtures.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.provision.http;
 
 import okhttp3.Interceptor;

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerRequestTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerRequestTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.provision.http;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/extensions/iam/decentralized-identity/identity-common-test/src/testFixtures/java/org/eclipse/dataspaceconnector/iam/did/testfixtures/TemporaryKeyLoader.java
+++ b/extensions/iam/decentralized-identity/identity-common-test/src/testFixtures/java/org/eclipse/dataspaceconnector/iam/did/testfixtures/TemporaryKeyLoader.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.testfixtures;
 
 import com.nimbusds.jose.JOSEException;

--- a/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtension.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtension.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did;
 
 import com.nimbusds.jose.JOSEException;

--- a/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/hub/IdentityHubApi.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/hub/IdentityHubApi.java
@@ -8,9 +8,10 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.hub;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;

--- a/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/hub/IdentityHubApiController.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/hub/IdentityHubApiController.java
@@ -9,9 +9,10 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.hub;
 
 import jakarta.ws.rs.Consumes;

--- a/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/hub/IdentityHubClientImpl.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/hub/IdentityHubClientImpl.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.hub;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/hub/IdentityHubImpl.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/hub/IdentityHubImpl.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.hub;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/hub/jwe/AbstractJweReader.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/hub/jwe/AbstractJweReader.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.hub.jwe;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/hub/jwe/AbstractJweWriter.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/hub/jwe/AbstractJweWriter.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.hub.jwe;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/hub/jwe/GenericJweReader.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/hub/jwe/GenericJweReader.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.hub.jwe;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/hub/jwe/WriteRequestReader.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/hub/jwe/WriteRequestReader.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.hub.jwe;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/hub/jwe/WriteRequestWriter.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/hub/jwe/WriteRequestWriter.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.hub.jwe;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/resolution/DidPublicKeyResolverImpl.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/resolution/DidPublicKeyResolverImpl.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.resolution;
 
 import org.eclipse.dataspaceconnector.iam.did.crypto.key.KeyConverter;

--- a/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/resolution/DidResolverRegistryImpl.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/resolution/DidResolverRegistryImpl.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.resolution;
 
 import org.eclipse.dataspaceconnector.iam.did.spi.document.DidDocument;

--- a/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/resolution/DidResolverRegistryImplTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/resolution/DidResolverRegistryImplTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.resolution;
 
 import org.eclipse.dataspaceconnector.iam.did.spi.document.DidDocument;

--- a/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/util/GaiaxAssumptions.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/util/GaiaxAssumptions.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.util;
 
 import org.junit.jupiter.api.Assumptions;

--- a/extensions/iam/decentralized-identity/identity-did-crypto/src/main/java/org/eclipse/dataspaceconnector/iam/did/crypto/CryptoException.java
+++ b/extensions/iam/decentralized-identity/identity-did-crypto/src/main/java/org/eclipse/dataspaceconnector/iam/did/crypto/CryptoException.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.crypto;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/extensions/iam/decentralized-identity/identity-did-crypto/src/main/java/org/eclipse/dataspaceconnector/iam/did/crypto/credentials/VerifiableCredentialFactory.java
+++ b/extensions/iam/decentralized-identity/identity-did-crypto/src/main/java/org/eclipse/dataspaceconnector/iam/did/crypto/credentials/VerifiableCredentialFactory.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.crypto.credentials;
 
 import com.nimbusds.jose.Algorithm;

--- a/extensions/iam/decentralized-identity/identity-did-crypto/src/main/java/org/eclipse/dataspaceconnector/iam/did/crypto/key/KeyPairFactory.java
+++ b/extensions/iam/decentralized-identity/identity-did-crypto/src/main/java/org/eclipse/dataspaceconnector/iam/did/crypto/key/KeyPairFactory.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2020-2021 Microsoft Corporation
+ *  Copyright (c) 2020 - 2021 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at

--- a/extensions/iam/decentralized-identity/identity-did-crypto/src/main/java/org/eclipse/dataspaceconnector/iam/did/crypto/key/RsaPrivateKeyWrapper.java
+++ b/extensions/iam/decentralized-identity/identity-did-crypto/src/main/java/org/eclipse/dataspaceconnector/iam/did/crypto/key/RsaPrivateKeyWrapper.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.crypto.key;
 
 import com.nimbusds.jose.JWEDecrypter;

--- a/extensions/iam/decentralized-identity/identity-did-crypto/src/main/java/org/eclipse/dataspaceconnector/iam/did/crypto/key/RsaPublicKeyWrapper.java
+++ b/extensions/iam/decentralized-identity/identity-did-crypto/src/main/java/org/eclipse/dataspaceconnector/iam/did/crypto/key/RsaPublicKeyWrapper.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.crypto.key;
 
 import com.nimbusds.jose.JWEAlgorithm;

--- a/extensions/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityService.java
+++ b/extensions/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityService.java
@@ -9,9 +9,10 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Fraunhofer Institute for Software and Systems Engineering
+ *       Fraunhofer Institute for Software and Systems Engineering - Improvements
  *
  */
+
 package org.eclipse.dataspaceconnector.identity;
 
 import com.nimbusds.jwt.SignedJWT;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/credentials/CredentialsVerifier.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/credentials/CredentialsVerifier.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.credentials;
 
 import org.eclipse.dataspaceconnector.iam.did.spi.key.PublicKeyWrapper;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/document/DidConstants.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/document/DidConstants.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.document;
 
 import org.eclipse.dataspaceconnector.spi.EdcSetting;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/document/DidDocument.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/document/DidDocument.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.document;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/document/DidDocumentMetadata.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/document/DidDocumentMetadata.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.document;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/document/DidResolveResponse.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/document/DidResolveResponse.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.document;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/document/EllipticCurvePublicKey.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/document/EllipticCurvePublicKey.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.document;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/document/JwkPublicKey.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/document/JwkPublicKey.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.document;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/document/Method.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/document/Method.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.document;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/document/Service.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/document/Service.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.document;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/document/VerificationMethod.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/document/VerificationMethod.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.document;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/IdentityHub.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/IdentityHub.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub;
 
 import org.eclipse.dataspaceconnector.iam.did.spi.hub.message.Commit;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/IdentityHubClient.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/IdentityHubClient.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub;
 
 import org.eclipse.dataspaceconnector.iam.did.spi.hub.message.ObjectQueryRequest;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/IdentityHubStore.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/IdentityHubStore.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub;
 
 import org.eclipse.dataspaceconnector.iam.did.spi.hub.message.Commit;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/AbstractHubRequest.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/AbstractHubRequest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import java.util.Objects;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/Commit.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/Commit.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/CommitHeader.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/CommitHeader.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/CommitQuery.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/CommitQuery.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/CommitQueryRequest.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/CommitQueryRequest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/CommitQueryResponse.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/CommitQueryResponse.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/CommitStrategy.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/CommitStrategy.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/ErrorResponse.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/ErrorResponse.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/HubMessage.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/HubMessage.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/HubMessageConstants.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/HubMessageConstants.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/HubObject.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/HubObject.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/InterfaceType.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/InterfaceType.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 /**

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/JsonCommitObject.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/JsonCommitObject.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/ObjectQuery.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/ObjectQuery.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/ObjectQueryRequest.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/ObjectQueryRequest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/ObjectQueryResponse.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/ObjectQueryResponse.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/QueryTypes.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/QueryTypes.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/WriteRequest.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/WriteRequest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/WriteResponse.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/WriteResponse.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/key/PrivateKeyWrapper.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/key/PrivateKeyWrapper.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.key;
 
 import com.nimbusds.jose.JWEDecrypter;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/key/PublicKeyWrapper.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/key/PublicKeyWrapper.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.key;
 
 import com.nimbusds.jose.EncryptionMethod;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/resolution/DidResolver.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/resolution/DidResolver.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.resolution;
 
 import org.eclipse.dataspaceconnector.iam.did.spi.document.DidDocument;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/resolution/DidResolverRegistry.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/resolution/DidResolverRegistry.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.resolution;
 
 import org.eclipse.dataspaceconnector.iam.did.spi.document.DidDocument;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/test/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/CommitQueryRequestTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/test/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/CommitQueryRequestTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/test/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/CommitQueryResponseTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/test/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/CommitQueryResponseTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/test/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/CommitQueryTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/test/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/CommitQueryTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/test/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/CommitTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/test/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/CommitTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/test/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/ErrorResponseTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/test/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/ErrorResponseTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/test/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/HubObjectTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/test/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/HubObjectTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/test/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/ObjectQueryRequestTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/test/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/ObjectQueryRequestTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/test/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/ObjectQueryResponseTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/test/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/ObjectQueryResponseTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/test/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/ObjectQueryTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/test/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/ObjectQueryTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/test/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/WriteRequestTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/test/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/WriteRequestTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/test/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/WriteResponseTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/test/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/message/WriteResponseTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.hub.message;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/extensions/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/dataspaceconnector/iam/did/web/ConfigurationKeys.java
+++ b/extensions/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/dataspaceconnector/iam/did/web/ConfigurationKeys.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.web;
 
 import org.eclipse.dataspaceconnector.spi.EdcSetting;

--- a/extensions/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/dataspaceconnector/iam/did/web/WebDidExtension.java
+++ b/extensions/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/dataspaceconnector/iam/did/web/WebDidExtension.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.web;
 
 import okhttp3.HttpUrl;

--- a/extensions/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/DidFunctions.java
+++ b/extensions/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/DidFunctions.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.web.resolution;
 
 import java.net.MalformedURLException;

--- a/extensions/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/WebDidResolver.java
+++ b/extensions/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/WebDidResolver.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.web.resolution;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/extensions/iam/decentralized-identity/identity-did-web/src/test/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/DidFunctionsTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-web/src/test/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/DidFunctionsTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.web.resolution;
 
 import org.assertj.core.api.Assertions;

--- a/extensions/iam/decentralized-identity/identity-did-web/src/test/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/WebDidResolverTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-web/src/test/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/WebDidResolverTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.web.resolution;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/extensions/iam/decentralized-identity/registration-service/src/main/java/org/eclipse/dataspaceconnector/iam/registrationservice/crawler/CrawlerContext.java
+++ b/extensions/iam/decentralized-identity/registration-service/src/main/java/org/eclipse/dataspaceconnector/iam/registrationservice/crawler/CrawlerContext.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.registrationservice.crawler;
 
 import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidResolverRegistry;

--- a/extensions/iam/decentralized-identity/registration-service/src/main/java/org/eclipse/dataspaceconnector/iam/registrationservice/crawler/CrawlerJob.java
+++ b/extensions/iam/decentralized-identity/registration-service/src/main/java/org/eclipse/dataspaceconnector/iam/registrationservice/crawler/CrawlerJob.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.registrationservice.crawler;
 
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/extensions/iam/decentralized-identity/registration-service/src/main/java/org/eclipse/dataspaceconnector/iam/registrationservice/events/CrawlerEventPublisher.java
+++ b/extensions/iam/decentralized-identity/registration-service/src/main/java/org/eclipse/dataspaceconnector/iam/registrationservice/events/CrawlerEventPublisher.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.registrationservice.events;
 
 import com.azure.core.credential.AzureKeyCredential;

--- a/extensions/iam/iam-mock/src/main/java/org/eclipse/dataspaceconnector/iam/mock/MockIdentityService.java
+++ b/extensions/iam/iam-mock/src/main/java/org/eclipse/dataspaceconnector/iam/mock/MockIdentityService.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Fraunhofer Institute for Software and Systems Engineering
+ *       Fraunhofer Institute for Software and Systems Engineering - Improvements
  *
  */
 

--- a/extensions/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/Oauth2Extension.java
+++ b/extensions/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/Oauth2Extension.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Fraunhofer Institute for Software and Systems Engineering
+ *       Fraunhofer Institute for Software and Systems Engineering - Improvements
  *
  */
 

--- a/extensions/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/identity/Oauth2ServiceImpl.java
+++ b/extensions/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/identity/Oauth2ServiceImpl.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Fraunhofer Institute for Software and Systems Engineering
+ *       Fraunhofer Institute for Software and Systems Engineering - Improvements
  *
  */
 

--- a/extensions/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/rule/Oauth2ValidationRule.java
+++ b/extensions/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/rule/Oauth2ValidationRule.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 - 2022
+ *  Copyright (c) 2020 - 2022 Fraunhofer Institute for Software and Systems Engineering
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Fraunhofer Institute for Software and Systems Engineering
+ *       Fraunhofer Institute for Software and Systems Engineering - Initial Implementation
  *
  */
 

--- a/extensions/iam/oauth2/oauth2-core/src/test/java/org/eclipse/dataspaceconnector/iam/oauth2/core/identity/Oauth2ServiceImplTest.java
+++ b/extensions/iam/oauth2/oauth2-core/src/test/java/org/eclipse/dataspaceconnector/iam/oauth2/core/identity/Oauth2ServiceImplTest.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Fraunhofer Institute for Software and Systems Engineering
+ *       Fraunhofer Institute for Software and Systems Engineering - Improvements
  *
  */
 

--- a/extensions/iam/oauth2/oauth2-core/src/test/java/org/eclipse/dataspaceconnector/iam/oauth2/core/jwt/Oauth2ValidationRuleTest.java
+++ b/extensions/iam/oauth2/oauth2-core/src/test/java/org/eclipse/dataspaceconnector/iam/oauth2/core/jwt/Oauth2ValidationRuleTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 - 2022
+ *  Copyright (c) 2020 - 2022 Fraunhofer Institute for Software and Systems Engineering
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Fraunhofer Institute for Software and Systems Engineering
+ *       Fraunhofer Institute for Software and Systems Engineering - Initial Implementation
  *
  */
 

--- a/extensions/in-memory/contractdefinition-store-memory/src/test/java/org/eclipse/dataspaceconnector/contractdefinition/store/memory/InMemoryContractDefinitionStoreTest.java
+++ b/extensions/in-memory/contractdefinition-store-memory/src/test/java/org/eclipse/dataspaceconnector/contractdefinition/store/memory/InMemoryContractDefinitionStoreTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.contractdefinition.store.memory;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;

--- a/extensions/in-memory/identity-hub-memory/src/main/java/org/eclipse/dataspaceconnector/iam/did/hub/memory/InMemoryIdentityHubExtension.java
+++ b/extensions/in-memory/identity-hub-memory/src/main/java/org/eclipse/dataspaceconnector/iam/did/hub/memory/InMemoryIdentityHubExtension.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.hub.memory;
 
 import org.eclipse.dataspaceconnector.iam.did.spi.hub.IdentityHubStore;

--- a/extensions/in-memory/identity-hub-memory/src/main/java/org/eclipse/dataspaceconnector/iam/did/hub/memory/InMemoryIdentityHubStore.java
+++ b/extensions/in-memory/identity-hub-memory/src/main/java/org/eclipse/dataspaceconnector/iam/did/hub/memory/InMemoryIdentityHubStore.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.hub.memory;
 
 import org.eclipse.dataspaceconnector.iam.did.spi.hub.IdentityHubStore;

--- a/extensions/in-memory/identity-hub-memory/src/test/java/org/eclipse/dataspaceconnector/iam/did/hub/memory/InMemoryIdentityHubStoreTest.java
+++ b/extensions/in-memory/identity-hub-memory/src/test/java/org/eclipse/dataspaceconnector/iam/did/hub/memory/InMemoryIdentityHubStoreTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.iam.did.hub.memory;
 
 import org.eclipse.dataspaceconnector.iam.did.spi.hub.message.Commit;

--- a/extensions/in-memory/policy-store-memory/src/main/java/org/eclipse/dataspaceconnector/policy/store/memory/InMemoryPolicyStore.java
+++ b/extensions/in-memory/policy-store-memory/src/main/java/org/eclipse/dataspaceconnector/policy/store/memory/InMemoryPolicyStore.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020-2022 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.policy.store.memory;
 
 import org.eclipse.dataspaceconnector.common.concurrency.LockManager;

--- a/extensions/in-memory/policy-store-memory/src/main/java/org/eclipse/dataspaceconnector/policy/store/memory/InMemoryPolicyStoreExtension.java
+++ b/extensions/in-memory/policy-store-memory/src/main/java/org/eclipse/dataspaceconnector/policy/store/memory/InMemoryPolicyStoreExtension.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020-2022 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.policy.store.memory;
 
 import org.eclipse.dataspaceconnector.common.concurrency.LockManager;

--- a/extensions/in-memory/policy-store-memory/src/test/java/org/eclipse/dataspaceconnector/policy/store/memory/InMemoryPolicyStoreTest.java
+++ b/extensions/in-memory/policy-store-memory/src/test/java/org/eclipse/dataspaceconnector/policy/store/memory/InMemoryPolicyStoreTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020-2022 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.policy.store.memory;
 
 import org.eclipse.dataspaceconnector.common.concurrency.LockManager;

--- a/extensions/jdk-logger-monitor/src/main/java/org/eclipse/dataspaceconnector/logger/LoggerMonitor.java
+++ b/extensions/jdk-logger-monitor/src/main/java/org/eclipse/dataspaceconnector/logger/LoggerMonitor.java
@@ -8,9 +8,10 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *      Catena-X Consortium - initial API and implementation
+ *       Catena-X Consortium - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.logger;
 
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;

--- a/extensions/jdk-logger-monitor/src/main/java/org/eclipse/dataspaceconnector/logger/LoggerMonitorExtension.java
+++ b/extensions/jdk-logger-monitor/src/main/java/org/eclipse/dataspaceconnector/logger/LoggerMonitorExtension.java
@@ -8,9 +8,10 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *      Catena-X Consortium - initial API and implementation
+ *       Catena-X Consortium - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.logger;
 
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;

--- a/extensions/jdk-logger-monitor/src/test/java/org/eclipse/dataspaceconnector/logger/LoggerMonitorTests.java
+++ b/extensions/jdk-logger-monitor/src/test/java/org/eclipse/dataspaceconnector/logger/LoggerMonitorTests.java
@@ -8,9 +8,10 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *      Catena-X Consortium - initial API and implementation
+ *       Catena-X Consortium - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.logger;
 
 import com.github.javafaker.Faker;

--- a/extensions/policy/ids-policy/src/test/java/org/eclipse/dataspaceconnector/ids/policy/MockPolicyContext.java
+++ b/extensions/policy/ids-policy/src/test/java/org/eclipse/dataspaceconnector/ids/policy/MockPolicyContext.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.ids.policy;
 
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgent;

--- a/extensions/sql/contract-negotiation-store/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/TestFunctions.java
+++ b/extensions/sql/contract-negotiation-store/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/TestFunctions.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021-2022 Microsoft Corporation
+ *  Copyright (c) 2021 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at

--- a/extensions/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/AtomikosDataSourceRegistry.java
+++ b/extensions/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/AtomikosDataSourceRegistry.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transaction.atomikos;
 
 import com.atomikos.jdbc.AtomikosDataSourceBean;

--- a/extensions/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/AtomikosTransactionContext.java
+++ b/extensions/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/AtomikosTransactionContext.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transaction.atomikos;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/extensions/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/AtomikosTransactionExtension.java
+++ b/extensions/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/AtomikosTransactionExtension.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transaction.atomikos;
 
 import org.eclipse.dataspaceconnector.spi.system.Provides;

--- a/extensions/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/AtomikosTransactionPlatform.java
+++ b/extensions/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/AtomikosTransactionPlatform.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transaction.atomikos;
 
 import com.atomikos.icatch.config.UserTransactionServiceImp;

--- a/extensions/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/DataSourceConfiguration.java
+++ b/extensions/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/DataSourceConfiguration.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transaction.atomikos;
 
 import org.jetbrains.annotations.NotNull;

--- a/extensions/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/DataSourceConfigurationKeys.java
+++ b/extensions/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/DataSourceConfigurationKeys.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transaction.atomikos;
 
 import org.eclipse.dataspaceconnector.spi.EdcSetting;

--- a/extensions/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/DataSourceConfigurationParser.java
+++ b/extensions/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/DataSourceConfigurationParser.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transaction.atomikos;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/extensions/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/Setters.java
+++ b/extensions/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/Setters.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transaction.atomikos;
 
 import org.eclipse.dataspaceconnector.spi.system.configuration.Config;

--- a/extensions/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/TransactionManagerConfiguration.java
+++ b/extensions/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/TransactionManagerConfiguration.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transaction.atomikos;
 
 import com.atomikos.datasource.xa.XID;

--- a/extensions/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/TransactionManagerConfigurationKeys.java
+++ b/extensions/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/TransactionManagerConfigurationKeys.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transaction.atomikos;
 
 import org.eclipse.dataspaceconnector.spi.EdcSetting;

--- a/extensions/transaction/transaction-atomikos/src/test/java/org/eclipse/dataspaceconnector/transaction/atomikos/AtomikosDataSourceRegistryTest.java
+++ b/extensions/transaction/transaction-atomikos/src/test/java/org/eclipse/dataspaceconnector/transaction/atomikos/AtomikosDataSourceRegistryTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transaction.atomikos;
 
 import org.junit.jupiter.api.Test;

--- a/extensions/transaction/transaction-atomikos/src/test/java/org/eclipse/dataspaceconnector/transaction/atomikos/AtomikosTransactionExtensionTest.java
+++ b/extensions/transaction/transaction-atomikos/src/test/java/org/eclipse/dataspaceconnector/transaction/atomikos/AtomikosTransactionExtensionTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transaction.atomikos;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/extensions/transaction/transaction-atomikos/src/test/java/org/eclipse/dataspaceconnector/transaction/atomikos/AtomikosTransactionPlatformTest.java
+++ b/extensions/transaction/transaction-atomikos/src/test/java/org/eclipse/dataspaceconnector/transaction/atomikos/AtomikosTransactionPlatformTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transaction.atomikos;
 
 import org.junit.jupiter.api.Test;

--- a/extensions/transaction/transaction-atomikos/src/test/java/org/eclipse/dataspaceconnector/transaction/atomikos/DataSourceConfigurationParserTest.java
+++ b/extensions/transaction/transaction-atomikos/src/test/java/org/eclipse/dataspaceconnector/transaction/atomikos/DataSourceConfigurationParserTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transaction.atomikos;
 
 import org.eclipse.dataspaceconnector.spi.system.configuration.Config;

--- a/extensions/transaction/transaction-atomikos/src/test/java/org/eclipse/dataspaceconnector/transaction/atomikos/JdbcTestFixtures.java
+++ b/extensions/transaction/transaction-atomikos/src/test/java/org/eclipse/dataspaceconnector/transaction/atomikos/JdbcTestFixtures.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transaction.atomikos;
 
 import org.eclipse.dataspaceconnector.spi.system.configuration.Config;

--- a/extensions/transaction/transaction-datasource-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transaction/datasource/DataSourceRegistry.java
+++ b/extensions/transaction/transaction-datasource-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transaction/datasource/DataSourceRegistry.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.transaction.datasource;
 
 import javax.sql.DataSource;

--- a/extensions/transaction/transaction-local/src/main/java/org/eclipse/dataspaceconnector/transaction/local/ConnectionWrapper.java
+++ b/extensions/transaction/transaction-local/src/main/java/org/eclipse/dataspaceconnector/transaction/local/ConnectionWrapper.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transaction.local;
 
 import java.sql.Array;

--- a/extensions/transaction/transaction-local/src/main/java/org/eclipse/dataspaceconnector/transaction/local/DataSourceResource.java
+++ b/extensions/transaction/transaction-local/src/main/java/org/eclipse/dataspaceconnector/transaction/local/DataSourceResource.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transaction.local;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/extensions/transaction/transaction-local/src/main/java/org/eclipse/dataspaceconnector/transaction/local/LocalDataSourceRegistry.java
+++ b/extensions/transaction/transaction-local/src/main/java/org/eclipse/dataspaceconnector/transaction/local/LocalDataSourceRegistry.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transaction.local;
 
 import org.eclipse.dataspaceconnector.spi.transaction.datasource.DataSourceRegistry;

--- a/extensions/transaction/transaction-local/src/main/java/org/eclipse/dataspaceconnector/transaction/local/LocalTransactionContext.java
+++ b/extensions/transaction/transaction-local/src/main/java/org/eclipse/dataspaceconnector/transaction/local/LocalTransactionContext.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021-2022 Microsoft Corporation and others
+ *  Copyright (c) 2021 - 2022 Microsoft Corporation and others
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -10,7 +10,9 @@
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
  *       Daimler TSS GmbH - wrap and re-throw handled exceptions
+ *
  */
+
 package org.eclipse.dataspaceconnector.transaction.local;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/extensions/transaction/transaction-local/src/main/java/org/eclipse/dataspaceconnector/transaction/local/LocalTransactionExtension.java
+++ b/extensions/transaction/transaction-local/src/main/java/org/eclipse/dataspaceconnector/transaction/local/LocalTransactionExtension.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transaction.local;
 
 import org.eclipse.dataspaceconnector.spi.system.Provides;

--- a/extensions/transaction/transaction-local/src/test/java/org/eclipse/dataspaceconnector/transaction/local/ConnectionWrapperTest.java
+++ b/extensions/transaction/transaction-local/src/test/java/org/eclipse/dataspaceconnector/transaction/local/ConnectionWrapperTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transaction.local;
 
 import org.junit.jupiter.api.Test;

--- a/extensions/transaction/transaction-local/src/test/java/org/eclipse/dataspaceconnector/transaction/local/DataSourceResourceTest.java
+++ b/extensions/transaction/transaction-local/src/test/java/org/eclipse/dataspaceconnector/transaction/local/DataSourceResourceTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transaction.local;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/extensions/transaction/transaction-local/src/test/java/org/eclipse/dataspaceconnector/transaction/local/LocalDataSourceRegistryTest.java
+++ b/extensions/transaction/transaction-local/src/test/java/org/eclipse/dataspaceconnector/transaction/local/LocalDataSourceRegistryTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transaction.local;
 
 import org.eclipse.dataspaceconnector.spi.transaction.datasource.DataSourceRegistry;

--- a/extensions/transaction/transaction-local/src/test/java/org/eclipse/dataspaceconnector/transaction/local/LocalTransactionContextTest.java
+++ b/extensions/transaction/transaction-local/src/test/java/org/eclipse/dataspaceconnector/transaction/local/LocalTransactionContextTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021-2022 Microsoft Corporation and others
+ *  Copyright (c) 2021 - 2022 Microsoft Corporation and others
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -10,7 +10,9 @@
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
  *       Daimler TSS GmbH - verify exceptions are re-thrown
+ *
  */
+
 package org.eclipse.dataspaceconnector.transaction.local;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/extensions/transaction/transaction-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transaction/TransactionContext.java
+++ b/extensions/transaction/transaction-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transaction/TransactionContext.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.transaction;
 
 

--- a/extensions/transaction/transaction-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transaction/local/LocalTransactionContextManager.java
+++ b/extensions/transaction/transaction-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transaction/local/LocalTransactionContextManager.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.transaction.local;
 
 /**

--- a/extensions/transaction/transaction-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transaction/local/LocalTransactionResource.java
+++ b/extensions/transaction/transaction-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transaction/local/LocalTransactionResource.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.transaction.local;
 
 /**

--- a/extensions/transfer-functions/transfer-functions-core/src/main/java/org/eclipse/dataspaceconnector/transfer/functions/core/TransferFunctionsCoreServiceExtension.java
+++ b/extensions/transfer-functions/transfer-functions-core/src/main/java/org/eclipse/dataspaceconnector/transfer/functions/core/TransferFunctionsCoreServiceExtension.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.functions.core;
 
 import okhttp3.OkHttpClient;

--- a/extensions/transfer-functions/transfer-functions-core/src/main/java/org/eclipse/dataspaceconnector/transfer/functions/core/flow/http/HttpDataFlowConfiguration.java
+++ b/extensions/transfer-functions/transfer-functions-core/src/main/java/org/eclipse/dataspaceconnector/transfer/functions/core/flow/http/HttpDataFlowConfiguration.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.functions.core.flow.http;
 
 import okhttp3.OkHttpClient;

--- a/extensions/transfer-functions/transfer-functions-core/src/main/java/org/eclipse/dataspaceconnector/transfer/functions/core/flow/http/HttpDataFlowController.java
+++ b/extensions/transfer-functions/transfer-functions-core/src/main/java/org/eclipse/dataspaceconnector/transfer/functions/core/flow/http/HttpDataFlowController.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.functions.core.flow.http;
 
 import okhttp3.MediaType;

--- a/extensions/transfer-functions/transfer-functions-core/src/main/java/org/eclipse/dataspaceconnector/transfer/functions/core/flow/http/HttpStatusChecker.java
+++ b/extensions/transfer-functions/transfer-functions-core/src/main/java/org/eclipse/dataspaceconnector/transfer/functions/core/flow/http/HttpStatusChecker.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.functions.core.flow.http;
 
 import okhttp3.OkHttpClient;

--- a/extensions/transfer-functions/transfer-functions-core/src/test/java/org/eclipse/dataspaceconnector/transfer/functions/core/TransferFunctionsCoreHttpTest.java
+++ b/extensions/transfer-functions/transfer-functions-core/src/test/java/org/eclipse/dataspaceconnector/transfer/functions/core/TransferFunctionsCoreHttpTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.functions.core;
 
 import okhttp3.MediaType;

--- a/extensions/transfer-functions/transfer-functions-core/src/test/java/org/eclipse/dataspaceconnector/transfer/functions/core/flow/http/HttpDataFlowControllerTest.java
+++ b/extensions/transfer-functions/transfer-functions-core/src/test/java/org/eclipse/dataspaceconnector/transfer/functions/core/flow/http/HttpDataFlowControllerTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.functions.core.flow.http;
 
 import okhttp3.Interceptor;

--- a/extensions/transfer-functions/transfer-functions-core/src/test/java/org/eclipse/dataspaceconnector/transfer/functions/core/flow/http/HttpStatusCheckerTest.java
+++ b/extensions/transfer-functions/transfer-functions-core/src/test/java/org/eclipse/dataspaceconnector/transfer/functions/core/flow/http/HttpStatusCheckerTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.functions.core.flow.http;
 
 import okhttp3.Interceptor;

--- a/extensions/transfer-functions/transfer-functions-spi/src/main/java/org/eclipse/dataspaceconnector/transfer/functions/spi/flow/http/TransferFunctionInterceptorRegistry.java
+++ b/extensions/transfer-functions/transfer-functions-spi/src/main/java/org/eclipse/dataspaceconnector/transfer/functions/spi/flow/http/TransferFunctionInterceptorRegistry.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.functions.spi.flow.http;
 
 import okhttp3.Interceptor;

--- a/launchers/data-loader-cli/src/main/java/org/eclipse/dataspaceconnector/dataloader/cli/DataLoaderRuntime.java
+++ b/launchers/data-loader-cli/src/main/java/org/eclipse/dataspaceconnector/dataloader/cli/DataLoaderRuntime.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataloader.cli;
 
 import org.eclipse.dataspaceconnector.boot.system.runtime.BaseRuntime;

--- a/launchers/data-loader-cli/src/main/java/org/eclipse/dataspaceconnector/dataloader/cli/LoadCommand.java
+++ b/launchers/data-loader-cli/src/main/java/org/eclipse/dataspaceconnector/dataloader/cli/LoadCommand.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataloader.cli;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/launchers/data-loader-cli/src/test/java/org/eclipse/dataspaceconnector/dataloader/cli/LoadCommandTest.java
+++ b/launchers/data-loader-cli/src/test/java/org/eclipse/dataspaceconnector/dataloader/cli/LoadCommandTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataloader.cli;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/launchers/junit/src/testFixtures/java/org/eclipse/dataspaceconnector/junit/launcher/EdcRuntimeExtension.java
+++ b/launchers/junit/src/testFixtures/java/org/eclipse/dataspaceconnector/junit/launcher/EdcRuntimeExtension.java
@@ -9,9 +9,10 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
+
 package org.eclipse.dataspaceconnector.junit.launcher;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/samples/other/run-from-junit/src/test/java/org/eclipse/dataspaceconnector/junit/EndToEndTest.java
+++ b/samples/other/run-from-junit/src/test/java/org/eclipse/dataspaceconnector/junit/EndToEndTest.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Fraunhofer Institute for Software and Systems Engineering
+ *       Fraunhofer Institute for Software and Systems Engineering - Improvements
  *
  */
 

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/ConsumerContractNegotiationManager.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/ConsumerContractNegotiationManager.java
@@ -12,6 +12,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - minor modifications
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.contract.negotiation;
 
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.response.NegotiationResult;

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/ContractNegotiationManager.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/ContractNegotiationManager.java
@@ -12,6 +12,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - added method
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.contract.negotiation;
 
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.response.NegotiationResult;

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/ProviderContractNegotiationManager.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/ProviderContractNegotiationManager.java
@@ -12,6 +12,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - extended parameter definition
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.contract.negotiation;
 
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.response.NegotiationResult;

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/observe/ContractNegotiationListener.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/observe/ContractNegotiationListener.java
@@ -11,6 +11,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.contract.negotiation.observe;
 
 import org.eclipse.dataspaceconnector.spi.observe.Observable;

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/observe/ContractNegotiationObservable.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/observe/ContractNegotiationObservable.java
@@ -11,6 +11,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.contract.negotiation.observe;
 
 import org.eclipse.dataspaceconnector.spi.observe.Observable;

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/response/NegotiationResult.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/response/NegotiationResult.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.contract.negotiation.response;
 
 import org.eclipse.dataspaceconnector.spi.result.AbstractResult;

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/store/ContractNegotiationStore.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/store/ContractNegotiationStore.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.contract.negotiation.store;
 
 import org.eclipse.dataspaceconnector.spi.persistence.StateEntityStore;

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/ContractOfferQuery.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/ContractOfferQuery.java
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
  *       Microsoft Corporation - Refactoring
+ *
  */
 
 package org.eclipse.dataspaceconnector.spi.contract.offer;

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/store/ContractDefinitionStore.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/store/ContractDefinitionStore.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.contract.offer.store;
 
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/validation/ContractValidationService.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/validation/ContractValidationService.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.contract.validation;
 
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/negotiation/ContractNegotiation.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/negotiation/ContractNegotiation.java
@@ -10,9 +10,10 @@
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
  *       Fraunhofer Institute for Software and Systems Engineering - extended method implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/negotiation/ContractNegotiationStates.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/negotiation/ContractNegotiationStates.java
@@ -10,9 +10,10 @@
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
  *       Fraunhofer Institute for Software and Systems Engineering - minor modifications
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation;
 
 import java.util.Arrays;

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/negotiation/command/ContractNegotiationCommand.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/negotiation/command/ContractNegotiationCommand.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021-2022 Fraunhofer Institute for Software and Systems Engineering
+ *  Copyright (c) 2021 - 2022 Fraunhofer Institute for Software and Systems Engineering
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -11,6 +11,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.command;
 
 import org.eclipse.dataspaceconnector.spi.command.Command;

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/offer/ContractDefinition.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/offer/ContractDefinition.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.types.domain.contract.offer;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/agent/ParticipantAgent.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/agent/ParticipantAgent.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.agent;
 
 import org.jetbrains.annotations.NotNull;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/agent/ParticipantAgentService.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/agent/ParticipantAgentService.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.agent;
 
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/agent/ParticipantAgentServiceExtension.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/agent/ParticipantAgentServiceExtension.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.agent;
 
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/command/BoundedCommandQueue.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/command/BoundedCommandQueue.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020-2022 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,6 +12,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - refactored
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.command;
 
 import org.jetbrains.annotations.Nullable;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/command/Command.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/command/Command.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.command;
 
 import java.util.UUID;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/command/CommandHandler.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/command/CommandHandler.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020-2022 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,6 +12,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - refactored
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.command;
 
 /**

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/command/CommandHandlerRegistry.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/command/CommandHandlerRegistry.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020-2022 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,6 +12,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - refactored
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.command;
 
 /**

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/command/CommandProcessor.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/command/CommandProcessor.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021-2022 Fraunhofer Institute for Software and Systems Engineering
+ *  Copyright (c) 2021 - 2022 Fraunhofer Institute for Software and Systems Engineering
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -11,6 +11,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.command;
 
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/command/CommandQueue.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/command/CommandQueue.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020-2022 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,6 +12,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - refactored
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.command;
 
 import org.jetbrains.annotations.Nullable;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/command/CommandRunner.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/command/CommandRunner.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020-2022 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,6 +12,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - refactored
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.command;
 
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/iam/IdentityService.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/iam/IdentityService.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Fraunhofer Institute for Software and Systems Engineering
+ *       Fraunhofer Institute for Software and Systems Engineering - Improvements
  *
  */
 

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/iam/TokenRepresentation.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/iam/TokenRepresentation.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Fraunhofer Institute for Software and Systems Engineering
+ *       Fraunhofer Institute for Software and Systems Engineering - Improvements
  *
  */
 

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/AtomicConstraintFunction.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/AtomicConstraintFunction.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.policy;
 
 import org.eclipse.dataspaceconnector.policy.model.Operator;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/PolicyContext.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/PolicyContext.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.policy;
 
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgent;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/PolicyEngine.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/PolicyEngine.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.policy;
 
 import org.eclipse.dataspaceconnector.policy.model.Action;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/PolicyScope.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/PolicyScope.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.policy;
 
 import java.lang.annotation.ElementType;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/RuleBindingRegistry.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/RuleBindingRegistry.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.policy;
 
 import org.eclipse.dataspaceconnector.policy.model.Action;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/RuleFunction.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/RuleFunction.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.policy;
 
 import org.eclipse.dataspaceconnector.policy.model.Rule;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/BaseCriterionToPredicateConverter.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/BaseCriterionToPredicateConverter.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/QueryResolver.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/QueryResolver.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.query;
 
 import java.util.stream.Stream;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/ReflectionBasedQueryResolver.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/ReflectionBasedQueryResolver.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.query;
 
 import org.eclipse.dataspaceconnector.common.reflection.ReflectionUtil;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/SettingResolver.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/SettingResolver.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
- *       Fraunhofer Institute for Software and Systems Engineering
+ *       Fraunhofer Institute for Software and Systems Engineering - Improvements
  *
  */
 

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/configuration/Config.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/configuration/Config.java
@@ -9,9 +9,10 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
- *       Fraunhofer Institute for Software and Systems Engineering
+ *       Fraunhofer Institute for Software and Systems Engineering - Improvements
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.system.configuration;
 
 import java.util.Map;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/configuration/ConfigFactory.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/configuration/ConfigFactory.java
@@ -11,6 +11,7 @@
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.system.configuration;
 
 import java.util.Map;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/configuration/ConfigImpl.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/configuration/ConfigImpl.java
@@ -9,9 +9,10 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
- *       Fraunhofer Institute for Software and Systems Engineering
+ *       Fraunhofer Institute for Software and Systems Engineering - Improvements
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.system.configuration;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/injection/EdcInjectionException.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/injection/EdcInjectionException.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.system.injection;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/injection/FieldInjectionPoint.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/injection/FieldInjectionPoint.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.system.injection;
 
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/injection/InjectionContainer.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/injection/InjectionContainer.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.system.injection;
 
 import org.eclipse.dataspaceconnector.spi.result.Result;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/injection/InjectionPoint.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/injection/InjectionPoint.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.system.injection;
 
 /**

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/injection/InjectionPointScanner.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/injection/InjectionPointScanner.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.system.injection;
 
 import org.eclipse.dataspaceconnector.spi.system.Feature;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/injection/Injector.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/injection/Injector.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.system.injection;
 
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/injection/ObjectFactory.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/injection/ObjectFactory.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.system.injection;
 
 import org.eclipse.dataspaceconnector.spi.system.Feature;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/edr/EndpointDataReference.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/edr/EndpointDataReference.java
@@ -12,7 +12,6 @@
  *
  */
 
-
 package org.eclipse.dataspaceconnector.spi.types.domain.edr;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/edr/EndpointDataReferenceMessage.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/edr/EndpointDataReferenceMessage.java
@@ -12,7 +12,6 @@
  *
  */
 
-
 package org.eclipse.dataspaceconnector.spi.types.domain.edr;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/command/BoundedCommandQueueTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/command/BoundedCommandQueueTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020-2022 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -10,7 +10,9 @@
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
  *       Fraunhofer Institute for Software and Systems Engineering - refactored
+ *
  */
+
 package org.eclipse.dataspaceconnector.spi.command;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/query/ReflectionBasedQueryResolverTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/query/ReflectionBasedQueryResolverTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.query;
 
 import org.junit.jupiter.api.Test;

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/system/configuration/ConfigImplTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/system/configuration/ConfigImplTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022
+ *  Copyright (c) 2022 Fraunhofer Institute for Software and Systems Engineering
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,9 +8,10 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Fraunhofer Institute for Software and Systems Engineering
+ *       Fraunhofer Institute for Software and Systems Engineering - Initial Implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.system.configuration;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataFlowRequestTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataFlowRequestTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.types.domain.transfer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/spi/policy-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/store/PolicyStore.java
+++ b/spi/policy-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/store/PolicyStore.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.policy.store;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/TransferProcessManager.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/TransferProcessManager.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2020-2021 Microsoft Corporation
+ *  Copyright (c) 2020 - 2021 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/DeprovisionResult.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/DeprovisionResult.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.transfer.provision;
 
 import org.eclipse.dataspaceconnector.spi.response.ResponseFailure;

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ProvisionResult.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ProvisionResult.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.transfer.provision;
 
 import org.eclipse.dataspaceconnector.spi.response.ResponseFailure;

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DeprovisionedResource.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DeprovisionedResource.java
@@ -10,7 +10,9 @@
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
  *       Microsoft Corporation
+ *
  */
+
 package org.eclipse.dataspaceconnector.spi.types.domain.transfer;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionResponse.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionResponse.java
@@ -10,7 +10,9 @@
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       Microsoft Corporation
+ *
  */
+
 package org.eclipse.dataspaceconnector.spi.types.domain.transfer;
 
 import org.jetbrains.annotations.Nullable;

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcess.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcess.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcessStates.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcessStates.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/command/AddProvisionedResourceCommand.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/command/AddProvisionedResourceCommand.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.types.domain.transfer.command;
 
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionResponse;

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/command/CancelTransferCommand.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/command/CancelTransferCommand.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020-2022 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,6 +12,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - refactored
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.types.domain.transfer.command;
 
 /**

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/command/DeprovisionRequest.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/command/DeprovisionRequest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020-2022 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,6 +12,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - refactored
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.types.domain.transfer.command;
 
 /**

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/command/SingleTransferProcessCommand.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/command/SingleTransferProcessCommand.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020-2022 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,6 +12,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - refactored
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.types.domain.transfer.command;
 
 import org.eclipse.dataspaceconnector.spi.command.Command;

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/command/TransferProcessCommand.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/command/TransferProcessCommand.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021-2022 Fraunhofer Institute for Software and Systems Engineering
+ *  Copyright (c) 2021 - 2022 Fraunhofer Institute for Software and Systems Engineering
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -11,6 +11,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.types.domain.transfer.command;
 
 import org.eclipse.dataspaceconnector.spi.command.Command;

--- a/spi/transfer-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DeprovisionedResourceTest.java
+++ b/spi/transfer-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DeprovisionedResourceTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.types.domain.transfer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/spi/transfer-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionedContentResourceTest.java
+++ b/spi/transfer-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionedContentResourceTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.types.domain.transfer;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/spi/transport-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transformer/TransformerContext.java
+++ b/spi/transport-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transformer/TransformerContext.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.transformer;
 
 import org.jetbrains.annotations.Nullable;

--- a/spi/web-spi/src/main/java/org/eclipse/dataspaceconnector/spi/WebServer.java
+++ b/spi/web-spi/src/main/java/org/eclipse/dataspaceconnector/spi/WebServer.java
@@ -11,6 +11,7 @@
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi;
 
 import org.eclipse.dataspaceconnector.spi.system.Feature;


### PR DESCRIPTION
## What this PR changes/adds

This PR only updates headers in existing Java source files that are not correctly formatted as per the rule in #997.

The PR does not add headers to files that currently do not have one at all (149 files).

## Why it does that

Reduce the developer overhead of fixing checkstyle header issues after merging #997.

## Further notes

## Linked Issue(s)

Relates to #991 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
