### PR TITLE
Contract negotiation Postgres DDL: allow null correlation id for type consumer

### DIFF
--- a/extensions/sql/contract-negotiation-store/docs/ddl_postgres.sql
+++ b/extensions/sql/contract-negotiation-store/docs/ddl_postgres.sql
@@ -40,7 +40,7 @@ CREATE TABLE IF NOT EXISTS edc_contract_negotiation
     id                    VARCHAR                                            NOT NULL
         CONSTRAINT contract_negotiation_pk
             PRIMARY KEY,
-    correlation_id        VARCHAR                                            NOT NULL,
+    correlation_id        VARCHAR,
     counterparty_id       VARCHAR                                            NOT NULL,
     counterparty_address  VARCHAR                                            NOT NULL,
     protocol              VARCHAR DEFAULT 'ids-multipart'::CHARACTER VARYING NOT NULL,
@@ -57,7 +57,8 @@ CREATE TABLE IF NOT EXISTS edc_contract_negotiation
     lease_id              VARCHAR
         CONSTRAINT contract_negotiation_lease_lease_id_fk
             REFERENCES edc_lease
-            ON DELETE SET NULL
+            ON DELETE SET NULL,
+    CONSTRAINT provider_correlation_id CHECK (type = '0' OR correlation_id IS NOT NULL)
 );
 
 COMMENT ON COLUMN edc_contract_negotiation.contract_agreement_id IS 'ContractAgreement serialized as JSON';


### PR DESCRIPTION
## What this PR changes/adds

It removes the `NOT_NULL` constraint on the column `correlation_id` of the `edc_contract_negotiation` table in `ddl_postgres.sql` of the `sql/contract-negotiation-store` module. It instead adds a `CHECK` constraint on the table, that checks whether the `correlation_id` column is not null for negotiations of type `PROVIDER`.

## Why it does that

Currently, the `correlation_id` column may not be null for any contract negotiation. As only the provider sets a correlation ID for negotiations, this causes an error as soon as a `ContractNegotiation` is created and persisted on consumer side.

