### PR TITLE
feat: add CODEOWNERS file to repository

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,93 @@
+# This file provides an overview of responsibilities in this repository.
+
+# Please note that this file does not represent all contributions to the code. What persons and organizations
+# actually contributed to each file can be seen on GitHub and is documented in the license headers.
+
+# Each line is a file pattern followed by one or more contact persons. The last matching pattern has the most precedence.
+# For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
+
+# The linked persons are automatically added as reviewers when a pull request is opened.
+
+# Docs and util directories are omitted. Spi files as well, as this should already be covered by extension and core implementations.
+
+CONTRIBUTING.md @MoritzKeppler @juliapampus @alexandrudanciu @mspiekermann
+LICENSE @MoritzKeppler @juliapampus @alexandrudanciu @mspiekermann
+NOTICE.md @alexandrudanciu @mspiekermann
+onboarding.md @paullatzelsperger
+openapi.md @paullatzelsperger
+SECURITY.md @alexandrudanciu @mspiekermann
+styleguide.md @paullatzelsperger
+
+.github/ISSUE_TEMPLATE @juliapampus @paullatzelsperger
+.github/workflows/ @paullatzelsperger @ndr-brt @algattik @ouphi
+
+/common/state-machine-lib/ @ndr-brt @algattik
+/common/token-generation-lib/ @bscholtes1A
+/common/token-validation-lib/ @bscholtes1A
+
+/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/agent/ @jimmarino
+/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/policy/ @jimmarino
+/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/health/ @paullatzelsperger
+
+/core/base/src/main/java/org/eclipse/dataspaceconnector/core/boot/ @jimmarino @paullatzelsperger
+/core/base/src/main/java/org/eclipse/dataspaceconnector/core/contract/ @jimmarino @juliapampus @ronjaquensel
+/core/base/src/main/java/org/eclipse/dataspaceconnector/core/micrometer/ @algattik
+/core/base/src/main/java/org/eclipse/dataspaceconnector/core/policy/ @jimmarino
+/core/base/src/main/java/org/eclipse/dataspaceconnector/core/transfer/ @jimmarino @bscholtes1A @paullatzelsperger @ndr-brt
+
+/data-protocols/ids/ @ronjaquensel @DominikPinsel @denisneuling @juliapampus
+
+/extensions/api/ @ndr-brt @paullatzelsperger
+/extensions/aws/ @paullatzelsperger
+/extensions/azure/ @paullatzelsperger
+/extensions/catalog/ @paullatzelsperger
+/extensions/data-plane/ @bscholtes1A @jimmarino
+/extensions/data-plane-selector/ @paullatzelsperger
+/extensions/data-plane-transfer/ @bscholtes1A
+/extensions/dataloading/ @paullatzelsperger
+/extensions/filesystem/ @jimmarino @paullatzelsperger
+/extensions/http/ @paullatzelsperger
+/extensions/http-receiver/ @bscholtes1A
+/extensions/iam/daps/ @bscholtes1A
+/extensions/iam/decentralized-identity/ @paullatzelsperger
+/extensions/iam/iam-mock/ @jimmarino
+/extensions/iam/oauth2/ @bscholtes1A @jimmarino
+/extensions/in-memory/assetindex-memory/ @paullatzelsperger
+/extensions/in-memory/contractdefinition-store-memory/ @jimmarino
+/extensions/in-memory/did-document-store-inmem/ @paullatzelsperger
+/extensions/in-memory/fcc-node-directory-memory/ @paullatzelsperger
+/extensions/in-memory/fcc-store-memory/ @paullatzelsperger
+/extensions/in-memory/identity-hub-memory/ @paullatzelsperger
+/extensions/in-memory/negotiation-store-memory/ @paullatzelsperger
+/extensions/in-memory/policy-store-memory/ @Izzzu
+/extensions/in-memory/transfer-store-memory/ @jimmarino
+/extensions/jdk-logger-monitor/ @cpeeyush
+/extensions/policy/ @ndr-brt
+/extensions/sql/ @bcronin90 @denisneuling @paullatzelsperger
+/extensions/transaction/ @jimmarino
+/extensions/transfer-functions/ @jimmarino
+
+/launchers/basic/ @paullatzelsperger
+/launchers/data-loader-cli/ @paullatzelsperger @ronjaquensel
+/launchers/data-plane-server/ @bscholtes1A
+/launchers/dpf-selector/ @paullatzelsperger
+/launchers/ids-connector/ @ronjaquensel
+/launchers/junit/ @jimmarino @paullatzelsperger @algattik @ndr-brt
+/launchers/registration-service-app/ @paullatzelsperger
+
+/resources/charts/ @algattik
+/resources/openapi/ @paullatzelsperger
+
+/samples/01-basic-connector/ @paullatzelsperger
+/samples/02-health-endpoint/ @paullatzelsperger
+/samples/03-configuration/ @paullatzelsperger
+/samples/04.0-file-transfer/ @ronjaquensel
+/samples/04.1-file-transfer-listener/ @algattik
+/samples/04.2-modify-transferprocess/ @paullatzelsperger
+/samples/04.3-open-telemetry/ @algattik
+/samples/05-file-transfer-cloud/ @paullatzelsperger
+/samples/other/ @paullatzelsperger
+
+/system-tests/e2e-transfer-test/ @ndr-brt
+/system-tests/minikube/ @algattik
+/system-tests/runtimes/ @algattik

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,13 @@ we would appreciate if your pull request applies to the following points:
   <http://keepachangelog.com>. Include more information via linking to existing pull requests,
   issues, or discussions.
 
+* If a new module has been added or a significant part of the code has been changed and you should 
+  or want to be seen as the contact person for any further changes, please add appropriate 
+  information to the [CODEOWNERS](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CODEOWNERS) 
+  file. You can find instructions on how to do this at <https://help.github.com/articles/about-codeowners/>.
+  Please note that this file does not represent all contributions to the code. What persons and organizations
+  actually contributed to each file can be seen on GitHub and is documented in the license headers.
+
 * PR descriptions should use the current [PR template](.github/PULL_REQUEST_TEMPLATE.md)
 
 * Submit a draft pull request at early-stage and add people previously working on the same code as 


### PR DESCRIPTION
## What this PR changes/adds

This adds a `CODEOWNERS` file to the repo. The `CONTRIBUTING.md` was extended to hint on how to maintain the file's content.

## Why it does that

As discussed in one of the latest committer rounds, this is a nice possibility to define contact persons (and automatically assign pull request reviewers) for specific modules and files. As noted in both modified files, the `CODEOWNERS` file should not represent all contributions to the code. What persons and organizations actually contributed to each file can be seen on GitHub and is documented in the license headers. It's all about major contact persons.

## Further notes

While creating this pull request, GitHub already provided some feedback:
![image](https://user-images.githubusercontent.com/72392527/161029411-67374ddd-cade-4d29-a5c1-ca7d81759571.png)

We can add this file nevertheless, to have and provide an overview about responsibilities. However, GitHub automatisms will work only partially (for committers, not for contributors).  

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
