### PR TITLE
Data Management API: Created TransferProcess transformers

### DIFF
--- a/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/transformer/DtoTransformerRegistryImpl.java
+++ b/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/transformer/DtoTransformerRegistryImpl.java
@@ -88,11 +88,11 @@ public class DtoTransformerRegistryImpl implements DtoTransformerRegistry {
         return outputType.cast(((DtoTransformer<INPUT, OUTPUT>) t).transform(object, context));
     }
 
-    private static class DtoTransformerContext implements TransformerContext {
+    public static class DtoTransformerContext implements TransformerContext {
         private final DtoTransformerRegistry registry;
         private final List<String> problems;
 
-        private DtoTransformerContext(DtoTransformerRegistry registry) {
+        public DtoTransformerContext(DtoTransformerRegistry registry) {
             this.registry = registry;
             problems = new ArrayList<>();
         }

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiExtension.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiExtension.java
@@ -15,6 +15,9 @@
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess;
 
 import org.eclipse.dataspaceconnector.api.datamanagement.configuration.DataManagementApiConfiguration;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform.DataRequestToDataRequestDtoTransformer;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform.TransferProcessToTransferProcessDtoTransformer;
+import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
 import org.eclipse.dataspaceconnector.spi.WebService;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
@@ -27,8 +30,14 @@ public class TransferProcessApiExtension implements ServiceExtension {
     @Inject
     private DataManagementApiConfiguration configuration;
 
+    @Inject
+    private DtoTransformerRegistry transformerRegistry;
+
     @Override
     public void initialize(ServiceExtensionContext context) {
         webService.registerResource(configuration.getContextAlias(), new TransferProcessApiController(context.getMonitor()));
+
+        transformerRegistry.register(new DataRequestToDataRequestDtoTransformer());
+        transformerRegistry.register(new TransferProcessToTransferProcessDtoTransformer());
     }
 }

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/DataRequestToDataRequestDtoTransformer.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/DataRequestToDataRequestDtoTransformer.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform;
+
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.DataRequestDto;
+import org.eclipse.dataspaceconnector.api.transformer.DtoTransformer;
+import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+public class DataRequestToDataRequestDtoTransformer implements DtoTransformer<DataRequest, DataRequestDto> {
+
+    @Override
+    public Class<DataRequest> getInputType() {
+        return DataRequest.class;
+    }
+
+    @Override
+    public Class<DataRequestDto> getOutputType() {
+        return DataRequestDto.class;
+    }
+
+    @Override
+    public @Nullable DataRequestDto transform(@Nullable DataRequest object, @NotNull TransformerContext context) {
+        Objects.requireNonNull(context);
+        if (object == null) {
+            return null;
+        }
+        return DataRequestDto.Builder.newInstance()
+                .assetId(object.getAssetId())
+                .contractId(object.getContractId())
+                .connectorId(object.getConnectorId())
+                .build();
+    }
+}

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessToTransferProcessDtoTransformer.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessToTransferProcessDtoTransformer.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform;
+
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.DataRequestDto;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferProcessDto;
+import org.eclipse.dataspaceconnector.api.transformer.DtoTransformer;
+import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+public class TransferProcessToTransferProcessDtoTransformer implements DtoTransformer<TransferProcess, TransferProcessDto> {
+
+    @Override
+    public Class<TransferProcess> getInputType() {
+        return TransferProcess.class;
+    }
+
+    @Override
+    public Class<TransferProcessDto> getOutputType() {
+        return TransferProcessDto.class;
+    }
+
+    @Override
+    public @Nullable TransferProcessDto transform(@Nullable TransferProcess object, @NotNull TransformerContext context) {
+        if (object == null) {
+            return null;
+        }
+        return TransferProcessDto.Builder.newInstance()
+                .id(object.getId())
+                .type(object.getType().name())
+                .state(getState(object.getState(), context))
+                .errorDetail(object.getErrorDetail())
+                .dataRequest(context.transform(object.getDataRequest(), DataRequestDto.class))
+                .build();
+    }
+
+    private String getState(int value, TransformerContext context) {
+        var result = TransferProcessStates.from(value);
+        if (result == null) {
+            context.reportProblem("Invalid value for TransferProcess.state");
+            return null;
+        }
+        return result.name();
+    }
+}

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiExtensionTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiExtensionTest.java
@@ -1,0 +1,44 @@
+package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess;
+
+import com.github.javafaker.Faker;
+import org.eclipse.dataspaceconnector.api.datamanagement.configuration.DataManagementApiConfiguration;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferProcessDto;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform.TransferProcessTransformerTestData;
+import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
+import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistryImpl;
+import org.eclipse.dataspaceconnector.junit.launcher.DependencyInjectionExtension;
+import org.eclipse.dataspaceconnector.spi.WebService;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.system.injection.ObjectFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class TransferProcessApiExtensionTest {
+    static Faker faker = new Faker();
+    TransferProcessTransformerTestData data = new TransferProcessTransformerTestData();
+    String contextAlias = faker.lorem().word();
+
+    @Test
+    void initialize(ServiceExtensionContext context, ObjectFactory factory) {
+        var registry = new DtoTransformerRegistryImpl();
+        context.registerService(DtoTransformerRegistry.class, registry);
+        var webServiceMock = mock(WebService.class);
+        context.registerService(WebService.class, webServiceMock);
+        var mockConfiguration = new DataManagementApiConfiguration(contextAlias);
+        context.registerService(DataManagementApiConfiguration.class, mockConfiguration);
+
+        var extension = factory.constructInstance(TransferProcessApiExtension.class);
+        extension.initialize(context);
+
+        verify(webServiceMock).registerResource(eq(contextAlias), any(TransferProcessApiController.class));
+
+        assertThat(registry.transform(data.entity.build(), TransferProcessDto.class).succeeded()).isTrue();
+    }
+}

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/DataRequestToDataRequestDtoTransformerTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/DataRequestToDataRequestDtoTransformerTest.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform;
+
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.DataRequestDto;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DataRequestToDataRequestDtoTransformerTest {
+    DataRequestTransformerTestData data = new DataRequestTransformerTestData();
+
+    DataRequestToDataRequestDtoTransformer transformer = new DataRequestToDataRequestDtoTransformer();
+
+    @Test
+    void getInputType() {
+        assertThat(transformer.getInputType()).isEqualTo(DataRequest.class);
+    }
+
+    @Test
+    void getOutputType() {
+        assertThat(transformer.getOutputType()).isEqualTo(DataRequestDto.class);
+    }
+
+    @Test
+    void transform() {
+        var result = transformer.transform(data.entity, data.context);
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(data.dto);
+    }
+}

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/DataRequestTransformerTestData.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/DataRequestTransformerTestData.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform;
+
+import com.github.javafaker.Faker;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.DataRequestDto;
+import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+
+import static org.mockito.Mockito.mock;
+
+class DataRequestTransformerTestData {
+    static Faker faker = new Faker();
+
+    TransformerContext context = mock(TransformerContext.class);
+    String assetId = faker.lorem().word();
+    String contractId = faker.lorem().word();
+    String connectorId = faker.lorem().word();
+
+    DataRequest entity = DataRequest.Builder.newInstance()
+            .assetId(assetId)
+            .contractId(contractId)
+            .connectorId(connectorId)
+            .dataDestination(DataAddress.Builder.newInstance().type(faker.lorem().word()).build())
+            .build();
+
+    DataRequestDto dto = DataRequestDto.Builder.newInstance()
+            .assetId(assetId)
+            .contractId(contractId)
+            .connectorId(connectorId)
+            .build();
+}

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessToTransferProcessDtoTransformerTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessToTransferProcessDtoTransformerTest.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform;
+
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.DataRequestDto;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferProcessDto;
+import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+class TransferProcessToTransferProcessDtoTransformerTest {
+    TransferProcessTransformerTestData data = new TransferProcessTransformerTestData();
+
+    TransferProcessToTransferProcessDtoTransformer transformer = new TransferProcessToTransferProcessDtoTransformer();
+    List<String> problems = new ArrayList<>();
+
+    @Test
+    void getInputType() {
+        assertThat(transformer.getInputType()).isEqualTo(TransferProcess.class);
+    }
+
+    @Test
+    void getOutputType() {
+        assertThat(transformer.getOutputType()).isEqualTo(TransferProcessDto.class);
+    }
+
+    @Test
+    void transform() {
+        assertThatEntityTransformsToDto();
+    }
+
+    @Test
+    void transform_whenInvalidState() {
+        data.entity.state(invalidStateCode());
+        data.dto.state(null);
+        problems.add("Invalid value for TransferProcess.state");
+
+        assertThatEntityTransformsToDto();
+    }
+
+    void assertThatEntityTransformsToDto() {
+        when(data.registry.transform(data.dataRequest, DataRequestDto.class)).thenReturn(Result.success(data.dataRequestDto));
+
+        var result = transformer.transform(data.entity.build(), data.context);
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(data.dto.build());
+
+        assertThat(data.context.getProblems()).containsExactlyElementsOf(problems);
+    }
+
+    private int invalidStateCode() {
+        var stateCode = 0;
+        while (TransferProcessStates.from(stateCode) != null) {
+            stateCode++;
+        }
+        return stateCode;
+    }
+}

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessTransformerTestData.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessTransformerTestData.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform;
+
+import com.github.javafaker.Faker;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.DataRequestDto;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferProcessDto;
+import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
+import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistryImpl;
+import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
+
+import static org.mockito.Mockito.mock;
+
+public class TransferProcessTransformerTestData {
+    static Faker faker = new Faker();
+
+    DtoTransformerRegistry registry = mock(DtoTransformerRegistry.class);
+    TransformerContext context = new DtoTransformerRegistryImpl.DtoTransformerContext(registry);
+    String id = faker.lorem().word();
+    TransferProcess.Type type = faker.options().option(TransferProcess.Type.class);
+    TransferProcessStates state = faker.options().option(TransferProcessStates.class);
+    String errorDetail = faker.lorem().word();
+
+    DataRequest dataRequest = DataRequest.Builder.newInstance()
+            .dataDestination(DataAddress.Builder.newInstance().type(faker.lorem().word()).build())
+            .build();
+    DataRequestDto dataRequestDto = DataRequestDto.Builder.newInstance().build();
+
+    public TransferProcess.Builder entity = TransferProcess.Builder.newInstance()
+            .id(id)
+            .type(type)
+            .state(state.code())
+            .errorDetail(errorDetail)
+            .dataRequest(dataRequest);
+
+    TransferProcessDto.Builder dto = TransferProcessDto.Builder.newInstance()
+            .id(id)
+            .type(type.name())
+            .state(state.name())
+            .errorDetail(errorDetail)
+            .dataRequest(dataRequestDto);
+}


### PR DESCRIPTION
## What this PR changes/adds

Add a transformer from TransferProcess to its DTO, for controllers in the Data Management API to expose transfer process information.

#809 implementation was split into this PR and PR #1005.

## Why it does that

Data Management API surface

## Further notes

## Linked Issue(s)

Relates to #809

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
