### PR TITLE
CI: checkstyle rule for Java file headers: add missing headers

### DIFF
--- a/common/state-machine-lib/src/test/java/org/eclipse/dataspaceconnector/common/statemachine/StateMachineTest.java
+++ b/common/state-machine-lib/src/test/java/org/eclipse/dataspaceconnector/common/statemachine/StateMachineTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.common.statemachine;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/common/state-machine-lib/src/test/java/org/eclipse/dataspaceconnector/common/statemachine/StateProcessorImplTest.java
+++ b/common/state-machine-lib/src/test/java/org/eclipse/dataspaceconnector/common/statemachine/StateProcessorImplTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.common.statemachine;
 
 import org.junit.jupiter.api.Test;

--- a/common/util/src/main/java/org/eclipse/dataspaceconnector/common/async/AsyncUtils.java
+++ b/common/util/src/main/java/org/eclipse/dataspaceconnector/common/async/AsyncUtils.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.common.async;
 
 import java.util.List;

--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/health/HealthCheckServiceConfiguration.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/health/HealthCheckServiceConfiguration.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.core.health;
 
 import java.time.Duration;

--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/health/HealthCheckServiceImpl.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/health/HealthCheckServiceImpl.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.core.health;
 
 import org.eclipse.dataspaceconnector.spi.system.ExecutorInstrumentation;

--- a/core/base/src/test/java/org/eclipse/dataspaceconnector/core/base/policy/PolicyEngineImplScenariosTest.java
+++ b/core/base/src/test/java/org/eclipse/dataspaceconnector/core/base/policy/PolicyEngineImplScenariosTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.core.base.policy;
 
 import org.eclipse.dataspaceconnector.policy.model.Action;

--- a/core/base/src/test/java/org/eclipse/dataspaceconnector/core/health/HealthCheckServiceImplTest.java
+++ b/core/base/src/test/java/org/eclipse/dataspaceconnector/core/health/HealthCheckServiceImplTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.core.health;
 
 import org.eclipse.dataspaceconnector.spi.system.ExecutorInstrumentation;

--- a/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/InjectorTest.java
+++ b/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/InjectorTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.boot.system;
 
 import org.eclipse.dataspaceconnector.boot.system.injection.InjectorImpl;

--- a/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/ReflectiveObjectFactoryTest.java
+++ b/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/ReflectiveObjectFactoryTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.boot.system;
 
 import org.eclipse.dataspaceconnector.boot.system.injection.InjectorImpl;

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/observe/ContractNegotiationObservableImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/observe/ContractNegotiationObservableImpl.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.contract.observe;
 
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.observe.ContractNegotiationListener;

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractDefinitionServiceImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractDefinitionServiceImplTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.contract.offer;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/inline/DataOperatorRegistryImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/inline/DataOperatorRegistryImpl.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.transfer.core.inline;
 
 import org.eclipse.dataspaceconnector.spi.transfer.inline.DataOperatorRegistry;

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/observe/TransferProcessObservableImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/observe/TransferProcessObservableImpl.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.transfer.core.observe;
 
 import org.eclipse.dataspaceconnector.spi.observe.ObservableImpl;

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/DeprovisionCommandHandlerTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/DeprovisionCommandHandlerTest.java
@@ -1,4 +1,3 @@
-
 /*
  *  Copyright (c) 2020-2022 Microsoft Corporation
  *

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/flow/DataFlowManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/flow/DataFlowManagerImplTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.transfer.core.flow;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/provision/ProvisionManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/provision/ProvisionManagerImplTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.transfer.core.provision;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/provision/ResourceManifestGeneratorImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/provision/ResourceManifestGeneratorImplTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.transfer.core.provision;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/message/MultipartResponse.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/message/MultipartResponse.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.message;
 
 import de.fraunhofer.iais.eis.Message;

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/version/ConnectorVersionProviderImplTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/version/ConnectorVersionProviderImplTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.ids.core.version;
 
 import org.eclipse.dataspaceconnector.ids.spi.version.ConnectorVersionProvider;

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/IdsIdParser.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/IdsIdParser.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.ids.spi;
 
 /**

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/IdsType.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/IdsType.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.ids.spi;
 
 /**

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/transform/TransformKeys.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/transform/TransformKeys.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.ids.spi.transform;
 
 /**

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/types/Connector.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/types/Connector.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.ids.spi.types;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/types/container/OfferedAsset.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/types/container/OfferedAsset.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.ids.spi.types.container;
 
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;

--- a/data-protocols/ids/ids-spi/src/test/java/org/eclipse/dataspaceconnector/ids/IdsIdParserTest.java
+++ b/data-protocols/ids/ids-spi/src/test/java/org/eclipse/dataspaceconnector/ids/IdsIdParserTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.ids;
 
 import org.eclipse.dataspaceconnector.ids.spi.IdsId;

--- a/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/ControlApiServiceExtension.java
+++ b/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/ControlApiServiceExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.api.control;
 
 import jakarta.ws.rs.container.ContainerRequestContext;

--- a/extensions/api/control/src/test/java/org/eclipse/dataspaceconnector/api/control/AbstractClientControlCatalogApiControllerTest.java
+++ b/extensions/api/control/src/test/java/org/eclipse/dataspaceconnector/api/control/AbstractClientControlCatalogApiControllerTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.api.control;
 
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;

--- a/extensions/api/control/src/test/java/org/eclipse/dataspaceconnector/api/control/ClientControlCatalogApiControllerTest.java
+++ b/extensions/api/control/src/test/java/org/eclipse/dataspaceconnector/api/control/ClientControlCatalogApiControllerTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.api.control;
 
 import io.restassured.RestAssured;

--- a/extensions/api/control/src/test/java/org/eclipse/dataspaceconnector/api/control/ClientControlCatalogApiControllerTestServiceExtension.java
+++ b/extensions/api/control/src/test/java/org/eclipse/dataspaceconnector/api/control/ClientControlCatalogApiControllerTestServiceExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.api.control;
 
 import org.eclipse.dataspaceconnector.dataloading.AssetLoader;

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApi.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApi.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.api.datamanagement.asset;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiApiControllerTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiApiControllerTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess;
 
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferRequestDto;

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiExtensionTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiExtensionTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess;
 
 import com.github.javafaker.Faker;

--- a/extensions/api/observability/src/main/java/org/eclipse/dataspaceconnector/api/observability/ObservabilityApiExtension.java
+++ b/extensions/api/observability/src/main/java/org/eclipse/dataspaceconnector/api/observability/ObservabilityApiExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.api.observability;
 
 import org.eclipse.dataspaceconnector.spi.WebService;

--- a/extensions/api/observability/src/test/java/org/eclipse/dataspaceconnector/api/observability/ObservabilityApiControllerTest.java
+++ b/extensions/api/observability/src/test/java/org/eclipse/dataspaceconnector/api/observability/ObservabilityApiControllerTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.api.observability;
 
 import jakarta.ws.rs.core.Response;

--- a/extensions/api/observability/src/test/java/org/eclipse/dataspaceconnector/api/observability/ObservabilityApiExtensionTest.java
+++ b/extensions/api/observability/src/test/java/org/eclipse/dataspaceconnector/api/observability/ObservabilityApiExtensionTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.api.observability;
 
 import org.eclipse.dataspaceconnector.junit.launcher.DependencyInjectionExtension;

--- a/extensions/aws/s3/s3-core/src/main/java/org/eclipse/dataspaceconnector/aws/s3/core/S3ClientProviderImpl.java
+++ b/extensions/aws/s3/s3-core/src/main/java/org/eclipse/dataspaceconnector/aws/s3/core/S3ClientProviderImpl.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.aws.s3.core;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/extensions/aws/s3/s3-data-operator/src/main/java/org/eclipse/dataspaceconnector/aws/s3/operator/S3BucketReader.java
+++ b/extensions/aws/s3/s3-data-operator/src/main/java/org/eclipse/dataspaceconnector/aws/s3/operator/S3BucketReader.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.aws.s3.operator;
 
 import org.eclipse.dataspaceconnector.aws.s3.core.AwsSecretToken;

--- a/extensions/aws/s3/s3-data-operator/src/main/java/org/eclipse/dataspaceconnector/aws/s3/operator/S3BucketWriter.java
+++ b/extensions/aws/s3/s3-data-operator/src/main/java/org/eclipse/dataspaceconnector/aws/s3/operator/S3BucketWriter.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.aws.s3.operator;
 
 

--- a/extensions/aws/s3/s3-data-operator/src/test/java/org/eclipse/dataspaceconnector/aws/s3/operator/S3DataOperatorIntegrationTest.java
+++ b/extensions/aws/s3/s3-data-operator/src/test/java/org/eclipse/dataspaceconnector/aws/s3/operator/S3DataOperatorIntegrationTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.aws.s3.operator;
 
 import net.jodah.failsafe.RetryPolicy;

--- a/extensions/aws/s3/s3-provision/src/main/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3BucketProvisionerConfiguration.java
+++ b/extensions/aws/s3/s3-provision/src/main/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3BucketProvisionerConfiguration.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.aws.s3.provision;
 
 public class S3BucketProvisionerConfiguration {

--- a/extensions/aws/s3/s3-provision/src/main/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3ProvisionResponse.java
+++ b/extensions/aws/s3/s3-provision/src/main/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3ProvisionResponse.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.aws.s3.provision;
 
 import software.amazon.awssdk.services.iam.model.Role;

--- a/extensions/azure/blobstorage/blob-data-operator/src/main/java/org/eclipse/dataspaceconnector/azure/blob/operator/BlobStoreReader.java
+++ b/extensions/azure/blobstorage/blob-data-operator/src/main/java/org/eclipse/dataspaceconnector/azure/blob/operator/BlobStoreReader.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.azure.blob.operator;
 
 import org.eclipse.dataspaceconnector.azure.blob.core.AzureBlobStoreSchema;

--- a/extensions/azure/blobstorage/blob-data-operator/src/main/java/org/eclipse/dataspaceconnector/azure/blob/operator/BlobStoreWriter.java
+++ b/extensions/azure/blobstorage/blob-data-operator/src/main/java/org/eclipse/dataspaceconnector/azure/blob/operator/BlobStoreWriter.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.azure.blob.operator;
 
 import com.azure.core.util.BinaryData;

--- a/extensions/azure/cosmos/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/AssetIndexCosmosConfig.java
+++ b/extensions/azure/cosmos/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/AssetIndexCosmosConfig.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.assetindex.azure;
 
 import org.eclipse.dataspaceconnector.azure.cosmos.AbstractCosmosConfig;

--- a/extensions/azure/cosmos/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetQueryBuilder.java
+++ b/extensions/azure/cosmos/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetQueryBuilder.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.assetindex.azure;
 
 import com.azure.cosmos.models.SqlQuerySpec;

--- a/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetQueryBuilderTest.java
+++ b/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetQueryBuilderTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.assetindex.azure;
 
 import com.azure.cosmos.models.SqlParameter;

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreConfig.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreConfig.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.contract.definition.store;
 
 import org.eclipse.dataspaceconnector.azure.cosmos.AbstractCosmosConfig;

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreConfig.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreConfig.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.contract.negotiation.store;
 
 import org.eclipse.dataspaceconnector.azure.cosmos.AbstractCosmosConfig;

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreTest.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.contract.negotiation.store;
 
 import com.azure.cosmos.models.SqlQuerySpec;

--- a/extensions/azure/cosmos/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/cosmos/azure/CosmosDbApiImplIntegrationTest.java
+++ b/extensions/azure/cosmos/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/cosmos/azure/CosmosDbApiImplIntegrationTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.cosmos.azure;
 
 import com.azure.cosmos.CosmosContainer;

--- a/extensions/azure/cosmos/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/cosmos/azure/TestCosmosDocument.java
+++ b/extensions/azure/cosmos/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/cosmos/azure/TestCosmosDocument.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.cosmos.azure;
 
 import org.eclipse.dataspaceconnector.azure.cosmos.CosmosDocument;

--- a/extensions/azure/cosmos/fcc-node-directory-cosmos/src/main/java/org/eclipse/dataspaceconnector/catalog/node/directory/azure/FederatedCacheNodeDirectoryCosmosConfig.java
+++ b/extensions/azure/cosmos/fcc-node-directory-cosmos/src/main/java/org/eclipse/dataspaceconnector/catalog/node/directory/azure/FederatedCacheNodeDirectoryCosmosConfig.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.node.directory.azure;
 
 import org.eclipse.dataspaceconnector.azure.cosmos.AbstractCosmosConfig;

--- a/extensions/azure/cosmos/fcc-node-directory-cosmos/src/test/java/org/eclipse/dataspaceconnector/catalog/node/directory/azure/CosmosFederatedCacheNodeDirectoryTest.java
+++ b/extensions/azure/cosmos/fcc-node-directory-cosmos/src/test/java/org/eclipse/dataspaceconnector/catalog/node/directory/azure/CosmosFederatedCacheNodeDirectoryTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.node.directory.azure;
 
 import net.jodah.failsafe.RetryPolicy;

--- a/extensions/azure/cosmos/transfer-process-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/TransferProcessStoreCosmosConfig.java
+++ b/extensions/azure/cosmos/transfer-process-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/TransferProcessStoreCosmosConfig.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.transfer.store.cosmos;
 
 import org.eclipse.dataspaceconnector.azure.cosmos.AbstractCosmosConfig;

--- a/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/adapter/BlobAdapterFactoryTest.java
+++ b/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/adapter/BlobAdapterFactoryTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.adapter;
 
 import org.junit.jupiter.api.Test;

--- a/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSinkTest.java
+++ b/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSinkTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline;
 
 import com.github.javafaker.Faker;

--- a/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSourceTest.java
+++ b/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSourceTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline;
 
 import com.github.javafaker.Faker;

--- a/extensions/azure/events-config/src/main/java/org/eclipse/dataspaceconnector/events/azure/AzureEventGridConfig.java
+++ b/extensions/azure/events-config/src/main/java/org/eclipse/dataspaceconnector/events/azure/AzureEventGridConfig.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.events.azure;
 
 import org.eclipse.dataspaceconnector.spi.EdcSetting;

--- a/extensions/azure/vault/src/test/java/org/eclipse/dataspaceconnector/core/security/azure/AzureVaultExtensionTest.java
+++ b/extensions/azure/vault/src/test/java/org/eclipse/dataspaceconnector/core/security/azure/AzureVaultExtensionTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.core.security.azure;
 
 import org.eclipse.dataspaceconnector.spi.monitor.ConsoleMonitor;

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/DefaultWorkItemQueue.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/DefaultWorkItemQueue.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.cache;
 
 import org.eclipse.dataspaceconnector.catalog.spi.WorkItem;

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheExtension.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.cache;
 
 import net.jodah.failsafe.RetryPolicy;

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/LoaderImpl.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/LoaderImpl.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.cache;
 
 import org.eclipse.dataspaceconnector.catalog.spi.CachedAsset;

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/controller/CatalogController.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/controller/CatalogController.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.cache.controller;
 
 import jakarta.ws.rs.Consumes;

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/crawler/CrawlerImpl.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/crawler/CrawlerImpl.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.cache.crawler;
 
 import net.jodah.failsafe.RetryPolicy;

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/crawler/NodeQueryAdapterRegistryImpl.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/crawler/NodeQueryAdapterRegistryImpl.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.cache.crawler;
 
 import org.eclipse.dataspaceconnector.catalog.spi.NodeQueryAdapter;

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/loader/LoaderManagerImpl.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/loader/LoaderManagerImpl.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.cache.loader;
 
 import org.eclipse.dataspaceconnector.catalog.spi.Loader;

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/management/PartitionManagerImpl.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/management/PartitionManagerImpl.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.cache.management;
 
 import org.eclipse.dataspaceconnector.catalog.spi.Crawler;

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/CacheQueryAdapterRegistryImpl.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/CacheQueryAdapterRegistryImpl.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.cache.query;
 
 import org.eclipse.dataspaceconnector.catalog.spi.CacheQueryAdapter;

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/IdsMultipartNodeQueryAdapter.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/IdsMultipartNodeQueryAdapter.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.cache.query;
 
 import org.eclipse.dataspaceconnector.catalog.spi.NodeQueryAdapter;

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/QueryEngineImpl.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/QueryEngineImpl.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.cache.query;
 
 import org.eclipse.dataspaceconnector.catalog.spi.CacheQueryAdapterRegistry;

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheEndToEndTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheEndToEndTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.cache;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/TestUtil.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/TestUtil.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.cache;
 
 import org.eclipse.dataspaceconnector.catalog.spi.WorkItem;

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/crawler/CrawlerImplTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/crawler/CrawlerImplTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.cache.crawler;
 
 import net.jodah.failsafe.RetryPolicy;

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/loader/LoaderManagerImplTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/loader/LoaderManagerImplTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.cache.loader;
 
 import org.eclipse.dataspaceconnector.catalog.spi.Loader;

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/management/PartitionManagerImplIntegrationTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/management/PartitionManagerImplIntegrationTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.cache.management;
 
 import net.jodah.failsafe.RetryPolicy;

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/management/PartitionManagerImplTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/management/PartitionManagerImplTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.cache.management;
 
 import org.eclipse.dataspaceconnector.catalog.spi.Crawler;

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/query/QueryEngineImplTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/query/QueryEngineImplTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.cache.query;
 
 import org.eclipse.dataspaceconnector.catalog.spi.CacheQueryAdapterRegistry;

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/CacheQueryAdapter.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/CacheQueryAdapter.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi;
 
 import org.eclipse.dataspaceconnector.catalog.spi.model.FederatedCatalogCacheQuery;

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/CacheQueryAdapterRegistry.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/CacheQueryAdapterRegistry.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi;
 
 import org.eclipse.dataspaceconnector.catalog.spi.model.FederatedCatalogCacheQuery;

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/CachedAsset.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/CachedAsset.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/Crawler.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/Crawler.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi;
 
 import org.eclipse.dataspaceconnector.spi.system.Feature;

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/CrawlerErrorHandler.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/CrawlerErrorHandler.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi;
 
 

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/FederatedCacheNode.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/FederatedCacheNode.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/FederatedCacheNodeDirectory.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/FederatedCacheNodeDirectory.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi;
 
 import org.eclipse.dataspaceconnector.spi.system.Feature;

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/FederatedCacheStore.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/FederatedCacheStore.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi;
 
 import org.eclipse.dataspaceconnector.spi.query.Criterion;

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/Loader.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/Loader.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi;
 
 import org.eclipse.dataspaceconnector.catalog.spi.model.UpdateResponse;

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/LoaderManager.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/LoaderManager.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi;
 
 

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/NodeQueryAdapter.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/NodeQueryAdapter.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi;
 
 

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/NodeQueryAdapterRegistry.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/NodeQueryAdapterRegistry.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi;
 
 import org.eclipse.dataspaceconnector.spi.system.Feature;

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/PartitionConfiguration.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/PartitionConfiguration.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi;
 
 import org.eclipse.dataspaceconnector.catalog.spi.model.ExecutionPlan;

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/PartitionManager.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/PartitionManager.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi;
 
 import org.eclipse.dataspaceconnector.catalog.spi.model.ExecutionPlan;

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/QueryEngine.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/QueryEngine.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi;
 
 import org.eclipse.dataspaceconnector.catalog.spi.model.FederatedCatalogCacheQuery;

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/WorkItem.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/WorkItem.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi;
 
 import java.util.ArrayList;

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/WorkItemQueue.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/WorkItemQueue.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi;
 
 import java.util.concurrent.BlockingQueue;

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/model/ExecutionPlan.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/model/ExecutionPlan.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi.model;
 
 /**

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/model/FederatedCatalogCacheQuery.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/model/FederatedCatalogCacheQuery.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/model/RecurringExecutionPlan.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/model/RecurringExecutionPlan.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi.model;
 
 import java.time.Duration;

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/model/UpdateRequest.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/model/UpdateRequest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi.model;
 
 

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/model/UpdateResponse.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/model/UpdateResponse.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi.model;
 
 

--- a/extensions/catalog/federated-catalog-spi/src/test/java/org/eclipse/dataspaceconnector/catalog/spi/CachedAssetTest.java
+++ b/extensions/catalog/federated-catalog-spi/src/test/java/org/eclipse/dataspaceconnector/catalog/spi/CachedAssetTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;

--- a/extensions/data-plane-transfer/data-plane-transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/core/security/NoopDataEncrypter.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/core/security/NoopDataEncrypter.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.transfer.dataplane.core.security;
 
 import org.eclipse.dataspaceconnector.transfer.dataplane.spi.security.DataEncrypter;

--- a/extensions/data-plane-transfer/data-plane-transfer-spi/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/spi/DataPlaneTransferType.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-spi/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/spi/DataPlaneTransferType.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.transfer.dataplane.spi;
 
 /**

--- a/extensions/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/api/controller/DataPlaneTransferSyncApiControllerTest.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/api/controller/DataPlaneTransferSyncApiControllerTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.transfer.dataplane.sync.api.controller;
 
 import org.eclipse.dataspaceconnector.common.token.TokenValidationService;

--- a/extensions/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/api/resolver/SelfPublicKeyResolverTest.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/api/resolver/SelfPublicKeyResolverTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.transfer.dataplane.sync.api.resolver;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/extensions/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/flow/ProviderDataPlaneProxyDataFlowControllerTest.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/flow/ProviderDataPlaneProxyDataFlowControllerTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.transfer.dataplane.sync.flow;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;

--- a/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/registry/TransferServiceSelectionStrategy.java
+++ b/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/registry/TransferServiceSelectionStrategy.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.dataplane.framework.registry;
 
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.TransferService;

--- a/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/pipeline/PipelineServiceImplTest.java
+++ b/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/pipeline/PipelineServiceImplTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.dataplane.framework.pipeline;
 
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSink;

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/StreamingRequestBodyTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/StreamingRequestBodyTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.dataplane.http.pipeline;
 
 import okio.BufferedSink;

--- a/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/OutputStreamDataSinkFactory.java
+++ b/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/OutputStreamDataSinkFactory.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.dataplane.spi.pipeline;
 
 import org.eclipse.dataspaceconnector.dataplane.spi.result.TransferResult;

--- a/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/response/TransferErrorResponse.java
+++ b/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/response/TransferErrorResponse.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.dataplane.spi.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/extensions/data-plane/data-plane-spi/src/test/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/OutputStreamDataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-spi/src/test/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/OutputStreamDataSinkFactoryTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.dataplane.spi.pipeline;
 
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;

--- a/extensions/data-plane/data-plane-spi/src/test/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSinkTest.java
+++ b/extensions/data-plane/data-plane-spi/src/test/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSinkTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.dataplane.spi.pipeline;
 
 import com.github.javafaker.Faker;

--- a/extensions/dataloading/src/test/java/org/eclipse/dataspaceconnector/dataloading/DataLoaderTest.java
+++ b/extensions/dataloading/src/test/java/org/eclipse/dataspaceconnector/dataloading/DataLoaderTest.java
@@ -1,4 +1,3 @@
-
 /*
  *  Copyright (c) 2020, 2021 Microsoft Corporation
  *

--- a/extensions/http/jersey/src/main/java/org/eclipse/dataspaceconnector/extension/jersey/CorsFilter.java
+++ b/extensions/http/jersey/src/main/java/org/eclipse/dataspaceconnector/extension/jersey/CorsFilter.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.extension.jersey;
 
 import jakarta.ws.rs.container.ContainerRequestContext;

--- a/extensions/http/jersey/src/main/java/org/eclipse/dataspaceconnector/extension/jersey/CorsFilterConfiguration.java
+++ b/extensions/http/jersey/src/main/java/org/eclipse/dataspaceconnector/extension/jersey/CorsFilterConfiguration.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.extension.jersey;
 
 import org.eclipse.dataspaceconnector.spi.EdcSetting;

--- a/extensions/http/jersey/src/main/java/org/eclipse/dataspaceconnector/extension/jersey/JerseyExtension.java
+++ b/extensions/http/jersey/src/main/java/org/eclipse/dataspaceconnector/extension/jersey/JerseyExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.extension.jersey;
 
 import org.eclipse.dataspaceconnector.extension.jetty.JettyService;

--- a/extensions/http/jersey/src/test/java/jetty/CorsFilterConfigurationTest.java
+++ b/extensions/http/jersey/src/test/java/jetty/CorsFilterConfigurationTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package jetty;
 
 import org.eclipse.dataspaceconnector.extension.jersey.CorsFilterConfiguration;

--- a/extensions/http/jetty/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyExtension.java
+++ b/extensions/http/jetty/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.extension.jetty;
 
 import org.eclipse.dataspaceconnector.spi.EdcSetting;

--- a/extensions/iam/decentralized-identity/dummy-credentials-verifier/src/main/java/org/eclipse/dataspaceconnector/iam/verifier/DummyCredentialsVerifier.java
+++ b/extensions/iam/decentralized-identity/dummy-credentials-verifier/src/main/java/org/eclipse/dataspaceconnector/iam/verifier/DummyCredentialsVerifier.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.iam.verifier;
 /*
  *  Copyright (c) 2021 Microsoft Corporation

--- a/extensions/iam/decentralized-identity/dummy-credentials-verifier/src/main/java/org/eclipse/dataspaceconnector/iam/verifier/DummyCredentialsVerifierExtension.java
+++ b/extensions/iam/decentralized-identity/dummy-credentials-verifier/src/main/java/org/eclipse/dataspaceconnector/iam/verifier/DummyCredentialsVerifierExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.iam.verifier;
 /*
  *  Copyright (c) 2021 Microsoft Corporation

--- a/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/hub/jwe/GenericJweWriter.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/hub/jwe/GenericJweWriter.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.iam.did.hub.jwe;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtensionTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtensionTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.iam.did;
 
 import okhttp3.OkHttpClient;

--- a/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/hub/IdentityHubImplTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/hub/IdentityHubImplTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.iam.did.hub;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/hub/jwe/GenericJweWriterReaderTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/hub/jwe/GenericJweWriterReaderTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.iam.did.hub.jwe;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/hub/jwe/WriteRequestWriterReaderTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/hub/jwe/WriteRequestWriterReaderTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.iam.did.hub.jwe;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/resolution/DidPublicKeyResolverImplTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/resolution/DidPublicKeyResolverImplTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.iam.did.resolution;
 
 import com.nimbusds.jose.JOSEException;

--- a/extensions/iam/decentralized-identity/identity-did-crypto/src/main/java/org/eclipse/dataspaceconnector/iam/did/crypto/key/EcPrivateKeyWrapper.java
+++ b/extensions/iam/decentralized-identity/identity-did-crypto/src/main/java/org/eclipse/dataspaceconnector/iam/did/crypto/key/EcPrivateKeyWrapper.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.iam.did.crypto.key;
 
 import com.nimbusds.jose.JOSEException;

--- a/extensions/iam/decentralized-identity/identity-did-crypto/src/main/java/org/eclipse/dataspaceconnector/iam/did/crypto/key/EcPublicKeyWrapper.java
+++ b/extensions/iam/decentralized-identity/identity-did-crypto/src/main/java/org/eclipse/dataspaceconnector/iam/did/crypto/key/EcPublicKeyWrapper.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.iam.did.crypto.key;
 
 import com.nimbusds.jose.JOSEException;

--- a/extensions/iam/decentralized-identity/identity-did-crypto/src/main/java/org/eclipse/dataspaceconnector/iam/did/crypto/key/KeyConverter.java
+++ b/extensions/iam/decentralized-identity/identity-did-crypto/src/main/java/org/eclipse/dataspaceconnector/iam/did/crypto/key/KeyConverter.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.iam.did.crypto.key;
 
 import com.nimbusds.jose.jwk.Curve;

--- a/extensions/iam/decentralized-identity/identity-did-crypto/src/test/java/org/eclipse/dataspaceconnector/iam/did/crypto/credentials/VerifiableCredentialFactoryTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-crypto/src/test/java/org/eclipse/dataspaceconnector/iam/did/crypto/credentials/VerifiableCredentialFactoryTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.iam.did.crypto.credentials;
 
 import com.nimbusds.jose.JOSEException;

--- a/extensions/iam/decentralized-identity/identity-did-crypto/src/test/java/org/eclipse/dataspaceconnector/iam/did/crypto/helper/PemKeyReaderUtility.java
+++ b/extensions/iam/decentralized-identity/identity-did-crypto/src/test/java/org/eclipse/dataspaceconnector/iam/did/crypto/helper/PemKeyReaderUtility.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.iam.did.crypto.helper;
 
 import com.nimbusds.jose.JOSEException;

--- a/extensions/iam/decentralized-identity/identity-did-crypto/src/test/java/org/eclipse/dataspaceconnector/iam/did/crypto/helper/TestHelper.java
+++ b/extensions/iam/decentralized-identity/identity-did-crypto/src/test/java/org/eclipse/dataspaceconnector/iam/did/crypto/helper/TestHelper.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.iam.did.crypto.helper;
 
 import java.util.Objects;

--- a/extensions/iam/decentralized-identity/identity-did-crypto/src/test/java/org/eclipse/dataspaceconnector/iam/did/crypto/key/KeyConverterTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-crypto/src/test/java/org/eclipse/dataspaceconnector/iam/did/crypto/key/KeyConverterTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.iam.did.crypto.key;
 
 import com.nimbusds.jose.JWEAlgorithm;

--- a/extensions/iam/decentralized-identity/identity-did-crypto/src/test/java/org/eclipse/dataspaceconnector/iam/did/crypto/key/KeyPairFactoryTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-crypto/src/test/java/org/eclipse/dataspaceconnector/iam/did/crypto/key/KeyPairFactoryTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial Implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.iam.did.crypto.key;
 
 import org.junit.jupiter.api.Test;

--- a/extensions/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityServiceExtension.java
+++ b/extensions/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityServiceExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.identity;
 
 import com.nimbusds.jose.jwk.ECKey;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/resolution/DidPublicKeyResolver.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/resolution/DidPublicKeyResolver.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.resolution;
 
 import org.eclipse.dataspaceconnector.iam.did.spi.key.PublicKeyWrapper;

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/store/DidStore.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/store/DidStore.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.iam.did.spi.store;
 
 import org.eclipse.dataspaceconnector.iam.did.spi.document.DidDocument;

--- a/extensions/iam/decentralized-identity/registration-service-api/src/main/java/org/eclipse/dataspaceconnector/samples/identity/registrationservice/api/RegistrationServiceApiExtension.java
+++ b/extensions/iam/decentralized-identity/registration-service-api/src/main/java/org/eclipse/dataspaceconnector/samples/identity/registrationservice/api/RegistrationServiceApiExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.samples.identity.registrationservice.api;
 
 import org.eclipse.dataspaceconnector.iam.did.spi.store.DidStore;

--- a/extensions/iam/decentralized-identity/registration-service-api/src/main/java/org/eclipse/dataspaceconnector/samples/identity/registrationservice/api/RegistrationServiceController.java
+++ b/extensions/iam/decentralized-identity/registration-service-api/src/main/java/org/eclipse/dataspaceconnector/samples/identity/registrationservice/api/RegistrationServiceController.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.samples.identity.registrationservice.api;
 
 import jakarta.ws.rs.Consumes;

--- a/extensions/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/jwt/Oauth2JwtDecoratorRegistryRegistryImpl.java
+++ b/extensions/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/jwt/Oauth2JwtDecoratorRegistryRegistryImpl.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.iam.oauth2.core.jwt;
 
 import org.eclipse.dataspaceconnector.common.token.JwtDecoratorRegistryImpl;

--- a/extensions/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/rule/Oauth2ValidationRulesRegistryImpl.java
+++ b/extensions/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/rule/Oauth2ValidationRulesRegistryImpl.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.iam.oauth2.core.rule;
 
 import org.eclipse.dataspaceconnector.common.token.TokenValidationRulesRegistryImpl;

--- a/extensions/iam/oauth2/oauth2-spi/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/spi/Oauth2JwtDecoratorRegistry.java
+++ b/extensions/iam/oauth2/oauth2-spi/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/spi/Oauth2JwtDecoratorRegistry.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.iam.oauth2.spi;
 
 import org.eclipse.dataspaceconnector.common.token.JwtDecoratorRegistry;

--- a/extensions/iam/oauth2/oauth2-spi/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/spi/Oauth2ValidationRulesRegistry.java
+++ b/extensions/iam/oauth2/oauth2-spi/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/spi/Oauth2ValidationRulesRegistry.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.iam.oauth2.spi;
 
 import org.eclipse.dataspaceconnector.common.token.TokenValidationRulesRegistry;

--- a/extensions/in-memory/assetindex-memory/src/main/java/org/eclipse/dataspaceconnector/metadata/memory/AssetPredicateConverter.java
+++ b/extensions/in-memory/assetindex-memory/src/main/java/org/eclipse/dataspaceconnector/metadata/memory/AssetPredicateConverter.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.metadata.memory;
 
 import org.eclipse.dataspaceconnector.spi.query.BaseCriterionToPredicateConverter;

--- a/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/AssetPredicateConverterTest.java
+++ b/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/AssetPredicateConverterTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.metadata.memory;
 
 import org.eclipse.dataspaceconnector.spi.query.Criterion;

--- a/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetIndexTest.java
+++ b/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetIndexTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.metadata.memory;
 
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;

--- a/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetLoaderIndexTest.java
+++ b/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetLoaderIndexTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.metadata.memory;
 
 import org.eclipse.dataspaceconnector.dataloading.AssetEntry;

--- a/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryDataAddressResolverTest.java
+++ b/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryDataAddressResolverTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.metadata.memory;
 
 import org.assertj.core.api.Assertions;

--- a/extensions/in-memory/did-document-store-inmem/src/main/java/org/eclipse/dataspaceconnector/samples/identity/did/DidDocumentStoreExtension.java
+++ b/extensions/in-memory/did-document-store-inmem/src/main/java/org/eclipse/dataspaceconnector/samples/identity/did/DidDocumentStoreExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.samples.identity.did;
 
 import org.eclipse.dataspaceconnector.iam.did.spi.store.DidStore;

--- a/extensions/in-memory/did-document-store-inmem/src/main/java/org/eclipse/dataspaceconnector/samples/identity/did/InMemoryDidDocumentStore.java
+++ b/extensions/in-memory/did-document-store-inmem/src/main/java/org/eclipse/dataspaceconnector/samples/identity/did/InMemoryDidDocumentStore.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.samples.identity.did;
 
 import org.eclipse.dataspaceconnector.iam.did.spi.document.DidDocument;

--- a/extensions/in-memory/did-document-store-inmem/src/test/java/org/eclipse/dataspaceconnector/samples/identity/did/InMemoryDidDocumentStoreTest.java
+++ b/extensions/in-memory/did-document-store-inmem/src/test/java/org/eclipse/dataspaceconnector/samples/identity/did/InMemoryDidDocumentStoreTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.samples.identity.did;
 
 import org.eclipse.dataspaceconnector.iam.did.spi.document.DidDocument;

--- a/extensions/in-memory/fcc-node-directory-memory/src/main/java/org/eclipse/dataspaceconnector/catalog/directory/InMemoryNodeDirectory.java
+++ b/extensions/in-memory/fcc-node-directory-memory/src/main/java/org/eclipse/dataspaceconnector/catalog/directory/InMemoryNodeDirectory.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.directory;
 
 import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheNode;

--- a/extensions/in-memory/fcc-node-directory-memory/src/main/java/org/eclipse/dataspaceconnector/catalog/directory/InMemoryNodeDirectoryExtension.java
+++ b/extensions/in-memory/fcc-node-directory-memory/src/main/java/org/eclipse/dataspaceconnector/catalog/directory/InMemoryNodeDirectoryExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.directory;
 
 import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheNodeDirectory;

--- a/extensions/in-memory/fcc-store-memory/src/main/java/org/eclipse/dataspaceconnector/catalog/store/InMemoryFederatedCacheStore.java
+++ b/extensions/in-memory/fcc-store-memory/src/main/java/org/eclipse/dataspaceconnector/catalog/store/InMemoryFederatedCacheStore.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.store;
 
 import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheStore;

--- a/extensions/in-memory/fcc-store-memory/src/main/java/org/eclipse/dataspaceconnector/catalog/store/InMemoryFederatedCacheStoreExtension.java
+++ b/extensions/in-memory/fcc-store-memory/src/main/java/org/eclipse/dataspaceconnector/catalog/store/InMemoryFederatedCacheStoreExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.store;
 
 import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheStore;

--- a/extensions/in-memory/fcc-store-memory/src/test/java/org/eclipse/dataspaceconnector/catalog/store/InMemoryFederatedCacheStoreTest.java
+++ b/extensions/in-memory/fcc-store-memory/src/test/java/org/eclipse/dataspaceconnector/catalog/store/InMemoryFederatedCacheStoreTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.store;
 
 import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheStore;

--- a/extensions/jdk-logger-monitor/src/test/java/org/eclipse/dataspaceconnector/logger/TestLogHandler.java
+++ b/extensions/jdk-logger-monitor/src/test/java/org/eclipse/dataspaceconnector/logger/TestLogHandler.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.logger;
 
 import java.util.ArrayList;

--- a/extensions/policy/ids-policy/src/test/java/org/eclipse/dataspaceconnector/ids/policy/AbsSpatialPositionConstraintFunctionTest.java
+++ b/extensions/policy/ids-policy/src/test/java/org/eclipse/dataspaceconnector/ids/policy/AbsSpatialPositionConstraintFunctionTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.ids.policy;
 
 import org.eclipse.dataspaceconnector.policy.model.Permission;

--- a/extensions/policy/ids-policy/src/test/java/org/eclipse/dataspaceconnector/ids/policy/PartnerLevelConstraintFunctionTest.java
+++ b/extensions/policy/ids-policy/src/test/java/org/eclipse/dataspaceconnector/ids/policy/PartnerLevelConstraintFunctionTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.ids.policy;
 
 import org.eclipse.dataspaceconnector.policy.model.Operator;

--- a/extensions/sql/contract-definition/store/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionTables.java
+++ b/extensions/sql/contract-definition/store/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionTables.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.sql.contractdefinition.store;
 
 public interface SqlContractDefinitionTables {

--- a/extensions/sql/pool/apache-commons-pool/src/main/java/org/eclipse/dataspaceconnector/sql/pool/commons/DriverManagerConnectionFactory.java
+++ b/extensions/sql/pool/apache-commons-pool/src/main/java/org/eclipse/dataspaceconnector/sql/pool/commons/DriverManagerConnectionFactory.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.sql.pool.commons;
 
 import org.eclipse.dataspaceconnector.spi.persistence.EdcPersistenceException;

--- a/extensions/transaction/transaction-atomikos/src/test/java/org/eclipse/dataspaceconnector/transaction/atomikos/AtomikosTransactionContextTest.java
+++ b/extensions/transaction/transaction-atomikos/src/test/java/org/eclipse/dataspaceconnector/transaction/atomikos/AtomikosTransactionContextTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.transaction.atomikos;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/extensions/transfer-functions/transfer-functions-core/src/main/java/org/eclipse/dataspaceconnector/transfer/functions/core/TransferFunction.java
+++ b/extensions/transfer-functions/transfer-functions-core/src/main/java/org/eclipse/dataspaceconnector/transfer/functions/core/TransferFunction.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.transfer.functions.core;
 
 import org.eclipse.dataspaceconnector.spi.system.Feature;

--- a/samples/02-health-endpoint/src/main/java/org/eclipse/dataspaceconnector/extensions/health/HealthApiController.java
+++ b/samples/02-health-endpoint/src/main/java/org/eclipse/dataspaceconnector/extensions/health/HealthApiController.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.extensions.health;
 
 

--- a/samples/02-health-endpoint/src/main/java/org/eclipse/dataspaceconnector/extensions/health/HealthEndpointExtension.java
+++ b/samples/02-health-endpoint/src/main/java/org/eclipse/dataspaceconnector/extensions/health/HealthEndpointExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.extensions.health;
 
 import org.eclipse.dataspaceconnector.spi.WebService;

--- a/samples/03-configuration/src/main/java/org/eclipse/dataspaceconnector/extensions/health/HealthApiController.java
+++ b/samples/03-configuration/src/main/java/org/eclipse/dataspaceconnector/extensions/health/HealthApiController.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.extensions.health;
 
 

--- a/samples/03-configuration/src/main/java/org/eclipse/dataspaceconnector/extensions/health/HealthEndpointExtension.java
+++ b/samples/03-configuration/src/main/java/org/eclipse/dataspaceconnector/extensions/health/HealthEndpointExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.extensions.health;
 
 import org.eclipse.dataspaceconnector.spi.WebService;

--- a/samples/04.0-file-transfer/transfer-file/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferDataStreamPublisher.java
+++ b/samples/04.0-file-transfer/transfer-file/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferDataStreamPublisher.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.extensions.api;
 
 import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;

--- a/samples/04.1-file-transfer-listener/listener/src/main/java/org/eclipse/dataspaceconnector/extensions/listener/MarkerFileCreator.java
+++ b/samples/04.1-file-transfer-listener/listener/src/main/java/org/eclipse/dataspaceconnector/extensions/listener/MarkerFileCreator.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.extensions.listener;
 
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;

--- a/samples/04.1-file-transfer-listener/listener/src/main/java/org/eclipse/dataspaceconnector/extensions/listener/TransferListenerExtension.java
+++ b/samples/04.1-file-transfer-listener/listener/src/main/java/org/eclipse/dataspaceconnector/extensions/listener/TransferListenerExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.extensions.listener;
 
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;

--- a/samples/04.2-modify-transferprocess/simulator/src/main/java/org/eclipse/dataspaceconnector/samples/sample042/TransferSimulationExtension.java
+++ b/samples/04.2-modify-transferprocess/simulator/src/main/java/org/eclipse/dataspaceconnector/samples/sample042/TransferSimulationExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.samples.sample042;
 
 import org.eclipse.dataspaceconnector.spi.system.Inject;

--- a/samples/04.2-modify-transferprocess/watchdog/src/main/java/org/eclipse/dataspaceconnector/samples/sample042/CheckTimeoutCommandHandler.java
+++ b/samples/04.2-modify-transferprocess/watchdog/src/main/java/org/eclipse/dataspaceconnector/samples/sample042/CheckTimeoutCommandHandler.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.samples.sample042;
 
 import org.eclipse.dataspaceconnector.spi.command.CommandHandler;

--- a/samples/04.2-modify-transferprocess/watchdog/src/main/java/org/eclipse/dataspaceconnector/samples/sample042/CheckTransferProcessTimeoutCommand.java
+++ b/samples/04.2-modify-transferprocess/watchdog/src/main/java/org/eclipse/dataspaceconnector/samples/sample042/CheckTransferProcessTimeoutCommand.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.samples.sample042;
 
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;

--- a/samples/04.2-modify-transferprocess/watchdog/src/main/java/org/eclipse/dataspaceconnector/samples/sample042/Watchdog.java
+++ b/samples/04.2-modify-transferprocess/watchdog/src/main/java/org/eclipse/dataspaceconnector/samples/sample042/Watchdog.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.samples.sample042;
 
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;

--- a/samples/04.2-modify-transferprocess/watchdog/src/main/java/org/eclipse/dataspaceconnector/samples/sample042/WatchdogExtension.java
+++ b/samples/04.2-modify-transferprocess/watchdog/src/main/java/org/eclipse/dataspaceconnector/samples/sample042/WatchdogExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.samples.sample042;
 
 import org.eclipse.dataspaceconnector.spi.command.CommandHandlerRegistry;

--- a/samples/05-file-transfer-cloud/api/src/main/java/org/eclipse/dataspaceconnector/extensions/api/ApiEndpointExtension.java
+++ b/samples/05-file-transfer-cloud/api/src/main/java/org/eclipse/dataspaceconnector/extensions/api/ApiEndpointExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.extensions.api;
 
 import org.eclipse.dataspaceconnector.spi.WebService;

--- a/samples/05-file-transfer-cloud/api/src/main/java/org/eclipse/dataspaceconnector/extensions/api/ConsumerApiController.java
+++ b/samples/05-file-transfer-cloud/api/src/main/java/org/eclipse/dataspaceconnector/extensions/api/ConsumerApiController.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.extensions.api;
 
 

--- a/samples/05-file-transfer-cloud/data-seeder/src/main/java/org/eclipse/dataspaceconnector/sample5/data/seeder/DataSeederServiceExtension.java
+++ b/samples/05-file-transfer-cloud/data-seeder/src/main/java/org/eclipse/dataspaceconnector/sample5/data/seeder/DataSeederServiceExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.sample5.data.seeder;
 
 import org.eclipse.dataspaceconnector.dataloading.AssetLoader;

--- a/samples/05-file-transfer-cloud/transfer-file/src/main/java/org/eclipse/dataspaceconnector/extensions/transfer/CloudTransferExtension.java
+++ b/samples/05-file-transfer-cloud/transfer-file/src/main/java/org/eclipse/dataspaceconnector/extensions/transfer/CloudTransferExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.extensions.transfer;
 
 import net.jodah.failsafe.RetryPolicy;

--- a/samples/other/custom-runtime/src/main/java/org/eclipse/dataspaceconnector/demo/runtime/CustomRuntime.java
+++ b/samples/other/custom-runtime/src/main/java/org/eclipse/dataspaceconnector/demo/runtime/CustomRuntime.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.demo.runtime;
 
 import org.eclipse.dataspaceconnector.boot.system.DefaultServiceExtensionContext;

--- a/spi/catalog-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/catalog/Catalog.java
+++ b/spi/catalog-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/catalog/Catalog.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.types.domain.catalog;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/spi/catalog-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/catalog/CatalogRequest.java
+++ b/spi/catalog-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/catalog/CatalogRequest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.types.domain.catalog;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/response/StatusFailure.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/response/StatusFailure.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.contract.negotiation.response;
 
 import org.eclipse.dataspaceconnector.spi.result.Failure;

--- a/spi/contract-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/offer/ContractDefinitionTest.java
+++ b/spi/contract-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/offer/ContractDefinitionTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.types.domain.contract.offer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/asset/DataAddressResolver.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/asset/DataAddressResolver.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.asset;
 
 import org.eclipse.dataspaceconnector.spi.system.Feature;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/iam/PublicKeyResolver.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/iam/PublicKeyResolver.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.iam;
 
 import org.jetbrains.annotations.Nullable;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/iam/RegistrationService.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/iam/RegistrationService.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.iam;
 
 public interface RegistrationService {

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/persistence/StateEntityStore.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/persistence/StateEntityStore.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.persistence;
 
 import org.jetbrains.annotations.NotNull;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/response/ResponseFailure.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/response/ResponseFailure.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.response;
 
 import org.eclipse.dataspaceconnector.spi.result.Failure;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/result/AbstractResult.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/result/AbstractResult.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.result;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/result/Failure.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/result/Failure.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.result;
 
 import java.util.List;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/retry/WaitStrategy.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/retry/WaitStrategy.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.retry;
 
 public interface WaitStrategy {

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/security/KeyParser.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/security/KeyParser.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.security;
 
 public interface KeyParser<T> {

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/security/PrivateKeyResolver.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/security/PrivateKeyResolver.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.security;
 
 import org.jetbrains.annotations.Nullable;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/security/VaultPrivateKeyResolver.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/security/VaultPrivateKeyResolver.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.security;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/BaseExtension.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/BaseExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.system;
 
 import java.lang.annotation.ElementType;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/CoreExtension.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/CoreExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.system;
 
 import java.lang.annotation.ElementType;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/Feature.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/Feature.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.system;
 
 import java.lang.annotation.ElementType;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/Inject.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/Inject.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.system;
 
 import java.lang.annotation.ElementType;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/Provides.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/Provides.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.system;
 
 import java.lang.annotation.ElementType;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/Requires.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/Requires.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.system;
 
 import java.lang.annotation.ElementType;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/health/HealthCheckResult.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/health/HealthCheckResult.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.system.health;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/health/HealthCheckService.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/health/HealthCheckService.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.system.health;
 
 import org.eclipse.dataspaceconnector.spi.system.Feature;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/health/HealthStatus.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/health/HealthStatus.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.system.health;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/health/LivenessProvider.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/health/LivenessProvider.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.system.health;
 
 import java.util.function.Supplier;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/health/ReadinessProvider.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/health/ReadinessProvider.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.system.health;
 
 import java.util.function.Supplier;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/health/StartupStatusProvider.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/health/StartupStatusProvider.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.system.health;
 
 import java.util.function.Supplier;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/telemetry/Telemetry.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/telemetry/Telemetry.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.telemetry;
 
 import io.opentelemetry.api.OpenTelemetry;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/telemetry/TraceCarrier.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/telemetry/TraceCarrier.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.telemetry;
 
 import java.util.Map;

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/asset/AssetSelectorExpressionTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/asset/AssetSelectorExpressionTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.asset;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/observe/ObservableImplTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/observe/ObservableImplTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.observe;
 
 import org.junit.jupiter.api.Test;

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/query/BaseCriterionToPredicateConverterTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/query/BaseCriterionToPredicateConverterTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.query;
 
 import org.eclipse.dataspaceconnector.common.reflection.ReflectionUtil;

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/security/VaultPrivateKeyResolverTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/security/VaultPrivateKeyResolverTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.security;
 
 import org.eclipse.dataspaceconnector.spi.EdcException;

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/system/injection/InjectionContainerTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/system/injection/InjectionContainerTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.system.injection;
 
 import org.eclipse.dataspaceconnector.spi.system.Provides;

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/asset/AssetTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/asset/AssetTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.types.domain.asset;
 
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/metadata/QueryRequestTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/metadata/QueryRequestTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.types.domain.metadata;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/edr/EndpointDataReferenceTransformer.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/edr/EndpointDataReferenceTransformer.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.transfer.edr;
 
 import org.eclipse.dataspaceconnector.spi.result.Result;

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/inline/StreamContext.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/inline/StreamContext.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.transfer.inline;
 
 /**

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/inline/StreamSession.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/inline/StreamSession.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.transfer.inline;
 
 /**

--- a/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferDataStreamPublisher.java
+++ b/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferDataStreamPublisher.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.extensions.api;
 
 import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;


### PR DESCRIPTION
## What this PR changes/adds

This PR adds headers to Java source files that were missing a header as per the rule in #997.

The year and organisation were inferred by inspecting the commit where each file was added. For simplicity, changes made in further commits were ignored and are therefore not accounted for in headers.

## Why it does that

Ensure minimal unwanted checkstyle rule violations following refactorings, after creation of a checkstyle rule for headers per #997.

## Further notes

## Linked Issue(s)

Relates to #991 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
