### PR TITLE
Bug fix: Default value if the environment variable is null or blank

### DIFF
--- a/common/util/build.gradle.kts
+++ b/common/util/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     testFixturesImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
     testFixturesRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")
     testFixturesImplementation("com.squareup.okhttp3:okhttp:${okHttpVersion}")
+    testImplementation("org.junit-pioneer:junit-pioneer:1.6.2")
 }
 
 publishing {

--- a/common/util/src/main/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctions.java
+++ b/common/util/src/main/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctions.java
@@ -32,7 +32,10 @@ public class ConfigurationFunctions {
         }
         String upperKey = key.toUpperCase().replace('.', '_');
         value = System.getenv(upperKey);
-        return value != null ? value : defaultValue;
+        if (!StringUtils.isNullOrBlank(value)) {
+            return value;
+        }
+        return defaultValue;
     }
 
 }

--- a/common/util/src/test/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctionsTest.java
+++ b/common/util/src/test/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctionsTest.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.common.configuration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junitpioneer.jupiter.ClearEnvironmentVariable;
+import org.junitpioneer.jupiter.ClearSystemProperty;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+import org.junitpioneer.jupiter.SetSystemProperty;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConfigurationFunctionsTest {
+
+    public static final String DEFAULT = "default";
+    public static final String ENV_VAR_1 = "EDC_KEY1";
+    public static final String ENV_VAR_2 = "EDC_KEY2";
+    public static final String EDC_VAR_3 = "EDC_KEY3";
+    private static final String SYS_PROP_1 = "edc.key1";
+    private static final String SYS_PROP_2 = "edc.key2";
+    private static final String SYS_PROP_3 = "edc.key3";
+    public static final String VALUE_1 = "value1";
+
+    @AfterEach
+    @ClearEnvironmentVariable(key = ENV_VAR_1)
+    @ClearEnvironmentVariable(key = ENV_VAR_2)
+    @ClearEnvironmentVariable(key = EDC_VAR_3)
+    @ClearSystemProperty(key = SYS_PROP_1)
+    @ClearSystemProperty(key = SYS_PROP_2)
+    @ClearSystemProperty(key = SYS_PROP_3)
+    public void cleanUp() {
+        // clear env vars and system properties
+    }
+
+    @ParameterizedTest
+    @MethodSource("propertiesSource")
+    @SetSystemProperty(key = SYS_PROP_1, value = VALUE_1)
+    @SetSystemProperty(key = SYS_PROP_2, value = "")
+    @SetSystemProperty(key = SYS_PROP_3, value = "    ")
+    public void returnSystemProperty(String key, String expected) {
+        String resultValue = ConfigurationFunctions.propOrEnv(key, DEFAULT);
+        assertThat(resultValue).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @SetEnvironmentVariable(key = ENV_VAR_1, value = VALUE_1)
+    @SetEnvironmentVariable(key = ENV_VAR_2, value = "")
+    @SetEnvironmentVariable(key = EDC_VAR_3, value = "    ")
+    @MethodSource("envVarsSource")
+    public void returnEnv(String key, String expected) {
+        String resultValue = ConfigurationFunctions.propOrEnv(key, DEFAULT);
+        assertThat(resultValue).isEqualTo(expected);
+    }
+
+    @Test
+    public void returnDefaultEnv_NullValue() {
+        String resultValue = ConfigurationFunctions.propOrEnv("nonexistent", DEFAULT);
+        assertThat(resultValue).isEqualTo(DEFAULT);
+    }
+
+    private static Stream<Arguments> propertiesSource() {
+        return Stream.of(
+                Arguments.of(SYS_PROP_1, VALUE_1),
+                Arguments.of(SYS_PROP_2, DEFAULT),
+                Arguments.of(SYS_PROP_3, DEFAULT)
+        );
+    }
+
+    private static Stream<Arguments> envVarsSource() {
+        return Stream.of(
+                Arguments.of(ENV_VAR_1, VALUE_1),
+                Arguments.of(SYS_PROP_1, VALUE_1),
+                Arguments.of(ENV_VAR_2, DEFAULT),
+                Arguments.of(EDC_VAR_3, DEFAULT)
+        );
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

ℹ️   This PR is a follow up for https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/pull/1064 which contained incomplete fix - changed the `if (value != null)` into `if (!StringUtils.isNullOrBlank(value))` only for system properties and not for environment variables. 

This PR modifies the _propOrEnv_ method in _ConfigurationFunctions_ class to use default value if **environment variable** is null or blank instead of checking only if it's null.

## Why it does that

Environment variable shouldn't be blank, but rather unset if that's the case. 

## Further notes

This change should fix the failing Cosmos DB integration tests on main branch.
It implements the 3rd possible solution from bug: #1057 

Added unit tests for the _ConfigurationFunctions_ class after PR feedback.

## Linked Issue(s)

Closes #1057 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)