### PR TITLE
CI: control test verbosity

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -179,7 +179,11 @@ allprojects {
         }
 
         testLogging {
-            events("failed")
+            if (project.hasProperty("verboseTest")) {
+                events("started", "passed", "skipped", "failed", "standard_out", "standard_error")
+            } else {
+                events("failed")
+            }
             showStackTraces = true
             exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
         }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,5 +1,13 @@
 # Writing Tests
 
+## Controlling test verbosity
+
+To run tests verbosely (displaying test events and output and error streams to the console), use the following system property:
+
+```shell
+./gradlew test -PverboseTest
+```
+
 ## Definition and distinction
 
 * _unit tests_ test one single class by stubbing or mocking dependencies.

--- a/extensions/catalog/federated-catalog-cache/build.gradle.kts
+++ b/extensions/catalog/federated-catalog-cache/build.gradle.kts
@@ -42,11 +42,6 @@ dependencies {
     testImplementation(project(":extensions:in-memory:fcc-store-memory"))
 }
 
-tasks.withType<Test> {
-    testLogging {
-        showStandardStreams = false
-    }
-}
 publishing {
     publications {
         create<MavenPublication>("catalog-cache") {

--- a/extensions/data-plane/integration-tests/build.gradle.kts
+++ b/extensions/data-plane/integration-tests/build.gradle.kts
@@ -40,7 +40,3 @@ dependencies {
 
     testRuntimeOnly(project(":launchers:data-plane-server"))
 }
-
-tasks.getByName<Test>("test") {
-    useJUnitPlatform()
-}

--- a/launchers/junit/src/testFixtures/java/org/eclipse/dataspaceconnector/junit/launcher/EdcExtension.java
+++ b/launchers/junit/src/testFixtures/java/org/eclipse/dataspaceconnector/junit/launcher/EdcExtension.java
@@ -42,7 +42,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.eclipse.dataspaceconnector.common.types.Cast.cast;
 
@@ -79,23 +78,18 @@ public class EdcExtension extends BaseRuntime implements BeforeTestExecutionCall
 
     @Override
     public void beforeTestExecution(ExtensionContext extensionContext) throws Exception {
-        boot();
+        bootWithoutShutdownHook();
     }
 
     @Override
     public void afterTestExecution(ExtensionContext context) throws Exception {
-        // TODO: this shutdown is duplicated but it's necessary to DataPlaneHttpIntegrationTests, needs to be fixed
-        if (runningServiceExtensions != null) {
-            shutdown(runningServiceExtensions, getMonitor());
-        }
-
+        shutdown();
         // clear the systemExtensions map to prevent it from piling up between subsequent runs
         ((MultiSourceServiceLocator) serviceLocator).clearSystemExtensions();
     }
 
     @Override
     protected void bootExtensions(ServiceExtensionContext context, List<InjectionContainer<ServiceExtension>> serviceExtensions) {
-        this.runningServiceExtensions = serviceExtensions.stream().map(InjectionContainer::getInjectionTarget).collect(Collectors.toList());
         super.bootExtensions(context, serviceExtensions);
     }
 

--- a/samples/other/custom-runtime/src/main/java/org/eclipse/dataspaceconnector/demo/runtime/CustomRuntime.java
+++ b/samples/other/custom-runtime/src/main/java/org/eclipse/dataspaceconnector/demo/runtime/CustomRuntime.java
@@ -34,8 +34,8 @@ public class CustomRuntime extends BaseRuntime {
     }
 
     @Override
-    protected void shutdown(List<ServiceExtension> serviceExtensions, Monitor monitor) {
-        super.shutdown(serviceExtensions, monitor);
+    protected void shutdown() {
+        super.shutdown();
 
         //this is the custom part here:
         monitor.info(" CUSTOM RUNTIME SHUTDOWN ! ");

--- a/system-tests/e2e-transfer-test/runner/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/runner/build.gradle.kts
@@ -35,9 +35,3 @@ dependencies {
     testCompileOnly(project(":system-tests:e2e-transfer-test:control-plane"))
     testCompileOnly(project(":system-tests:e2e-transfer-test:data-plane"))
 }
-
-tasks.getByName<Test>("test") {
-    testLogging {
-        showStandardStreams = true
-    }
-}

--- a/system-tests/tests/build.gradle.kts
+++ b/system-tests/tests/build.gradle.kts
@@ -39,8 +39,3 @@ dependencies {
     testCompileOnly(project(":system-tests:runtimes:file-transfer-consumer"))
 }
 
-tasks.getByName<Test>("test") {
-    testLogging {
-        showStandardStreams = true
-    }
-}


### PR DESCRIPTION
## What this PR changes/adds

- `./gradlew clean test` does not log anything from (successful) test runs.
- A runtime flag is available (and documented) to make test runs verbose.
- With `./gradlew clean test`, if a test fails, the test name and failure cause are printed

## Why it does that

Improve developer experience

## Further notes

Fixed BaseRuntime so as not to apply a shutdown hook to tests, that was causing extra logging at test completion.

Sample run showing clear message when a test fails:
https://github.com/agera-edc/DataSpaceConnector/runs/5749889045?check_suite_focus=true
```
2022-03-30T07:23:21.2000714Z CoreServicesExtensionIntegrationTest > shouldProvideHostnameExtension(Hostname) FAILED
2022-03-30T07:23:21.2001408Z     java.lang.AssertionError: Something strange happened
2022-03-30T07:23:21.2002146Z         at org.eclipse.dataspaceconnector.core.CoreServicesExtensionIntegrationTest.shouldProvideHostnameExtension(CoreServicesExtensionIntegrationTest.java:40)
2022-03-30T07:23:27.6996011Z 
```

## Linked Issue(s)

Closes #994

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
