### PR TITLE
refactor: replace Asset with assetId on ContractAgreement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,11 +63,12 @@ the detailed section referring to by linking pull requests or issues.
 * Extract interfaces for every api controller class to improve swagger documentation (#891)
 * Instrument executors with metrics (#912)
 * Call the listeners before the state transition is persisted. (#876)
-* Added an overload to `TransactionContext#execute()` (#968)
+* Add an overload to `TransactionContext#execute()` (#968)
 * Run CosmosDB integration tests on cloud in CI (#964)
-* Added SQL-AssetIndex to support `QuerySpec` (#1014)
-* Improved provision signalling and align deprovisioning to handle error conditions (#992)
 * Set policy and rule target dynamically when generating contract offers (#609)
+* Add SQL-AssetIndex to support `QuerySpec` (#1014)
+* Improve provision signalling and align deprovisioning to handle error conditions (#992)
+* Replace Asset with assetId on ContractAgreement (#1009)
 
 #### Removed
 

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021-2022 Microsoft Corporation
+ *  Copyright (c) 2021 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -11,7 +11,8 @@
  *       Microsoft Corporation - initial API and implementation
  *       Fraunhofer Institute for Software and Systems Engineering - extended method implementation
  *       Daimler TSS GmbH - fixed contract dates to epoch seconds
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - refactor
+ *
  */
 
 package org.eclipse.dataspaceconnector.contract.negotiation;
@@ -397,7 +398,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
                 .providerAgentId(String.valueOf(lastOffer.getProvider()))
                 .consumerAgentId(String.valueOf(lastOffer.getConsumer()))
                 .policy(lastOffer.getPolicy())
-                .asset(lastOffer.getAsset())
+                .assetId(lastOffer.getAsset().getId())
                 .build();
 
         var request = ContractAgreementRequest.Builder.newInstance()

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021-2022 Microsoft Corporation
+ *  Copyright (c) 2021 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -11,9 +11,10 @@
  *       Microsoft Corporation - initial API and implementation
  *       Fraunhofer Institute for Software and Systems Engineering - extended method implementation
  *       Daimler TSS GmbH - fixed contract dates to epoch seconds
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - refactor
  *
  */
+
 package org.eclipse.dataspaceconnector.contract.negotiation;
 
 import io.opentelemetry.extension.annotations.WithSpan;
@@ -388,7 +389,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                     .providerAgentId(String.valueOf(lastOffer.getProvider()))
                     .consumerAgentId(String.valueOf(lastOffer.getConsumer()))
                     .policy(lastOffer.getPolicy())
-                    .asset(lastOffer.getAsset())
+                    .assetId(lastOffer.getAsset().getId())
                     .build();
         } else {
             agreement = retrievedAgreement;

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImplTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021-2022 Microsoft Corporation
+ *  Copyright (c) 2021 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
  *       Daimler TSS GmbH - fixed contract dates to epoch seconds
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - refactor
  *
  */
 
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import java.net.URI;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import static java.time.Instant.MAX;
@@ -104,7 +106,7 @@ class ContractValidationServiceImplTest {
                 .providerAgentId("provider")
                 .consumerAgentId("consumer")
                 .policy(originalPolicy)
-                .asset(Asset.Builder.newInstance().build())
+                .assetId(UUID.randomUUID().toString())
                 .contractStartDate(Instant.now().getEpochSecond())
                 .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())
                 .contractSigningDate(Instant.now().getEpochSecond())
@@ -148,7 +150,7 @@ class ContractValidationServiceImplTest {
                 .providerAgentId("provider")
                 .consumerAgentId("consumer")
                 .policy(originalPolicy)
-                .asset(Asset.Builder.newInstance().build())
+                .assetId(UUID.randomUUID().toString())
                 .contractSigningDate(signingDate)
                 .contractStartDate(startDate)
                 .contractEndDate(endDate)

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
@@ -88,7 +88,7 @@ class IdsApiMultipartDispatcherV1IntegrationTestServiceExtension implements Serv
                 .contractAgreement(ContractAgreement.Builder.newInstance().id("1")
                         .providerAgentId("provider")
                         .consumerAgentId("consumer")
-                        .asset(Asset.Builder.newInstance().build())
+                        .assetId(UUID.randomUUID().toString())
                         .policy(Policy.Builder.newInstance().build())
                         .contractSigningDate(Instant.now().getEpochSecond())
                         .contractStartDate(Instant.now().getEpochSecond())

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/MultipartDispatcherIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/MultipartDispatcherIntegrationTest.java
@@ -196,7 +196,7 @@ class MultipartDispatcherIntegrationTest extends AbstractMultipartDispatcherInte
         var contractAgreement = ContractAgreement.Builder.newInstance()
                 .id("1:23456").consumerAgentId("consumer").providerAgentId("provider")
                 .policy(Policy.Builder.newInstance().build())
-                .asset(Asset.Builder.newInstance().build())
+                .assetId(UUID.randomUUID().toString())
                 .build();
 
         when(transformerRegistry.transform(any(), eq(de.fraunhofer.iais.eis.ContractAgreement.class)))

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
@@ -98,7 +98,7 @@ class IdsApiMultipartEndpointV1IntegrationTestServiceExtension implements Servic
                 .contractAgreement(ContractAgreement.Builder.newInstance().id("1")
                         .providerAgentId("provider")
                         .consumerAgentId("consumer")
-                        .asset(Asset.Builder.newInstance().build())
+                        .assetId(UUID.randomUUID().toString())
                         .policy(Policy.Builder.newInstance().build())
                         .contractStartDate(Instant.now().getEpochSecond())
                         .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ArtifactRequestHandlerTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ArtifactRequestHandlerTest.java
@@ -125,7 +125,7 @@ class ArtifactRequestHandlerTest {
                 .id(UUID.randomUUID().toString())
                 .providerAgentId("provider")
                 .consumerAgentId("consumer")
-                .asset(Asset.Builder.newInstance().build())
+                .assetId(UUID.randomUUID().toString())
                 .policy(Policy.Builder.newInstance().build())
                 .build();
     }

--- a/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/dataspaceconnector/ids/transform/IdsContractAgreementToContractAgreementTransformer.java
+++ b/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/dataspaceconnector/ids/transform/IdsContractAgreementToContractAgreementTransformer.java
@@ -91,7 +91,7 @@ public class IdsContractAgreementToContractAgreementTransformer implements IdsTy
                 .policy(policyBuilder.build())
                 .consumerAgentId(String.valueOf(contractAgreement.getConsumer()))
                 .providerAgentId(String.valueOf(contractAgreement.getProvider()))
-                .asset(asset);
+                .assetId(asset.getId());
 
         var idsUri = contractAgreement.getId();
         if (idsUri != null) {

--- a/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/dataspaceconnector/ids/transform/ContractAgreementToIdsContractAgreementTransformerTest.java
+++ b/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/dataspaceconnector/ids/transform/ContractAgreementToIdsContractAgreementTransformerTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import java.net.URI;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -113,7 +114,7 @@ public class ContractAgreementToIdsContractAgreementTransformerTest {
         return ContractAgreement.Builder.newInstance()
                 .id(String.valueOf(AGREEMENT_ID))
                 .providerAgentId(PROVIDER_ID)
-                .asset(Asset.Builder.newInstance().build())
+                .assetId(UUID.randomUUID().toString())
                 .consumerAgentId("id")
                 .contractStartDate(Instant.now().getEpochSecond())
                 .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImpl.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImpl.java
@@ -55,7 +55,7 @@ public class AssetServiceImpl implements AssetService {
     @Override
     public ServiceResult<Asset> delete(String assetId) {
         return transactionContext.execute(() -> {
-            var filter = format("contractAgreement.asset.properties.%s = %s", PROPERTY_ID, assetId);
+            var filter = format("contractAgreement.assetId = %s", assetId);
             var query = QuerySpec.Builder.newInstance().filter(filter).build();
 
             var negotiationsOnAsset = contractNegotiationStore.queryNegotiations(query);

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiControllerIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 ZF Friedrichshafen AG
+ * Copyright (c) 2022 - 2022 ZF Friedrichshafen AG
  *
  * This program and the accompanying materials are made available under the
  * terms of the Apache License, Version 2.0 which is available at
@@ -183,7 +183,7 @@ public class AssetApiControllerIntegrationTest {
                 .id(UUID.randomUUID().toString())
                 .providerAgentId(UUID.randomUUID().toString())
                 .consumerAgentId(UUID.randomUUID().toString())
-                .asset(asset)
+                .assetId(asset.getId())
                 .policy(Policy.Builder.newInstance().build())
                 .build();
     }

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImplTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImplTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 - 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.api.datamanagement.asset.service;
 
 import org.eclipse.dataspaceconnector.dataloading.AssetLoader;
@@ -97,7 +111,7 @@ class AssetServiceImplTest {
     void delete_shouldNotDeleteIfAssetIsAlreadyPartOfAnAgreement() {
         var asset = createAsset("assetId");
         when(loader.deleteById("assetId")).thenReturn(asset);
-        ContractNegotiation contractNegotiation = ContractNegotiation.Builder.newInstance()
+        var contractNegotiation = ContractNegotiation.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .counterPartyId(UUID.randomUUID().toString())
                 .counterPartyAddress("address")
@@ -106,7 +120,7 @@ class AssetServiceImplTest {
                         .id(UUID.randomUUID().toString())
                         .providerAgentId(UUID.randomUUID().toString())
                         .consumerAgentId(UUID.randomUUID().toString())
-                        .asset(asset)
+                        .assetId("assetId")
                         .policy(Policy.Builder.newInstance().build())
                         .build())
                 .build();

--- a/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/ContractAgreementToContractAgreementDtoTransformer.java
+++ b/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/ContractAgreementToContractAgreementDtoTransformer.java
@@ -37,7 +37,7 @@ public class ContractAgreementToContractAgreementDtoTransformer implements DtoTr
     public @Nullable ContractAgreementDto transform(@Nullable ContractAgreement object, @NotNull TransformerContext context) {
         return ContractAgreementDto.Builder.newInstance()
                 .id(object.getId())
-                .assetId(object.getAsset().getId())
+                .assetId(object.getAssetId())
                 .policyId(object.getPolicy().getUid())
                 .consumerAgentId(object.getConsumerAgentId())
                 .providerAgentId(object.getProviderAgentId())

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 ZF Friedrichshafen AG
+ * Copyright (c) 2022 - 2022 ZF Friedrichshafen AG
  *
  * This program and the accompanying materials are made available under the
  * terms of the Apache License, Version 2.0 which is available at
@@ -200,7 +200,7 @@ class ContractNegotiationApiControllerIntegrationTest {
                 .id(negotiationId)
                 .providerAgentId(UUID.randomUUID().toString())
                 .consumerAgentId(UUID.randomUUID().toString())
-                .asset(Asset.Builder.newInstance().build())
+                .assetId(UUID.randomUUID().toString())
                 .policy(Policy.Builder.newInstance().build())
                 .build();
     }

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 ZF Friedrichshafen AG
+ * Copyright (c) 2022 - 2022 ZF Friedrichshafen AG
  *
  * This program and the accompanying materials are made available under the
  * terms of the Apache License, Version 2.0 which is available at
@@ -269,7 +269,7 @@ class ContractNegotiationApiControllerTest {
                 .id(negotiationId)
                 .providerAgentId(UUID.randomUUID().toString())
                 .consumerAgentId(UUID.randomUUID().toString())
-                .asset(Asset.Builder.newInstance().build())
+                .assetId(UUID.randomUUID().toString())
                 .policy(Policy.Builder.newInstance().build())
                 .build();
     }

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/service/ContractNegotiationServiceImplTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/service/ContractNegotiationServiceImplTest.java
@@ -216,20 +216,8 @@ class ContractNegotiationServiceImplTest {
                 .id(agreementId)
                 .providerAgentId(UUID.randomUUID().toString())
                 .consumerAgentId(UUID.randomUUID().toString())
-                .asset(Asset.Builder.newInstance().build())
+                .assetId(UUID.randomUUID().toString())
                 .policy(Policy.Builder.newInstance().build())
-                .build();
-    }
-
-    private ContractOfferRequest createContractOfferRequest() {
-        return ContractOfferRequest.Builder.newInstance()
-                .protocol("protocol")
-                .connectorId("connectorId")
-                .connectorAddress("connectorAddress")
-                .contractOffer(ContractOffer.Builder.newInstance()
-                        .id(UUID.randomUUID().toString())
-                        .policy(Policy.Builder.newInstance().build())
-                        .build())
                 .build();
     }
 

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/ContractAgreementToContractAgreementDtoTransformerTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/ContractAgreementToContractAgreementDtoTransformerTest.java
@@ -40,7 +40,7 @@ class ContractAgreementToContractAgreementDtoTransformerTest {
                 .id("agreementId")
                 .consumerAgentId("consumerAgentId")
                 .providerAgentId("providerAgentId")
-                .asset(Asset.Builder.newInstance().id("assetId").build())
+                .assetId("assetId")
                 .policy(Policy.Builder.newInstance().id("policyId").build())
                 .contractStartDate(1)
                 .contractSigningDate(2)

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/ContractNegotiationToContractNegotiationDtoTransformerTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/ContractNegotiationToContractNegotiationDtoTransformerTest.java
@@ -22,6 +22,8 @@ import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.Cont
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates;
 import org.junit.jupiter.api.Test;
 
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation.Type.PROVIDER;
 import static org.mockito.Mockito.mock;
@@ -67,7 +69,7 @@ class ContractNegotiationToContractNegotiationDtoTransformerTest {
                 .id(id)
                 .consumerAgentId("any")
                 .providerAgentId("any")
-                .asset(Asset.Builder.newInstance().build())
+                .assetId(UUID.randomUUID().toString())
                 .policy(Policy.Builder.newInstance().build())
                 .build();
     }

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/TestFunctions.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/TestFunctions.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020-2022 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -47,7 +47,7 @@ public class TestFunctions {
                 .contractAgreement(ContractAgreement.Builder.newInstance().id("1")
                         .providerAgentId("provider")
                         .consumerAgentId("consumer")
-                        .asset(Asset.Builder.newInstance().build())
+                        .assetId(UUID.randomUUID().toString())
                         .policy(Policy.Builder.newInstance().build())
                         .contractStartDate(Instant.now().getEpochSecond())
                         .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())

--- a/extensions/in-memory/negotiation-store-memory/src/test/java/org/eclipse/dataspaceconnector/negotiation/store/memory/TestFunctions.java
+++ b/extensions/in-memory/negotiation-store-memory/src/test/java/org/eclipse/dataspaceconnector/negotiation/store/memory/TestFunctions.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021-2022 Microsoft Corporation
+ *  Copyright (c) 2021 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -24,6 +24,7 @@ import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOf
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.UUID;
 
 public class TestFunctions {
 
@@ -45,7 +46,7 @@ public class TestFunctions {
                 .id("agreementId")
                 .providerAgentId("provider")
                 .consumerAgentId("consumer")
-                .asset(Asset.Builder.newInstance().build())
+                .assetId(UUID.randomUUID().toString())
                 .policy(Policy.Builder.newInstance().build())
                 .contractStartDate(Instant.now().getEpochSecond())
                 .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())

--- a/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -22,7 +22,6 @@ import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
 import org.eclipse.dataspaceconnector.spi.transaction.datasource.DataSourceRegistry;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
-import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
 import org.eclipse.dataspaceconnector.sql.lease.SqlLeaseContextBuilder;
@@ -214,7 +213,7 @@ public class SqlContractNegotiationStore implements ContractNegotiationStore {
                     agr.getContractSigningDate(),
                     agr.getContractStartDate(),
                     agr.getContractEndDate(),
-                    agr.getAsset().getId(),
+                    agr.getAssetId(),
                     agr.getPolicy().getUid());
         }
 
@@ -250,7 +249,7 @@ public class SqlContractNegotiationStore implements ContractNegotiationStore {
                 .id(resultSet.getString(statements.getContractAgreementIdColumn()))
                 .providerAgentId(resultSet.getString(statements.getProviderAgentColumn()))
                 .consumerAgentId(resultSet.getString(statements.getConsumerAgentColumn()))
-                .asset(Asset.Builder.newInstance().id(resultSet.getString(statements.getAssetIdColumn())).build())
+                .assetId(resultSet.getString(statements.getAssetIdColumn()))
                 .policy(Policy.Builder.newInstance().id(resultSet.getString(statements.getPolicyIdColumn())).build())
                 .contractStartDate(resultSet.getLong(statements.getStartDateColumn()))
                 .contractEndDate(resultSet.getLong(statements.getEndDateColumn()))

--- a/extensions/sql/contract-negotiation-store/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/SqlContractNegotiationStoreExtensionTest.java
+++ b/extensions/sql/contract-negotiation-store/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/SqlContractNegotiationStoreExtensionTest.java
@@ -35,18 +35,10 @@ import static org.mockito.Mockito.mock;
 @ExtendWith(DependencyInjectionExtension.class)
 class SqlContractNegotiationStoreExtensionTest {
 
-    private ServiceExtensionContext context;
     private SqlContractNegotiationStoreExtension extension;
-    private ObjectFactory factory;
-
-    @BeforeEach
-    void setUp(ServiceExtensionContext context, ObjectFactory factory) {
-        this.context = context;
-        this.factory = factory;
-    }
 
     @Test
-    void initialize() {
+    void initialize(ServiceExtensionContext context, ObjectFactory factory) {
         context.registerService(DataSourceRegistry.class, mock(DataSourceRegistry.class));
         context.registerService(TransactionContext.class, mock(TransactionContext.class));
 
@@ -60,7 +52,7 @@ class SqlContractNegotiationStoreExtensionTest {
     }
 
     @Test
-    void initialize_withCustomSqlDialect() {
+    void initialize_withCustomSqlDialect(ServiceExtensionContext context, ObjectFactory factory) {
         context.registerService(DataSourceRegistry.class, mock(DataSourceRegistry.class));
         context.registerService(TransactionContext.class, mock(TransactionContext.class));
         context.registerService(ContractNegotiationStatements.class, new TestStatements());
@@ -75,7 +67,7 @@ class SqlContractNegotiationStoreExtensionTest {
     }
 
     @Test
-    void initialize_missingDataSourceRegistry() {
+    void initialize_missingDataSourceRegistry(ServiceExtensionContext context, ObjectFactory factory) {
         context.registerService(TransactionContext.class, mock(TransactionContext.class));
 
         assertThatThrownBy(() -> factory.constructInstance(SqlContractNegotiationStoreExtension.class))
@@ -83,7 +75,7 @@ class SqlContractNegotiationStoreExtensionTest {
     }
 
     @Test
-    void initialize_missingTransactionContext() {
+    void initialize_missingTransactionContext(ServiceExtensionContext context, ObjectFactory factory) {
         context.registerService(TransactionContext.class, mock(TransactionContext.class));
 
         assertThatThrownBy(() -> factory.constructInstance(SqlContractNegotiationStoreExtension.class))

--- a/extensions/sql/contract-negotiation-store/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/TestFunctions.java
+++ b/extensions/sql/contract-negotiation-store/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/TestFunctions.java
@@ -23,6 +23,7 @@ import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.Cont
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.UUID;
 
 public class TestFunctions {
 
@@ -57,7 +58,7 @@ public class TestFunctions {
                 .id(id)
                 .providerAgentId("provider")
                 .consumerAgentId("consumer")
-                .asset(Asset.Builder.newInstance().build())
+                .assetId(UUID.randomUUID().toString())
                 .policy(Policy.Builder.newInstance().build())
                 .contractStartDate(Instant.now().getEpochSecond())
                 .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/agreement/ContractAgreement.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/agreement/ContractAgreement.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021 Daimler TSS GmbH
+ *  Copyright (c) 2021 - 2022 Daimler TSS GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - refactor
  *
  */
 
@@ -35,7 +36,7 @@ public class ContractAgreement {
     private final long contractSigningDate;
     private final long contractStartDate;
     private final long contractEndDate;
-    private final Asset asset;
+    private final String assetId;
     private final Policy policy;
 
     private ContractAgreement(@NotNull String id,
@@ -44,15 +45,15 @@ public class ContractAgreement {
                               long contractSigningDate,
                               long contractStartDate,
                               long contractEndDate,
-                              @NotNull Asset asset,
-                              @NotNull Policy policy) {
+                              @NotNull Policy policy,
+                              @NotNull String assetId) {
         this.id = Objects.requireNonNull(id);
         this.providerAgentId = Objects.requireNonNull(providerAgentId);
         this.consumerAgentId = Objects.requireNonNull(consumerAgentId);
         this.contractSigningDate = contractSigningDate;
         this.contractStartDate = contractStartDate;
         this.contractEndDate = contractEndDate;
-        this.asset = Objects.requireNonNull(asset);
+        this.assetId = Objects.requireNonNull(assetId);
         this.policy = Objects.requireNonNull(policy);
     }
 
@@ -126,13 +127,13 @@ public class ContractAgreement {
     }
 
     /**
-     * The Asset that is covered by the {@link ContractAgreement}.
+     * The ID of the Asset that is covered by the {@link ContractAgreement}.
      *
-     * @return asset
+     * @return assetId
      */
     @NotNull
-    public Asset getAsset() {
-        return asset;
+    public String getAssetId() {
+        return assetId;
     }
 
     /**
@@ -147,7 +148,7 @@ public class ContractAgreement {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, providerAgentId, consumerAgentId, contractSigningDate, contractStartDate, contractEndDate, asset, policy);
+        return Objects.hash(id, providerAgentId, consumerAgentId, contractSigningDate, contractStartDate, contractEndDate, assetId, policy);
     }
 
     @Override
@@ -161,7 +162,7 @@ public class ContractAgreement {
         ContractAgreement that = (ContractAgreement) o;
         return contractSigningDate == that.contractSigningDate && contractStartDate == that.contractStartDate && contractEndDate == that.contractEndDate &&
                 Objects.equals(id, that.id) && Objects.equals(providerAgentId, that.providerAgentId) && Objects.equals(consumerAgentId, that.consumerAgentId) &&
-                Objects.equals(asset, that.asset) && Objects.equals(policy, that.policy);
+                Objects.equals(assetId, that.assetId) && Objects.equals(policy, that.policy);
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -173,7 +174,7 @@ public class ContractAgreement {
         private long contractSigningDate;
         private long contractStartDate;
         private long contractEndDate;
-        private Asset asset;
+        private String assetId;
         private Policy policy;
 
         private Builder() {
@@ -214,8 +215,8 @@ public class ContractAgreement {
             return this;
         }
 
-        public Builder asset(Asset asset) {
-            this.asset = asset;
+        public Builder assetId(String assetId) {
+            this.assetId = assetId;
             return this;
         }
 
@@ -225,7 +226,7 @@ public class ContractAgreement {
         }
 
         public ContractAgreement build() {
-            return new ContractAgreement(id, providerAgentId, consumerAgentId, contractSigningDate, contractStartDate, contractEndDate, asset, policy);
+            return new ContractAgreement(id, providerAgentId, consumerAgentId, contractSigningDate, contractStartDate, contractEndDate, policy, assetId);
         }
 
     }


### PR DESCRIPTION
## What this PR changes/adds

Replaces `Asset` with `assetId` on `ContractAgreement`

## Why it does that

Simplifies object structure, avoid data duplication.

## Further notes

-

## Linked Issue(s)

Point 1. of #828

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
