### PR TITLE
Revert "ci: add checkstyle rule for Java file headers (#997)"

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -14,9 +14,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
+
       # lets run Checkstyle explicitly (as opposed to within gradle) due to better reporting capabilities
       - name: Run Checkstyle
-        if: github.event_name == 'pull_request'
         uses: nikitasavinov/checkstyle-action@0.4.0
         with:
           checkstyle_config: resources/edc-checkstyle-config.xml
@@ -24,16 +29,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tool_name: 'checkstyle'
           checkstyle_version: '9.0'
-          # Filtering does not work on github-check, needs github-pr-check
-          reporter: 'github-pr-check'
-          # Include only violations on added or modified files
-          filter_mode: 'file'
-
-      - uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+          reporter: 'github-check'
+          filter_mode: 'nofilter'
 
       - name: Gradle Test Core
         env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,10 +76,8 @@ allprojects {
     checkstyle {
         toolVersion = "9.0"
         configFile = rootProject.file("resources/edc-checkstyle-config.xml")
-        maxErrors = 0 // does not tolerate errors
-        configProperties = mapOf(
-            "base_dir" to rootDir,
-        )
+        maxErrors = 0 // does not tolerate errors ...
+        maxWarnings = 0 // ... or warnings
     }
 
     java {

--- a/resources/edc-checkstyle-config.xml
+++ b/resources/edc-checkstyle-config.xml
@@ -19,7 +19,7 @@
 <module name = "Checker">
   <property name="charset" value="UTF-8"/>
 
-  <property name="severity" value="error"/>
+  <property name="severity" value="warning"/>
 
   <property name="fileExtensions" value="java, properties, xml"/>
   <!-- Excludes all 'module-info.java' files              -->
@@ -44,15 +44,6 @@
     <property name="fileExtensions" value="java"/>
     <property name="max" value="250"/>
     <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
-  </module>
-
-  <!-- Checks for header format                                   -->
-  <!-- See https://checkstyle.org/config_header.html#RegexpHeader -->
-  <module name="RegexpHeader">
-    <property name="severity" value="warning"/>
-    <property name="fileExtensions" value="java"/>
-    <property name="header" value="^/\*$\n^ \*  Copyright \(c\) 20\d\d((,| -) 20\d{2})? [A-Za-z].+\S$\n^ \*$\n^ \*  This program and the accompanying materials are made available under the$\n^ \*  terms of the Apache License, Version 2\.0 which is available at$\n^ \*  https://www\.apache\.org/licenses/LICENSE-2\.0$\n^ \*$\n^ \*  SPDX-License-Identifier: Apache-2\.0$\n^ \*$\n^ \*  Contributors:$\n^ \*       \S.*\S - \S.*\S$\n^ \*$\n^ \*/$\n^$\n^package"/>
-    <property name="multiLines" value="11"/>
   </module>
 
   <module name="TreeWalker">


### PR DESCRIPTION
This reverts commit 5f523dcf1233451ca2932855098c70baf2854de1.

## What this PR changes/adds

Revert the header checkstyle rule for now. We realized that the rule is too strict. PR with unrelated changes are failing.
We want to revert it for now to avoid disturbing opening of PRs.
We will come with a better solution later.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
