### PR TITLE
sample 5: change request to get agreement id

### DIFF
--- a/samples/05-file-transfer-cloud/README.md
+++ b/samples/05-file-transfer-cloud/README.md
@@ -174,12 +174,12 @@ The EDC will answer with the contract negotiation id. This id will be used in st
 To get the contract agreement id insert the negotiation id into the following statement end execute it.
 
 ```bash
-curl --location --request GET 'http://localhost:9191/api/control/agreement/<NegotiationId>' \
+curl --location --request GET 'http://localhost:9191/api/control/negotiation/<NegotiationId>/state' \
 --header 'X-API-Key: password'
 ```
 
-The EDC will answer with the serialized contract negotiation. After the negotiation is done the serialized contract
-negotiation will contain an agreement with id, that is required in the next step. This may take a few seconds.
+The EDC will return the current state of the contract negotiation. When the negotiation is completed successfully,
+the response will also contain an agreement id, that is required in the next step. This may take a few seconds.
 
 #### 4. Transfer Data
 


### PR DESCRIPTION
## What this PR changes/adds

It changes the URL used for obtaining the agreement ID after initiating a contract negotiation in sample 5's README.

## Why it does that

The URL currently used for getting the agreement points to the endpoint for getting agreements by their ID. Using the negotiation ID as stated in the README, it always returns 404, as no agreement with that ID exists.
