### PR TITLE
AssetIndex: add support for `QuerySpec` filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ the detailed section referring to by linking pull requests or issues.
 * Call the listeners before the state transition is persisted. (#876)
 * Added an overload to `TransactionContext#execute()` (#968)
 * Run CosmosDB integration tests on cloud in CI (#964)
+* Added SQL-AssetIndex to support `QuerySpec` (#1014)
 * Improved provision signalling and align deprovisioning to handle error conditions (#992)
 
 #### Removed

--- a/extensions/sql/asset/index/src/main/java/org/eclipse/dataspaceconnector/sql/asset/index/PostgresSqlAssetQueries.java
+++ b/extensions/sql/asset/index/src/main/java/org/eclipse/dataspaceconnector/sql/asset/index/PostgresSqlAssetQueries.java
@@ -1,150 +1,98 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.sql.asset.index;
 
 
+import static java.lang.String.format;
+
 public class PostgresSqlAssetQueries implements SqlAssetQueries {
 
-    private static final String ASSET_TABLE = "edc_asset";
-    private static final String ASSET_COLUMN_ID = "asset_id";
-
-    private static final String DATA_ADDRESS_TABLE = "edc_asset_dataaddress";
-    private static final String DATA_ADDRESS_COLUMN_PROPERTIES = "properties";
-
-    private static final String ASSET_PROPERTY_TABLE = "edc_asset_property";
-    private static final String ASSET_PROPERTY_COLUMN_NAME = "property_name";
-    private static final String ASSET_PROPERTY_COLUMN_VALUE = "property_value";
-    private static final String ASSET_PROPERTY_COLUMN_TYPE = "property_type";
-
-    private static final String COUNT_VARIABLE_NAME = "count";
-
-    private static final String SQL_ASSET_INSERT_CLAUSE_TEMPLATE = String.format("INSERT INTO %s (%s) VALUES (?)",
-            ASSET_TABLE,
-            ASSET_COLUMN_ID);
-    private static final String SQL_DATA_ADDRESS_INSERT_CLAUSE_TEMPLATE = String.format("INSERT INTO %s (%s, %s) VALUES (?, ?)",
-            DATA_ADDRESS_TABLE,
-            ASSET_COLUMN_ID,
-            DATA_ADDRESS_COLUMN_PROPERTIES);
-    private static final String SQL_PROPERTY_INSERT_CLAUSE_TEMPLATE = String.format("INSERT INTO %s (%s, %s, %s, %s) VALUES (?, ?, ?, ?)",
-            ASSET_PROPERTY_TABLE,
-            ASSET_COLUMN_ID,
-            ASSET_PROPERTY_COLUMN_NAME,
-            ASSET_PROPERTY_COLUMN_VALUE,
-            ASSET_PROPERTY_COLUMN_TYPE);
-
-    private static final String SQL_ASSET_COUNT_BY_ID_CLAUSE_TEMPLATE = String.format("SELECT COUNT(*) AS %s FROM %s WHERE %s = ?",
-            COUNT_VARIABLE_NAME,
-            ASSET_TABLE,
-            ASSET_COLUMN_ID);
-    private static final String SQL_ASSET_PROPERTY_FIND_BY_ID_CLAUSE_TEMPLATE = String.format("SELECT * FROM %s WHERE %s = ?",
-            ASSET_PROPERTY_TABLE,
-            ASSET_COLUMN_ID);
-    private static final String SQL_DATA_ADDRESS_FIND_BY_ID_CLAUSE_TEMPLATE = String.format("SELECT * FROM %s WHERE %s = ?",
-            DATA_ADDRESS_TABLE,
-            ASSET_COLUMN_ID);
-    private static final String SQL_ASSET_LIST_CLAUSE_TEMPLATE = String.format("SELECT * FROM %s",
-            ASSET_TABLE);
-
-    private static final String SQL_ASSET_DELETE_BY_ID_CLAUSE_TEMPLATE = String.format("DELETE FROM %s WHERE %s = ?",
-            ASSET_TABLE,
-            ASSET_COLUMN_ID);
-    private static final String SQL_DATA_ADDRESS_DELETE_BY_ID_CLAUSE_TEMPLATE = String.format("DELETE FROM %s WHERE %s = ?",
-            DATA_ADDRESS_TABLE,
-            ASSET_COLUMN_ID);
-    private static final String SQL_ASSET_PROPERTY_DELETE_BY_ID_CLAUSE_TEMPLATE = String.format("DELETE FROM %s WHERE %s = ?",
-            ASSET_PROPERTY_TABLE,
-            ASSET_COLUMN_ID);
 
     @Override
     public String getSqlAssetInsertClause() {
-        return SQL_ASSET_INSERT_CLAUSE_TEMPLATE;
+        return format("INSERT INTO %s (%s) VALUES (?)", getAssetTable(), getAssetColumnId());
     }
 
     @Override
     public String getSqlDataAddressInsertClause() {
-        return SQL_DATA_ADDRESS_INSERT_CLAUSE_TEMPLATE;
+        return format("INSERT INTO %s (%s, %s) VALUES (?, ?)",
+                getDataAddressTable(),
+                getAssetColumnId(),
+                getDataAddressColumnProperties());
     }
 
     @Override
     public String getSqlPropertyInsertClause() {
-        return SQL_PROPERTY_INSERT_CLAUSE_TEMPLATE;
+        return format("INSERT INTO %s (%s, %s, %s, %s) VALUES (?, ?, ?, ?)",
+                getAssetPropertyTable(),
+                getAssetColumnId(),
+                getAssetPropertyColumnName(),
+                getAssetPropertyColumnValue(),
+                getAssetPropertyColumnType());
     }
 
     @Override
     public String getSqlAssetCountByIdClause() {
-        return SQL_ASSET_COUNT_BY_ID_CLAUSE_TEMPLATE;
+        return format("SELECT COUNT(*) AS %s FROM %s WHERE %s = ?",
+                getCountVariableName(),
+                getAssetTable(),
+                getAssetColumnId());
     }
 
     @Override
     public String getSqlPropertyFindByIdClause() {
-        return SQL_ASSET_PROPERTY_FIND_BY_ID_CLAUSE_TEMPLATE;
+        return format("SELECT * FROM %s WHERE %s = ?",
+                getAssetPropertyTable(),
+                getAssetColumnId());
     }
 
     @Override
     public String getSqlDataAddressFindByIdClause() {
-        return SQL_DATA_ADDRESS_FIND_BY_ID_CLAUSE_TEMPLATE;
+        return format("SELECT * FROM %s WHERE %s = ?",
+                getDataAddressTable(),
+                getAssetColumnId());
     }
 
     @Override
     public String getSqlAssetListClause() {
-        return SQL_ASSET_LIST_CLAUSE_TEMPLATE;
+        return format("SELECT * FROM %s AS a", getAssetTable());
     }
 
     @Override
     public String getSqlAssetDeleteByIdClause() {
-        return SQL_ASSET_DELETE_BY_ID_CLAUSE_TEMPLATE;
+        return format("DELETE FROM %s WHERE %s = ?", getAssetTable(), getAssetColumnId());
     }
 
     @Override
     public String getSqlDataAddressDeleteByIdClause() {
-        return SQL_DATA_ADDRESS_DELETE_BY_ID_CLAUSE_TEMPLATE;
+        return format("DELETE FROM %s WHERE %s = ?", getDataAddressTable(), getAssetColumnId());
     }
 
     @Override
     public String getSqlPropertyDeleteByIdClause() {
-        return SQL_ASSET_PROPERTY_DELETE_BY_ID_CLAUSE_TEMPLATE;
+        return format("DELETE FROM %s WHERE %s = ?", getAssetPropertyTable(), getAssetColumnId());
     }
 
     @Override
     public String getCountVariableName() {
-        return COUNT_VARIABLE_NAME;
+        return "COUNT";
     }
 
     @Override
-    public String getAssetTable() {
-        return ASSET_TABLE;
-    }
-
-    @Override
-    public String getAssetColumnId() {
-        return ASSET_COLUMN_ID;
-    }
-
-    @Override
-    public String getDataAddressTable() {
-        return DATA_ADDRESS_TABLE;
-    }
-
-    @Override
-    public String getDataAddressColumnProperties() {
-        return DATA_ADDRESS_COLUMN_PROPERTIES;
-    }
-
-    @Override
-    public String getAssetPropertyTable() {
-        return ASSET_PROPERTY_TABLE;
-    }
-
-    @Override
-    public String getAssetPropertyColumnName() {
-        return ASSET_PROPERTY_COLUMN_NAME;
-    }
-
-    @Override
-    public String getAssetPropertyColumnValue() {
-        return ASSET_PROPERTY_COLUMN_VALUE;
-    }
-
-    @Override
-    public String getAssetPropertyColumnType() {
-        return ASSET_PROPERTY_COLUMN_TYPE;
+    public String getQuerySubSelectClause() {
+        return format("EXISTS (SELECT 1 FROM %s AS eap WHERE eap.%s = a.%s AND eap.%s = ? AND eap.%s", getAssetPropertyTable(), getAssetColumnId(), getAssetColumnId(), getAssetPropertyColumnName(),
+                getAssetPropertyColumnValue());
     }
 }

--- a/extensions/sql/asset/index/src/main/java/org/eclipse/dataspaceconnector/sql/asset/index/SqlAssetQueries.java
+++ b/extensions/sql/asset/index/src/main/java/org/eclipse/dataspaceconnector/sql/asset/index/SqlAssetQueries.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.sql.asset.index;
 
 /**
@@ -59,4 +73,10 @@ public interface SqlAssetQueries extends SqlAssetTables {
      * The COUNT variable used in SELECT COUNT queries.
      */
     String getCountVariableName();
+
+    /**
+     * Provides a dynamically assembled SELECT statement for use with {@link org.eclipse.dataspaceconnector.spi.query.QuerySpec}
+     * queries.
+     */
+    String getQuerySubSelectClause();
 }

--- a/extensions/sql/asset/index/src/main/java/org/eclipse/dataspaceconnector/sql/asset/index/SqlAssetTables.java
+++ b/extensions/sql/asset/index/src/main/java/org/eclipse/dataspaceconnector/sql/asset/index/SqlAssetTables.java
@@ -21,40 +21,56 @@ public interface SqlAssetTables {
     /**
      * The asset table name.
      */
-    String getAssetTable();
+    default String getAssetTable() {
+        return "edc_asset";
+    }
 
     /**
      * The asset table ID column.
      */
-    String getAssetColumnId();
+    default String getAssetColumnId() {
+        return "asset_id";
+    }
 
     /**
      * The data address table name.
      */
-    String getDataAddressTable();
+    default String getDataAddressTable() {
+        return "edc_asset_dataaddress";
+    }
 
     /**
      * The data address table properties column.
      */
-    String getDataAddressColumnProperties();
+    default String getDataAddressColumnProperties() {
+        return "properties";
+    }
 
     /**
      * The asset property table name.
      */
-    String getAssetPropertyTable();
+    default String getAssetPropertyTable() {
+        return "edc_asset_property";
+    }
 
     /**
      * The asset property name column.
      */
-    String getAssetPropertyColumnName();
+    default String getAssetPropertyColumnName() {
+        return "property_name";
+    }
 
     /**
      * The asset property value column.
      */
-    String getAssetPropertyColumnValue();
+    default String getAssetPropertyColumnValue() {
+        return "property_value";
+    }
 
     /**
      * The asset property type column.
      */
-    String getAssetPropertyColumnType();
+    default String getAssetPropertyColumnType() {
+        return "property_type";
+    }
 }

--- a/extensions/sql/asset/index/src/main/java/org/eclipse/dataspaceconnector/sql/asset/index/SqlConditionExpression.java
+++ b/extensions/sql/asset/index/src/main/java/org/eclipse/dataspaceconnector/sql/asset/index/SqlConditionExpression.java
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.sql.asset.index;
+
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.result.Result;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static java.lang.String.format;
+
+/**
+ * Parses a {@link Criterion} and provides methods to validate it and extract SQL prepared statement placeholders and parameters.
+ */
+class SqlConditionExpression {
+
+    private static final String IN_OPERATOR = "in";
+    private static final String LIKE_OPERATOR = "like";
+    private static final String EQUALS_OPERATOR = "=";
+    private static final List<String> SUPPORTED_PREPARED_STATEMENT_OPERATORS = List.of(EQUALS_OPERATOR, LIKE_OPERATOR, IN_OPERATOR);
+    private static final String PREPARED_STATEMENT_PLACEHOLDER = "?";
+    private final Criterion criterion;
+
+    public SqlConditionExpression(Criterion criterion) {
+
+        this.criterion = criterion;
+    }
+
+    /**
+     * Checks whether the given {@link Criterion} is valid or not, i.e. if its {@linkplain Criterion#getOperator()} is in the list
+     * of supported operators, and whether the {@linkplain Criterion#getOperandRight()} has the correct type.
+     */
+    public Result<Void> isValidExpression() {
+        var isSupportedOperator = SUPPORTED_PREPARED_STATEMENT_OPERATORS.contains(criterion.getOperator().toLowerCase());
+        if (!isSupportedOperator) {
+            return Result.failure("unsupported operator " + criterion.getOperator());
+        }
+
+        if (Objects.equals(IN_OPERATOR, criterion.getOperator()) && !(criterion.getOperandRight() instanceof Iterable)) {
+            return Result.failure(format("The \"%s\" operator requires the right-hand operand to be of type %s", IN_OPERATOR, Iterable.class));
+        }
+        return Result.success();
+    }
+
+
+    /**
+     * Converts an operand into a simple SQL statement placeholder ("?"), or, if the operand is actually a list, converts
+     * it into "(?,...?)", with as many placeholders as there are list items
+     */
+    public String toValuePlaceholder() {
+        var operandRight = criterion.getOperandRight();
+        if (operandRight instanceof Iterable) {
+            var size = StreamSupport.stream(((Iterable) operandRight).spliterator(), false).count();
+            return format("(%s)", String.join(",", Collections.nCopies((int) size, PREPARED_STATEMENT_PLACEHOLDER)));
+        }
+        return PREPARED_STATEMENT_PLACEHOLDER;
+    }
+
+    /**
+     * Converts the {@link Criterion#getOperandRight()} to a {@link Stream} of Strings
+     * which can then be used as parameters for  prepared statements.
+     * <p>
+     * Note: {@link Stream} is used to allow a convenient use in a {@code flatMap} call
+     */
+    @SuppressWarnings("unchecked")
+    public Stream<String> toStatementParameter() {
+        List<String> result = new ArrayList<>();
+        result.add(criterion.getOperandLeft().toString());
+
+        var operandRight = criterion.getOperandRight();
+        if (operandRight instanceof Iterable) {
+            var iterable = (Iterable) operandRight;
+            iterable.forEach(o -> result.add(o.toString()));
+        } else {
+            result.add(operandRight.toString());
+        }
+        return result.stream();
+    }
+
+    public Criterion getCriterion() {
+        return criterion;
+    }
+}

--- a/extensions/sql/asset/index/src/test/java/org/eclipse/dataspaceconnector/sql/asset/index/SqlAssetIndexTest.java
+++ b/extensions/sql/asset/index/src/test/java/org/eclipse/dataspaceconnector/sql/asset/index/SqlAssetIndexTest.java
@@ -239,11 +239,24 @@ public class SqlAssetIndexTest {
         sqlAssetIndex.accept(asset2, getDataAddress());
 
         var assetsFound = sqlAssetIndex.queryAssets(AssetSelectorExpression.Builder.newInstance()
-                .constraint(Asset.PROPERTY_ID, "in", "('id1', 'id2')")
+                .constraint(Asset.PROPERTY_ID, "in", List.of("id1", "id2"))
                 .build());
 
         assertThat(assetsFound).isNotNull();
         assertThat(assetsFound).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("Query assets with selector expression using the IN operator, invalid righ-operand")
+    void queryAsset_selectorExpression_invalidOperand() {
+        var asset1 = getAsset("id1");
+        sqlAssetIndex.accept(asset1, getDataAddress());
+        var asset2 = getAsset("id2");
+        sqlAssetIndex.accept(asset2, getDataAddress());
+
+        assertThatThrownBy(() -> sqlAssetIndex.queryAssets(AssetSelectorExpression.Builder.newInstance()
+                .constraint(Asset.PROPERTY_ID, "in", "(id1, id2)")
+                .build())).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/extensions/sql/asset/index/src/test/java/org/eclipse/dataspaceconnector/sql/asset/index/SqlAssetIndexTest.java
+++ b/extensions/sql/asset/index/src/test/java/org/eclipse/dataspaceconnector/sql/asset/index/SqlAssetIndexTest.java
@@ -9,16 +9,19 @@
  *
  *  Contributors:
  *       Daimler TSS GmbH - Initial Tests
+ *       Microsoft Corporation - added full QuerySpec support
  *
  */
 
 package org.eclipse.dataspaceconnector.sql.asset.index;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.dataspaceconnector.dataloading.AssetEntry;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.persistence.EdcPersistenceException;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
 import org.eclipse.dataspaceconnector.spi.transaction.datasource.DataSourceRegistry;
@@ -44,6 +47,7 @@ import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.AbstractMap;
+import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -227,17 +231,49 @@ public class SqlAssetIndexTest {
     }
 
     @Test
-    @DisplayName("Query assets with selector expression")
-    void queryAsset_selectorExpression() {
+    @DisplayName("Query assets with selector expression using the IN operator")
+    void queryAsset_selectorExpression_in() {
         var asset1 = getAsset("id1");
         sqlAssetIndex.accept(asset1, getDataAddress());
         var asset2 = getAsset("id2");
         sqlAssetIndex.accept(asset2, getDataAddress());
 
-        var assetsFound = sqlAssetIndex.queryAssets(AssetSelectorExpression.Builder.newInstance().build());
+        var assetsFound = sqlAssetIndex.queryAssets(AssetSelectorExpression.Builder.newInstance()
+                .constraint(Asset.PROPERTY_ID, "in", "('id1', 'id2')")
+                .build());
 
         assertThat(assetsFound).isNotNull();
-        assertThat(assetsFound.count()).isEqualTo(2);
+        assertThat(assetsFound).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("Query assets with selector expression using the LIKE operator")
+    void queryAsset_selectorExpression_like() {
+        var asset1 = getAsset("id1");
+        sqlAssetIndex.accept(asset1, getDataAddress());
+        var asset2 = getAsset("id2");
+        sqlAssetIndex.accept(asset2, getDataAddress());
+
+        var assetsFound = sqlAssetIndex.queryAssets(AssetSelectorExpression.Builder.newInstance()
+                .constraint(Asset.PROPERTY_ID, "LIKE", "id%")
+                .build());
+
+        assertThat(assetsFound).isNotNull();
+        assertThat(assetsFound).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("Query assets with selector expression using the LIKE operator on a json value")
+    void queryAsset_selectorExpression_likeJson() throws JsonProcessingException {
+        var asset = getAsset("id1");
+        asset.getProperties().put("myjson", new ObjectMapper().writeValueAsString(new TestObject("test123", 42, false)));
+        sqlAssetIndex.accept(asset, getDataAddress());
+
+        var assetsFound = sqlAssetIndex.queryAssets(AssetSelectorExpression.Builder.newInstance()
+                .constraint("myjson", "LIKE", "%test123%")
+                .build());
+
+        assertThat(assetsFound).usingRecursiveFieldByFieldElementComparator().containsExactly(asset);
     }
 
     @Test
@@ -255,6 +291,47 @@ public class SqlAssetIndexTest {
     }
 
     @Test
+    @DisplayName("Query assets with query spec where the property (=leftOperand) does not exist")
+    void queryAsset_querySpec_nonExistProperty() {
+        var asset = getAsset("id1");
+        sqlAssetIndex.accept(asset, getDataAddress());
+
+        var qs = QuerySpec.Builder
+                .newInstance()
+                .filter(List.of(new Criterion("noexist", "=", "42")))
+                .build();
+        assertThat(sqlAssetIndex.queryAssets(qs)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Query assets with selector expression using the LIKE operator on a json value")
+    void queryAsset_querySpec_likeJson() throws JsonProcessingException {
+        var asset = getAsset("id1");
+        asset.getProperties().put("myjson", new ObjectMapper().writeValueAsString(new TestObject("test123", 42, false)));
+        sqlAssetIndex.accept(asset, getDataAddress());
+
+        var assetsFound = sqlAssetIndex.queryAssets(QuerySpec.Builder.newInstance()
+                .filter(List.of(new Criterion("myjson", "LIKE", "%test123%")))
+                .build());
+
+        assertThat(assetsFound).usingRecursiveFieldByFieldElementComparator().containsExactly(asset);
+    }
+
+    @Test
+    @DisplayName("Query assets with query spec where the value (=rightOperand) does not exist")
+    void queryAsset_querySpec_nonExistValue() {
+        var asset = getAsset("id1");
+        asset.getProperties().put("someprop", "someval");
+        sqlAssetIndex.accept(asset, getDataAddress());
+
+        var qs = QuerySpec.Builder
+                .newInstance()
+                .filter(List.of(new Criterion("someprop", "=", "some-other-val")))
+                .build();
+        assertThat(sqlAssetIndex.queryAssets(qs)).isEmpty();
+    }
+
+    @Test
     @DisplayName("Query assets with query spec and short asset count")
     void queryAsset_querySpecShortCount() {
         IntStream.range(1, 5).forEach((item) -> {
@@ -267,6 +344,24 @@ public class SqlAssetIndexTest {
         assertThat(assetsFound).isNotNull();
         assertThat(assetsFound.count()).isEqualTo(2);
     }
+
+    @Test
+    void queryAsset_withFilterExpression() {
+        var qs = QuerySpec.Builder.newInstance().filter(List.of(
+                new Criterion("version", "=", "2.0"),
+                new Criterion("content-type", "=", "whatever")
+        ));
+
+        var asset = getAsset("id1");
+        asset.getProperties().put("version", "2.0");
+        asset.getProperties().put("content-type", "whatever");
+        sqlAssetIndex.accept(asset, getDataAddress());
+
+        var result = sqlAssetIndex.queryAssets(qs.build()).collect(Collectors.toList());
+        assertThat(result).usingRecursiveFieldByFieldElementComparator().containsOnly(asset);
+
+    }
+
 
     @Test
     @DisplayName("Find an asset that doesn't exist")
@@ -332,4 +427,42 @@ public class SqlAssetIndexTest {
         return dataSourceRegistry.resolve(DATASOURCE_NAME).getConnection();
     }
 
+    private static class TestObject {
+        private String someText;
+        private int someNumber;
+        private boolean someBoolean;
+
+        public TestObject(String text, int number, boolean bool) {
+            someText = text;
+            someNumber = number;
+            someBoolean = bool;
+        }
+
+        public TestObject() {
+        }
+
+        public String getSomeText() {
+            return someText;
+        }
+
+        public void setSomeText(String someText) {
+            this.someText = someText;
+        }
+
+        public int getSomeNumber() {
+            return someNumber;
+        }
+
+        public void setSomeNumber(int someNumber) {
+            this.someNumber = someNumber;
+        }
+
+        public boolean isSomeBoolean() {
+            return someBoolean;
+        }
+
+        public void setSomeBoolean(boolean someBoolean) {
+            this.someBoolean = someBoolean;
+        }
+    }
 }

--- a/extensions/sql/asset/index/src/test/java/org/eclipse/dataspaceconnector/sql/asset/index/SqlConditionExpressionTest.java
+++ b/extensions/sql/asset/index/src/test/java/org/eclipse/dataspaceconnector/sql/asset/index/SqlConditionExpressionTest.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.sql.asset.index;
+
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SqlConditionExpressionTest {
+
+
+    public static Stream<Arguments> validArgs() {
+        return Stream.of(
+                Arguments.of("something", "=", List.of("foo")),
+                Arguments.of("something", "=", 123),
+                Arguments.of("something", "=", "other"),
+                Arguments.of("something", "like", "other"),
+                Arguments.of("something", "like", "%other"),
+                Arguments.of("something", "like", List.of()),
+                Arguments.of("something", "like", ""),
+                Arguments.of("something", "like", null),
+                Arguments.of("something", "in", List.of("first", "second")),
+                Arguments.of("something", "in", List.of("first")),
+                Arguments.of("something", "in", List.of())
+        );
+    }
+
+    public static Stream<Arguments> invalidArgs() {
+        return Stream.of(
+                Arguments.of("something", "contains", "value"),
+                Arguments.of("something", "in", "(item1, item2)"),
+                Arguments.of("something", "in", "list"),
+                Arguments.of("something", "in", null)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("validArgs")
+    void isValidExpression_whenValid(String left, String op, Object right) {
+        var e = new SqlConditionExpression(new Criterion(left, op, right));
+        assertThat(e.isValidExpression().succeeded()).isTrue();
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidArgs")
+    void isValidExpression_whenInvalid(String left, String op, Object right) {
+        var e = new SqlConditionExpression(new Criterion(left, op, right));
+        assertThat(e.isValidExpression().succeeded()).isFalse();
+    }
+
+    @Test
+    void toValuePlaceholder() {
+        var e = new SqlConditionExpression(new Criterion("key", "=", "value"));
+        assertThat(e.toValuePlaceholder()).isEqualTo("?");
+
+        var e2 = new SqlConditionExpression(new Criterion("key", "in", List.of("item1", "item2")));
+        assertThat(e2.toValuePlaceholder()).matches("\\(\\?,.*\\?\\)");
+    }
+
+    @Test
+    void toStatementParameter() {
+        var e = new SqlConditionExpression(new Criterion("key", "=", "value"));
+        assertThat(e.toStatementParameter()).containsExactly("key", "value");
+
+        var e2 = new SqlConditionExpression(new Criterion("key", "in", List.of("item1", "item2")));
+        assertThat(e2.toStatementParameter()).containsExactly("key", "item1", "item2");
+    }
+}

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/asset/AssetSelectorExpression.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/asset/AssetSelectorExpression.java
@@ -49,11 +49,6 @@ public final class AssetSelectorExpression {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(criteria);
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -63,6 +58,11 @@ public final class AssetSelectorExpression {
         }
         AssetSelectorExpression that = (AssetSelectorExpression) o;
         return criteria == that.criteria || criteria.equals(that.criteria);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(criteria);
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -84,7 +84,7 @@ public final class AssetSelectorExpression {
         }
 
         @JsonIgnore
-        public Builder constraint(String left, String op, String right) {
+        public Builder constraint(String left, String op, Object right) {
             expression.criteria.add(new Criterion(left, op, right));
             return this;
         }


### PR DESCRIPTION
## What this PR changes/adds

Adds support for `QuerySpec` filtering and `AssetSelectorExpression`, i.e. filtering on Asset properties.

## Why it does that

This is necessary for generating and validating `ContractOffer`s.

## Further notes

- Currently not all operators support prepared statements, e.g., the `IN` operator.
- sorting is not yet implemented

## Linked Issue(s)

Closes #1014 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
