### PR TITLE
SqlContractNegotiationStore: serialize entire `Policy` instead of just the ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ the detailed section referring to by linking pull requests or issues.
 * Add SQL-AssetIndex to support `QuerySpec` (#1014)
 * Improve provision signalling and align deprovisioning to handle error conditions (#992)
 * Replace Asset with assetId on ContractAgreement (#1009)
+* Serialize entire Policy in an SQL based `ContractNegotiationStore` (#1068)
 
 #### Removed
 

--- a/extensions/sql/contract-negotiation-store/docs/ddl_postgres.sql
+++ b/extensions/sql/contract-negotiation-store/docs/ddl_postgres.sql
@@ -31,8 +31,9 @@ CREATE TABLE IF NOT EXISTS edc_contract_agreement
     start_date        BIGINT,
     end_date          INTEGER,
     asset_id          VARCHAR NOT NULL,
-    policy_id         VARCHAR
+    policy            VARCHAR
 );
+COMMENT ON COLUMN edc_contract_agreement.policy IS 'JSON-serialized contract policy';
 
 
 CREATE TABLE IF NOT EXISTS edc_contract_negotiation

--- a/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/ContractNegotiationStatements.java
+++ b/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/ContractNegotiationStatements.java
@@ -119,8 +119,8 @@ public interface ContractNegotiationStatements extends LeaseStatements {
         return "asset_id";
     }
 
-    default String getPolicyIdColumn() {
-        return "policy_id";
+    default String getPolicyColumn() {
+        return "policy";
     }
 
     default String getContractAgreementIdFkColumn() {

--- a/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/PostgresStatements.java
+++ b/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/PostgresStatements.java
@@ -92,7 +92,7 @@ public final class PostgresStatements implements ContractNegotiationStatements {
     public String getInsertAgreementTemplate() {
         return format("INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s, %s) " +
                         "VALUES (?, ?, ?, ?, ?, ?, ?, ?);", getContractAgreementTable(), getIdColumn(), getProviderAgentColumn(), getConsumerAgentColumn(),
-                getSigningDateColumn(), getStartDateColumn(), getEndDateColumn(), getAssetIdColumn(), getPolicyIdColumn());
+                getSigningDateColumn(), getStartDateColumn(), getEndDateColumn(), getAssetIdColumn(), getPolicyColumn());
     }
 
     @Override

--- a/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -16,7 +16,6 @@
 package org.eclipse.dataspaceconnector.sql.contractnegotiation.store;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
 import org.eclipse.dataspaceconnector.spi.persistence.EdcPersistenceException;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
@@ -243,7 +242,7 @@ public class SqlContractNegotiationStore implements ContractNegotiationStore {
                     agr.getContractStartDate(),
                     agr.getContractEndDate(),
                     agr.getAssetId(),
-                    agr.getPolicy().getUid());
+                    toJson(agr.getPolicy()));
         }
 
         var stmt = statements.getInsertNegotiationTemplate();
@@ -279,11 +278,11 @@ public class SqlContractNegotiationStore implements ContractNegotiationStore {
                 .providerAgentId(resultSet.getString(statements.getProviderAgentColumn()))
                 .consumerAgentId(resultSet.getString(statements.getConsumerAgentColumn()))
                 .assetId(resultSet.getString(statements.getAssetIdColumn()))
-                .policy(Policy.Builder.newInstance().id(resultSet.getString(statements.getPolicyIdColumn())).build())
+                .policy(fromJson(resultSet.getString(statements.getPolicyColumn()), new TypeReference<>() {
+                }))
                 .contractStartDate(resultSet.getLong(statements.getStartDateColumn()))
                 .contractEndDate(resultSet.getLong(statements.getEndDateColumn()))
                 .contractSigningDate(resultSet.getLong(statements.getSigningDateColumn()))
-                //todo
                 .build();
     }
 

--- a/extensions/sql/contract-negotiation-store/src/test/resources/schema.sql
+++ b/extensions/sql/contract-negotiation-store/src/test/resources/schema.sql
@@ -71,7 +71,7 @@ CREATE TABLE IF NOT EXISTS edc_contract_agreement
     start_date        BIGINT,
     end_date          INTEGER,
     asset_id          VARCHAR NOT NULL,
-    policy_id         VARCHAR
+    policy            VARCHAR
 );
 
 


### PR DESCRIPTION
## What this PR changes/adds

Store the entire `Policy` object serialized as JSON in the SQL database when persisting `ContractNegotiation` objects.

## Why it does that

In order to maintain consistency with e.g. the `CosmosDB` implementation, and because it might be required for both contract parties to have an instance of the agreed-upon policy.


## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
