### PR TITLE
ci: add paths ignore to workflow files

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,13 +2,11 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ main ]
     paths-ignore:
-      - '**/*.md'
-      - '**/*.txt'
+      - '**.md'
+      - 'docs/**'
 
 jobs:
   analyze:

--- a/.github/workflows/generate_openapi_spec.yaml
+++ b/.github/workflows/generate_openapi_spec.yaml
@@ -1,6 +1,12 @@
 name: Generate OpenApi Spec
 
-on: [ push, pull_request ]
+on:
+  push:
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 jobs:
   GenerateOAS:

--- a/.github/workflows/integrationtests.yaml
+++ b/.github/workflows/integrationtests.yaml
@@ -1,6 +1,12 @@
 name: Integration Tests
 
-on: [ push, pull_request ]
+on:
+  push:
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 jobs:
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,6 +1,12 @@
 name: Test Code (Style, Tests)
 
-on: [ push, pull_request ]
+on:
+  push:
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 jobs:
   Unit-Test:
@@ -128,7 +134,7 @@ jobs:
           sleep 5
           grep "INFO.*edc-.*ready" log.txt
           rm log.txt
-          killall java      
+          killall java
 
       # we cannot check sample 5 currently because we'd need repo secrets for that (client id,...)
 


### PR DESCRIPTION
## What this PR changes/adds

Workflow files now ignore changes to the `/docs` and root `.md` files. CodeQL, OpenApi generation, (unit and integration) tests, and style checks will therefore not be (re-)run if changes are made to those files.

## Why it does that

Prevents the unnecessary consumption of resources and waste of time. E.g. when merge conflicts in the `CHANGELOG.md` are resolved, the pipeline does not need to be triggered again.

## Linked Issue(s)

Closes #1023 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
