### PR TITLE
Bugfix: adds extension to register SQL TPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ the detailed section referring to by linking pull requests or issues.
 * Added missing Data Management Asset controller openapi (#853)
 * Policy deserialization (#898)
 * Fix extensions loading of EdcRuntimeExtension (#180)
+* Fix missing extension to register TPS (#1027)
 
 ---
 

--- a/extensions/sql/transfer-process-store/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/SqlTransferProcessStoreExtension.java
+++ b/extensions/sql/transfer-process-store/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/SqlTransferProcessStoreExtension.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.sql.transferprocess;
+
+import org.eclipse.dataspaceconnector.spi.system.Inject;
+import org.eclipse.dataspaceconnector.spi.system.Provides;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
+import org.eclipse.dataspaceconnector.spi.transaction.datasource.DataSourceRegistry;
+import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
+import org.eclipse.dataspaceconnector.sql.transferprocess.store.PostgresStatements;
+import org.eclipse.dataspaceconnector.sql.transferprocess.store.SqlTransferProcessStore;
+import org.eclipse.dataspaceconnector.sql.transferprocess.store.TransferProcessStoreStatements;
+
+@Provides(TransferProcessStore.class)
+public class SqlTransferProcessStoreExtension implements ServiceExtension {
+
+    private static final String DATASOURCE_NAME_SETTING = "edc.datasource.transferprocess.name";
+    private static final String DEFAULT_DATASOURCE_NAME = "transferprocess";
+
+    @Inject
+    private DataSourceRegistry dataSourceRegistry;
+    @Inject
+    private TransactionContext trxContext;
+
+    @Inject(required = false)
+    private TransferProcessStoreStatements statements;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var store = new SqlTransferProcessStore(dataSourceRegistry, getDataSourceName(context), trxContext, context.getTypeManager().getMapper(), getStatementImpl(), context.getConnectorId());
+        context.registerService(TransferProcessStore.class, store);
+    }
+
+    /**
+     * returns an externally-provided sql statement dialect, or postgres as a default
+     */
+    private TransferProcessStoreStatements getStatementImpl() {
+        return statements != null ? statements : new PostgresStatements();
+    }
+
+    private String getDataSourceName(ServiceExtensionContext context) {
+        return context.getConfig().getString(DATASOURCE_NAME_SETTING, DEFAULT_DATASOURCE_NAME);
+    }
+}

--- a/extensions/sql/transfer-process-store/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/SqlTransferProcessStoreExtension.java
+++ b/extensions/sql/transfer-process-store/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/SqlTransferProcessStoreExtension.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.sql.transferprocess;
 
+import org.eclipse.dataspaceconnector.spi.EdcSetting;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.Provides;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
@@ -28,6 +29,7 @@ import org.eclipse.dataspaceconnector.sql.transferprocess.store.TransferProcessS
 @Provides(TransferProcessStore.class)
 public class SqlTransferProcessStoreExtension implements ServiceExtension {
 
+    @EdcSetting
     private static final String DATASOURCE_NAME_SETTING = "edc.datasource.transferprocess.name";
     private static final String DEFAULT_DATASOURCE_NAME = "transferprocess";
 

--- a/extensions/sql/transfer-process-store/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/PostgresStatements.java
+++ b/extensions/sql/transfer-process-store/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/PostgresStatements.java
@@ -19,7 +19,7 @@ import static java.lang.String.format;
 /**
  * Postgres-specific variants and implementations of the statements required for the TransferProcessStore
  */
-class PostgresStatements implements TransferProcessStoreStatements {
+public class PostgresStatements implements TransferProcessStoreStatements {
     @Override
     public String getDeleteLeaseTemplate() {
         return format("DELETE FROM %s WHERE %s=?", getLeaseTableName(), getLeaseIdColumn());
@@ -34,6 +34,12 @@ class PostgresStatements implements TransferProcessStoreStatements {
     @Override
     public String getUpdateLeaseTemplate() {
         return format("UPDATE %s SET %s=? WHERE %s = ?;", getTableName(), getLeaseIdColumn(), getIdColumn());
+    }
+
+    @Override
+    public String getFindLeaseByEntityTemplate() {
+        return format("SELECT * FROM %s  WHERE %s = (SELECT lease_id FROM %s WHERE %s=? )",
+                getLeaseTableName(), getLeaseIdColumn(), getTableName(), getIdColumn());
     }
 
     @Override
@@ -58,12 +64,6 @@ class PostgresStatements implements TransferProcessStoreStatements {
     @Override
     public String getDeleteTransferProcessTemplate() {
         return format("DELETE FROM %s WHERE id = ?;", getTableName());
-    }
-
-    @Override
-    public String getFindLeaseByEntityTemplate() {
-        return format("SELECT * FROM %s  WHERE %s = (SELECT lease_id FROM %s WHERE %s=? )",
-                getLeaseTableName(), getLeaseIdColumn(), getTableName(), getIdColumn());
     }
 
     @Override

--- a/extensions/sql/transfer-process-store/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
+++ b/extensions/sql/transfer-process-store/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2022 Daimler TSS GmbH
+#  Copyright (c) 2020 - 2022 Microsoft Corporation
 #
 #  This program and the accompanying materials are made available under the
 #  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 #  Contributors:
-#       Daimler TSS GmbH - Initial API and Implementation
+#       Microsoft Corporation - initial API and implementation
 #
 #
 org.eclipse.dataspaceconnector.sql.transferprocess.SqlTransferProcessStoreExtension

--- a/extensions/sql/transfer-process-store/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
+++ b/extensions/sql/transfer-process-store/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
@@ -1,0 +1,14 @@
+#
+#  Copyright (c) 2022 Daimler TSS GmbH
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Daimler TSS GmbH - Initial API and Implementation
+#
+#
+org.eclipse.dataspaceconnector.sql.transferprocess.SqlTransferProcessStoreExtension


### PR DESCRIPTION
## What this PR changes/adds

Adds the previously forgotten service extension to register the SQL TPS.

## Why it does that

It wasn't there before.

## Further notes

n/a

## Linked Issue(s)

Closes #1027

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
