### PR TITLE
CI: checkstyle rule for Java file headers: additional fixes

### DIFF
--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/util/CyclicDependencyException.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/util/CyclicDependencyException.java
@@ -1,25 +1,5 @@
-//
-//  Code based on TopologicalSort from Eclipse Jetty licensed under Apache 2.0 (https://www.eclipse.org/jetty/).
-//
-//  Original license notice:
-//
-//  ========================================================================
-//  Copyright (c) 1995-2018 Mort Bay Consulting Pty. Ltd.
-//  ------------------------------------------------------------------------
-//  All rights reserved. This program and the accompanying materials
-//  are made available under the terms of the Eclipse Public License v1.0
-//  and Apache License v2.0 which accompanies this distribution.
-//
-//      The Eclipse Public License is available at
-//      http://www.eclipse.org/legal/epl-v10.html
-//
-//      The Apache License v2.0 is available at
-//      http://www.opensource.org/licenses/apache2.0.php
-//
-//  You may elect to redistribute this code under either of these licenses.
-//  ========================================================================
 /*
- *  Copyright (c) 2020, 1995-2021 Microsoft Corporation
+ *  Copyright (c) 2021 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at

--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/util/TopologicalSort.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/util/TopologicalSort.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.boot.util;
+
 //
 //  Code based on TopologicalSort from Eclipse Jetty licensed under Apache 2.0 (https://www.eclipse.org/jetty/).
 //
@@ -18,21 +34,6 @@
 //
 //  You may elect to redistribute this code under either of these licenses.
 //  ========================================================================
-/*
- *  Copyright (c) 2020, 1995-2021 Microsoft Corporation
- *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
- *
- *  SPDX-License-Identifier: Apache-2.0
- *
- *  Contributors:
- *       Microsoft Corporation - initial API and implementation
- *
- */
-
-package org.eclipse.dataspaceconnector.boot.util;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiControllerIntegrationTest.java
@@ -1,15 +1,16 @@
 /*
- * Copyright (c) 2022 - 2022 ZF Friedrichshafen AG
+ *  Copyright (c) 2022 - 2022 ZF Friedrichshafen AG
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * Contributors:
- *    ZF Friedrichshafen AG - Initial API and Implementation
- *    Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial API and Implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
  */
 
 package org.eclipse.dataspaceconnector.api.datamanagement.asset;

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
@@ -1,15 +1,16 @@
 /*
- * Copyright (c) 2022 - 2022 ZF Friedrichshafen AG
+ *  Copyright (c) 2022 - 2022 ZF Friedrichshafen AG
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * Contributors:
- *    ZF Friedrichshafen AG - Initial API and Implementation
- *    Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial API and Implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
  */
 
 package org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation;

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerTest.java
@@ -1,18 +1,18 @@
 /*
- * Copyright (c) 2022 - 2022 ZF Friedrichshafen AG
+ *  Copyright (c) 2022 - 2022 ZF Friedrichshafen AG
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * Contributors:
- *    ZF Friedrichshafen AG - Initial API and Implementation
- *    Microsoft Corporation - Added initiate-negotiation endpoint tests
- *    Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial API and Implementation
+ *       Microsoft Corporation - Added initiate-negotiation endpoint tests
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
  */
-
 
 package org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation;
 

--- a/extensions/azure/azure-test/README.md
+++ b/extensions/azure/azure-test/README.md
@@ -21,5 +21,4 @@ Then run the CosmosDB Emulator image:
 docker run --rm -d -p 8081:8081 -p 10251:10251 -p 10252:10252 -p 10253:10253 -p 10254:10254 --name=test-linux-emulator \ 
     -e AZURE_COSMOS_EMULATOR_PARTITION_COUNT=1 -e AZURE_COSMOS_EMULATOR_IP_ADDRESS_OVERRIDE=$IP_ADDRESS \
     -it mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator
->>>>>>> 016a67d08 (Make CosmosAssetIndexIntegrationTest run locally)
 ```

--- a/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/DataTransferExecutorServiceContainer.java
+++ b/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/DataTransferExecutorServiceContainer.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.dataplane.spi.pipeline;
 
 import org.jetbrains.annotations.NotNull;

--- a/launchers/data-loader-cli/README.md
+++ b/launchers/data-loader-cli/README.md
@@ -124,7 +124,7 @@ Before starting the connector that will load data from a file, a few prepartions
 3. Create a `*.json` file which contains assets or contract definitions. This file will be loaded by the connector and
    its entries will be persisted. Examples for both assets and contract definitions can be found in the `resources`
    folder of this launcher. For an example on how to generate these `*.json` files, have a look at the
-   `JsonFileGenerator` in the `test` directory of this launcher.
+   `JsonFileGenerator` under the `test/java/org/eclipse/dataspaceconnector/examples` directory of this launcher.
 
 Once the preparation is complete, the connector can be built using gradle and then started. Depending on whether you
 are using CosmosDB or in-memory stores, the `config.properties` file has to be supplied:

--- a/launchers/data-loader-cli/src/test/java/org/eclipse/dataspaceconnector/examples/JsonFileGenerator.java
+++ b/launchers/data-loader-cli/src/test/java/org/eclipse/dataspaceconnector/examples/JsonFileGenerator.java
@@ -12,6 +12,8 @@
  *
  */
 
+package org.eclipse.dataspaceconnector.examples;
+
 import org.eclipse.dataspaceconnector.dataloading.AssetEntry;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;

--- a/samples/04.2-modify-transferprocess/simulator/src/main/java/org/eclipse/dataspaceconnector/samples/sample042/TransferSimulationExtension.java
+++ b/samples/04.2-modify-transferprocess/simulator/src/main/java/org/eclipse/dataspaceconnector/samples/sample042/TransferSimulationExtension.java
@@ -8,20 +8,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Microsoft Corporation - initial API and implementation
- *
- */
-
-/*
- *  Copyright (c) 2022 Microsoft Corporation
- *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
- *
- *  SPDX-License-Identifier: Apache-2.0
- *
- *  Contributors:
  *       Microsoft Corporation - Initial implementation
  *
  */

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ExecutorInstrumentationImplementation.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ExecutorInstrumentationImplementation.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.system;
 
 /**


### PR DESCRIPTION
## What this PR changes/adds

This PR modifies some Java source files to enable the checkstyle header check rule in #997.

## Why it does that

Reduce the developer overhead of fixing checkstyle header issues after merging #997.

## Further notes

- CyclicDependencyException.java: removed Jetty notice since the class is a generic implementation of `EdcException`
- TopologicalSort.java: moved Jetty notice down so that standard header goes first
- DataRequestMessageSender.java: deleted empty file
- JsonFileGenerator.java: moved out of default package. This will also allow to create a package name rule later

Also fixed an unrelated merge remnant marker in a README file.

## Linked Issue(s)

Relates to #991 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
