### PR TITLE
contract offers: add asset id as policy and rule target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ the detailed section referring to by linking pull requests or issues.
 * Added an overload to `TransactionContext#execute()` (#968)
 * Run CosmosDB integration tests on cloud in CI (#964)
 * Improved provision signalling and align deprovisioning to handle error conditions (#992)
+* Set policy and rule target dynamically when generating contract offers (#609)
 
 #### Removed
 

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImpl.java
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
  *       Microsoft Corporation - Refactoring
+ *       Fraunhofer Institute for Software and Systems Engineering - extended method implementation
  *
  */
 package org.eclipse.dataspaceconnector.contract.offer;
@@ -52,7 +53,7 @@ public class ContractOfferServiceImpl implements ContractOfferService {
             var assets = assetIndex.queryAssets(definition.getSelectorExpression());
             return assets.map(asset -> ContractOffer.Builder.newInstance()
                     .id(ContractId.createContractId(definition.getId()))
-                    .policy(definition.getContractPolicy())
+                    .policy(definition.getContractPolicy().copy(asset.getId()))
                     .asset(asset)
                     // TODO: this is a workaround for the bug described in https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/753
                     .provider(uri("urn:connector:provider"))

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImpl.java
@@ -53,7 +53,7 @@ public class ContractOfferServiceImpl implements ContractOfferService {
             var assets = assetIndex.queryAssets(definition.getSelectorExpression());
             return assets.map(asset -> ContractOffer.Builder.newInstance()
                     .id(ContractId.createContractId(definition.getId()))
-                    .policy(definition.getContractPolicy().copy(asset.getId()))
+                    .policy(definition.getContractPolicy().withTarget(asset.getId()))
                     .asset(asset)
                     // TODO: this is a workaround for the bug described in https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/753
                     .provider(uri("urn:connector:provider"))

--- a/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Duty.java
+++ b/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Duty.java
@@ -76,7 +76,7 @@ public class Duty extends Rule {
                 .action(this.action)
                 .constraints(this.constraints)
                 .parentPermission(this.parentPermission)
-                .consequence(this.consequence)
+                .consequence(this.consequence == null ? null : this.consequence.copy(target))
                 .target(target)
                 .build();
     }

--- a/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Duty.java
+++ b/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Duty.java
@@ -68,7 +68,7 @@ public class Duty extends Rule {
      * @param target the target.
      * @return a copy with the specified target.
      */
-    public Duty copy(String target) {
+    public Duty withTarget(String target) {
         return Builder.newInstance()
                 .uid(this.uid)
                 .assigner(this.assigner)
@@ -76,7 +76,7 @@ public class Duty extends Rule {
                 .action(this.action)
                 .constraints(this.constraints)
                 .parentPermission(this.parentPermission)
-                .consequence(this.consequence == null ? null : this.consequence.copy(target))
+                .consequence(this.consequence == null ? null : this.consequence.withTarget(target))
                 .target(target)
                 .build();
     }

--- a/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Duty.java
+++ b/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Duty.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - added method
  *
  */
 
@@ -59,6 +60,25 @@ public class Duty extends Rule {
     @Override
     public String toString() {
         return "Duty constraint: [" + getConstraints().stream().map(Object::toString).collect(joining(",")) + "]";
+    }
+    
+    /**
+     * Returns a copy of this duty with the specified target.
+     *
+     * @param target the target.
+     * @return a copy with the specified target.
+     */
+    public Duty copy(String target) {
+        return Builder.newInstance()
+                .uid(this.uid)
+                .assigner(this.assigner)
+                .assignee(this.assignee)
+                .action(this.action)
+                .constraints(this.constraints)
+                .parentPermission(this.parentPermission)
+                .consequence(this.consequence)
+                .target(target)
+                .build();
     }
 
     @JsonPOJOBuilder(withPrefix = "")

--- a/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Permission.java
+++ b/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Permission.java
@@ -54,14 +54,14 @@ public class Permission extends Rule {
      * @param target the target.
      * @return a copy with the specified target.
      */
-    public Permission copy(String target) {
+    public Permission withTarget(String target) {
         return Builder.newInstance()
                 .uid(this.uid)
                 .assigner(this.assigner)
                 .assignee(this.assignee)
                 .action(this.action)
                 .constraints(this.constraints)
-                .duties(this.duties.stream().map(d -> d.copy(target)).collect(Collectors.toList()))
+                .duties(this.duties.stream().map(d -> d.withTarget(target)).collect(Collectors.toList()))
                 .target(target)
                 .build();
     }

--- a/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Permission.java
+++ b/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Permission.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.joining;
 
@@ -60,7 +61,7 @@ public class Permission extends Rule {
                 .assignee(this.assignee)
                 .action(this.action)
                 .constraints(this.constraints)
-                .duties(this.duties)
+                .duties(this.duties.stream().map(d -> d.copy(target)).collect(Collectors.toList()))
                 .target(target)
                 .build();
     }

--- a/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Permission.java
+++ b/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Permission.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - added method
  *
  */
 
@@ -44,6 +45,24 @@ public class Permission extends Rule {
     @Override
     public String toString() {
         return "Permission constraints: [" + getConstraints().stream().map(Object::toString).collect(joining(",")) + "]";
+    }
+    
+    /**
+     * Returns a copy of this permission with the specified target.
+     *
+     * @param target the target.
+     * @return a copy with the specified target.
+     */
+    public Permission copy(String target) {
+        return Builder.newInstance()
+                .uid(this.uid)
+                .assigner(this.assigner)
+                .assignee(this.assignee)
+                .action(this.action)
+                .constraints(this.constraints)
+                .duties(this.duties)
+                .target(target)
+                .build();
     }
 
     @JsonPOJOBuilder(withPrefix = "")

--- a/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Policy.java
+++ b/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Policy.java
@@ -122,12 +122,12 @@ public class Policy extends Identifiable {
      * @param target the target.
      * @return a copy with the specified target.
      */
-    public Policy copy(String target) {
+    public Policy withTarget(String target) {
         return Builder.newInstance()
                 .id(this.uid)
-                .prohibitions(this.prohibitions.stream().map(p -> p.copy(target)).collect(Collectors.toList()))
-                .permissions(this.permissions.stream().map(p -> p.copy(target)).collect(Collectors.toList()))
-                .duties(this.obligations.stream().map(o -> o.copy(target)).collect(Collectors.toList()))
+                .prohibitions(this.prohibitions.stream().map(p -> p.withTarget(target)).collect(Collectors.toList()))
+                .permissions(this.permissions.stream().map(p -> p.withTarget(target)).collect(Collectors.toList()))
+                .duties(this.obligations.stream().map(o -> o.withTarget(target)).collect(Collectors.toList()))
                 .assigner(this.assigner)
                 .assignee(this.assignee)
                 .inheritsFrom(this.inheritsFrom)

--- a/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Policy.java
+++ b/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Policy.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - added method
  *
  */
 
@@ -25,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * A collection of permissions, prohibitions, and obligations associated with an asset. Subtypes are defined by {@link PolicyType}.
@@ -112,6 +114,27 @@ public class Policy extends Identifiable {
 
     public interface Visitor<R> {
         R visitPolicy(Policy policy);
+    }
+    
+    /**
+     * Returns a copy of this policy with the specified target.
+     *
+     * @param target the target.
+     * @return a copy with the specified target.
+     */
+    public Policy copy(String target) {
+        return Builder.newInstance()
+                .id(this.uid)
+                .prohibitions(this.prohibitions.stream().map(p -> p.copy(target)).collect(Collectors.toList()))
+                .permissions(this.permissions.stream().map(p -> p.copy(target)).collect(Collectors.toList()))
+                .duties(this.obligations.stream().map(o -> o.copy(target)).collect(Collectors.toList()))
+                .assigner(this.assigner)
+                .assignee(this.assignee)
+                .inheritsFrom(this.inheritsFrom)
+                .type(this.type)
+                .extensibleProperties(this.extensibleProperties)
+                .target(target)
+                .build();
     }
 
     @JsonPOJOBuilder(withPrefix = "")

--- a/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Prohibition.java
+++ b/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Prohibition.java
@@ -38,7 +38,7 @@ public class Prohibition extends Rule {
      * @param target the target.
      * @return a copy with the specified target.
      */
-    public Prohibition copy(String target) {
+    public Prohibition withTarget(String target) {
         return Builder.newInstance()
                 .uid(this.uid)
                 .assigner(this.assigner)

--- a/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Prohibition.java
+++ b/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Prohibition.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - added method
  *
  */
 
@@ -29,6 +30,23 @@ public class Prohibition extends Rule {
     @Override
     public String toString() {
         return "Prohibition constraints: [" + getConstraints().stream().map(Object::toString).collect(joining(",")) + "]";
+    }
+    
+    /**
+     * Returns a copy of this prohibition with the specified target.
+     *
+     * @param target the target.
+     * @return a copy with the specified target.
+     */
+    public Prohibition copy(String target) {
+        return Builder.newInstance()
+                .uid(this.uid)
+                .assigner(this.assigner)
+                .assignee(this.assignee)
+                .action(this.action)
+                .constraints(this.constraints)
+                .target(target)
+                .build();
     }
 
     public static class Builder extends Rule.Builder<Prohibition, Prohibition.Builder> {

--- a/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/DutyTest.java
+++ b/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/DutyTest.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - added test
  *
  */
 package org.eclipse.dataspaceconnector.policy.model;
@@ -26,5 +27,32 @@ class DutyTest {
         var mapper = new ObjectMapper();
         var serialized = mapper.writeValueAsString(Duty.Builder.newInstance().action(Action.Builder.newInstance().type("USE").build()).build());
         assertThat(mapper.readValue(serialized, Duty.class).getAction()).isNotNull();
+    }
+    
+    @Test
+    void copyWithTarget() {
+        var target = "target-id";
+        var duty = Duty.Builder.newInstance()
+                .uid("id")
+                .assigner("assigner")
+                .assignee("assignee")
+                .action(Action.Builder.newInstance().type("DELETE").build())
+                .constraint(AtomicConstraint.Builder.newInstance()
+                        .leftExpression(new LiteralExpression("left"))
+                        .operator(Operator.EQ)
+                        .rightExpression(new LiteralExpression("right"))
+                        .build())
+                .consequence(Duty.Builder.newInstance().build())
+                .build();
+        
+        var copy = duty.copy(target);
+    
+        assertThat(copy.getUid()).isEqualTo(duty.getUid());
+        assertThat(copy.getAssigner()).isEqualTo(duty.getAssigner());
+        assertThat(copy.getAssignee()).isEqualTo(duty.getAssignee());
+        assertThat(copy.getAction()).isEqualTo(duty.getAction());
+        assertThat(copy.getConstraints()).isEqualTo(duty.getConstraints());
+        assertThat(copy.getConsequence().getTarget()).isEqualTo(target);
+        assertThat(copy.getTarget()).isEqualTo(target);
     }
 }

--- a/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/DutyTest.java
+++ b/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/DutyTest.java
@@ -30,7 +30,7 @@ class DutyTest {
     }
     
     @Test
-    void copyWithTarget() {
+    void withTarget() {
         var target = "target-id";
         var duty = Duty.Builder.newInstance()
                 .uid("id")
@@ -45,7 +45,7 @@ class DutyTest {
                 .consequence(Duty.Builder.newInstance().build())
                 .build();
         
-        var copy = duty.copy(target);
+        var copy = duty.withTarget(target);
     
         assertThat(copy.getUid()).isEqualTo(duty.getUid());
         assertThat(copy.getAssigner()).isEqualTo(duty.getAssigner());

--- a/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/PermissionTest.java
+++ b/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/PermissionTest.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - added test
  *
  */
 package org.eclipse.dataspaceconnector.policy.model;
@@ -26,6 +27,34 @@ class PermissionTest {
         var mapper = new ObjectMapper();
         var serialized = mapper.writeValueAsString(Permission.Builder.newInstance().action(Action.Builder.newInstance().type("USE").build()).build());
         assertThat(mapper.readValue(serialized, Permission.class).getAction()).isNotNull();
+    }
+    
+    @Test
+    void copyWithTarget() {
+        var target = "target-id";
+        var permission = Permission.Builder.newInstance()
+                .uid("id")
+                .assigner("assigner")
+                .assignee("assignee")
+                .action(Action.Builder.newInstance().type("USE").build())
+                .constraint(AtomicConstraint.Builder.newInstance()
+                        .leftExpression(new LiteralExpression("left"))
+                        .operator(Operator.EQ)
+                        .rightExpression(new LiteralExpression("right"))
+                        .build())
+                .duty(Duty.Builder.newInstance().build())
+                .build();
+        
+        var copy = permission.copy(target);
+        
+        assertThat(copy.getUid()).isEqualTo(permission.getUid());
+        assertThat(copy.getAssigner()).isEqualTo(permission.getAssigner());
+        assertThat(copy.getAssignee()).isEqualTo(permission.getAssignee());
+        assertThat(copy.getAction()).isEqualTo(permission.getAction());
+        assertThat(copy.getConstraints()).isEqualTo(permission.getConstraints());
+        assertThat(copy.getDuties().size()).isEqualTo(permission.getDuties().size());
+        copy.getDuties().forEach(d -> assertThat(d.getTarget()).isEqualTo(target));
+        assertThat(copy.getTarget()).isEqualTo(target);
     }
 
 }

--- a/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/PermissionTest.java
+++ b/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/PermissionTest.java
@@ -30,7 +30,7 @@ class PermissionTest {
     }
     
     @Test
-    void copyWithTarget() {
+    void withTarget() {
         var target = "target-id";
         var permission = Permission.Builder.newInstance()
                 .uid("id")
@@ -45,7 +45,7 @@ class PermissionTest {
                 .duty(Duty.Builder.newInstance().build())
                 .build();
         
-        var copy = permission.copy(target);
+        var copy = permission.withTarget(target);
         
         assertThat(copy.getUid()).isEqualTo(permission.getUid());
         assertThat(copy.getAssigner()).isEqualTo(permission.getAssigner());

--- a/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/PolicyTest.java
+++ b/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/PolicyTest.java
@@ -36,7 +36,7 @@ class PolicyTest {
     }
     
     @Test
-    void copyWithTarget() {
+    void withTarget() {
         var target = "target-id";
         var permission = Permission.Builder.newInstance().action(Action.Builder.newInstance().type("USE").build()).build();
         var prohibition = Prohibition.Builder.newInstance().action(Action.Builder.newInstance().type("MODIFY").build()).build();
@@ -53,7 +53,7 @@ class PolicyTest {
                 .extensibleProperties(new HashMap<>())
                 .build();
         
-        var copy = policy.copy(target);
+        var copy = policy.withTarget(target);
         
         assertThat(copy.getUid()).isEqualTo(policy.getUid());
         assertThat(copy.getPermissions().size()).isEqualTo(policy.getPermissions().size());

--- a/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/PolicyTest.java
+++ b/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/PolicyTest.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - added test
  *
  */
 package org.eclipse.dataspaceconnector.policy.model;
@@ -16,6 +17,8 @@ package org.eclipse.dataspaceconnector.policy.model;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,6 +33,39 @@ class PolicyTest {
 
         var serialized = mapper.writeValueAsString(policy);
         assertThat(mapper.readValue(serialized, Policy.class).getPermissions()).isNotEmpty();
+    }
+    
+    @Test
+    void copyWithTarget() {
+        var target = "target-id";
+        var permission = Permission.Builder.newInstance().action(Action.Builder.newInstance().type("USE").build()).build();
+        var prohibition = Prohibition.Builder.newInstance().action(Action.Builder.newInstance().type("MODIFY").build()).build();
+        var duty = Duty.Builder.newInstance().action(Action.Builder.newInstance().type("DELETE").build()).build();
+        var policy = Policy.Builder.newInstance()
+                .id("id")
+                .permission(permission)
+                .prohibition(prohibition)
+                .duty(duty)
+                .assigner("assigner")
+                .assignee("assignee")
+                .inheritsFrom("inheritsFroms")
+                .type(PolicyType.SET)
+                .extensibleProperties(new HashMap<>())
+                .build();
+        
+        var copy = policy.copy(target);
+        
+        assertThat(copy.getUid()).isEqualTo(policy.getUid());
+        assertThat(copy.getPermissions().size()).isEqualTo(policy.getPermissions().size());
+        copy.getPermissions().forEach(p -> assertThat(p.getTarget()).isEqualTo(target));
+        copy.getProhibitions().forEach(p -> assertThat(p.getTarget()).isEqualTo(target));
+        copy.getObligations().forEach(o -> assertThat(o.getTarget()).isEqualTo(target));
+        assertThat(copy.getAssigner()).isEqualTo(policy.getAssigner());
+        assertThat(copy.getAssignee()).isEqualTo(policy.getAssignee());
+        assertThat(copy.getInheritsFrom()).isEqualTo(policy.getInheritsFrom());
+        assertThat(copy.getType()).isEqualTo(policy.getType());
+        assertThat(copy.getExtensibleProperties()).isEqualTo(policy.getExtensibleProperties());
+        assertThat(copy.getTarget()).isEqualTo(target);
     }
 
 }

--- a/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/ProhibitionTest.java
+++ b/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/ProhibitionTest.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2022 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.policy.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProhibitionTest {
+    
+    @Test
+    void copyWithTarget() {
+        var target = "target-id";
+        var prohibition = Prohibition.Builder.newInstance()
+                .uid("id")
+                .assigner("assigner")
+                .assignee("assignee")
+                .action(Action.Builder.newInstance().type("DELETE").build())
+                .constraint(AtomicConstraint.Builder.newInstance()
+                        .leftExpression(new LiteralExpression("left"))
+                        .operator(Operator.EQ)
+                        .rightExpression(new LiteralExpression("right"))
+                        .build())
+                .build();
+        
+        var copy = prohibition.copy(target);
+    
+        assertThat(copy.getUid()).isEqualTo(prohibition.getUid());
+        assertThat(copy.getAssigner()).isEqualTo(prohibition.getAssigner());
+        assertThat(copy.getAssignee()).isEqualTo(prohibition.getAssignee());
+        assertThat(copy.getAction()).isEqualTo(prohibition.getAction());
+        assertThat(copy.getConstraints()).isEqualTo(prohibition.getConstraints());
+        assertThat(copy.getTarget()).isEqualTo(target);
+    }
+    
+}

--- a/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/ProhibitionTest.java
+++ b/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/ProhibitionTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ProhibitionTest {
     
     @Test
-    void copyWithTarget() {
+    void withTarget() {
         var target = "target-id";
         var prohibition = Prohibition.Builder.newInstance()
                 .uid("id")
@@ -35,7 +35,7 @@ class ProhibitionTest {
                         .build())
                 .build();
         
-        var copy = prohibition.copy(target);
+        var copy = prohibition.withTarget(target);
     
         assertThat(copy.getUid()).isEqualTo(prohibition.getUid());
         assertThat(copy.getAssigner()).isEqualTo(prohibition.getAssigner());

--- a/samples/04.0-file-transfer/transfer-file/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferExtension.java
+++ b/samples/04.0-file-transfer/transfer-file/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferExtension.java
@@ -70,13 +70,11 @@ public class FileTransferExtension implements ServiceExtension {
 
         var usePermission = Permission.Builder.newInstance()
                 .action(Action.Builder.newInstance().type("USE").build())
-                .target("test-document")
                 .build();
 
         return Policy.Builder.newInstance()
                 .id(USE_POLICY)
                 .permission(usePermission)
-                .target("test-document")
                 .build();
     }
 

--- a/samples/05-file-transfer-cloud/data-seeder/src/main/java/org/eclipse/dataspaceconnector/sample5/data/seeder/FakeSetup.java
+++ b/samples/05-file-transfer-cloud/data-seeder/src/main/java/org/eclipse/dataspaceconnector/sample5/data/seeder/FakeSetup.java
@@ -67,7 +67,6 @@ public class FakeSetup {
     public void setupContractOffers() {
         Policy publicPolicy = Policy.Builder.newInstance()
                 .permission(Permission.Builder.newInstance()
-                        .target("1")
                         .action(Action.Builder.newInstance()
                                 .type("USE")
                                 .build())
@@ -76,7 +75,6 @@ public class FakeSetup {
 
         Policy publicPolicy2 = Policy.Builder.newInstance()
                 .permission(Permission.Builder.newInstance()
-                        .target("2")
                         .action(Action.Builder.newInstance()
                                 .type("USE")
                                 .build())


### PR DESCRIPTION
## What this PR changes/adds

It sets the target for policies and rules to the corresponding asset ID when `ContractOffers` are created.

## Why it does that

At the moment, a `ContractDefinition's` contract policy is added to the `ContractOffer` as is. If the target of a rule is missing, this leads to errors during transformation. Therefore, it is currently required that a fixed target is set for each rule.

## Further notes

The static target has been removed from the rules created in samples 04.0 and 05, as the target will now be added when `ContractOffers` are requested.

## Linked Issue(s)

Closes #609 

## Checklist

- [X] added appropriate tests?
- [ ] performed checkstyle check locally?
- [X] added/updated copyright headers?
- [X] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [X] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [X] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
