### PR TITLE
contract definition store: add findById method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ the detailed section referring to by linking pull requests or issues.
 * Let Control Plane delegate data transfer to Data Plane (#988)
 * CosmosDb based `PolicyStore` (#826)
 * Http Provisioner Webhook endpoint (#1039)
+* Add `findById` method to `ContractDefinitionStore` (#967)
 
 #### Changed
 

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/service/ContractDefinitionServiceImpl.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/service/ContractDefinitionServiceImpl.java
@@ -17,13 +17,11 @@ package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.ser
 import org.eclipse.dataspaceconnector.api.result.ServiceResult;
 import org.eclipse.dataspaceconnector.dataloading.ContractDefinitionLoader;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
-import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
 
 import java.util.Collection;
-import java.util.List;
 
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
@@ -41,11 +39,7 @@ public class ContractDefinitionServiceImpl implements ContractDefinitionService 
 
     @Override
     public ContractDefinition findById(String contractDefinitionId) {
-        var querySpec = QuerySpec.Builder.newInstance()
-                .filter(List.of(new Criterion("id", "=", contractDefinitionId)))
-                .build();
-
-        return transactionContext.execute(() -> store.findAll(querySpec).findFirst().orElse(null));
+        return transactionContext.execute(() -> store.findById(contractDefinitionId));
     }
 
     @Override

--- a/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/service/ContractDefinitionServiceImplTest.java
+++ b/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/service/ContractDefinitionServiceImplTest.java
@@ -18,7 +18,6 @@ import org.eclipse.dataspaceconnector.dataloading.ContractDefinitionLoader;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
-import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.transaction.NoopTransactionContext;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
@@ -32,6 +31,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.api.result.ServiceFailure.Reason.CONFLICT;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
@@ -49,17 +49,16 @@ class ContractDefinitionServiceImplTest {
     @Test
     void findById_filtersById() {
         var definition = createContractDefinition();
-        when(store.findAll(isA(QuerySpec.class))).thenReturn(Stream.of(definition));
+        when(store.findById(definition.getId())).thenReturn(definition);
 
         var result = service.findById(definition.getId());
 
         assertThat(result).matches(hasId(definition.getId()));
-        verify(store).findAll(argThat(q -> q.getFilterExpression().contains(new Criterion("id", "=", definition.getId()))));
     }
 
     @Test
     void findById_returnsNullIfNotFound() {
-        when(store.findAll(isA(QuerySpec.class))).thenReturn(Stream.empty());
+        when(store.findById(anyString())).thenReturn(null);
 
         var result = service.findById("any");
 
@@ -92,7 +91,7 @@ class ContractDefinitionServiceImplTest {
     @Test
     void create_shouldNotCreateDefinitionIfItAlreadyExists() {
         var definition = createContractDefinition();
-        when(store.findAll(isA(QuerySpec.class))).thenReturn(Stream.of(definition));
+        when(store.findById(definition.getId())).thenReturn(definition);
 
         var inserted = service.create(definition);
 

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStore.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStore.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - added method
  *
  */
 
@@ -70,7 +71,12 @@ public class CosmosContractDefinitionStore implements ContractDefinitionStore {
     public @NotNull Stream<ContractDefinition> findAll(QuerySpec spec) {
         return lockManager.readLock(() -> queryResolver.query(getCache().values().stream(), spec));
     }
-
+    
+    @Override
+    public ContractDefinition findById(String definitionId) {
+        return lockManager.readLock(() -> getCache().get(definitionId));
+    }
+    
     @Override
     public void save(Collection<ContractDefinition> definitions) {
         lockManager.writeLock(() -> {

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreIntegrationTest.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - added tests
  *
  */
 
@@ -120,6 +121,21 @@ public class CosmosContractDefinitionStoreIntegrationTest {
     @Test
     void findAll_emptyResult() {
         assertThat(store.findAll()).isNotNull().isEmpty();
+    }
+    
+    @Test
+    void findById() {
+        var doc = generateDocument(TEST_PARTITION_KEY);
+        container.createItem(doc);
+        
+        var result = store.findById(doc.getId());
+        
+        assertThat(result).isNotNull().isEqualTo(doc.getWrappedInstance());
+    }
+    
+    @Test
+    void findById_invalidId() {
+        assertThat(store.findById("invalid-id")).isNull();
     }
 
     @Test

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreTest.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreTest.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - added tests
  *
  */
 
@@ -79,6 +80,27 @@ class CosmosContractDefinitionStoreTest {
 
         var all = store.findAll();
         assertThat(all).isEmpty();
+        verify(cosmosDbApiMock).queryAllItems();
+    }
+    
+    @Test
+    void findById() {
+        var doc = generateDocument(TEST_PART_KEY);
+        when(cosmosDbApiMock.queryAllItems()).thenReturn(List.of(doc));
+        
+        var result = store.findById(doc.getId());
+        
+        assertThat(result).isNotNull().isEqualTo(doc.getWrappedInstance());
+        verify(cosmosDbApiMock).queryAllItems();
+    }
+    
+    @Test
+    void findById_invalidId() {
+        when(cosmosDbApiMock.queryAllItems()).thenReturn(Collections.emptyList());
+        
+        var result = store.findById("invalid-id");
+        
+        assertThat(result).isNull();
         verify(cosmosDbApiMock).queryAllItems();
     }
 

--- a/extensions/in-memory/contractdefinition-store-memory/src/main/java/org/eclipse/dataspaceconnector/contractdefinition/store/memory/InMemoryContractDefinitionStore.java
+++ b/extensions/in-memory/contractdefinition-store-memory/src/main/java/org/eclipse/dataspaceconnector/contractdefinition/store/memory/InMemoryContractDefinitionStore.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - added method
  *
  */
 
@@ -44,7 +45,13 @@ public class InMemoryContractDefinitionStore implements ContractDefinitionStore 
         return queryResolver.query(cache.values().stream(), spec);
 
     }
-
+    
+    @Override
+    public ContractDefinition findById(String definitionId) {
+        return cache.get(definitionId);
+    }
+    
+    
     @Override
     public void save(Collection<ContractDefinition> definitions) {
         definitions.forEach(d -> cache.put(d.getId(), d));

--- a/extensions/in-memory/contractdefinition-store-memory/src/test/java/org/eclipse/dataspaceconnector/contractdefinition/store/memory/InMemoryContractDefinitionStoreTest.java
+++ b/extensions/in-memory/contractdefinition-store-memory/src/test/java/org/eclipse/dataspaceconnector/contractdefinition/store/memory/InMemoryContractDefinitionStoreTest.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - added tests
  *
  */
 
@@ -99,6 +100,22 @@ class InMemoryContractDefinitionStoreTest {
 
         // must actually collect, otherwise the stream is not materialized
         assertThat(store.findAll(query).collect(Collectors.toList())).isEmpty();
+    }
+    
+    @Test
+    void findById() {
+        var id = "id";
+        var definition = createContractDefinition(id);
+        store.save(definition);
+        
+        var result = store.findById(id);
+        
+        assertThat(result).isNotNull().isEqualTo(definition);
+    }
+    
+    @Test
+    void findById_invalidId() {
+        assertThat(store.findById("invalid-id")).isNull();
     }
 
     private ContractDefinition createContractDefinition(String id) {

--- a/extensions/sql/contract-definition/store/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionStore.java
+++ b/extensions/sql/contract-definition/store/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionStore.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - added method
  *
  */
 
@@ -125,7 +126,20 @@ public class SqlContractDefinitionStore implements ContractDefinitionStore {
             }
         });
     }
-
+    
+    @Override
+    public ContractDefinition findById(String definitionId) {
+        Objects.requireNonNull(definitionId);
+        return transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                return findById(connection, definitionId);
+            } catch (Exception exception) {
+                throw new EdcPersistenceException(exception);
+            }
+        });
+    }
+    
+    
     @Override
     public void save(Collection<ContractDefinition> definitions) {
         Objects.requireNonNull(definitions);

--- a/extensions/sql/contract-definition/store/src/test/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionStoreTest.java
+++ b/extensions/sql/contract-definition/store/src/test/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionStoreTest.java
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Daimler TSS GmbH - Initial Tests
  *       Microsoft Corporation - Method signature change
+ *       Fraunhofer Institute for Software and Systems Engineering - added tests
  *
  */
 
@@ -238,6 +239,22 @@ public class SqlContractDefinitionStoreTest {
 
         assertThat(definitionsRetrieved).isNotNull();
         assertThat(definitionsRetrieved.size()).isEqualTo(limit);
+    }
+    
+    @Test
+    void findById() {
+        var id = "definitionId";
+        var definition = getContractDefinition(id, "contractId", "policyId");
+        sqlContractDefinitionStore.save(definition);
+    
+        var result = sqlContractDefinitionStore.findById(id);
+    
+        assertThat(result).isNotNull().isEqualTo(definition);
+    }
+    
+    @Test
+    void findById_invalidId() {
+        assertThat(sqlContractDefinitionStore.findById("invalid-id")).isNull();
     }
 
     @Test

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/store/ContractDefinitionStore.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/store/ContractDefinitionStore.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - added method
  *
  */
 
@@ -44,6 +45,14 @@ public interface ContractDefinitionStore {
      */
     @NotNull
     Stream<ContractDefinition> findAll(QuerySpec spec);
+    
+    /**
+     * Returns the definition with the given id, if it exists.
+     *
+     * @param definitionId the id.
+     * @return the definition with with the given id, or null.
+     */
+    ContractDefinition findById(String definitionId);
 
     /**
      * Persists the definitions.


### PR DESCRIPTION
## What this PR changes/adds

It adds a `findById` method to the `ContractDefinitionStore` and its implementations.

## Why it does that

The contract definition API currently uses the store's `findAll` method to fetch a specific contract definition by id.

## Linked Issue(s)

Closes #967 

## Checklist

- [X] added appropriate tests?
- [ ] performed checkstyle check locally?
- [X] added/updated copyright headers?
- [X] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [X] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [X] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
