### PR TITLE
feature: Implement HTTP Provisioner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ the detailed section referring to by linking pull requests or issues.
 * Implement ContractNegotiation service for Data Management API (#957)
 * In-memory implementation of PolicyStore (#930)
 * Implement AssetLoader, AssetIndex, DataAddressResolver for SQL (#863)
+* Support for HTTP-based provisioning (#963)
 * Let Control Plane delegate data transfer to Data Plane (#988)
 * CosmosDb based `PolicyStore` (#826)
 

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
@@ -15,6 +15,10 @@
 
 package org.eclipse.dataspaceconnector.transfer.core.transfer;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
@@ -185,7 +189,7 @@ class TransferProcessManagerImplTest {
                 .resourceManifest(ResourceManifest.Builder.newInstance().definitions(List.of(resourceDefinition)).build())
                 .build();
 
-        var resource = ProvisionedContentResource.Builder.newInstance()
+        var resource = TestProvisionedContentResource.Builder.newInstance()
                 .resourceName("test")
                 .id("1")
                 .transferProcessId("2")
@@ -590,5 +594,23 @@ class TransferProcessManagerImplTest {
         }).when(store).update(any());
 
         return latch;
+    }
+
+    @JsonTypeName("dataspaceconnector:testprovisioneddcontentresource")
+    @JsonDeserialize(builder = TestProvisionedContentResource.Builder.class)
+    private static class TestProvisionedContentResource extends ProvisionedContentResource {
+
+        @JsonPOJOBuilder(withPrefix = "")
+        public static class Builder extends ProvisionedContentResource.Builder<TestProvisionedContentResource, Builder> {
+
+            protected Builder() {
+                super(new TestProvisionedContentResource());
+            }
+
+            @JsonCreator
+            public static Builder newInstance() {
+                return new Builder();
+            }
+        }
     }
 }

--- a/extensions/http-provisioner/build.gradle.kts
+++ b/extensions/http-provisioner/build.gradle.kts
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+val okHttpVersion: String by project
+val jodahFailsafeVersion: String by project
+
+dependencies {
+    api(project(":spi:transfer-spi"))
+
+    implementation("com.squareup.okhttp3:okhttp:${okHttpVersion}")
+    implementation("net.jodah:failsafe:${jodahFailsafeVersion}")
+
+    testImplementation(testFixtures(project(":common:util")))
+    testImplementation(project(":core:transfer"))
+    testImplementation(project(":extensions:in-memory:assetindex-memory"))
+    testImplementation(project(":extensions:in-memory:transfer-store-memory"))
+    testImplementation(project(":extensions:dataloading"))
+    testImplementation(testFixtures(project(":launchers:junit")))
+
+}
+
+
+publishing {
+    publications {
+        create<MavenPublication>("http-provisioner") {
+            artifactId = "http-provisioner"
+            from(components["java"])
+        }
+    }
+}

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/AbstractHttpResourceDefinition.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/AbstractHttpResourceDefinition.java
@@ -24,6 +24,9 @@ import java.util.Objects;
 public abstract class AbstractHttpResourceDefinition extends ResourceDefinition {
     protected String dataAddressType;
 
+    /**
+     * Returns the data address type the definition is associated with. This is used to determine which provisioner will be engaged.
+     */
     public String getDataAddressType() {
         return dataAddressType;
     }

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/AbstractHttpResourceDefinition.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/AbstractHttpResourceDefinition.java
@@ -23,7 +23,6 @@ import java.util.Objects;
  */
 public abstract class AbstractHttpResourceDefinition extends ResourceDefinition {
     protected String dataAddressType;
-    protected String transferProcessId;
 
     public String getDataAddressType() {
         return dataAddressType;
@@ -43,12 +42,6 @@ public abstract class AbstractHttpResourceDefinition extends ResourceDefinition 
         @SuppressWarnings("unchecked")
         public B dataAddressType(String dataAddressType) {
             resourceDefinition.dataAddressType = dataAddressType;
-            return (B) this;
-        }
-
-        @SuppressWarnings("unchecked")
-        public B transferProcessId(String transferProcessId) {
-            resourceDefinition.transferProcessId = transferProcessId;
             return (B) this;
         }
 

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/AbstractHttpResourceDefinition.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/AbstractHttpResourceDefinition.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.transfer.provision.http;
+
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
+
+import java.util.Objects;
+
+/**
+ * Defines common attributes for HTTP-based provisioning asset resources.
+ */
+public abstract class AbstractHttpResourceDefinition extends ResourceDefinition {
+    protected String dataAddressType;
+    protected String transferProcessId;
+
+    public String getDataAddressType() {
+        return dataAddressType;
+    }
+
+    @Override
+    public String getTransferProcessId() {
+        return transferProcessId;
+    }
+
+    protected AbstractHttpResourceDefinition() {
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder<RD extends AbstractHttpResourceDefinition, B extends ResourceDefinition.Builder<RD, B>> extends ResourceDefinition.Builder<RD, B> {
+
+        @SuppressWarnings("unchecked")
+        public B dataAddressType(String dataAddressType) {
+            resourceDefinition.dataAddressType = dataAddressType;
+            return (B) this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public B transferProcessId(String transferProcessId) {
+            resourceDefinition.transferProcessId = transferProcessId;
+            return (B) this;
+        }
+
+        @Override
+        protected void verify() {
+            super.verify();
+            Objects.requireNonNull(resourceDefinition.dataAddressType, "transferType");
+        }
+
+        protected Builder(RD definition) {
+            super(definition);
+        }
+
+    }
+
+}

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/ConfigParser.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/ConfigParser.java
@@ -1,0 +1,119 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.transfer.provision.http;
+
+import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.EdcSetting;
+import org.eclipse.dataspaceconnector.spi.system.configuration.Config;
+import org.eclipse.dataspaceconnector.transfer.provision.http.ProvisionerConfiguration.ProvisionerType;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Parses provisioner configuration.
+ *
+ * Multiple named provisioners can be configured per runtime.
+ */
+class ConfigParser {
+    private static final String DEFAULT_POLICY_SCOPE = "http.provisioner";
+
+    private static final String CONFIG_PREFIX = "provisioner.http";
+
+    private static final String HTTP_PROVISIONER_ENTRIES = CONFIG_PREFIX + ".entries";
+
+    @EdcSetting(required = true)
+    private static final String PROVISIONER_TYPE = "provisioner.type";
+
+    @EdcSetting(required = true)
+    private static final String DATA_ADDRESS_TYPE = "data.address.type";
+
+    @EdcSetting(required = true)
+    private static final String ENDPOINT_URL = "endpoint";
+
+    @EdcSetting
+    private static final String POLICY_SCOPE = "policy.scope";
+
+    @EdcSetting
+    private static final String CALLBACK_ADDRESS = "callback.address";
+
+    // TODO replace
+    private static final String DEFAULT_CALLBACK_ADDRESS = "http://localhost:8080";
+
+    /**
+     * Parses the runtime configuration source, returning a provisioner configuration.
+     */
+    public static List<ProvisionerConfiguration> parseConfigurations(Config root) {
+
+        var callbackAddress = parseCallback(root);
+
+        var configurations = root.getConfig(HTTP_PROVISIONER_ENTRIES);
+
+        return configurations.partition()
+                .map(config -> {
+                    var provisionerName = config.currentNode();
+
+                    var provisionerType = parseProvisionerType(config, provisionerName);
+
+                    var endpoint = parseEndpoint(config, provisionerName);
+
+                    var policyScope = config.getString(POLICY_SCOPE, DEFAULT_POLICY_SCOPE);
+
+                    var dataAddressType = config.getString(DATA_ADDRESS_TYPE);
+
+                    return ProvisionerConfiguration.Builder.newInstance()
+                            .name(provisionerName)
+                            .provisionerType(provisionerType)
+                            .dataAddressType(dataAddressType)
+                            .policyScope(policyScope)
+                            .endpoint(endpoint)
+                            .callbackAddress(callbackAddress)
+                            .build();
+                }).collect(toList());
+    }
+
+    private static URL parseCallback(Config root) {
+        var callbackAddress = root.getConfig(CONFIG_PREFIX).getString(CALLBACK_ADDRESS, DEFAULT_CALLBACK_ADDRESS);
+        try {
+            return new URL(callbackAddress);
+        } catch (MalformedURLException e) {
+            throw new EdcException("Invalid callback address for HTTP provisioners", e);
+        }
+    }
+
+    private static URL parseEndpoint(Config config, String provisionerName) {
+        var endpoint = config.getString(ENDPOINT_URL);
+        try {
+            return new URL(endpoint);
+        } catch (MalformedURLException e) {
+            throw new EdcException("Invalid endpoint URL for HTTP provisioner: " + provisionerName, e);
+        }
+    }
+
+    private static ProvisionerType parseProvisionerType(Config config, String provisionerName) {
+        var typeValue = config.getString(PROVISIONER_TYPE, ProvisionerType.PROVIDER.name());
+        try {
+            return ProvisionerType.valueOf(typeValue.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new EdcException(format("Invalid provisioner type specified for %s: %s", provisionerName, typeValue));
+        }
+    }
+
+    private ConfigParser() {
+    }
+}

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderProvisioner.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderProvisioner.java
@@ -1,0 +1,162 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.transfer.provision.http;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.policy.PolicyEngine;
+import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
+import org.eclipse.dataspaceconnector.spi.transfer.provision.DeprovisionResult;
+import org.eclipse.dataspaceconnector.spi.transfer.provision.ProvisionResult;
+import org.eclipse.dataspaceconnector.spi.transfer.provision.Provisioner;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DeprovisionedResource;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionResponse;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedResource;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.eclipse.dataspaceconnector.transfer.provision.http.HttpProvisionerRequest.Type.DEPROVISION;
+import static org.eclipse.dataspaceconnector.transfer.provision.http.HttpProvisionerRequest.Type.PROVISION;
+
+/**
+ * Invokes an HTTP endpoint to provision asset data. The endpoint will asynchronously return a content data address to a callback supplied with the address that can be used to
+ * resolve the provisioned data.
+ */
+public class HttpProviderProvisioner implements Provisioner<HttpProviderResourceDefinition, HttpProvisionedContentResource> {
+    private static final MediaType JSON = MediaType.get("application/json");
+
+    private final String name;
+
+    private String dataAddressType;
+    private String policyScope;
+    private URL endpoint;
+    private URL callbackAddress;
+    private PolicyEngine policyEngine;
+    private OkHttpClient httpClient;
+    private ObjectMapper mapper;
+    private Monitor monitor;
+
+    public HttpProviderProvisioner(ProvisionerConfiguration configuration,
+                                   PolicyEngine policyEngine,
+                                   OkHttpClient httpClient,
+                                   ObjectMapper objectMapper,
+                                   Monitor monitor) {
+        this.name = configuration.getName();
+        this.dataAddressType = configuration.getDataAddressType();
+        this.policyScope = configuration.getPolicyScope();
+        this.endpoint = configuration.getEndpoint();
+        this.callbackAddress = configuration.getCallbackAddress();
+        this.policyEngine = policyEngine;
+        this.httpClient = httpClient;
+        this.mapper = objectMapper;
+        this.monitor = monitor;
+    }
+
+    @Override
+    public boolean canProvision(ResourceDefinition resourceDefinition) {
+        return resourceDefinition instanceof HttpProviderResourceDefinition && dataAddressType.equals(((HttpProviderResourceDefinition) resourceDefinition).getDataAddressType());
+    }
+
+    @Override
+    public boolean canDeprovision(ProvisionedResource provisionedResource) {
+        return provisionedResource instanceof HttpProvisionedContentResource &&
+                dataAddressType.equals(((HttpProvisionedContentResource) provisionedResource).getContentDataAddress().getType());
+    }
+
+    @Override
+    public CompletableFuture<ProvisionResult> provision(HttpProviderResourceDefinition resourceDefinition, Policy policy) {
+        // TODO expose scope from PolicyEngine
+        var scopedPolicy = policy;
+
+        Request request;
+        try {
+            request = createRequest(PROVISION, resourceDefinition.getTransferProcessId(), resourceDefinition.getAssetId(), scopedPolicy);
+        } catch (JsonProcessingException e) {
+            monitor.severe("Error serializing provision request for provisioner: " + name, e);
+            return completedFuture(ProvisionResult.failure(ResponseStatus.FATAL_ERROR, "Fatal error serializing request: " + e.getMessage()));
+        }
+
+        try (var response = httpClient.newCall(request).execute()) {
+            if (response.code() == 200) {
+                return completedFuture(ProvisionResult.success(new ProvisionResponse()));   // in-process
+            } else if (response.code() >= 500 && response.code() <= 504) {
+                // retry
+                return completedFuture(ProvisionResult.failure(ResponseStatus.ERROR_RETRY, "Received error code: " + response.code()));
+            } else {
+                // fatal error
+                return completedFuture(ProvisionResult.failure(ResponseStatus.FATAL_ERROR, "Received fatal error code: " + response.code()));
+            }
+        } catch (IOException e) {
+            monitor.severe("Error invoking provisioner: " + name, e);
+            return completedFuture(ProvisionResult.failure(ResponseStatus.ERROR_RETRY, "Received error: " + e.getMessage()));
+        }
+    }
+
+    @Override
+    public CompletableFuture<DeprovisionResult> deprovision(HttpProvisionedContentResource provisionedResource, Policy policy) {
+        // TODO expose scope from PolicyEngine
+        var scopedPolicy = policy;
+
+        Request request;
+        try {
+            request = createRequest(DEPROVISION, provisionedResource.getTransferProcessId(), provisionedResource.getAssetId(), scopedPolicy);
+        } catch (JsonProcessingException e) {
+            monitor.severe("Error serializing deprovision request for provisioner: " + name, e);
+            return completedFuture(DeprovisionResult.failure(ResponseStatus.FATAL_ERROR, "Fatal error serializing request: " + e.getMessage()));
+        }
+
+        try (var response = httpClient.newCall(request).execute()) {
+            if (response.code() == 200) {
+                var deprovisionedResource = DeprovisionedResource.Builder.newInstance()
+                        .provisionedResourceId(provisionedResource.getTransferProcessId())
+                        .inProcess(true)
+                        .build();
+                return completedFuture(DeprovisionResult.success(deprovisionedResource));
+            } else if (response.code() >= 500 && response.code() <= 504) {
+                // retry
+                return completedFuture(DeprovisionResult.failure(ResponseStatus.ERROR_RETRY, "Received error code: " + response.code()));
+            } else {
+                // fatal error
+                return completedFuture(DeprovisionResult.failure(ResponseStatus.FATAL_ERROR, "Received fatal error code: " + response.code()));
+            }
+        } catch (IOException e) {
+            monitor.severe("Error invoking provisioner: " + name, e);
+            return completedFuture(DeprovisionResult.failure(ResponseStatus.ERROR_RETRY, "Received error: " + e.getMessage()));
+        }
+
+    }
+
+    private Request createRequest(HttpProvisionerRequest.Type type, String processId, String assetId, Policy scopedPolicy) throws JsonProcessingException {
+        var provisionerRequest = HttpProvisionerRequest.Builder.newInstance()
+                .assetId(assetId)
+                .transferProcessId(processId)
+                .type(type)
+                .policy(scopedPolicy)
+                .callbackAddress(callbackAddress.toString())
+                .build();
+        var requestBody = RequestBody.create(mapper.writeValueAsString(provisionerRequest), JSON);
+        return new Request.Builder().url(endpoint).post(requestBody).build();
+    }
+
+}

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderProvisioner.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderProvisioner.java
@@ -98,7 +98,7 @@ public class HttpProviderProvisioner implements Provisioner<HttpProviderResource
         }
 
         try (var response = httpClient.newCall(request).execute()) {
-            if (response.code() == 200) {
+            if (response.isSuccessful()) {
                 return completedFuture(ProvisionResult.success(new ProvisionResponse()));   // in-process
             } else if (response.code() >= 500 && response.code() <= 504) {
                 // retry

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderResourceDefinition.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderResourceDefinition.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.transfer.provision.http;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A resource to be provisioned by an external HTTP endpoint.
+ */
+@JsonTypeName("dataspaceconnector:httpproviderresourcedefinition")
+@JsonDeserialize(builder = HttpProviderResourceDefinition.Builder.class)
+public class HttpProviderResourceDefinition extends AbstractHttpResourceDefinition {
+    private String assetId;
+
+    public String getAssetId() {
+        return assetId;
+    }
+
+    private HttpProviderResourceDefinition() {
+        super();
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends AbstractHttpResourceDefinition.Builder<HttpProviderResourceDefinition, Builder> {
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder assetId(String assetId) {
+            resourceDefinition.assetId = assetId;
+            return this;
+        }
+
+        @Override
+        protected void verify() {
+            super.verify();
+            requireNonNull(resourceDefinition.assetId, "assetId");
+        }
+
+        private Builder() {
+            super(new HttpProviderResourceDefinition());
+        }
+
+    }
+
+}

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderResourceDefinitionGenerator.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderResourceDefinitionGenerator.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.transfer.provision.http;
+
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.transfer.provision.ProviderResourceDefinitionGenerator;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Generates {@link HttpProviderResourceDefinition}s for data addresses matching a type.
+ */
+public class HttpProviderResourceDefinitionGenerator implements ProviderResourceDefinitionGenerator {
+    private String dataAddressType;
+
+    public HttpProviderResourceDefinitionGenerator(String dataAddressType) {
+        this.dataAddressType = requireNonNull(dataAddressType);
+    }
+
+    @Override
+    public @Nullable ResourceDefinition generate(DataRequest dataRequest, DataAddress assetAddress, Policy policy) {
+        if (!dataAddressType.equals(assetAddress.getType())) {
+            return null;
+        }
+        var assetId = dataRequest.getAssetId();
+        if (assetId == null) {
+            // programming error
+            throw new EdcException("Asset id was null for request: " + dataRequest.getId());
+        }
+        return HttpProviderResourceDefinition.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .dataAddressType(dataAddressType)
+                .transferProcessId(dataRequest.getProcessId())
+                .assetId(assetId)
+                .build();
+    }
+}

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionedContentResource.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionedContentResource.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.transfer.provision.http;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedContentResource;
+
+/**
+ * A reference to a provisioned resource.
+ */
+@JsonDeserialize(builder = HttpProvisionedContentResource.Builder.class)
+@JsonTypeName("dataspaceconnector:httpprovisionedresource")
+public class HttpProvisionedContentResource extends ProvisionedContentResource {
+    private String assetId;
+
+    public String getAssetId() {
+        return assetId;
+    }
+
+    private HttpProvisionedContentResource() {
+        super();
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ProvisionedContentResource.Builder<HttpProvisionedContentResource, Builder> {
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder transferProcessId(String transferProcessId) {
+            provisionedResource.transferProcessId = transferProcessId;
+            return this;
+        }
+
+        public Builder assetId(String assetId) {
+            provisionedResource.assetId = assetId;
+            return this;
+        }
+
+        private Builder() {
+            super(new HttpProvisionedContentResource());
+        }
+    }
+}

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerExtension.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerExtension.java
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.transfer.provision.http;
+
+import okhttp3.OkHttpClient;
+import org.eclipse.dataspaceconnector.spi.policy.PolicyEngine;
+import org.eclipse.dataspaceconnector.spi.system.Inject;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.transfer.provision.ProvisionManager;
+import org.eclipse.dataspaceconnector.spi.transfer.provision.ResourceManifestGenerator;
+
+import static java.lang.String.format;
+import static org.eclipse.dataspaceconnector.transfer.provision.http.ConfigParser.parseConfigurations;
+import static org.eclipse.dataspaceconnector.transfer.provision.http.ProvisionerConfiguration.ProvisionerType.PROVIDER;
+
+/**
+ * The HTTP Provisioner extension delegates to HTTP endpoints to perform provision operations.
+ */
+public class HttpProvisionerExtension implements ServiceExtension {
+
+    private OkHttpClient overrideHttpClient;
+
+    @Inject
+    ResourceManifestGenerator manifestGenerator;
+
+    @Inject
+    protected ProvisionManager provisionManager;
+
+    @Inject
+    protected PolicyEngine policyEngine;
+
+    @Inject
+    protected OkHttpClient httpClient;
+
+    @Override
+    public String name() {
+        return "HTTP Provisioning";
+    }
+
+    /**
+     * Default ctor.
+     */
+    @SuppressWarnings("unused")
+    public HttpProvisionerExtension() {
+    }
+
+    /**
+     * Overrides the default HTTP client. Intended for testing.
+     */
+    public HttpProvisionerExtension(OkHttpClient httpClient) {
+        this.overrideHttpClient = httpClient;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+
+        var configurations = parseConfigurations(context.getConfig());
+
+        var client = overrideHttpClient != null ? overrideHttpClient : httpClient;
+        var typeManager = context.getTypeManager();
+        var monitor = context.getMonitor();
+
+        for (var configuration : configurations) {
+
+            var provisioner = new HttpProviderProvisioner(configuration, policyEngine, client, typeManager.getMapper(), monitor);
+
+            if (configuration.getProvisionerType() == PROVIDER) {
+                var generator = new HttpProviderResourceDefinitionGenerator(configuration.getDataAddressType());
+                manifestGenerator.registerGenerator(generator);
+                monitor.info(format("Registering provider provisioner: %s [%s]", configuration.getName(), configuration.getEndpoint().toString()));
+            } else {
+                monitor.warning(format("Client-side provisioning not yet supported by the %s. Skipping configuration for %s", name(), configuration.getName()));
+            }
+
+            provisionManager.register(provisioner);
+        }
+
+        typeManager.registerTypes(
+                HttpProviderResourceDefinition.class,
+                HttpProvisionedContentResource.class,
+                HttpProvisionerRequest.class);
+    }
+
+
+}

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerRequest.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerRequest.java
@@ -1,0 +1,109 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.transfer.provision.http;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+
+/**
+ * A request to provision or deprovision asset content that can be sent to an out-of-process systen.
+ */
+@JsonTypeName("dataspaceconnector:httpprovisionerrequest")
+@JsonDeserialize(builder = HttpProvisionerRequest.Builder.class)
+public class HttpProvisionerRequest {
+
+    public enum Type {
+        @JsonProperty("provision")
+        PROVISION,
+
+        @JsonProperty("deprovision")
+        DEPROVISION
+    }
+
+    private String assetId;
+    private String transferProcessId;
+    private Policy policy;
+    private String callbackAddress;
+
+    private Type type = Type.PROVISION;
+
+    public String getAssetId() {
+        return assetId;
+    }
+
+    public String getTransferProcessId() {
+        return transferProcessId;
+    }
+
+    public Policy getPolicy() {
+        return policy;
+    }
+
+    public String getCallbackAddress() {
+        return callbackAddress;
+    }
+
+    private HttpProvisionerRequest() {
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder {
+
+        private HttpProvisionerRequest request;
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder assetId(String assetId) {
+            request.assetId = assetId;
+            return this;
+        }
+
+        public Builder transferProcessId(String transferProcessId) {
+            request.transferProcessId = transferProcessId;
+            return this;
+        }
+
+        public Builder policy(Policy policy) {
+            request.policy = policy;
+            return this;
+        }
+
+        public Builder callbackAddress(String callbackAddress) {
+            request.callbackAddress = callbackAddress;
+            return this;
+        }
+
+        public Builder type(Type type) {
+            request.type = type;
+            return this;
+        }
+
+        public HttpProvisionerRequest build() {
+            return request;
+        }
+
+        private Builder() {
+            request = new HttpProvisionerRequest();
+        }
+
+    }
+
+}

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/ProvisionerConfiguration.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/ProvisionerConfiguration.java
@@ -1,0 +1,123 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.transfer.provision.http;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.net.URL;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Configuration to create a resource definition and provisioner pair.
+ */
+class ProvisionerConfiguration {
+
+    public enum ProvisionerType {
+        CLIENT,
+        PROVIDER
+    }
+
+    private String name;
+
+    private ProvisionerType provisionerType = ProvisionerType.PROVIDER;
+
+    private String dataAddressType;
+
+    private String policyScope;
+
+    private URL endpoint;
+
+    private URL callbackAddress;
+
+    public String getName() {
+        return name;
+    }
+
+    public ProvisionerType getProvisionerType() {
+        return provisionerType;
+    }
+
+    public String getDataAddressType() {
+        return dataAddressType;
+    }
+
+    public String getPolicyScope() {
+        return policyScope;
+    }
+
+    public URL getEndpoint() {
+        return endpoint;
+    }
+
+    public URL getCallbackAddress() {
+        return callbackAddress;
+    }
+
+    private ProvisionerConfiguration() {
+    }
+
+    public static class Builder {
+
+        private ProvisionerConfiguration configuration;
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder name(String name) {
+            configuration.name = name;
+            return this;
+        }
+
+        public Builder provisionerType(ProvisionerType type) {
+            configuration.provisionerType = type;
+            return this;
+        }
+
+        public Builder dataAddressType(String type) {
+            configuration.dataAddressType = type;
+            return this;
+        }
+
+        public Builder policyScope(String policyScope) {
+            configuration.policyScope = policyScope;
+            return this;
+        }
+
+        public Builder endpoint(URL endpoint) {
+            configuration.endpoint = endpoint;
+            return this;
+        }
+
+        public Builder callbackAddress(URL callbackAddress) {
+            configuration.callbackAddress = callbackAddress;
+            return this;
+        }
+
+        public ProvisionerConfiguration build() {
+            requireNonNull(configuration.name, "name");
+            requireNonNull(configuration.provisionerType, "type");
+            requireNonNull(configuration.policyScope, "policyScope");
+            requireNonNull(configuration.callbackAddress, "callbackAddress");
+            return configuration;
+        }
+
+        private Builder() {
+            configuration = new ProvisionerConfiguration();
+        }
+
+    }
+}

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/ConfigParserTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/ConfigParserTest.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.transfer.provision.http;
+
+import org.eclipse.dataspaceconnector.spi.system.configuration.ConfigFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.transfer.provision.http.ConfigParser.parseConfigurations;
+import static org.eclipse.dataspaceconnector.transfer.provision.http.HttpProvisionerFixtures.PROVISIONER_CONFIG;
+import static org.eclipse.dataspaceconnector.transfer.provision.http.HttpProvisionerFixtures.TEST_DATA_TYPE;
+
+class ConfigParserTest {
+
+    @Test
+    void verifyParse() {
+        var config = ConfigFactory.fromMap(PROVISIONER_CONFIG);
+        var configurations = parseConfigurations(config);
+        assertThat(configurations.size()).isEqualTo(1);
+
+        var configuration = configurations.get(0);
+
+        assertThat(configuration.getProvisionerType()).isEqualTo(ProvisionerConfiguration.ProvisionerType.PROVIDER);
+        assertThat(configuration.getPolicyScope().toString()).isEqualTo("provision1.scope");
+        assertThat(configuration.getEndpoint().toString()).isEqualTo("http://foo.com");
+        assertThat(configuration.getDataAddressType()).isEqualTo(TEST_DATA_TYPE);
+    }
+
+
+}

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderProvisionerTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderProvisionerTest.java
@@ -1,0 +1,209 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.transfer.provision.http;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.Interceptor;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.policy.PolicyEngine;
+import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedResource;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
+import static org.eclipse.dataspaceconnector.transfer.provision.http.HttpProvisionerFixtures.createResponse;
+import static org.eclipse.dataspaceconnector.transfer.provision.http.ProvisionerConfiguration.ProvisionerType.PROVIDER;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class HttpProviderProvisionerTest {
+    private HttpProviderProvisioner provisioner;
+    private Interceptor delegate;
+
+    @Test
+    void verifyCanProvision() {
+        assertThat(provisioner.canProvision(createResourceDefinition())).isTrue();
+        assertThat(provisioner.canProvision(new TestResourceDefinition())).isFalse();
+
+        var differentType = HttpProviderResourceDefinition.Builder.newInstance()
+                .assetId("1")
+                .transferProcessId("2")
+                .dataAddressType("another-type")
+                .id("3")
+                .build();
+        assertThat(provisioner.canProvision(differentType)).isFalse();
+    }
+
+    @Test
+    void verifyCanDeprovision() {
+        assertThat(provisioner.canDeprovision(createProvisionedResource())).isTrue();
+        assertThat(provisioner.canDeprovision(new TestProvisionedResource())).isFalse();
+
+        var dataAddress = DataAddress.Builder.newInstance().type("another-type").build();
+        var differentType = HttpProvisionedContentResource.Builder.newInstance()
+                .assetId("1")
+                .transferProcessId("2")
+                .resourceName("test")
+                .contentDataAddress(dataAddress)
+                .resourceDefinitionId("3")
+                .id("3")
+                .build();
+
+        assertThat(provisioner.canDeprovision(differentType)).isFalse();
+    }
+
+    @Test
+    void verifyProvisionOkAndInProcess() throws Exception {
+        when(delegate.intercept(any())).thenAnswer((invocation -> createResponse(200, invocation)));
+
+        var policy = Policy.Builder.newInstance().build();
+
+        var definition = createResourceDefinition();
+
+        var result = provisioner.provision(definition, policy).get();
+
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent().isInProcess()).isTrue();
+    }
+
+    @Test
+    void verifyProvision404Response() throws Exception {
+        when(delegate.intercept(any())).thenAnswer((invocation -> createResponse(404, invocation)));
+
+        var policy = Policy.Builder.newInstance().build();
+
+        var definition = createResourceDefinition();
+
+        var result = provisioner.provision(definition, policy).get();
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailure().status()).isEqualTo(ResponseStatus.FATAL_ERROR);
+    }
+
+    @Test
+    void verifyProvisionRetryResponse() throws Exception {
+        when(delegate.intercept(any())).thenAnswer((invocation -> createResponse(503, invocation)));
+
+        var policy = Policy.Builder.newInstance().build();
+
+        var definition = createResourceDefinition();
+
+        var result = provisioner.provision(definition, policy).get();
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailure().status()).isEqualTo(ResponseStatus.ERROR_RETRY);
+    }
+
+    @Test
+    void verifyDeprovisionOkAndInProcess() throws Exception {
+        when(delegate.intercept(any())).thenAnswer((invocation -> createResponse(200, invocation)));
+
+        var policy = Policy.Builder.newInstance().build();
+
+        var definition = createProvisionedResource();
+
+        var result = provisioner.deprovision(definition, policy).get();
+
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent().isInProcess()).isTrue();
+    }
+
+
+    @Test
+    void verifyDeprovision404Response() throws Exception {
+        when(delegate.intercept(any())).thenAnswer((invocation -> createResponse(404, invocation)));
+
+        var policy = Policy.Builder.newInstance().build();
+
+        var definition = createProvisionedResource();
+
+        var result = provisioner.deprovision(definition, policy).get();
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailure().status()).isEqualTo(ResponseStatus.FATAL_ERROR);
+    }
+
+
+    @Test
+    void verifyDeprovisionRetryResponse() throws Exception {
+        when(delegate.intercept(any())).thenAnswer((invocation -> createResponse(503, invocation)));
+
+        var policy = Policy.Builder.newInstance().build();
+
+        var definition = createProvisionedResource();
+
+        var result = provisioner.deprovision(definition, policy).get();
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailure().status()).isEqualTo(ResponseStatus.ERROR_RETRY);
+    }
+
+
+    @BeforeEach
+    void setUp() throws MalformedURLException {
+        var configuration = ProvisionerConfiguration.Builder.newInstance()
+                .name("test")
+                .provisionerType(PROVIDER)
+                .dataAddressType("test")
+                .policyScope("test")
+                .callbackAddress(new URL("http://foo.com"))
+                .endpoint(new URL("http://bar.com"))
+                .build();
+
+        delegate = mock(Interceptor.class);
+        var httpClient = testOkHttpClient().newBuilder().addInterceptor(delegate).build();
+        provisioner = new HttpProviderProvisioner(configuration, mock(PolicyEngine.class), httpClient, new ObjectMapper(), mock(Monitor.class));
+    }
+
+    private HttpProviderResourceDefinition createResourceDefinition() {
+        return HttpProviderResourceDefinition.Builder.newInstance()
+                .assetId("1")
+                .transferProcessId("2")
+                .dataAddressType("test")
+                .id("3")
+                .build();
+    }
+
+    private HttpProvisionedContentResource createProvisionedResource() {
+        var dataAddress = DataAddress.Builder.newInstance().type("test").build();
+
+        return HttpProvisionedContentResource.Builder.newInstance()
+                .assetId("1")
+                .transferProcessId("2")
+                .resourceName("test")
+                .contentDataAddress(dataAddress)
+                .resourceDefinitionId("3")
+                .id("3")
+                .build();
+    }
+
+
+    private static class TestResourceDefinition extends ResourceDefinition {
+
+    }
+
+    private static class TestProvisionedResource extends ProvisionedResource {
+
+    }
+
+}

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderResourceDefinitionGeneratorTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderResourceDefinitionGeneratorTest.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.transfer.provision.http;
+
+
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HttpProviderResourceDefinitionGeneratorTest {
+    private static final String DATA_ADDRESS_TYPE = "test-address";
+
+    private HttpProviderResourceDefinitionGenerator generator;
+
+    @Test
+    void verifyGeneration() {
+        var dataRequest = DataRequest.Builder.newInstance().destinationType("destination").assetId("id").build();
+        var policy = Policy.Builder.newInstance().build();
+
+        var assetAddress1 = DataAddress.Builder.newInstance().type(DATA_ADDRESS_TYPE).build();
+        assertThat(generator.generate(dataRequest, assetAddress1, policy)).isNotNull();
+
+        var assetAddress2 = DataAddress.Builder.newInstance().type("another-type").build();
+        assertThat(generator.generate(dataRequest, assetAddress2, policy)).isNull();
+    }
+
+
+    @BeforeEach
+    void setUp() {
+        generator = new HttpProviderResourceDefinitionGenerator(DATA_ADDRESS_TYPE);
+    }
+}

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderResourceDefinitionTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderResourceDefinitionTest.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.transfer.provision.http;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HttpProviderResourceDefinitionTest {
+    @Test
+    void verifySerializeDeserialize() throws JsonProcessingException {
+        var mapper = new ObjectMapper();
+
+        var request = HttpProviderResourceDefinition.Builder.newInstance().assetId("123").transferProcessId("1").id("2").dataAddressType("test").build();
+
+        var serialized = mapper.writeValueAsString(request);
+
+        var deserialized = mapper.readValue(serialized, HttpProviderResourceDefinition.class);
+
+        assertThat(deserialized).isNotNull();
+        assertThat(deserialized.getAssetId()).isEqualTo("123");
+        assertThat(deserialized.getTransferProcessId()).isEqualTo("1");
+        assertThat(deserialized.getDataAddressType()).isEqualTo("test");
+
+    }
+}

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerExtensionEndToEndTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerExtensionEndToEndTest.java
@@ -14,7 +14,6 @@
 package org.eclipse.dataspaceconnector.transfer.provision.http;
 
 import okhttp3.Interceptor;
-import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.dataloading.AssetLoader;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
@@ -78,7 +77,6 @@ public class HttpProvisionerExtensionEndToEndTest {
         delegate = mock(Interceptor.class);
         var httpClient = testOkHttpClient().newBuilder().addInterceptor(delegate).build();
 
-        extension.registerServiceMock(OkHttpClient.class, httpClient);
         extension.registerServiceMock(TransferWaitStrategy.class, () -> 1);
         extension.registerSystemExtension(ServiceExtension.class, new HttpProvisionerExtension(httpClient));
         extension.setConfiguration(PROVISIONER_CONFIG);

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerExtensionEndToEndTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerExtensionEndToEndTest.java
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.transfer.provision.http;
+
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import org.eclipse.dataspaceconnector.dataloading.AssetLoader;
+import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
+import org.eclipse.dataspaceconnector.spi.transfer.retry.TransferWaitStrategy;
+import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.CountDownLatch;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
+import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.PROVISIONING;
+import static org.eclipse.dataspaceconnector.transfer.provision.http.HttpProvisionerFixtures.PROVISIONER_CONFIG;
+import static org.eclipse.dataspaceconnector.transfer.provision.http.HttpProvisionerFixtures.TEST_DATA_TYPE;
+import static org.eclipse.dataspaceconnector.transfer.provision.http.HttpProvisionerFixtures.createResponse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(EdcExtension.class)
+public class HttpProvisionerExtensionEndToEndTest {
+
+    private Interceptor delegate;
+
+    /**
+     * Tests the case where an initial request returns a retryable failure and the second request completes.
+     */
+    @Test
+    void processProviderRequestRetry(TransferProcessManager processManager, AssetLoader loader, TransferProcessStore store) throws Exception {
+        var latch = new CountDownLatch(1);
+
+        when(delegate.intercept(any()))
+                .thenAnswer(invocation -> createResponse(503, invocation))
+                .thenAnswer(invocation -> {
+                    latch.countDown();
+                    return createResponse(200, invocation);
+                });
+
+
+        loadData(loader);
+
+        var result = processManager.initiateProviderRequest(createRequest());
+
+        assertThat(latch.await(10000, MILLISECONDS)).isTrue();
+
+        var transferProcess = store.find(result.getContent());
+
+        assertThat(transferProcess).isNotNull();
+        assertThat(transferProcess.getState()).isEqualTo(PROVISIONING.code());
+    }
+
+    @BeforeEach
+    void setup(EdcExtension extension) {
+        delegate = mock(Interceptor.class);
+        var httpClient = testOkHttpClient().newBuilder().addInterceptor(delegate).build();
+
+        extension.registerServiceMock(OkHttpClient.class, httpClient);
+        extension.registerServiceMock(TransferWaitStrategy.class, () -> 1);
+        extension.registerSystemExtension(ServiceExtension.class, new HttpProvisionerExtension(httpClient));
+        extension.setConfiguration(PROVISIONER_CONFIG);
+    }
+
+    private void loadData(AssetLoader loader) {
+        var asset = Asset.Builder.newInstance().id("1").build();
+        var dataAddress = DataAddress.Builder.newInstance().type(TEST_DATA_TYPE).build();
+
+        // load the asset
+        loader.accept(asset, dataAddress);
+    }
+
+    private DataRequest createRequest() {
+        return DataRequest.Builder.newInstance().destinationType("test").assetId("1").build();
+    }
+
+}

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerFixtures.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerFixtures.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.transfer.provision.http;
+
+import okhttp3.Interceptor;
+import okhttp3.MediaType;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.mockito.invocation.InvocationOnMock;
+
+import java.util.Map;
+
+import static okhttp3.Protocol.HTTP_1_1;
+
+/**
+ * Test configuration.
+ */
+public class HttpProvisionerFixtures {
+    public static final String HTTP_PROVISIONER_ENTRIES = "provisioner.http.entries.";
+
+    public static final String TEST_DATA_TYPE = "test-data-type";
+
+    public static final Map<String, String> PROVISIONER_CONFIG = Map.of(
+            HTTP_PROVISIONER_ENTRIES + "provisioner1.provisioner.type", "provider",
+            HTTP_PROVISIONER_ENTRIES + "provisioner1.policy.scope", "provision1.scope",
+            HTTP_PROVISIONER_ENTRIES + "provisioner1.endpoint", "http://foo.com",
+            HTTP_PROVISIONER_ENTRIES + "provisioner1.data.address.type", TEST_DATA_TYPE
+    );
+
+    public static Response createResponse(int code, InvocationOnMock invocation) {
+        Interceptor.Chain chain = invocation.getArgument(0);
+        return new Response.Builder()
+                .request(chain.request())
+                .protocol(HTTP_1_1).code(code)
+                .body(ResponseBody.create("", MediaType.get("application/json"))).message("test")
+                .build();
+    }
+
+    private HttpProvisionerFixtures() {
+    }
+}

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerRequestTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerRequestTest.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.transfer.provision.http;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HttpProvisionerRequestTest {
+
+    @Test
+    void verifySerializeDeserialize() throws JsonProcessingException {
+        var mapper = new ObjectMapper();
+
+        var request = HttpProvisionerRequest.Builder.newInstance().assetId("123").transferProcessId("1").callbackAddress("http://test.com").build();
+
+        var serialized = mapper.writeValueAsString(request);
+
+        var deserialized = mapper.readValue(serialized, HttpProvisionerRequest.class);
+
+        assertThat(deserialized).isNotNull();
+        assertThat(deserialized.getAssetId()).isEqualTo("123");
+        assertThat(deserialized.getTransferProcessId()).isEqualTo("1");
+        assertThat(deserialized.getCallbackAddress()).isEqualTo("http://test.com");
+
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -146,6 +146,7 @@ include(":extensions:sql:pool:apache-commons-pool")
 include(":extensions:sql:asset:index")
 include(":extensions:sql:transfer-process-store")
 include(":extensions:http-receiver")
+include(":extensions:http-provisioner")
 
 // modules for launchers, i.e. runnable compositions of the app
 include(":launchers:basic")

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionResponse.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionResponse.java
@@ -85,7 +85,7 @@ public class ProvisionResponse {
         }
 
         public ProvisionResponse build() {
-            Objects.requireNonNull(resource, "provisionedDataDestinationResource");
+            Objects.requireNonNull(resource, "resource");
             return new ProvisionResponse(resource, secretToken);
         }
     }

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionedContentResource.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionedContentResource.java
@@ -14,24 +14,19 @@
 
 package org.eclipse.dataspaceconnector.spi.types.domain.transfer;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 /**
  * A provisioned resource that is a content data address.
  *
  * This resource type is created when a provider's backend system provisions data as part of a data transfer.
  */
-@JsonTypeName("dataspaceconnector:provisioneddcontentresource")
-@JsonDeserialize(builder = ProvisionedContentResource.Builder.class)
-public class ProvisionedContentResource extends ProvisionedResource {
-    private String resourceName;
-    private DataAddress contentDataAddress;
+public abstract class ProvisionedContentResource extends ProvisionedResource {
+    protected String resourceName;
+    protected DataAddress contentDataAddress;
 
     public String getResourceName() {
         return resourceName;
@@ -41,34 +36,33 @@ public class ProvisionedContentResource extends ProvisionedResource {
         return contentDataAddress;
     }
 
-    private ProvisionedContentResource() {
+    protected ProvisionedContentResource() {
     }
 
     @JsonPOJOBuilder(withPrefix = "")
-    public static class Builder extends ProvisionedResource.Builder<ProvisionedContentResource, Builder> {
+    // public static class Builder<RD extends ResourceDefinition, B extends Builder<RD, B>> {
+    public static class Builder<T extends ProvisionedContentResource, B extends Builder<T, B>> extends ProvisionedResource.Builder<T, B> {
 
-        @JsonCreator
-        public static Builder newInstance() {
-            return new Builder();
-        }
-
-        public Builder resourceName(String name) {
+        @SuppressWarnings("unchecked")
+        public B resourceName(String name) {
             provisionedResource.resourceName = name;
-            return this;
+            return (B) this;
         }
 
-        public Builder contentDataAddress(DataAddress dataAddress) {
+        @SuppressWarnings("unchecked")
+        public B contentDataAddress(DataAddress dataAddress) {
             provisionedResource.contentDataAddress = dataAddress;
-            return this;
+            return (B) this;
+        }
+
+        protected Builder(T resource) {
+            super(resource);
         }
 
         @Override
         protected void verify() {
-            Objects.requireNonNull(provisionedResource.resourceName, "resourceName");
-        }
-
-        private Builder() {
-            super(new ProvisionedContentResource());
+            requireNonNull(provisionedResource.resourceName, "resourceName");
+            requireNonNull(provisionedResource.contentDataAddress, "contentDataAddress");
         }
 
     }

--- a/spi/transfer-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionedContentResourceTest.java
+++ b/spi/transfer-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionedContentResourceTest.java
@@ -13,8 +13,12 @@
  */
 package org.eclipse.dataspaceconnector.spi.types.domain.transfer;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.junit.jupiter.api.Test;
 
@@ -25,7 +29,7 @@ class ProvisionedContentResourceTest {
     @Test
     void verifySerializeDeserialize() throws JsonProcessingException {
         var dataAddress = DataAddress.Builder.newInstance().type("test").build();
-        var resource = ProvisionedContentResource.Builder.newInstance()
+        var resource = TestProvisionedContentResource.Builder.newInstance()
                 .resourceName("test")
                 .contentDataAddress(dataAddress)
                 .id("1")
@@ -34,7 +38,7 @@ class ProvisionedContentResourceTest {
                 .build();
         var mapper = new ObjectMapper();
         var serialized = mapper.writeValueAsString(resource);
-        var deserialized = mapper.readValue(serialized, ProvisionedContentResource.class);
+        var deserialized = mapper.readValue(serialized, TestProvisionedContentResource.class);
 
         assertThat(deserialized).isNotNull();
         assertThat(deserialized.getContentDataAddress()).isNotNull();
@@ -42,5 +46,23 @@ class ProvisionedContentResourceTest {
         assertThat(deserialized.getId()).isEqualTo("1");
         assertThat(deserialized.getTransferProcessId()).isEqualTo("2");
         assertThat(deserialized.getResourceDefinitionId()).isEqualTo("12");
+    }
+
+    @JsonTypeName("dataspaceconnector:testprovisioneddcontentresource")
+    @JsonDeserialize(builder = TestProvisionedContentResource.Builder.class)
+    private static class TestProvisionedContentResource extends ProvisionedContentResource {
+
+        @JsonPOJOBuilder(withPrefix = "")
+        public static class Builder extends ProvisionedContentResource.Builder<TestProvisionedContentResource, Builder> {
+
+            protected Builder() {
+                super(new TestProvisionedContentResource());
+            }
+
+            @JsonCreator
+            public static Builder newInstance() {
+                return new Builder();
+            }
+        }
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

This PR implements the HTTP Provisioner as described by #963.

## Further notes

The API callback endpoint and support for token-based authorization will be added by @paullatzelsperger in a subsequent PR. 

## Linked Issue(s)

Closes #963

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
