### PR TITLE
Transfers: reliably send transfers from consumer to provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ the detailed section referring to by linking pull requests or issues.
 * Data plane: control proxy mode with data address toggles (#882)
 * Resolve policies using the `PolicyArchive` (#1089)
 * Resolve content addresses in the `TransferProcessManager` (#1090)
-
+* Reliably send transfers from consumer to provider (#1007)
 
 #### Changed
 

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/SendRetryManager.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/SendRetryManager.java
@@ -1,0 +1,27 @@
+package org.eclipse.dataspaceconnector.transfer.core.transfer;
+
+/**
+ * Service enabling a "long retry" mechanism when sending entities across applications.
+ * Implementations may support a retry strategy (e.g. an exponential wait mechanism
+ * so as not to overflow the remote service when it becomes available again).
+ *
+ * @param <T> entity type
+ */
+interface SendRetryManager<T> {
+    /**
+     * Determines whether the given entity may be sent at this time, or the system
+     * should wait and send the entity later.
+     *
+     * @param entity entity to be evaluated.
+     * @return {@code true} if the entity should not be sent at this time.
+     */
+    boolean shouldDelay(T entity);
+
+    /**
+     * Determines whether retries for sending the given entity have been exhausted.
+     *
+     * @param entity entity to be evaluated.
+     * @return {@code true} if the entity should not be sent anymore.
+     */
+    boolean retriesExhausted(T entity);
+}

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessSendRetryManager.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessSendRetryManager.java
@@ -1,0 +1,59 @@
+package org.eclipse.dataspaceconnector.transfer.core.transfer;
+
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.retry.WaitStrategy;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+
+import java.time.Clock;
+import java.util.function.Supplier;
+
+import static java.lang.String.format;
+
+/**
+ * Service enabling a "long retry" mechanism when sending {@link TransferProcess}es across applications.
+ * The implementation supports a pluggable retry strategy (e.g. an exponential wait mechanism
+ * so as not to overflow the remote service when it becomes available again).
+ */
+public class TransferProcessSendRetryManager implements SendRetryManager<TransferProcess> {
+    private final Monitor monitor;
+    private final Supplier<WaitStrategy> delayStrategySupplier;
+    private final int retryLimit;
+    protected Clock clock = Clock.systemUTC();
+
+    public TransferProcessSendRetryManager(Monitor monitor, Supplier<WaitStrategy> delayStrategySupplier, int retryLimit) {
+        this.monitor = monitor;
+        this.delayStrategySupplier = delayStrategySupplier;
+        this.retryLimit = retryLimit;
+    }
+
+    @Override
+    public boolean shouldDelay(TransferProcess process) {
+        int retryCount = process.getStateCount() - 1;
+        if (retryCount <= 0) {
+            return false;
+        }
+
+        // Get a new instance of WaitStrategy.
+        var delayStrategy = delayStrategySupplier.get();
+
+        // Set the WaitStrategy to have observed <retryCount> previous failures.
+        // This is relevant for stateful strategies such as exponential wait.
+        delayStrategy.failures(retryCount);
+
+        // Get the delay time following the number of failures.
+        var waitMillis = delayStrategy.retryInMillis();
+
+        long remainingWaitMillis = process.getStateTimestamp() + waitMillis - clock.millis();
+        if (remainingWaitMillis > 0) {
+            monitor.debug(format("Process %s transfer retry #%d will not be attempted before %d ms.", process.getId(), retryCount, remainingWaitMillis));
+            return true;
+        }
+        monitor.debug(format("Process %s transfer retry #%d of %d.", process.getId(), retryCount, retryLimit));
+        return false;
+    }
+
+    @Override
+    public boolean retriesExhausted(TransferProcess entity) {
+        return entity.getStateCount() > retryLimit;
+    }
+}

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessSendRetryManagerTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessSendRetryManagerTest.java
@@ -1,0 +1,91 @@
+package org.eclipse.dataspaceconnector.transfer.core.transfer;
+
+import com.github.javafaker.Faker;
+import org.eclipse.dataspaceconnector.spi.monitor.ConsoleMonitor;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.retry.WaitStrategy;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.REQUESTING;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TransferProcessSendRetryManagerTest {
+    static final String DESTINATION_TYPE = "test-type";
+    static Faker faker = new Faker();
+
+    final Monitor monitor = new ConsoleMonitor();
+    final WaitStrategy delayStrategy = mock(WaitStrategy.class);
+    final int sendRetryLimit = faker.number().numberBetween(5, 10);
+
+    final TransferProcessSendRetryManager sendRetryManager =
+            new TransferProcessSendRetryManager(monitor, () -> delayStrategy, sendRetryLimit);
+
+    @ParameterizedTest
+    @MethodSource("delayArgs")
+    void shouldDelay(long stateTimestamp, long currentTime, long retryDelay, boolean shouldDelay) {
+        var stateCount = sendRetryLimit - 2;
+        var process = TransferProcess.Builder.newInstance()
+                .type(TransferProcess.Type.CONSUMER)
+                .state(REQUESTING.code())
+                .id(UUID.randomUUID().toString())
+                .stateCount(stateCount)
+                .stateTimestamp(stateTimestamp)
+                .dataRequest(DataRequest.Builder.newInstance().destinationType(DESTINATION_TYPE).build())
+                .build();
+
+        when(delayStrategy.retryInMillis())
+                .thenAnswer(i -> {
+                    verify(delayStrategy).failures(stateCount - 1);
+                    return retryDelay;
+                }).thenThrow(new RuntimeException("should call only once"));
+
+        sendRetryManager.clock = Clock.fixed(Instant.ofEpochMilli(currentTime), UTC);
+
+        assertThat(sendRetryManager.shouldDelay(process))
+                .isEqualTo(shouldDelay);
+    }
+
+    static Stream<Arguments> delayArgs() {
+        return Stream.of(
+                arguments(0, 0, 0, false),
+                arguments(0, 10, 9, false),
+                arguments(0, 9, 10, true),
+                arguments(2, 10, 9, true),
+                arguments(2, 12, 9, false)
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-2, -1, 0, 1, 2})
+    void retriesExhausted(int retriesLeft) {
+        var stateCount = sendRetryLimit - retriesLeft;
+        var stateTimestamp = faker.number().randomNumber();
+        var process = TransferProcess.Builder.newInstance()
+                .type(TransferProcess.Type.CONSUMER)
+                .state(REQUESTING.code())
+                .id(UUID.randomUUID().toString())
+                .stateCount(stateCount)
+                .stateTimestamp(stateTimestamp)
+                .dataRequest(DataRequest.Builder.newInstance().destinationType(DESTINATION_TYPE).build())
+                .build();
+
+        var expected = retriesLeft < 0;
+        assertThat(sendRetryManager.retriesExhausted(process))
+                .isEqualTo(expected);
+    }
+}

--- a/extensions/in-memory/transfer-store-memory/src/main/java/org/eclipse/dataspaceconnector/transfer/store/memory/InMemoryTransferProcessStore.java
+++ b/extensions/in-memory/transfer-store-memory/src/main/java/org/eclipse/dataspaceconnector/transfer/store/memory/InMemoryTransferProcessStore.java
@@ -93,7 +93,6 @@ public class InMemoryTransferProcessStore implements TransferProcessStore {
     @Override
     public void update(TransferProcess process) {
         lockManager.writeLock(() -> {
-            process.updateStateTimestamp();
             delete(process.getId());
             TransferProcess internalCopy = process.copy();
             processesByExternalId.put(process.getDataRequest().getId(), internalCopy);

--- a/extensions/in-memory/transfer-store-memory/src/test/java/org/eclipse/dataspaceconnector/transfer/store/memory/InMemoryTransferProcessStoreTest.java
+++ b/extensions/in-memory/transfer-store-memory/src/test/java/org/eclipse/dataspaceconnector/transfer/store/memory/InMemoryTransferProcessStoreTest.java
@@ -39,7 +39,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class InMemoryTransferProcessStoreTest {
     private InMemoryTransferProcessStore store;
@@ -166,7 +165,10 @@ class InMemoryTransferProcessStoreTest {
 
         var list1 = store.nextForState(INITIAL.code(), 5);
         Thread.sleep(50); //simulate a short delay to generate different timestamps
-        list1.forEach(tp -> store.update(tp));
+        list1.forEach(tp -> {
+            tp.updateStateTimestamp();
+            store.update(tp);
+        });
         var list2 = store.nextForState(INITIAL.code(), 5);
         assertThat(list1).isNotEqualTo(list2).doesNotContainAnyElementsOf(list2);
     }

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/retry/WaitStrategy.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/retry/WaitStrategy.java
@@ -21,11 +21,16 @@ public interface WaitStrategy {
      */
     long waitForMillis();
 
-
     /**
      * Marks the iteration as successful.
      */
     default void success() {
+    }
+
+    /**
+     * Registers that a number of previous attempts were unsuccessful.
+     */
+    default void failures(int numberOfFailures) {
     }
 
     /**


### PR DESCRIPTION
## What this PR changes/adds

If the Consumer tries to initiate a transfer but the Provider is not available, the consumer does not manage the error. If the Provider later becomes available, the request did not get processed. This PR solves this issue.

If the request is unsuccessful, we keep the entity in the same state (with a state update, to increment its internal state count) and save it to break the lease and send the TP again potentially on the next iteration.

This "long retry" mechanism implements an exponential wait mechanism so as not to overflow the provider when it becomes available again. There might be many consumers queuing up requests to one provider.

After a given number of retries is exhausted, the transfer state moves to ERROR.

An additional "short retry" mechanism could also be implemented later in the IdsMultipartSender side, as a complement to this mechanism. The low level retry should be very short so as not to hog consumer resources and hammer the provider. 

## Why it does that

Reliable delivery

## Further notes

## Linked Issue(s)

Closes #336 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
