### PR TITLE
Feature: adds HTTP provisioner webhook endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ the detailed section referring to by linking pull requests or issues.
 * Support for HTTP-based provisioning (#963)
 * Let Control Plane delegate data transfer to Data Plane (#988)
 * CosmosDb based `PolicyStore` (#826)
+* Http Provisioner Webhook endpoint (#1039)
 
 #### Changed
 

--- a/extensions/http-provisioner/build.gradle.kts
+++ b/extensions/http-provisioner/build.gradle.kts
@@ -14,16 +14,24 @@
 
 plugins {
     `java-library`
+    id("io.swagger.core.v3.swagger-gradle-plugin")
 }
 
 val okHttpVersion: String by project
 val jodahFailsafeVersion: String by project
+val rsApi: String by project
+val restAssured: String by project
+
 
 dependencies {
     api(project(":spi:transfer-spi"))
+    api(project(":spi:web-spi"))
+    implementation(project(":extensions:api:auth-spi"))
+    implementation(project(":core:transfer")) // needs the AddProvisionedResourceCommand
 
     implementation("com.squareup.okhttp3:okhttp:${okHttpVersion}")
     implementation("net.jodah:failsafe:${jodahFailsafeVersion}")
+    implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
 
     testImplementation(testFixtures(project(":common:util")))
     testImplementation(project(":core:transfer"))
@@ -31,6 +39,7 @@ dependencies {
     testImplementation(project(":extensions:in-memory:transfer-store-memory"))
     testImplementation(project(":extensions:dataloading"))
     testImplementation(testFixtures(project(":launchers:junit")))
+    testImplementation("io.rest-assured:rest-assured:${restAssured}")
 
 }
 

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerExtension.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerExtension.java
@@ -21,34 +21,33 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ProvisionManager;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ResourceManifestGenerator;
+import org.eclipse.dataspaceconnector.transfer.provision.http.impl.HttpProviderProvisioner;
+import org.eclipse.dataspaceconnector.transfer.provision.http.impl.HttpProviderResourceDefinition;
+import org.eclipse.dataspaceconnector.transfer.provision.http.impl.HttpProviderResourceDefinitionGenerator;
+import org.eclipse.dataspaceconnector.transfer.provision.http.impl.HttpProvisionedContentResource;
+import org.eclipse.dataspaceconnector.transfer.provision.http.impl.HttpProvisionerRequest;
 
 import static java.lang.String.format;
-import static org.eclipse.dataspaceconnector.transfer.provision.http.ConfigParser.parseConfigurations;
-import static org.eclipse.dataspaceconnector.transfer.provision.http.ProvisionerConfiguration.ProvisionerType.PROVIDER;
+import static org.eclipse.dataspaceconnector.transfer.provision.http.config.ConfigParser.parseConfigurations;
+import static org.eclipse.dataspaceconnector.transfer.provision.http.config.ProvisionerConfiguration.ProvisionerType.PROVIDER;
 
 /**
  * The HTTP Provisioner extension delegates to HTTP endpoints to perform provision operations.
  */
 public class HttpProvisionerExtension implements ServiceExtension {
 
+    @Inject
+    protected ProvisionManager provisionManager;
+    @Inject
+    protected PolicyEngine policyEngine;
+    @Inject
+    protected OkHttpClient httpClient;
+    @Inject
+    private ResourceManifestGenerator manifestGenerator;
     private OkHttpClient overrideHttpClient;
 
     @Inject
-    ResourceManifestGenerator manifestGenerator;
-
-    @Inject
-    protected ProvisionManager provisionManager;
-
-    @Inject
-    protected PolicyEngine policyEngine;
-
-    @Inject
-    protected OkHttpClient httpClient;
-
-    @Override
-    public String name() {
-        return "HTTP Provisioning";
-    }
+    private HttpProvisionerWebhookUrl callbackUrl;
 
     /**
      * Default ctor.
@@ -61,7 +60,12 @@ public class HttpProvisionerExtension implements ServiceExtension {
      * Overrides the default HTTP client. Intended for testing.
      */
     public HttpProvisionerExtension(OkHttpClient httpClient) {
-        this.overrideHttpClient = httpClient;
+        overrideHttpClient = httpClient;
+    }
+
+    @Override
+    public String name() {
+        return "HTTP Provisioning";
     }
 
     @Override
@@ -75,7 +79,7 @@ public class HttpProvisionerExtension implements ServiceExtension {
 
         for (var configuration : configurations) {
 
-            var provisioner = new HttpProviderProvisioner(configuration, policyEngine, client, typeManager.getMapper(), monitor);
+            var provisioner = new HttpProviderProvisioner(configuration, callbackUrl.get(), policyEngine, client, typeManager.getMapper(), monitor);
 
             if (configuration.getProvisionerType() == PROVIDER) {
                 var generator = new HttpProviderResourceDefinitionGenerator(configuration.getDataAddressType());

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerWebhookUrl.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProvisionerWebhookUrl.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.transfer.provision.http;
+
+import java.net.URL;
+
+/**
+ * Provides the URL where the {@link org.eclipse.dataspaceconnector.transfer.provision.http.webhook.HttpProvisionerWebhookApiController}
+ * is reachable
+ */
+@FunctionalInterface
+public interface HttpProvisionerWebhookUrl {
+    /**
+     * gets the URL which the HTTP Provisioner webhook provides for out-of-process systems to call back into.
+     */
+    URL get();
+}

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpWebhookExtension.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpWebhookExtension.java
@@ -1,0 +1,105 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.transfer.provision.http;
+
+import org.eclipse.dataspaceconnector.api.auth.AuthenticationRequestFilter;
+import org.eclipse.dataspaceconnector.api.auth.AuthenticationService;
+import org.eclipse.dataspaceconnector.api.exception.mappers.EdcApiExceptionMapper;
+import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.WebServer;
+import org.eclipse.dataspaceconnector.spi.WebService;
+import org.eclipse.dataspaceconnector.spi.system.Hostname;
+import org.eclipse.dataspaceconnector.spi.system.Inject;
+import org.eclipse.dataspaceconnector.spi.system.Provides;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
+import org.eclipse.dataspaceconnector.transfer.provision.http.webhook.HttpProvisionerWebhookApiController;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static java.lang.String.format;
+
+@Provides(HttpProvisionerWebhookUrl.class)
+public class HttpWebhookExtension implements ServiceExtension {
+    //not an EdcSetting, because it is only the first part of the config path
+    public static final String PROVISIONER_WEBHOOK_CONFIG = "web.http.provisioner";
+    public static final String PROVISIONER_CONTEXT_ALIAS = "provisioner";
+
+    public static final int DEFUALT_WEBHOOK_PORT = 8383;
+    public static final String DEFAULT_PROVISIONER_CONTEXT_PATH = "/api/v1/provisioner";
+
+    @Inject
+    private WebServer webServer;
+
+    @Inject
+    private WebService webService;
+
+    @Inject
+    private AuthenticationService authService;
+
+    @Inject
+    private TransferProcessManager transferProcessManager;
+
+    @Inject
+    private Hostname hostname;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var monitor = context.getMonitor();
+        var alias = PROVISIONER_CONTEXT_ALIAS;
+        var path = DEFAULT_PROVISIONER_CONTEXT_PATH;
+        var port = DEFUALT_WEBHOOK_PORT;
+
+        var config = context.getConfig(PROVISIONER_WEBHOOK_CONFIG);
+        if (config.getEntries().isEmpty()) {
+            monitor.warning(format("Settings for [%s] and/or [%s] were not provided. Using default" +
+                    " value(s) instead.", PROVISIONER_WEBHOOK_CONFIG + ".path", PROVISIONER_WEBHOOK_CONFIG + ".path"));
+            webServer.addPortMapping(alias, port, path);
+        } else {
+            path = config.getString("path", path);
+            port = config.getInteger("port", port);
+        }
+
+        registerCallbackUrl(context, path, port);
+
+        monitor.info(format("IDS API will be available at [path=%s], [port=%s].", path, port));
+
+
+        webService.registerResource(alias, new HttpProvisionerWebhookApiController(transferProcessManager));
+        webService.registerResource(alias, new AuthenticationRequestFilter(authService));
+        webService.registerResource(alias, new EdcApiExceptionMapper());
+    }
+
+    private void registerCallbackUrl(ServiceExtensionContext context, String path, int port) {
+        var s = hostname.get();
+
+        if (!s.startsWith("http")) { // a hostname should never have a protocol prefix, but just to be safe
+            s = "http://" + s;
+        }
+        if (!s.matches(".*:([0-9]){1,5}$")) { // a hostname also shouldn't have a port, but again, to be sure
+            s += ":" + port;
+        }
+        s += path + "/callback";
+        try {
+            var url = new URL(s);
+            context.registerService(HttpProvisionerWebhookUrl.class, () -> url);
+        } catch (MalformedURLException e) {
+            context.getMonitor().severe("Error creating callback endpoint", e);
+            throw new EdcException(e);
+        }
+    }
+}

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/config/ConfigParser.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/config/ConfigParser.java
@@ -12,12 +12,12 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.transfer.provision.http;
+package org.eclipse.dataspaceconnector.transfer.provision.http.config;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.EdcSetting;
 import org.eclipse.dataspaceconnector.spi.system.configuration.Config;
-import org.eclipse.dataspaceconnector.transfer.provision.http.ProvisionerConfiguration.ProvisionerType;
+import org.eclipse.dataspaceconnector.transfer.provision.http.config.ProvisionerConfiguration.ProvisionerType;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -28,10 +28,10 @@ import static java.util.stream.Collectors.toList;
 
 /**
  * Parses provisioner configuration.
- *
+ * <p>
  * Multiple named provisioners can be configured per runtime.
  */
-class ConfigParser {
+public class ConfigParser {
     private static final String DEFAULT_POLICY_SCOPE = "http.provisioner";
 
     private static final String CONFIG_PREFIX = "provisioner.http";
@@ -50,18 +50,13 @@ class ConfigParser {
     @EdcSetting
     private static final String POLICY_SCOPE = "policy.scope";
 
-    @EdcSetting
-    private static final String CALLBACK_ADDRESS = "callback.address";
-
-    // TODO replace
-    private static final String DEFAULT_CALLBACK_ADDRESS = "http://localhost:8080";
+    private ConfigParser() {
+    }
 
     /**
      * Parses the runtime configuration source, returning a provisioner configuration.
      */
     public static List<ProvisionerConfiguration> parseConfigurations(Config root) {
-
-        var callbackAddress = parseCallback(root);
 
         var configurations = root.getConfig(HTTP_PROVISIONER_ENTRIES);
 
@@ -83,18 +78,8 @@ class ConfigParser {
                             .dataAddressType(dataAddressType)
                             .policyScope(policyScope)
                             .endpoint(endpoint)
-                            .callbackAddress(callbackAddress)
                             .build();
                 }).collect(toList());
-    }
-
-    private static URL parseCallback(Config root) {
-        var callbackAddress = root.getConfig(CONFIG_PREFIX).getString(CALLBACK_ADDRESS, DEFAULT_CALLBACK_ADDRESS);
-        try {
-            return new URL(callbackAddress);
-        } catch (MalformedURLException e) {
-            throw new EdcException("Invalid callback address for HTTP provisioners", e);
-        }
     }
 
     private static URL parseEndpoint(Config config, String provisionerName) {
@@ -113,8 +98,5 @@ class ConfigParser {
         } catch (IllegalArgumentException e) {
             throw new EdcException(format("Invalid provisioner type specified for %s: %s", provisionerName, typeValue));
         }
-    }
-
-    private ConfigParser() {
     }
 }

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/config/ProvisionerConfiguration.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/config/ProvisionerConfiguration.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.transfer.provision.http;
+package org.eclipse.dataspaceconnector.transfer.provision.http.config;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
@@ -23,24 +23,16 @@ import static java.util.Objects.requireNonNull;
 /**
  * Configuration to create a resource definition and provisioner pair.
  */
-class ProvisionerConfiguration {
-
-    public enum ProvisionerType {
-        CLIENT,
-        PROVIDER
-    }
+public class ProvisionerConfiguration {
 
     private String name;
-
     private ProvisionerType provisionerType = ProvisionerType.PROVIDER;
-
     private String dataAddressType;
-
     private String policyScope;
-
     private URL endpoint;
 
-    private URL callbackAddress;
+    private ProvisionerConfiguration() {
+    }
 
     public String getName() {
         return name;
@@ -62,16 +54,18 @@ class ProvisionerConfiguration {
         return endpoint;
     }
 
-    public URL getCallbackAddress() {
-        return callbackAddress;
-    }
-
-    private ProvisionerConfiguration() {
+    public enum ProvisionerType {
+        CLIENT,
+        PROVIDER
     }
 
     public static class Builder {
 
-        private ProvisionerConfiguration configuration;
+        private final ProvisionerConfiguration configuration;
+
+        private Builder() {
+            configuration = new ProvisionerConfiguration();
+        }
 
         @JsonCreator
         public static Builder newInstance() {
@@ -103,21 +97,11 @@ class ProvisionerConfiguration {
             return this;
         }
 
-        public Builder callbackAddress(URL callbackAddress) {
-            configuration.callbackAddress = callbackAddress;
-            return this;
-        }
-
         public ProvisionerConfiguration build() {
             requireNonNull(configuration.name, "name");
             requireNonNull(configuration.provisionerType, "type");
             requireNonNull(configuration.policyScope, "policyScope");
-            requireNonNull(configuration.callbackAddress, "callbackAddress");
             return configuration;
-        }
-
-        private Builder() {
-            configuration = new ProvisionerConfiguration();
         }
 
     }

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/AbstractHttpResourceDefinition.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/AbstractHttpResourceDefinition.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.transfer.provision.http;
+package org.eclipse.dataspaceconnector.transfer.provision.http.impl;
 
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
@@ -24,6 +24,9 @@ import java.util.Objects;
  */
 public abstract class AbstractHttpResourceDefinition extends ResourceDefinition {
     protected String dataAddressType;
+
+    protected AbstractHttpResourceDefinition() {
+    }
 
     /**
      * Returns the data address type the definition is associated with. This is used to determine which provisioner will be engaged.
@@ -37,11 +40,12 @@ public abstract class AbstractHttpResourceDefinition extends ResourceDefinition 
         return transferProcessId;
     }
 
-    protected AbstractHttpResourceDefinition() {
-    }
-
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder<RD extends AbstractHttpResourceDefinition, B extends ResourceDefinition.Builder<RD, B>> extends ResourceDefinition.Builder<RD, B> {
+
+        protected Builder(RD definition) {
+            super(definition);
+        }
 
         @SuppressWarnings("unchecked")
         public B dataAddressType(String dataAddressType) {
@@ -53,10 +57,6 @@ public abstract class AbstractHttpResourceDefinition extends ResourceDefinition 
         protected void verify() {
             super.verify();
             Objects.requireNonNull(resourceDefinition.dataAddressType, "transferType");
-        }
-
-        protected Builder(RD definition) {
-            super(definition);
         }
 
     }

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderProvisioner.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderProvisioner.java
@@ -84,7 +84,7 @@ public class HttpProviderProvisioner implements Provisioner<HttpProviderResource
     @Override
     public boolean canDeprovision(ProvisionedResource provisionedResource) {
         return provisionedResource instanceof HttpProvisionedContentResource &&
-                dataAddressType.equals(((HttpProvisionedContentResource) provisionedResource).getContentDataAddress().getType());
+                dataAddressType.equals(((HttpProvisionedContentResource) provisionedResource).getDataAddress().getType());
     }
 
     @Override

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderProvisioner.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderProvisioner.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.transfer.provision.http;
+package org.eclipse.dataspaceconnector.transfer.provision.http.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -31,14 +31,15 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DeprovisionedRes
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionResponse;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedResource;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
+import org.eclipse.dataspaceconnector.transfer.provision.http.config.ProvisionerConfiguration;
 
 import java.io.IOException;
 import java.net.URL;
 import java.util.concurrent.CompletableFuture;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.eclipse.dataspaceconnector.transfer.provision.http.HttpProvisionerRequest.Type.DEPROVISION;
-import static org.eclipse.dataspaceconnector.transfer.provision.http.HttpProvisionerRequest.Type.PROVISION;
+import static org.eclipse.dataspaceconnector.transfer.provision.http.impl.HttpProvisionerRequest.Type.DEPROVISION;
+import static org.eclipse.dataspaceconnector.transfer.provision.http.impl.HttpProvisionerRequest.Type.PROVISION;
 
 /**
  * Invokes an HTTP endpoint to provision asset data. The endpoint will asynchronously return a content data address to a callback supplied with the address that can be used to
@@ -49,28 +50,29 @@ public class HttpProviderProvisioner implements Provisioner<HttpProviderResource
 
     private final String name;
 
-    private String dataAddressType;
-    private String policyScope;
-    private URL endpoint;
-    private URL callbackAddress;
-    private PolicyEngine policyEngine;
-    private OkHttpClient httpClient;
-    private ObjectMapper mapper;
-    private Monitor monitor;
+    private final String dataAddressType;
+    private final String policyScope;
+    private final URL endpoint;
+    private final URL callbackAddress;
+    private final PolicyEngine policyEngine;
+    private final OkHttpClient httpClient;
+    private final ObjectMapper mapper;
+    private final Monitor monitor;
 
     public HttpProviderProvisioner(ProvisionerConfiguration configuration,
+                                   URL callbackAddress,
                                    PolicyEngine policyEngine,
                                    OkHttpClient httpClient,
                                    ObjectMapper objectMapper,
                                    Monitor monitor) {
-        this.name = configuration.getName();
-        this.dataAddressType = configuration.getDataAddressType();
-        this.policyScope = configuration.getPolicyScope();
-        this.endpoint = configuration.getEndpoint();
-        this.callbackAddress = configuration.getCallbackAddress();
+        name = configuration.getName();
+        dataAddressType = configuration.getDataAddressType();
+        policyScope = configuration.getPolicyScope();
+        endpoint = configuration.getEndpoint();
+        this.callbackAddress = callbackAddress;
         this.policyEngine = policyEngine;
         this.httpClient = httpClient;
-        this.mapper = objectMapper;
+        mapper = objectMapper;
         this.monitor = monitor;
     }
 
@@ -82,7 +84,7 @@ public class HttpProviderProvisioner implements Provisioner<HttpProviderResource
     @Override
     public boolean canDeprovision(ProvisionedResource provisionedResource) {
         return provisionedResource instanceof HttpProvisionedContentResource &&
-                dataAddressType.equals(((HttpProvisionedContentResource) provisionedResource).getDataAddress().getType());
+                dataAddressType.equals(((HttpProvisionedContentResource) provisionedResource).getContentDataAddress().getType());
     }
 
     @Override

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderResourceDefinition.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderResourceDefinition.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.transfer.provision.http;
+package org.eclipse.dataspaceconnector.transfer.provision.http.impl;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -29,16 +29,20 @@ import static java.util.Objects.requireNonNull;
 public class HttpProviderResourceDefinition extends AbstractHttpResourceDefinition {
     private String assetId;
 
-    public String getAssetId() {
-        return assetId;
-    }
-
     private HttpProviderResourceDefinition() {
         super();
     }
 
+    public String getAssetId() {
+        return assetId;
+    }
+
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder extends AbstractHttpResourceDefinition.Builder<HttpProviderResourceDefinition, Builder> {
+
+        private Builder() {
+            super(new HttpProviderResourceDefinition());
+        }
 
         @JsonCreator
         public static Builder newInstance() {
@@ -54,10 +58,6 @@ public class HttpProviderResourceDefinition extends AbstractHttpResourceDefiniti
         protected void verify() {
             super.verify();
             requireNonNull(resourceDefinition.assetId, "assetId");
-        }
-
-        private Builder() {
-            super(new HttpProviderResourceDefinition());
         }
 
     }

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderResourceDefinitionGenerator.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderResourceDefinitionGenerator.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.transfer.provision.http;
+package org.eclipse.dataspaceconnector.transfer.provision.http.impl;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.EdcException;
@@ -30,7 +30,7 @@ import static java.util.Objects.requireNonNull;
  * Generates {@link HttpProviderResourceDefinition}s for data addresses matching a type.
  */
 public class HttpProviderResourceDefinitionGenerator implements ProviderResourceDefinitionGenerator {
-    private String dataAddressType;
+    private final String dataAddressType;
 
     public HttpProviderResourceDefinitionGenerator(String dataAddressType) {
         this.dataAddressType = requireNonNull(dataAddressType);

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProvisionedContentResource.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProvisionedContentResource.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.transfer.provision.http;
+package org.eclipse.dataspaceconnector.transfer.provision.http.impl;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -28,22 +28,27 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedConte
 public class HttpProvisionedContentResource extends ProvisionedContentResource {
     private String assetId;
 
-    public String getAssetId() {
-        return assetId;
-    }
-
     private HttpProvisionedContentResource() {
         super();
     }
 
+    public String getAssetId() {
+        return assetId;
+    }
+
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder extends ProvisionedContentResource.Builder<HttpProvisionedContentResource, Builder> {
+
+        private Builder() {
+            super(new HttpProvisionedContentResource());
+        }
 
         @JsonCreator
         public static Builder newInstance() {
             return new Builder();
         }
 
+        @Override
         public Builder transferProcessId(String transferProcessId) {
             provisionedResource.transferProcessId = transferProcessId;
             return this;
@@ -52,10 +57,6 @@ public class HttpProvisionedContentResource extends ProvisionedContentResource {
         public Builder assetId(String assetId) {
             provisionedResource.assetId = assetId;
             return this;
-        }
-
-        private Builder() {
-            super(new HttpProvisionedContentResource());
         }
     }
 }

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProvisionerRequest.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProvisionerRequest.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.transfer.provision.http;
+package org.eclipse.dataspaceconnector.transfer.provision.http.impl;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -28,20 +28,14 @@ import org.eclipse.dataspaceconnector.policy.model.Policy;
 @JsonDeserialize(builder = HttpProvisionerRequest.Builder.class)
 public class HttpProvisionerRequest {
 
-    public enum Type {
-        @JsonProperty("provision")
-        PROVISION,
-
-        @JsonProperty("deprovision")
-        DEPROVISION
-    }
-
     private String assetId;
     private String transferProcessId;
     private Policy policy;
     private String callbackAddress;
-
     private Type type = Type.PROVISION;
+
+    private HttpProvisionerRequest() {
+    }
 
     public String getAssetId() {
         return assetId;
@@ -59,13 +53,22 @@ public class HttpProvisionerRequest {
         return callbackAddress;
     }
 
-    private HttpProvisionerRequest() {
+    public enum Type {
+        @JsonProperty("provision")
+        PROVISION,
+
+        @JsonProperty("deprovision")
+        DEPROVISION
     }
 
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder {
 
-        private HttpProvisionerRequest request;
+        private final HttpProvisionerRequest request;
+
+        private Builder() {
+            request = new HttpProvisionerRequest();
+        }
 
         @JsonCreator
         public static Builder newInstance() {
@@ -99,10 +102,6 @@ public class HttpProvisionerRequest {
 
         public HttpProvisionerRequest build() {
             return request;
-        }
-
-        private Builder() {
-            request = new HttpProvisionerRequest();
         }
 
     }

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/webhook/HttpProvisionerWebhookApi.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/webhook/HttpProvisionerWebhookApi.java
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.transfer.provision.http.webhook;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+
+/**
+ * Carrier for OpenAPI annotations
+ */
+@OpenAPIDefinition
+public interface HttpProvisionerWebhookApi {
+    void callWebhook(ProvisionerWebhookRequest request);
+}

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/webhook/HttpProvisionerWebhookApiController.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/webhook/HttpProvisionerWebhookApiController.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.transfer.provision.http.webhook;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionResponse;
+import org.eclipse.dataspaceconnector.transfer.core.command.commands.AddProvisionedResourceCommand;
+import org.eclipse.dataspaceconnector.transfer.provision.http.impl.HttpProvisionedContentResource;
+
+import java.util.Objects;
+import java.util.UUID;
+
+
+@Consumes({ MediaType.APPLICATION_JSON })
+@Produces({ MediaType.APPLICATION_JSON })
+@Path("/callback")
+public class HttpProvisionerWebhookApiController implements HttpProvisionerWebhookApi {
+    private final TransferProcessManager transferProcessManager;
+
+    public HttpProvisionerWebhookApiController(TransferProcessManager transferProcessManager) {
+        this.transferProcessManager = transferProcessManager;
+    }
+
+    @Override
+    @POST
+    public void callWebhook(ProvisionerWebhookRequest request) {
+
+        Objects.requireNonNull(request);
+        Objects.requireNonNull(request.getAssetId());
+        Objects.requireNonNull(request.getContentDataAddress());
+        Objects.requireNonNull(request.getResourceName());
+        Objects.requireNonNull(request.getTransferProcessId());
+        Objects.requireNonNull(request.getResourceDefinitionId());
+
+        var cr = HttpProvisionedContentResource.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .assetId(request.getAssetId())
+                .contentDataAddress(request.getContentDataAddress())
+                .resourceName(request.getResourceName())
+                .transferProcessId(request.getTransferProcessId())
+                .hasToken(request.hasToken())
+                .resourceDefinitionId(request.getResourceDefinitionId())
+                .build();
+
+        var response = ProvisionResponse.Builder.newInstance()
+                .resource(cr)
+                .secretToken(new SimpleSecretToken(request.getApiToken()))
+                .build();
+        var cmd = new AddProvisionedResourceCommand(request.getTransferProcessId(), response);
+
+        transferProcessManager.enqueueCommand(cmd);
+
+    }
+
+}

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/webhook/HttpProvisionerWebhookApiController.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/webhook/HttpProvisionerWebhookApiController.java
@@ -21,7 +21,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionResponse;
-import org.eclipse.dataspaceconnector.transfer.core.command.commands.AddProvisionedResourceCommand;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.command.AddProvisionedResourceCommand;
 import org.eclipse.dataspaceconnector.transfer.provision.http.impl.HttpProvisionedContentResource;
 
 import java.util.Objects;
@@ -52,7 +52,7 @@ public class HttpProvisionerWebhookApiController implements HttpProvisionerWebho
         var cr = HttpProvisionedContentResource.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .assetId(request.getAssetId())
-                .contentDataAddress(request.getContentDataAddress())
+                .dataAddress(request.getContentDataAddress())
                 .resourceName(request.getResourceName())
                 .transferProcessId(request.getTransferProcessId())
                 .hasToken(request.hasToken())

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/webhook/ProvisionerWebhookRequest.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/webhook/ProvisionerWebhookRequest.java
@@ -1,0 +1,120 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.transfer.provision.http.webhook;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.Polymorphic;
+
+@JsonDeserialize(builder = ProvisionerWebhookRequest.Builder.class)
+@JsonTypeName("dataspaceconnector:provisioner-callback-request")
+public class ProvisionerWebhookRequest implements Polymorphic {
+    private String transferProcessId;
+    private String resourceDefinitionId;
+    private boolean hasToken;
+    private String assetId;
+    private String resourceName;
+    private DataAddress contentDataAddress;
+    private String apiKeyJwt;
+
+    private ProvisionerWebhookRequest() {
+    }
+
+    public String getResourceName() {
+        return resourceName;
+    }
+
+    public DataAddress getContentDataAddress() {
+        return contentDataAddress;
+    }
+
+    public String getAssetId() {
+        return assetId;
+    }
+
+    public String getTransferProcessId() {
+        return transferProcessId;
+    }
+
+    public String getResourceDefinitionId() {
+        return resourceDefinitionId;
+    }
+
+    @JsonProperty("hasToken")
+    public boolean hasToken() {
+        return hasToken;
+    }
+
+    public String getApiToken() {
+        return apiKeyJwt;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder {
+        private final ProvisionerWebhookRequest request;
+
+        private Builder() {
+            request = new ProvisionerWebhookRequest();
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder assetId(String assetId) {
+            request.assetId = assetId;
+            return this;
+        }
+
+        public Builder resourceName(String resourceName) {
+            request.resourceName = resourceName;
+            return this;
+        }
+
+        public Builder contentDataAddress(DataAddress contentDataAddress) {
+            request.contentDataAddress = contentDataAddress;
+            return this;
+        }
+
+        public Builder transferProcessId(String transferProcessId) {
+            request.transferProcessId = transferProcessId;
+            return this;
+        }
+
+        public Builder resourceDefinitionId(String resourceDefinitionId) {
+            request.resourceDefinitionId = resourceDefinitionId;
+            return this;
+        }
+
+        public Builder hasToken(boolean hasToken) {
+            request.hasToken = hasToken;
+            return this;
+        }
+
+        public Builder apiToken(String token) {
+            request.apiKeyJwt = token;
+            return this;
+        }
+
+        public ProvisionerWebhookRequest build() {
+            return request;
+        }
+    }
+}

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/webhook/SimpleSecretToken.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/webhook/SimpleSecretToken.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.transfer.provision.http.webhook;
+
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.SecretToken;
+
+import java.util.Map;
+
+/**
+ * Implementation of the {@link SecretToken} that is based on a simple String.
+ * This could be an API key, a JWT or any other format serialized to String (e.g. JSON).
+ */
+public class SimpleSecretToken implements SecretToken {
+
+
+    private final String token;
+
+    public SimpleSecretToken(String base64SerializedToken) {
+        token = base64SerializedToken;
+    }
+
+    @Override
+    public long getExpiration() {
+        return 0;
+    }
+
+    @Override
+    public Map<String, ?> flatten() {
+        return Map.of("token", token);
+    }
+}

--- a/extensions/http-provisioner/src/main/resources/META-INF/services/ org.eclipse.dataspaceconnector.spi.system.ServiceExtension
+++ b/extensions/http-provisioner/src/main/resources/META-INF/services/ org.eclipse.dataspaceconnector.spi.system.ServiceExtension
@@ -1,0 +1,16 @@
+#
+#  Copyright (c) 2020 - 2022 Microsoft Corporation
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Microsoft Corporation - initial API and implementation
+#
+#
+
+org.eclipse.dataspaceconnector.transfer.provision.http.HttpWebhookExtension
+org.eclipse.dataspaceconnector.transfer.provision.http.HttpProvisionerExtension

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/config/ConfigParserTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/config/ConfigParserTest.java
@@ -11,16 +11,15 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
-
-package org.eclipse.dataspaceconnector.transfer.provision.http;
+package org.eclipse.dataspaceconnector.transfer.provision.http.config;
 
 import org.eclipse.dataspaceconnector.spi.system.configuration.ConfigFactory;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.dataspaceconnector.transfer.provision.http.ConfigParser.parseConfigurations;
 import static org.eclipse.dataspaceconnector.transfer.provision.http.HttpProvisionerFixtures.PROVISIONER_CONFIG;
 import static org.eclipse.dataspaceconnector.transfer.provision.http.HttpProvisionerFixtures.TEST_DATA_TYPE;
+import static org.eclipse.dataspaceconnector.transfer.provision.http.config.ConfigParser.parseConfigurations;
 
 class ConfigParserTest {
 
@@ -33,7 +32,7 @@ class ConfigParserTest {
         var configuration = configurations.get(0);
 
         assertThat(configuration.getProvisionerType()).isEqualTo(ProvisionerConfiguration.ProvisionerType.PROVIDER);
-        assertThat(configuration.getPolicyScope().toString()).isEqualTo("provision1.scope");
+        assertThat(configuration.getPolicyScope()).isEqualTo("provision1.scope");
         assertThat(configuration.getEndpoint().toString()).isEqualTo("http://foo.com");
         assertThat(configuration.getDataAddressType()).isEqualTo(TEST_DATA_TYPE);
     }

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderProvisionerTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderProvisionerTest.java
@@ -65,7 +65,7 @@ class HttpProviderProvisionerTest {
                 .assetId("1")
                 .transferProcessId("2")
                 .resourceName("test")
-                .contentDataAddress(dataAddress)
+                .dataAddress(dataAddress)
                 .resourceDefinitionId("3")
                 .id("3")
                 .build();
@@ -191,7 +191,7 @@ class HttpProviderProvisionerTest {
                 .assetId("1")
                 .transferProcessId("2")
                 .resourceName("test")
-                .contentDataAddress(dataAddress)
+                .dataAddress(dataAddress)
                 .resourceDefinitionId("3")
                 .id("3")
                 .build();

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderProvisionerTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderProvisionerTest.java
@@ -11,8 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
-
-package org.eclipse.dataspaceconnector.transfer.provision.http;
+package org.eclipse.dataspaceconnector.transfer.provision.http.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.Interceptor;
@@ -23,6 +22,7 @@ import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedResource;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
+import org.eclipse.dataspaceconnector.transfer.provision.http.config.ProvisionerConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +32,7 @@ import java.net.URL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
 import static org.eclipse.dataspaceconnector.transfer.provision.http.HttpProvisionerFixtures.createResponse;
-import static org.eclipse.dataspaceconnector.transfer.provision.http.ProvisionerConfiguration.ProvisionerType.PROVIDER;
+import static org.eclipse.dataspaceconnector.transfer.provision.http.config.ProvisionerConfiguration.ProvisionerType.PROVIDER;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -65,7 +65,7 @@ class HttpProviderProvisionerTest {
                 .assetId("1")
                 .transferProcessId("2")
                 .resourceName("test")
-                .dataAddress(dataAddress)
+                .contentDataAddress(dataAddress)
                 .resourceDefinitionId("3")
                 .id("3")
                 .build();
@@ -167,13 +167,12 @@ class HttpProviderProvisionerTest {
                 .provisionerType(PROVIDER)
                 .dataAddressType("test")
                 .policyScope("test")
-                .callbackAddress(new URL("http://foo.com"))
                 .endpoint(new URL("http://bar.com"))
                 .build();
 
         delegate = mock(Interceptor.class);
         var httpClient = testOkHttpClient().newBuilder().addInterceptor(delegate).build();
-        provisioner = new HttpProviderProvisioner(configuration, mock(PolicyEngine.class), httpClient, new ObjectMapper(), mock(Monitor.class));
+        provisioner = new HttpProviderProvisioner(configuration, new URL("http://foo.com"), mock(PolicyEngine.class), httpClient, new ObjectMapper(), mock(Monitor.class));
     }
 
     private HttpProviderResourceDefinition createResourceDefinition() {
@@ -192,7 +191,7 @@ class HttpProviderProvisionerTest {
                 .assetId("1")
                 .transferProcessId("2")
                 .resourceName("test")
-                .dataAddress(dataAddress)
+                .contentDataAddress(dataAddress)
                 .resourceDefinitionId("3")
                 .id("3")
                 .build();

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderResourceDefinitionGeneratorTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderResourceDefinitionGeneratorTest.java
@@ -11,8 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
-
-package org.eclipse.dataspaceconnector.transfer.provision.http;
+package org.eclipse.dataspaceconnector.transfer.provision.http.impl;
 
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderResourceDefinitionTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderResourceDefinitionTest.java
@@ -11,8 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
-
-package org.eclipse.dataspaceconnector.transfer.provision.http;
+package org.eclipse.dataspaceconnector.transfer.provision.http.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProvisionerRequestTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProvisionerRequestTest.java
@@ -11,8 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
-
-package org.eclipse.dataspaceconnector.transfer.provision.http;
+package org.eclipse.dataspaceconnector.transfer.provision.http.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/webhook/HttpProvisionerWebhookApiControllerIntegrationTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/webhook/HttpProvisionerWebhookApiControllerIntegrationTest.java
@@ -1,0 +1,126 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.transfer.provision.http.webhook;
+
+import io.restassured.specification.RequestSpecification;
+import org.eclipse.dataspaceconnector.api.auth.AuthenticationService;
+import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
+import org.eclipse.dataspaceconnector.spi.system.Provides;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.eclipse.dataspaceconnector.transfer.provision.http.HttpWebhookExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static io.restassured.RestAssured.given;
+import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.getFreePort;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anything;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
+
+@ExtendWith(EdcExtension.class)
+class HttpProvisionerWebhookApiControllerIntegrationTest {
+
+    private static final String PROVISIONER_BASE_PATH = "/api/v1/provisioner";
+    private final int port = getFreePort();
+    private final String authKey = "123456";
+
+    public static Stream<Arguments> invalidRequestParams() {
+        return Stream.of(
+                Arguments.of(null, DataAddress.Builder.newInstance().type("foo").build(), "resourcename", "transferprocess", "resourcedef"),
+                Arguments.of("assetid", null, "resourcename", "transferprocess", "resourcedef"),
+                Arguments.of("assetid", DataAddress.Builder.newInstance().type("foo").build(), null, "transferprocess", "resourcedef"),
+                Arguments.of("assetid", DataAddress.Builder.newInstance().type("foo").build(), "resourcename", null, "resourcedef"),
+                Arguments.of("assetid", DataAddress.Builder.newInstance().type("foo").build(), "resourcename", "transferprocess", null)
+        );
+    }
+
+    @BeforeEach
+    void setUp(EdcExtension extension) {
+        extension.registerSystemExtension(ServiceExtension.class, new DummyAuthenticationExtension());
+        extension.registerSystemExtension(ServiceExtension.class, new HttpWebhookExtension());
+
+        extension.setConfiguration(Map.of(
+                "web.http.provisioner.port", String.valueOf(port),
+                "web.http.provisioner.path", PROVISIONER_BASE_PATH,
+                "edc.api.auth.key", authKey
+        ));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidRequestParams")
+    void callWebhook_invalidRequest(String assetId, DataAddress cda, String resName, String tpId, String resDefId) {
+        var rq = ProvisionerWebhookRequest.Builder.newInstance()
+                .assetId(assetId)
+                .contentDataAddress(cda)
+                .resourceName(resName)
+                .transferProcessId(tpId)
+                .resourceDefinitionId(resDefId)
+                .build();
+
+        baseRequest()
+                .body(rq)
+                .contentType("application/json")
+                .post("/callback")
+                .then()
+                .statusCode(400)
+                .body(containsString(""));
+    }
+
+    @Test
+    void callWebhook() {
+        var rq = ProvisionerWebhookRequest.Builder.newInstance()
+                .assetId("test-asset")
+                .contentDataAddress(DataAddress.Builder.newInstance().type("foo").build())
+                .resourceName("resource-name")
+                .transferProcessId("tp-id")
+                .resourceDefinitionId("resource-definition")
+                .build();
+
+        baseRequest()
+                .body(rq)
+                .contentType("application/json")
+                .post("/callback")
+                .then()
+                .statusCode(allOf(greaterThanOrEqualTo(200), lessThan(300)))
+                .body(anything());
+    }
+
+    private RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + port)
+                .basePath(PROVISIONER_BASE_PATH)
+                .header("x-api-key", authKey)
+                .when();
+    }
+
+    @Provides(AuthenticationService.class)
+    private static class DummyAuthenticationExtension implements ServiceExtension {
+        @Override
+        public void initialize(ServiceExtensionContext context) {
+            context.registerService(AuthenticationService.class, h -> true);
+        }
+    }
+}

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/webhook/HttpWebhookExtensionTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/webhook/HttpWebhookExtensionTest.java
@@ -1,0 +1,145 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.transfer.provision.http.webhook;
+
+import org.eclipse.dataspaceconnector.api.auth.AuthenticationRequestFilter;
+import org.eclipse.dataspaceconnector.api.auth.AuthenticationService;
+import org.eclipse.dataspaceconnector.api.exception.mappers.EdcApiExceptionMapper;
+import org.eclipse.dataspaceconnector.junit.launcher.DependencyInjectionExtension;
+import org.eclipse.dataspaceconnector.spi.WebServer;
+import org.eclipse.dataspaceconnector.spi.WebService;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.system.Hostname;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.system.configuration.ConfigFactory;
+import org.eclipse.dataspaceconnector.spi.system.injection.ObjectFactory;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
+import org.eclipse.dataspaceconnector.transfer.provision.http.HttpWebhookExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class HttpWebhookExtensionTest {
+
+    private HttpWebhookExtension extension;
+    private ServiceExtensionContext context;
+    private WebServer mockWebServer;
+    private WebService mockWebService;
+
+    @BeforeEach
+    void setup(ServiceExtensionContext context, ObjectFactory factory) {
+
+        mockWebServer = mock(WebServer.class);
+        mockWebService = mock(WebService.class);
+        context.registerService(WebServer.class, mockWebServer);
+        context.registerService(WebService.class, mockWebService);
+        context.registerService(Hostname.class, () -> "localhost");
+        context.registerService(TransferProcessManager.class, mock(TransferProcessManager.class));
+        context.registerService(AuthenticationService.class, mock(AuthenticationService.class));
+
+        this.context = spy(context); //used to inject the config
+        when(this.context.getMonitor()).thenReturn(mock(Monitor.class));
+
+        extension = factory.constructInstance(HttpWebhookExtension.class);
+    }
+
+    @Test
+    void initialize_withDefault() {
+        when(context.getConfig("web.http.provisioner")).thenReturn(ConfigFactory.fromMap(Map.of()));
+
+        extension.initialize(context);
+
+        verify(mockWebServer).addPortMapping(eq("provisioner"), eq(8383), eq("/api/v1/provisioner"));
+        verify(mockWebService).registerResource(eq("provisioner"), isA(HttpProvisionerWebhookApiController.class));
+        verify(mockWebService).registerResource(eq("provisioner"), isA(AuthenticationRequestFilter.class));
+        verify(mockWebService).registerResource(eq("provisioner"), isA(EdcApiExceptionMapper.class));
+        verifyNoMoreInteractions(mockWebServer, mockWebService);
+    }
+
+    @Test
+    void initialize_withCustomSettings() {
+        when(context.getConfig("web.http.provisioner")).thenReturn(ConfigFactory.fromMap(Map.of(
+                "port", "4242",
+                "path", "/api/v1/someotherpath/webhook"
+        )));
+
+        extension.initialize(context);
+
+        verify(mockWebServer, never()).addPortMapping(anyString(), anyInt(), anyString());
+        verify(mockWebService).registerResource(eq("provisioner"), isA(HttpProvisionerWebhookApiController.class));
+        verify(mockWebService).registerResource(eq("provisioner"), isA(AuthenticationRequestFilter.class));
+        verify(mockWebService).registerResource(eq("provisioner"), isA(EdcApiExceptionMapper.class));
+        verifyNoMoreInteractions(mockWebServer, mockWebService);
+    }
+
+    @Test
+    void initialize_onlyWithPort() {
+        when(context.getConfig("web.http.provisioner")).thenReturn(ConfigFactory.fromMap(Map.of(
+                "port", "4242"
+        )));
+
+        extension.initialize(context);
+
+        verify(mockWebServer, never()).addPortMapping(anyString(), anyInt(), anyString());
+        verify(mockWebService).registerResource(eq("provisioner"), isA(HttpProvisionerWebhookApiController.class));
+        verify(mockWebService).registerResource(eq("provisioner"), isA(AuthenticationRequestFilter.class));
+        verify(mockWebService).registerResource(eq("provisioner"), isA(EdcApiExceptionMapper.class));
+        verifyNoMoreInteractions(mockWebServer, mockWebService);
+    }
+
+    @Test
+    void initialize_verifyHostname() {
+        when(context.getConfig("web.http.provisioner")).thenReturn(ConfigFactory.fromMap(Map.of(
+                "port", "4242"
+        )));
+
+        extension.initialize(context);
+
+        verify(mockWebServer, never()).addPortMapping(anyString(), anyInt(), anyString());
+        verify(mockWebService).registerResource(eq("provisioner"), isA(HttpProvisionerWebhookApiController.class));
+        verify(mockWebService).registerResource(eq("provisioner"), isA(AuthenticationRequestFilter.class));
+        verify(mockWebService).registerResource(eq("provisioner"), isA(EdcApiExceptionMapper.class));
+        verifyNoMoreInteractions(mockWebServer, mockWebService);
+    }
+
+    @Test
+    void initialize_onlyWithPath() {
+        when(context.getConfig("web.http.provisioner")).thenReturn(ConfigFactory.fromMap(Map.of(
+                "path", "/api/v1/someotherpath/webhook"
+        )));
+
+        extension.initialize(context);
+
+        verify(mockWebServer, never()).addPortMapping(anyString(), anyInt(), anyString());
+        verify(mockWebService).registerResource(eq("provisioner"), isA(HttpProvisionerWebhookApiController.class));
+        verify(mockWebService).registerResource(eq("provisioner"), isA(AuthenticationRequestFilter.class));
+        verify(mockWebService).registerResource(eq("provisioner"), isA(EdcApiExceptionMapper.class));
+        verifyNoMoreInteractions(mockWebServer, mockWebService);
+    }
+}

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/webhook/ProvisionerWebhookRequestSerializationTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/webhook/ProvisionerWebhookRequestSerializationTest.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.transfer.provision.http.webhook;
+
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProvisionerWebhookRequestSerializationTest {
+
+    private TypeManager typeManager;
+
+    @BeforeEach
+    void setUp() {
+        typeManager = new TypeManager();
+        typeManager.registerTypes(ProvisionerWebhookRequest.class);
+    }
+
+    @Test
+    void verifySerialization() {
+        var rq = ProvisionerWebhookRequest.Builder.newInstance()
+                .assetId("test-asset")
+                .resourceName("test-resource")
+                .transferProcessId("test-transfer")
+                .resourceDefinitionId("test-res-def")
+                .hasToken(true)
+                .apiToken("barbaz")
+                .contentDataAddress(DataAddress.Builder.newInstance().type("test-type").build())
+                .build();
+        var json = typeManager.writeValueAsString(rq);
+
+        assertThat(json).contains("test-asset")
+                .contains("test-resource")
+                .contains("test-type")
+                .contains("hasToken")
+                .contains("dataspaceconnector:provisioner-callback-request");
+    }
+
+    @Test
+    void verifyDeserialization() {
+        var rq = ProvisionerWebhookRequest.Builder.newInstance()
+                .assetId("test-asset")
+                .resourceName("test-resource")
+                .transferProcessId("test-transfer")
+                .resourceDefinitionId("test-res-def")
+                .apiToken("foobar")
+                .hasToken(true)
+                .contentDataAddress(DataAddress.Builder.newInstance().type("test-type").build())
+                .build();
+        var json = typeManager.writeValueAsString(rq);
+
+        var deserialized = typeManager.readValue(json, ProvisionerWebhookRequest.class);
+        assertThat(deserialized).usingRecursiveComparison().isEqualTo(rq);
+    }
+
+}

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/webhook/SimpleSecretTokenTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/webhook/SimpleSecretTokenTest.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.transfer.provision.http.webhook;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SimpleSecretTokenTest {
+
+    @Test
+    void getExpiration() {
+        assertThat(new SimpleSecretToken("sometoken").getExpiration()).isEqualTo(0);
+    }
+
+    @Test
+    void flatten() {
+        var token = "test-token";
+        var m = Map.of("token", token);
+
+        //cannot use containsEntry due to the open value type on flatten()
+        assertThat(new SimpleSecretToken(token).flatten()).usingRecursiveComparison().isEqualTo(m);
+
+    }
+}

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -908,6 +908,19 @@ paths:
           description: default response
           content:
             application/json: {}
+  /callback:
+    post:
+      operationId: callWebhook
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProvisionerWebhookRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
 components:
   schemas:
     Action:
@@ -970,8 +983,6 @@ components:
         assetId:
           type: string
         policyId:
-          type: string
-        negotiationId:
           type: string
     ContractDefinitionDto:
       type: object
@@ -1271,6 +1282,23 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Constraint'
+    ProvisionerWebhookRequest:
+      type: object
+      properties:
+        transferProcessId:
+          type: string
+        resourceDefinitionId:
+          type: string
+        assetId:
+          type: string
+        resourceName:
+          type: string
+        contentDataAddress:
+          $ref: '#/components/schemas/DataAddress'
+        apiToken:
+          type: string
+        hasToken:
+          type: boolean
     SelectionRequest:
       type: object
       properties:

--- a/resources/openapi/yaml/contractnegotiation.yaml
+++ b/resources/openapi/yaml/contractnegotiation.yaml
@@ -152,8 +152,6 @@ components:
           type: string
         policyId:
           type: string
-        negotiationId:
-          type: string
     ContractNegotiationDto:
       type: object
       properties:

--- a/resources/openapi/yaml/http-provisioner.yaml
+++ b/resources/openapi/yaml/http-provisioner.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.1
+paths:
+  /callback:
+    post:
+      operationId: callWebhook
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProvisionerWebhookRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+components:
+  schemas:
+    DataAddress:
+      type: object
+      properties:
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+    ProvisionerWebhookRequest:
+      type: object
+      properties:
+        transferProcessId:
+          type: string
+        resourceDefinitionId:
+          type: string
+        assetId:
+          type: string
+        resourceName:
+          type: string
+        contentDataAddress:
+          $ref: '#/components/schemas/DataAddress'
+        apiToken:
+          type: string
+        hasToken:
+          type: boolean


### PR DESCRIPTION
## What this PR changes/adds

Adds a webhook for the external system to call back into during an HTTP provisioning sequence.

## Why it does that

The HTTP provisioner calls out to an external system via HTTP and includes the callback URL to that request. After the external system has finished, it needs a webhook endpoint with which the EDC runtime can be informed about the completion.

## Further notes

- the `apiToken` property on the webhook's request body is opaque
- the webhook's URL is provided by the `HttpProvisionerWebhookUrl` service, that can be `@Inject`-ed
- the `SimpleSecretToken` is now located directly in the HTTP provisioner package, but since that is a pretty generic object, we may want to move it into a more general package if needed.
- Much of the changeset is caused by refactoring the package structure.

## Checklist

- [x] added appropriate tests?
- [ ] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
