### PR TITLE
chore: Provisioning types cleanup

### DIFF
--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -88,7 +88,7 @@ class ContractNegotiationIntegrationTest extends AbstractContractNegotiationInte
         ContractOffer offer = getContractOffer();
 
         when(validationService.validate(token, offer)).thenReturn(Result.success(offer));
-    
+
         // Create and register listeners for provider and consumer
         providerObservable.registerListener(new DeclinedContractNegotiationListener(countDownLatch));
         consumerObservable.registerListener(new DeclinedContractNegotiationListener(countDownLatch));
@@ -137,7 +137,7 @@ class ContractNegotiationIntegrationTest extends AbstractContractNegotiationInte
         when(validationService.validate(token, offer)).thenReturn(Result.success(offer));
         when(validationService.validate(eq(token), any(ContractAgreement.class),
                 any(ContractOffer.class))).thenReturn(false);
-    
+
         // Create and register listeners for provider and consumer
         providerObservable.registerListener(new DeclinedContractNegotiationListener(countDownLatch));
         consumerObservable.registerListener(new DeclinedContractNegotiationListener(countDownLatch));
@@ -249,7 +249,7 @@ class ContractNegotiationIntegrationTest extends AbstractContractNegotiationInte
 
         when(validationService.validate(token, initialOffer)).thenReturn(Result.success(null));
         when(validationService.validate(token, counterOffer, initialOffer)).thenReturn(Result.success(null));
-    
+
         // Create and register listeners for provider and consumer
         providerObservable.registerListener(new DeclinedContractNegotiationListener(countDownLatch));
         consumerObservable.registerListener(new DeclinedContractNegotiationListener(countDownLatch));
@@ -389,7 +389,7 @@ class ContractNegotiationIntegrationTest extends AbstractContractNegotiationInte
 
         //Mock validation of second counter offer on provider side => decline
         when(validationService.validate(token, consumerCounterOffer, counterOffer)).thenReturn(Result.success(null));
-        
+
         // Create and register listeners for provider and consumer
         providerObservable.registerListener(new DeclinedContractNegotiationListener(countDownLatch));
         consumerObservable.registerListener(new DeclinedContractNegotiationListener(countDownLatch));

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
@@ -91,7 +91,7 @@ import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferP
  * Each iteration will seek to transition a set number of processes for each state to avoid situations where an excessive number of processes in one state block progress of
  * processes in other states.
  * <br/>
- * If no processes need to be transitioned, the transfer manager will wait according to the the defined {@link WaitStrategy} before conducting the next iteration.
+ * If no processes need to be transitioned, the transfer manager will wait according to the defined {@link WaitStrategy} before conducting the next iteration.
  * A wait strategy may implement a backoff scheme.
  */
 public class TransferProcessManagerImpl implements TransferProcessManager, ProvisionCallbackDelegate {

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/TestProvisionedDataDestinationResource.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/TestProvisionedDataDestinationResource.java
@@ -15,25 +15,11 @@
 
 package org.eclipse.dataspaceconnector.transfer.core;
 
-import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedDataDestinationResource;
 
 public class TestProvisionedDataDestinationResource extends ProvisionedDataDestinationResource {
-    private final String resourceName;
-
     public TestProvisionedDataDestinationResource(String resourceName, String id) {
-        super();
         this.resourceName = resourceName;
         this.id = id;
-    }
-
-    @Override
-    public DataAddress createDataDestination() {
-        return null;
-    }
-
-    @Override
-    public String getResourceName() {
-        return resourceName;
     }
 }

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
@@ -194,7 +194,7 @@ class TransferProcessManagerImplTest {
                 .id("1")
                 .transferProcessId("2")
                 .resourceDefinitionId("3")
-                .contentDataAddress(DataAddress.Builder.newInstance().type("test").build())
+                .dataAddress(DataAddress.Builder.newInstance().type("test").build())
                 .build();
 
         var provisionResult = ProvisionResult.success(ProvisionResponse.Builder.newInstance()

--- a/extensions/aws/s3/s3-provision/src/main/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3BucketProvisioner.java
+++ b/extensions/aws/s3/s3-provision/src/main/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3BucketProvisioner.java
@@ -91,6 +91,7 @@ public class S3BucketProvisioner implements Provisioner<S3BucketResourceDefiniti
                 .bucketName(resourceDefinition.getBucketName())
                 .role(role.roleName())
                 .transferProcessId(resourceDefinition.getTransferProcessId())
+                .resourceName(resourceDefinition.getBucketName())
                 .build();
 
         var secretToken = new AwsTemporarySecretToken(credentials.accessKeyId(), credentials.secretAccessKey(), credentials.sessionToken(), credentials.expiration().toEpochMilli());

--- a/extensions/aws/s3/s3-provision/src/test/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3BucketProvisionedResourceTest.java
+++ b/extensions/aws/s3/s3-provision/src/test/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3BucketProvisionedResourceTest.java
@@ -46,6 +46,12 @@ class S3BucketProvisionedResourceTest {
     @BeforeEach
     void setUp() {
         provisionedResource = S3BucketProvisionedResource.Builder.newInstance()
-                .id(randomUUID().toString()).transferProcessId("123").resourceDefinitionId(randomUUID().toString()).region("region").bucketName("bucket").build();
+                .id(randomUUID().toString())
+                .transferProcessId("123")
+                .resourceDefinitionId(randomUUID().toString())
+                .resourceName("resource")
+                .region("region")
+                .bucketName("bucket")
+                .build();
     }
 }

--- a/extensions/aws/s3/s3-provision/src/test/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3StatusCheckerIntegrationTest.java
+++ b/extensions/aws/s3/s3-provision/src/test/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3StatusCheckerIntegrationTest.java
@@ -132,6 +132,7 @@ class S3StatusCheckerIntegrationTest extends AbstractS3Test {
                 .resourceDefinitionId(UUID.randomUUID().toString())
                 .transferProcessId(transferProcess.getId())
                 .id(UUID.randomUUID().toString())
+                .resourceName(bucketName)
                 .build();
     }
 

--- a/extensions/azure/blobstorage/blob-provision/src/main/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectContainerProvisionedResource.java
+++ b/extensions/azure/blobstorage/blob-provision/src/main/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectContainerProvisionedResource.java
@@ -15,55 +15,38 @@
 package org.eclipse.dataspaceconnector.provision.azure.blob;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.dataspaceconnector.azure.blob.core.AzureBlobStoreSchema;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedDataDestinationResource;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedResource;
+
+import static org.eclipse.dataspaceconnector.azure.blob.core.AzureBlobStoreSchema.ACCOUNT_NAME;
+import static org.eclipse.dataspaceconnector.azure.blob.core.AzureBlobStoreSchema.CONTAINER_NAME;
 
 @JsonDeserialize(builder = ObjectContainerProvisionedResource.Builder.class)
 @JsonTypeName("dataspaceconnector:objectcontainerprovisionedresource")
 public class ObjectContainerProvisionedResource extends ProvisionedDataDestinationResource {
 
-    @JsonProperty
-    private String accountName;
-    @JsonProperty
-    private String containerName;
-
     public String getAccountName() {
-        return accountName;
+        return getDataAddress().getProperty(ACCOUNT_NAME);
     }
 
     public String getContainerName() {
-        return containerName;
-    }
-
-    @Override
-    public DataAddress createDataDestination() {
-        return DataAddress.Builder.newInstance()
-                .type(AzureBlobStoreSchema.TYPE)
-                .property(AzureBlobStoreSchema.CONTAINER_NAME, containerName)
-                .keyName(getResourceName())
-                .property(AzureBlobStoreSchema.ACCOUNT_NAME, accountName)
-                .build();
-    }
-
-    @Override
-    public String getResourceName() {
-        return containerName;
+        return getDataAddress().getProperty(CONTAINER_NAME);
     }
 
     private ObjectContainerProvisionedResource() {
     }
 
     @JsonPOJOBuilder(withPrefix = "")
-    public static class Builder extends ProvisionedResource.Builder<ObjectContainerProvisionedResource, Builder> {
+    public static class Builder extends ProvisionedDataDestinationResource.Builder<ObjectContainerProvisionedResource, Builder> {
+        private DataAddress.Builder dataAddressBuilder;
 
         private Builder() {
             super(new ObjectContainerProvisionedResource());
+            dataAddressBuilder = DataAddress.Builder.newInstance().type(AzureBlobStoreSchema.TYPE);
         }
 
         @JsonCreator
@@ -72,14 +55,26 @@ public class ObjectContainerProvisionedResource extends ProvisionedDataDestinati
         }
 
         public Builder accountName(String accountName) {
-            provisionedResource.accountName = accountName;
+            this.dataAddressBuilder.property(ACCOUNT_NAME, accountName);
             return this;
         }
 
         public Builder containerName(String containerName) {
-            provisionedResource.containerName = containerName;
+            this.dataAddressBuilder.property(CONTAINER_NAME, containerName);
             return this;
         }
 
+        @Override
+        public Builder resourceName(String name) {
+            this.dataAddressBuilder.keyName(name);
+            super.resourceName(name);
+            return this;
+        }
+
+        @Override
+        public ObjectContainerProvisionedResource build() {
+            provisionedResource.dataAddress = dataAddressBuilder.build();
+            return super.build();
+        }
     }
 }

--- a/extensions/azure/blobstorage/blob-provision/src/main/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageProvisioner.java
+++ b/extensions/azure/blobstorage/blob-provision/src/main/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageProvisioner.java
@@ -79,6 +79,7 @@ public class ObjectStorageProvisioner implements Provisioner<ObjectStorageResour
                             .containerName(containerName)
                             .resourceDefinitionId(resourceDefinition.getId())
                             .transferProcessId(resourceDefinition.getTransferProcessId())
+                            .resourceName("resource")
                             .hasToken(true)
                             .build();
 

--- a/extensions/azure/blobstorage/blob-provision/src/test/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectContainerProvisionedResourceTest.java
+++ b/extensions/azure/blobstorage/blob-provision/src/test/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectContainerProvisionedResourceTest.java
@@ -33,6 +33,7 @@ class ObjectContainerProvisionedResourceTest {
                 .accountName("test-account")
                 .transferProcessId("test-process-id")
                 .resourceDefinitionId("test-resdef-id")
+                .resourceName("test-container")
                 .id("test-id")
                 .build();
     }
@@ -40,7 +41,7 @@ class ObjectContainerProvisionedResourceTest {
     @Test
     void createDataDestination() {
 
-        DataAddress dest = resource.createDataDestination();
+        DataAddress dest = resource.getDataAddress();
         assertThat(dest.getType()).isEqualTo(AzureBlobStoreSchema.TYPE);
         assertThat(dest.getKeyName()).isEqualTo("test-container");
         assertThat(dest.getProperties())

--- a/extensions/azure/blobstorage/blob-provision/src/test/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectContainerStatusCheckerIntegrationTest.java
+++ b/extensions/azure/blobstorage/blob-provision/src/test/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectContainerStatusCheckerIntegrationTest.java
@@ -126,6 +126,7 @@ class ObjectContainerStatusCheckerIntegrationTest extends AbstractAzureBlobTest 
                 .resourceDefinitionId(UUID.randomUUID().toString())
                 .transferProcessId(tp.getId())
                 .id(UUID.randomUUID().toString())
+                .resourceName(account1ContainerName)
                 .build();
     }
 }

--- a/extensions/azure/blobstorage/blob-provision/src/test/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageProvisionerTest.java
+++ b/extensions/azure/blobstorage/blob-provision/src/test/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageProvisionerTest.java
@@ -58,7 +58,7 @@ class ObjectStorageProvisionerTest {
 
     @Test
     void canDeprovision() {
-        var resource = ObjectContainerProvisionedResource.Builder.newInstance().id("1").transferProcessId("2").resourceDefinitionId("3").build();
+        var resource = createProvisionedResource();
         assertThat(provisioner.canDeprovision(resource)).isTrue();
         assertThat(provisioner.canDeprovision(new ProvisionedResource() {
         })).isFalse();
@@ -66,7 +66,7 @@ class ObjectStorageProvisionerTest {
 
     @Test
     void deprovision_should_not_do_anything() {
-        var resource = ObjectContainerProvisionedResource.Builder.newInstance().id("1").transferProcessId("2").resourceDefinitionId("3").build();
+        ObjectContainerProvisionedResource resource = createProvisionedResource();
         var result = provisioner.deprovision(resource, policy);
 
         assertThat(result).succeedsWithin(1, SECONDS);
@@ -74,7 +74,7 @@ class ObjectStorageProvisionerTest {
 
     @Test
     void provision_success() {
-        var resourceDef = resourceDefinition().transferProcessId("tpId").build();
+        var resourceDef = createResourceDefinitionBuilder().transferProcessId("tpId").build();
         String accountName = resourceDef.getAccountName();
         String containerName = resourceDef.getContainerName();
         when(blobStoreApiMock.exists(anyString(), anyString())).thenReturn(false);
@@ -94,7 +94,7 @@ class ObjectStorageProvisionerTest {
 
     @Test
     void provision_container_already_exists() {
-        var resourceDef = resourceDefinition().transferProcessId("tpId").build();
+        var resourceDef = createResourceDefinitionBuilder().transferProcessId("tpId").build();
         String accountName = resourceDef.getAccountName();
         String containerName = resourceDef.getContainerName();
         when(blobStoreApiMock.exists(accountName, containerName)).thenReturn(true);
@@ -114,7 +114,7 @@ class ObjectStorageProvisionerTest {
 
     @Test
     void provision_no_key_found_in_vault() {
-        var resourceDefinition = resourceDefinition().build();
+        var resourceDefinition = createResourceDefinitionBuilder().build();
         when(blobStoreApiMock.exists(any(), anyString()))
                 .thenThrow(new IllegalArgumentException("No Object Storage credential found in vault"));
 
@@ -124,7 +124,7 @@ class ObjectStorageProvisionerTest {
 
     @Test
     void provision_key_not_authorized() {
-        var resourceDef = resourceDefinition().build();
+        var resourceDef = createResourceDefinitionBuilder().build();
         when(blobStoreApiMock.exists(anyString(), anyString())).thenReturn(false);
         doThrow(new BlobStorageException("not authorized", null, null))
                 .when(blobStoreApiMock).createContainer(resourceDef.getAccountName(), resourceDef.getContainerName());
@@ -133,7 +133,7 @@ class ObjectStorageProvisionerTest {
         verify(blobStoreApiMock).exists(anyString(), anyString());
     }
 
-    private ObjectStorageResourceDefinition.Builder resourceDefinition() {
+    private ObjectStorageResourceDefinition.Builder createResourceDefinitionBuilder() {
         return ObjectStorageResourceDefinition.Builder
                 .newInstance()
                 .accountName("test-account-name")
@@ -141,4 +141,14 @@ class ObjectStorageProvisionerTest {
                 .transferProcessId("test-process-id")
                 .id("test-id");
     }
+
+    private ObjectContainerProvisionedResource createProvisionedResource() {
+        return ObjectContainerProvisionedResource.Builder.newInstance()
+                .id("1")
+                .transferProcessId("2")
+                .resourceDefinitionId("3")
+                .resourceName("resource")
+                .build();
+    }
+
 }

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderProvisioner.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderProvisioner.java
@@ -82,7 +82,7 @@ public class HttpProviderProvisioner implements Provisioner<HttpProviderResource
     @Override
     public boolean canDeprovision(ProvisionedResource provisionedResource) {
         return provisionedResource instanceof HttpProvisionedContentResource &&
-                dataAddressType.equals(((HttpProvisionedContentResource) provisionedResource).getContentDataAddress().getType());
+                dataAddressType.equals(((HttpProvisionedContentResource) provisionedResource).getDataAddress().getType());
     }
 
     @Override

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderProvisionerTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpProviderProvisionerTest.java
@@ -65,7 +65,7 @@ class HttpProviderProvisionerTest {
                 .assetId("1")
                 .transferProcessId("2")
                 .resourceName("test")
-                .contentDataAddress(dataAddress)
+                .dataAddress(dataAddress)
                 .resourceDefinitionId("3")
                 .id("3")
                 .build();
@@ -192,7 +192,7 @@ class HttpProviderProvisionerTest {
                 .assetId("1")
                 .transferProcessId("2")
                 .resourceName("test")
-                .contentDataAddress(dataAddress)
+                .dataAddress(dataAddress)
                 .resourceDefinitionId("3")
                 .id("3")
                 .build();

--- a/samples/04.2-modify-transferprocess/simulator/src/main/java/org/eclipse/dataspaceconnector/samples/sample042/TransferSimulationExtension.java
+++ b/samples/04.2-modify-transferprocess/simulator/src/main/java/org/eclipse/dataspaceconnector/samples/sample042/TransferSimulationExtension.java
@@ -8,6 +8,20 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
  *       Microsoft Corporation - Initial implementation
  *
  */
@@ -18,7 +32,6 @@ import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
-import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedDataDestinationResource;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.StatusCheckerRegistry;
@@ -69,15 +82,6 @@ public class TransferSimulationExtension implements ServiceExtension {
     @NotNull
     private ProvisionedDataDestinationResource createDummyResource() {
         return new ProvisionedDataDestinationResource() {
-            @Override
-            public DataAddress createDataDestination() {
-                return null;
-            }
-
-            @Override
-            public String getResourceName() {
-                return "test resource";
-            }
         };
     }
 

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionedContentResource.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionedContentResource.java
@@ -15,54 +15,22 @@
 package org.eclipse.dataspaceconnector.spi.types.domain.transfer;
 
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
-
-import static java.util.Objects.requireNonNull;
 
 /**
- * A provisioned resource that is a content data address.
+ * A provisioned resource that is asset content.
  *
  * This resource type is created when a provider's backend system provisions data as part of a data transfer.
  */
-public abstract class ProvisionedContentResource extends ProvisionedResource {
-    protected String resourceName;
-    protected DataAddress contentDataAddress;
-
-    public String getResourceName() {
-        return resourceName;
-    }
-
-    public DataAddress getContentDataAddress() {
-        return contentDataAddress;
-    }
+public abstract class ProvisionedContentResource extends ProvisionedDataAddressResource {
 
     protected ProvisionedContentResource() {
     }
 
     @JsonPOJOBuilder(withPrefix = "")
-    // public static class Builder<RD extends ResourceDefinition, B extends Builder<RD, B>> {
-    public static class Builder<T extends ProvisionedContentResource, B extends Builder<T, B>> extends ProvisionedResource.Builder<T, B> {
-
-        @SuppressWarnings("unchecked")
-        public B resourceName(String name) {
-            provisionedResource.resourceName = name;
-            return (B) this;
-        }
-
-        @SuppressWarnings("unchecked")
-        public B contentDataAddress(DataAddress dataAddress) {
-            provisionedResource.contentDataAddress = dataAddress;
-            return (B) this;
-        }
+    public static class Builder<T extends ProvisionedContentResource, B extends Builder<T, B>> extends ProvisionedDataAddressResource.Builder<T, B> {
 
         protected Builder(T resource) {
             super(resource);
-        }
-
-        @Override
-        protected void verify() {
-            requireNonNull(provisionedResource.resourceName, "resourceName");
-            requireNonNull(provisionedResource.contentDataAddress, "contentDataAddress");
         }
 
     }

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionedDataAddressResource.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionedDataAddressResource.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2020, 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.types.domain.transfer;
+
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A provisioned resource that is referenced using a {@link DataAddress}.
+ */
+public abstract class ProvisionedDataAddressResource extends ProvisionedResource {
+    protected String resourceName;
+    protected DataAddress dataAddress;
+
+    public String getResourceName() {
+        return resourceName;
+    }
+
+    public DataAddress getDataAddress() {
+        return dataAddress;
+    }
+
+    protected ProvisionedDataAddressResource() {
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder<T extends ProvisionedDataAddressResource, B extends Builder<T, B>> extends ProvisionedResource.Builder<T, B> {
+
+        @SuppressWarnings("unchecked")
+        public B resourceName(String name) {
+            provisionedResource.resourceName = name;
+            return (B) this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public B dataAddress(DataAddress dataAddress) {
+            provisionedResource.dataAddress = dataAddress;
+            return (B) this;
+        }
+
+        protected Builder(T resource) {
+            super(resource);
+        }
+
+        @Override
+        protected void verify() {
+            requireNonNull(provisionedResource.resourceName, "resourceName");
+            requireNonNull(provisionedResource.dataAddress, "dataAddress");
+        }
+
+    }
+}

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionedDataDestinationResource.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionedDataDestinationResource.java
@@ -17,27 +17,22 @@ package org.eclipse.dataspaceconnector.spi.types.domain.transfer;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 
 /**
  * A provisioned resource that serves as a data destination.
  */
 @JsonTypeName("dataspaceconnector:provisioneddatadestinationresource")
 @JsonDeserialize(builder = ProvisionedDataDestinationResource.Builder.class)
-public abstract class ProvisionedDataDestinationResource extends ProvisionedResource {
+public abstract class ProvisionedDataDestinationResource extends ProvisionedDataAddressResource {
 
     protected ProvisionedDataDestinationResource() {
         super();
     }
 
-    public abstract DataAddress createDataDestination();
-
-    public abstract String getResourceName();
-
     @JsonPOJOBuilder(withPrefix = "")
-    protected static class Builder<PR extends ProvisionedResource, B extends ProvisionedResource.Builder<PR, B>> extends ProvisionedResource.Builder<PR, B> {
+    public static class Builder<T extends ProvisionedDataDestinationResource, B extends ProvisionedDataDestinationResource.Builder<T, B>> extends ProvisionedDataAddressResource.Builder<T, B> {
 
-        protected Builder(PR resource) {
+        protected Builder(T resource) {
             super(resource);
         }
 

--- a/spi/transfer-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionedContentResourceTest.java
+++ b/spi/transfer-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionedContentResourceTest.java
@@ -32,7 +32,7 @@ class ProvisionedContentResourceTest {
         var dataAddress = DataAddress.Builder.newInstance().type("test").build();
         var resource = TestProvisionedContentResource.Builder.newInstance()
                 .resourceName("test")
-                .contentDataAddress(dataAddress)
+                .dataAddress(dataAddress)
                 .id("1")
                 .transferProcessId("2")
                 .resourceDefinitionId("12")
@@ -42,7 +42,7 @@ class ProvisionedContentResourceTest {
         var deserialized = mapper.readValue(serialized, TestProvisionedContentResource.class);
 
         assertThat(deserialized).isNotNull();
-        assertThat(deserialized.getContentDataAddress()).isNotNull();
+        assertThat(deserialized.getDataAddress()).isNotNull();
         assertThat(deserialized.getResourceName()).isEqualTo("test");
         assertThat(deserialized.getId()).isEqualTo("1");
         assertThat(deserialized.getTransferProcessId()).isEqualTo("2");


### PR DESCRIPTION
## What this PR changes/adds

This PR adds a `ProvisionedDataAddressResource` and creates a class hierarchy for data address resources. This consolidates common properties and simplifies the `TPM`.

## Why it does that

It simplifies the codebase.

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
