### PR TITLE
Feature: add `PolicyArchive` plus implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ the detailed section referring to by linking pull requests or issues.
 * Http Provisioner Webhook endpoint (#1039)
 * Add `ContractAgreement` query methods on `ContractNegotiationStore` (#1044)
 * Add `findById` method to `ContractDefinitionStore` (#967)
+* Add `PolicyArchive` for foreign policies (#1072)
 
 #### Changed
 

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreExtension.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreExtension.java
@@ -18,13 +18,14 @@ import net.jodah.failsafe.RetryPolicy;
 import org.eclipse.dataspaceconnector.azure.cosmos.CosmosDbApiImpl;
 import org.eclipse.dataspaceconnector.contract.negotiation.store.model.ContractNegotiationDocument;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
+import org.eclipse.dataspaceconnector.spi.policy.store.PolicyArchive;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.system.Provides;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.system.health.HealthCheckService;
 
-@Provides(ContractNegotiationStore.class)
+@Provides({ ContractNegotiationStore.class, PolicyArchive.class })
 public class CosmosContractNegotiationStoreExtension implements ServiceExtension {
 
     @Override
@@ -41,6 +42,7 @@ public class CosmosContractNegotiationStoreExtension implements ServiceExtension
         var cosmosDbApi = new CosmosDbApiImpl(vault, configuration);
         var store = new CosmosContractNegotiationStore(cosmosDbApi, context.getTypeManager(), (RetryPolicy<Object>) context.getService(RetryPolicy.class), configuration.getPartitionKey());
         context.registerService(ContractNegotiationStore.class, store);
+        context.registerService(PolicyArchive.class, store);
 
         context.getTypeManager().registerTypes(ContractNegotiationDocument.class);
 

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
@@ -584,10 +584,11 @@ class CosmosContractNegotiationStoreIntegrationTest {
     }
 
     @Test
-    void findPolicy_whenAgreement_noPolicyAttached() {
+    void findPolicy_whenAgreement_policyWithRandomId() {
+        var expectedPolicy = Policy.Builder.newInstance().id(null).build();
         var negotiation = generateNegotiationBuilder("id1")
                 .state(ContractNegotiationStates.CONFIRMED.code())
-                .contractAgreement(generateAgreementBuilder().id("test-agreement").policy(null).build())
+                .contractAgreement(generateAgreementBuilder().id("test-agreement").policy(expectedPolicy).build())
                 .build();
 
         container.createItem(new ContractNegotiationDocument(negotiation, partitionKey));
@@ -596,7 +597,7 @@ class CosmosContractNegotiationStoreIntegrationTest {
         var policy = store.findPolicyById("test-policy");
         assertThat(policy).isNull();
 
-        assertThat(store.findContractAgreement("test-agreement")).isNotNull().extracting(ContractAgreement::getPolicy).isNull();
+        assertThat(store.findContractAgreement("test-agreement")).isNotNull().extracting(ContractAgreement::getPolicy).isEqualTo(expectedPolicy);
     }
 
     private ContractNegotiationDocument toDocument(Object object) {

--- a/extensions/in-memory/negotiation-store-memory/src/main/java/org/eclipse/dataspaceconnector/negotiation/store/memory/InMemoryContractNegotiationStore.java
+++ b/extensions/in-memory/negotiation-store-memory/src/main/java/org/eclipse/dataspaceconnector/negotiation/store/memory/InMemoryContractNegotiationStore.java
@@ -16,6 +16,7 @@
 package org.eclipse.dataspaceconnector.negotiation.store.memory;
 
 import org.eclipse.dataspaceconnector.common.concurrency.LockManager;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
 import org.eclipse.dataspaceconnector.spi.query.QueryResolver;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
@@ -109,6 +110,21 @@ public class InMemoryContractNegotiationStore implements ContractNegotiationStor
     }
 
     @Override
+    public @NotNull Stream<ContractNegotiation> queryNegotiations(QuerySpec querySpec) {
+        return lockManager.readLock(() -> negotiationQueryResolver.query(processesById.values().stream(), querySpec));
+    }
+
+    @Override
+    public @NotNull Stream<ContractAgreement> getAgreementsForDefinitionId(String definitionId) {
+        return lockManager.readLock(() -> getAgreements().filter(it -> it.getId().startsWith(definitionId + ":")));
+    }
+
+    @Override
+    public @NotNull Stream<ContractAgreement> queryAgreements(QuerySpec querySpec) {
+        return lockManager.readLock(() -> agreementQueryResolver.query(getAgreements(), querySpec));
+    }
+
+    @Override
     public @NotNull List<ContractNegotiation> nextForState(int state, int max) {
         return lockManager.readLock(() -> {
             var set = stateCache.get(state);
@@ -132,18 +148,8 @@ public class InMemoryContractNegotiationStore implements ContractNegotiationStor
     }
 
     @Override
-    public Stream<ContractNegotiation> queryNegotiations(QuerySpec querySpec) {
-        return lockManager.readLock(() -> negotiationQueryResolver.query(processesById.values().stream(), querySpec));
-    }
-
-    @Override
-    public @NotNull Stream<ContractAgreement> getAgreementsForDefinitionId(String definitionId) {
-        return lockManager.readLock(() -> getAgreements().filter(it -> it.getId().startsWith(definitionId + ":")));
-    }
-
-    @Override
-    public @NotNull Stream<ContractAgreement> queryAgreements(QuerySpec querySpec) {
-        return lockManager.readLock(() -> agreementQueryResolver.query(getAgreements(), querySpec));
+    public Policy findPolicyById(String policyId) {
+        throw new UnsupportedOperationException();
     }
 
     @NotNull

--- a/extensions/in-memory/negotiation-store-memory/src/main/java/org/eclipse/dataspaceconnector/negotiation/store/memory/InMemoryContractNegotiationStoreExtension.java
+++ b/extensions/in-memory/negotiation-store-memory/src/main/java/org/eclipse/dataspaceconnector/negotiation/store/memory/InMemoryContractNegotiationStoreExtension.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.negotiation.store.memory;
 
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
+import org.eclipse.dataspaceconnector.spi.policy.store.PolicyArchive;
 import org.eclipse.dataspaceconnector.spi.system.Provides;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
@@ -22,7 +23,7 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 /**
  * Provides an in-memory implementation of the {@link ContractNegotiationStore} for testing.
  */
-@Provides(ContractNegotiationStore.class)
+@Provides({ ContractNegotiationStore.class, PolicyArchive.class })
 public class InMemoryContractNegotiationStoreExtension implements ServiceExtension {
 
     @Override
@@ -32,7 +33,9 @@ public class InMemoryContractNegotiationStoreExtension implements ServiceExtensi
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        context.registerService(ContractNegotiationStore.class, new InMemoryContractNegotiationStore());
+        var store = new InMemoryContractNegotiationStore();
+        context.registerService(ContractNegotiationStore.class, store);
+        context.registerService(PolicyArchive.class, store);
     }
 
 }

--- a/extensions/in-memory/negotiation-store-memory/src/test/java/org/eclipse/dataspaceconnector/negotiation/store/memory/InMemoryContractNegotiationStoreTest.java
+++ b/extensions/in-memory/negotiation-store-memory/src/test/java/org/eclipse/dataspaceconnector/negotiation/store/memory/InMemoryContractNegotiationStoreTest.java
@@ -16,6 +16,7 @@
 package org.eclipse.dataspaceconnector.negotiation.store.memory;
 
 import org.eclipse.dataspaceconnector.contract.common.ContractId;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
@@ -28,15 +29,14 @@ import org.junit.jupiter.api.Test;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.dataspaceconnector.negotiation.store.memory.TestFunctions.createAgreementBuilder;
 import static org.eclipse.dataspaceconnector.negotiation.store.memory.TestFunctions.createNegotiation;
 import static org.eclipse.dataspaceconnector.negotiation.store.memory.TestFunctions.createNegotiationBuilder;
+import static org.eclipse.dataspaceconnector.negotiation.store.memory.TestFunctions.createPolicy;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.INITIAL;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.REQUESTED;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.REQUESTING;
@@ -320,6 +320,61 @@ class InMemoryContractNegotiationStoreTest {
         var query = QuerySpec.Builder.newInstance().sortField("notexist").sortOrder(SortOrder.DESC).build();
 
         assertThat(store.queryAgreements(query)).isEmpty();
+    }
+
+    @Test
+    void findPolicy_whenNoAgreement() {
+        var n = createNegotiationBuilder(UUID.randomUUID().toString()).build();
+        store.save(n);
+
+        store.save(n);
+
+        var archivedPolicy = store.findPolicyById("test-policy");
+        assertThat(archivedPolicy).isEmpty();
+    }
+
+    @Test
+    void findPolicy_whenAgreement() {
+        var policy = createPolicy("test-policy");
+
+        var contractAgreement = createAgreementBuilder().policy(policy).id(ContractId.createContractId(UUID.randomUUID().toString())).build();
+        var n = createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
+
+        store.save(n);
+
+        var archivedPolicy = store.findPolicyById("test-policy");
+        assertThat(archivedPolicy).usingRecursiveFieldByFieldElementComparator().containsExactly(policy);
+    }
+
+    @Test
+    void findPolicy_whenMultipleAgreements() {
+        var policy = createPolicy("test-policy");
+
+        var contractAgreement1 = createAgreementBuilder().policy(policy).id(ContractId.createContractId(UUID.randomUUID().toString())).build();
+        var negotiation1 = createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement1).build();
+
+        var contractAgreement2 = createAgreementBuilder().policy(policy).id(ContractId.createContractId(UUID.randomUUID().toString())).build();
+        var negotiation2 = createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement2).build();
+
+        store.save(negotiation1);
+        store.save(negotiation2);
+
+        var policies = store.findPolicyById("test-policy");
+        assertThat(policies).usingRecursiveFieldByFieldElementComparator().containsExactly(policy);
+    }
+
+    @Test
+    void findPolicy_whenAgreement_policyWithRandomId() {
+        var expectedPolicy = Policy.Builder.newInstance().build();
+
+        var contractAgreement = createAgreementBuilder().policy(expectedPolicy).id("test-contract").build();
+        var n = createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
+
+        store.save(n);
+
+        var archivedPolicy = store.findPolicyById("test-policy");
+        assertThat(archivedPolicy).isEmpty();
+        assertThat(store.findContractAgreement("test-contract")).isNotNull().extracting(ContractAgreement::getPolicy).isEqualTo(expectedPolicy);
     }
 
     @NotNull

--- a/extensions/in-memory/negotiation-store-memory/src/test/java/org/eclipse/dataspaceconnector/negotiation/store/memory/TestFunctions.java
+++ b/extensions/in-memory/negotiation-store-memory/src/test/java/org/eclipse/dataspaceconnector/negotiation/store/memory/TestFunctions.java
@@ -15,8 +15,12 @@
 
 package org.eclipse.dataspaceconnector.negotiation.store.memory;
 
+import org.eclipse.dataspaceconnector.policy.model.Action;
+import org.eclipse.dataspaceconnector.policy.model.AtomicConstraint;
+import org.eclipse.dataspaceconnector.policy.model.LiteralExpression;
+import org.eclipse.dataspaceconnector.policy.model.Operator;
+import org.eclipse.dataspaceconnector.policy.model.Permission;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
-import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
@@ -60,5 +64,22 @@ public class TestFunctions {
                 .contractStartDate(Instant.now().getEpochSecond())
                 .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())
                 .contractSigningDate(Instant.now().getEpochSecond());
+    }
+
+    public static Policy createPolicy(String uid) {
+        return Policy.Builder.newInstance()
+                .id(uid)
+                .permission(Permission.Builder.newInstance()
+                        .target("")
+                        .action(Action.Builder.newInstance()
+                                .type("USE")
+                                .build())
+                        .constraint(AtomicConstraint.Builder.newInstance()
+                                .leftExpression(new LiteralExpression("foo"))
+                                .operator(Operator.EQ)
+                                .rightExpression(new LiteralExpression("bar"))
+                                .build())
+                        .build())
+                .build();
     }
 }

--- a/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/SqlContractNegotiationStoreExtension.java
+++ b/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/SqlContractNegotiationStoreExtension.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.sql.contractnegotiation;
 
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
+import org.eclipse.dataspaceconnector.spi.policy.store.PolicyArchive;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.Provides;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
@@ -25,7 +26,7 @@ import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.ContractNego
 import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.PostgresStatements;
 import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.SqlContractNegotiationStore;
 
-@Provides({ ContractNegotiationStore.class })
+@Provides({ ContractNegotiationStore.class, PolicyArchive.class })
 public class SqlContractNegotiationStoreExtension implements ServiceExtension {
 
     private static final String DATASOURCE_NAME_SETTING = "edc.datasource.contractnegotiation.name";
@@ -44,6 +45,7 @@ public class SqlContractNegotiationStoreExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         var sqlStore = new SqlContractNegotiationStore(dataSourceRegistry, getDataSourceName(context), trxContext, context.getTypeManager(), getStatementImpl(), context.getConnectorId());
         context.registerService(ContractNegotiationStore.class, sqlStore);
+        context.registerService(PolicyArchive.class, sqlStore);
     }
 
     /**

--- a/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/ContractNegotiationStatements.java
+++ b/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/ContractNegotiationStatements.java
@@ -43,6 +43,8 @@ public interface ContractNegotiationStatements extends LeaseStatements {
 
     String getInsertAgreementTemplate();
 
+    String getSelectByPolicyIdTemplate();
+
     @Override
     default String getLeasedByColumn() {
         return "leased_by";
@@ -61,6 +63,11 @@ public interface ContractNegotiationStatements extends LeaseStatements {
     @Override
     default String getLeaseIdColumn() {
         return "lease_id";
+    }
+
+
+    default String getPolicyColumnSeralized() {
+        return "serialized_policy";
     }
 
     default String getContractNegotiationTable() {

--- a/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/PostgresStatements.java
+++ b/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/PostgresStatements.java
@@ -90,9 +90,14 @@ public final class PostgresStatements implements ContractNegotiationStatements {
 
     @Override
     public String getInsertAgreementTemplate() {
-        return format("INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s, %s) " +
-                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?);", getContractAgreementTable(), getIdColumn(), getProviderAgentColumn(), getConsumerAgentColumn(),
-                getSigningDateColumn(), getStartDateColumn(), getEndDateColumn(), getAssetIdColumn(), getPolicyIdColumn());
+        return format("INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s, %s, %s) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);", getContractAgreementTable(), getIdColumn(), getProviderAgentColumn(), getConsumerAgentColumn(),
+                getSigningDateColumn(), getStartDateColumn(), getEndDateColumn(), getAssetIdColumn(), getPolicyIdColumn(), getPolicyColumnSeralized());
+    }
+
+    @Override
+    public String getSelectByPolicyIdTemplate() {
+        return format("SELECT %s FROM %s WHERE %s = ?", getPolicyColumnSeralized(), getContractAgreementTable(), getPolicyIdColumn());
     }
 
     @Override

--- a/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/PostgresStatements.java
+++ b/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/PostgresStatements.java
@@ -97,7 +97,7 @@ public final class PostgresStatements implements ContractNegotiationStatements {
 
     @Override
     public String getSelectByPolicyIdTemplate() {
-        return format("SELECT %s FROM %s WHERE %s = ?", getPolicyColumnSeralized(), getContractAgreementTable(), getPolicyIdColumn());
+        return format("SELECT DISTINCT %s FROM %s WHERE %s = ?", getPolicyColumnSeralized(), getContractAgreementTable(), getPolicyIdColumn());
     }
 
     @Override

--- a/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -150,7 +150,7 @@ public class SqlContractNegotiationStore implements ContractNegotiationStore {
     }
 
     @Override
-    public Stream<ContractNegotiation> queryNegotiations(QuerySpec querySpec) {
+    public @NotNull Stream<ContractNegotiation> queryNegotiations(QuerySpec querySpec) {
         return transactionContext.execute(() -> {
             try (var connection = getConnection()) {
                 var stmt = statements.getQueryTemplate();
@@ -205,6 +205,11 @@ public class SqlContractNegotiationStore implements ContractNegotiationStore {
                 throw new EdcPersistenceException(e);
             }
         });
+    }
+
+    @Override
+    public Policy findPolicyById(String policyId) {
+        throw new UnsupportedOperationException();
     }
 
 

--- a/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -208,14 +208,14 @@ public class SqlContractNegotiationStore implements ContractNegotiationStore {
     }
 
     @Override
-    public Policy findPolicyById(String policyId) {
+    public Stream<Policy> findPolicyById(String policyId) {
         var stmt = statements.getSelectByPolicyIdTemplate();
 
         return transactionContext.execute(() -> {
             try (var conn = getConnection()) {
                 TypeReference<Policy> tr = new TypeReference<>() {
                 };
-                return single(executeQuery(conn, (rs) -> fromJson(rs.getString(statements.getPolicyColumnSeralized()), tr), stmt, policyId));
+                return executeQuery(conn, (rs) -> fromJson(rs.getString(statements.getPolicyColumnSeralized()), tr), stmt, policyId).stream();
             } catch (SQLException e) {
                 throw new EdcPersistenceException(e);
             }

--- a/extensions/sql/contract-negotiation-store/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/TestFunctions.java
+++ b/extensions/sql/contract-negotiation-store/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/TestFunctions.java
@@ -15,8 +15,12 @@
 
 package org.eclipse.dataspaceconnector.sql.contractnegotiation;
 
+import org.eclipse.dataspaceconnector.policy.model.Action;
+import org.eclipse.dataspaceconnector.policy.model.AtomicConstraint;
+import org.eclipse.dataspaceconnector.policy.model.LiteralExpression;
+import org.eclipse.dataspaceconnector.policy.model.Operator;
+import org.eclipse.dataspaceconnector.policy.model.Permission;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
-import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates;
@@ -53,6 +57,11 @@ public class TestFunctions {
     }
 
     public static ContractAgreement createContract(String id) {
+        return createContractBuilder(id)
+                .build();
+    }
+
+    public static ContractAgreement.Builder createContractBuilder(String id) {
         return ContractAgreement.Builder.newInstance()
                 .id(id)
                 .providerAgentId("provider")
@@ -61,7 +70,23 @@ public class TestFunctions {
                 .policy(Policy.Builder.newInstance().build())
                 .contractStartDate(Instant.now().getEpochSecond())
                 .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())
-                .contractSigningDate(Instant.now().getEpochSecond())
+                .contractSigningDate(Instant.now().getEpochSecond());
+    }
+
+    public static Policy createPolicy(String uid) {
+        return Policy.Builder.newInstance()
+                .id(uid)
+                .permission(Permission.Builder.newInstance()
+                        .target("")
+                        .action(Action.Builder.newInstance()
+                                .type("USE")
+                                .build())
+                        .constraint(AtomicConstraint.Builder.newInstance()
+                                .leftExpression(new LiteralExpression("foo"))
+                                .operator(Operator.EQ)
+                                .rightExpression(new LiteralExpression("bar"))
+                                .build())
+                        .build())
                 .build();
     }
 }

--- a/extensions/sql/contract-negotiation-store/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStoreTest.java
+++ b/extensions/sql/contract-negotiation-store/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStoreTest.java
@@ -16,10 +16,11 @@
 package org.eclipse.dataspaceconnector.sql.contractnegotiation.store;
 
 import org.eclipse.dataspaceconnector.contract.common.ContractId;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyRegistrationTypes;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
-import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
@@ -45,7 +46,6 @@ import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.Duration;
-import java.util.Comparator;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -55,7 +55,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.dataspaceconnector.sql.SqlQueryExecutor.executeQuery;
 import static org.eclipse.dataspaceconnector.sql.contractnegotiation.TestFunctions.createContract;
+import static org.eclipse.dataspaceconnector.sql.contractnegotiation.TestFunctions.createContractBuilder;
 import static org.eclipse.dataspaceconnector.sql.contractnegotiation.TestFunctions.createNegotiation;
+import static org.eclipse.dataspaceconnector.sql.contractnegotiation.TestFunctions.createPolicy;
 
 class SqlContractNegotiationStoreTest {
 
@@ -83,7 +85,10 @@ class SqlContractNegotiationStoreTest {
         dataSourceRegistry.register(DATASOURCE_NAME, poolDataSource);
         txManager.registerResource(new DataSourceResource(poolDataSource));
         var statements = new PostgresStatements();
-        store = new SqlContractNegotiationStore(dataSourceRegistry, DATASOURCE_NAME, transactionContext, new TypeManager(), statements, CONNECTOR_NAME);
+        TypeManager manager = new TypeManager();
+
+        manager.registerTypes(PolicyRegistrationTypes.TYPES.toArray(Class<?>[]::new));
+        store = new SqlContractNegotiationStore(dataSourceRegistry, DATASOURCE_NAME, transactionContext, manager, statements, CONNECTOR_NAME);
 
         try (var inputStream = getClass().getClassLoader().getResourceAsStream("schema.sql")) {
             var schema = new String(Objects.requireNonNull(inputStream).readAllBytes(), StandardCharsets.UTF_8);
@@ -483,6 +488,42 @@ class SqlContractNegotiationStoreTest {
 
         // page size too large
         assertThat(store.queryAgreements(QuerySpec.Builder.newInstance().offset(5).limit(100).build())).hasSize(5);
+    }
+
+    @Test
+    void findPolicy_whenNoAgreement() {
+        var policy = createPolicy("test-policy");
+        var n = createNegotiation("id1");
+
+        store.save(n);
+
+        var archivedPolicy = store.findPolicyById("test-policy");
+        assertThat(archivedPolicy).isNull();
+    }
+
+    @Test
+    void findPolicy_whenAgreement() {
+        var policy = createPolicy("test-policy");
+        var c = createContractBuilder("test-contract").policy(policy).build();
+        var n = createNegotiation("id1", c);
+
+        store.save(n);
+
+        var archivedPolicy = store.findPolicyById("test-policy");
+        assertThat(archivedPolicy).usingRecursiveComparison().isEqualTo(policy);
+    }
+
+    @Test
+    void findPolicy_whenAgreement_policyWithRandomId() {
+        var expectedPolicy = Policy.Builder.newInstance().build();
+        var c = createContractBuilder("test-contract").policy(expectedPolicy).build();
+        var n = createNegotiation("id1", c);
+
+        store.save(n);
+
+        var archivedPolicy = store.findPolicyById("test-policy");
+        assertThat(archivedPolicy).isNull();
+        assertThat(store.findContractAgreement("test-contract")).isNotNull().extracting(ContractAgreement::getPolicy).isEqualTo(expectedPolicy);
     }
 
     private Connection getConnection() {

--- a/extensions/sql/contract-negotiation-store/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStoreTest.java
+++ b/extensions/sql/contract-negotiation-store/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStoreTest.java
@@ -492,13 +492,12 @@ class SqlContractNegotiationStoreTest {
 
     @Test
     void findPolicy_whenNoAgreement() {
-        var policy = createPolicy("test-policy");
         var n = createNegotiation("id1");
 
         store.save(n);
 
         var archivedPolicy = store.findPolicyById("test-policy");
-        assertThat(archivedPolicy).isNull();
+        assertThat(archivedPolicy).isEmpty();
     }
 
     @Test
@@ -510,7 +509,22 @@ class SqlContractNegotiationStoreTest {
         store.save(n);
 
         var archivedPolicy = store.findPolicyById("test-policy");
-        assertThat(archivedPolicy).usingRecursiveComparison().isEqualTo(policy);
+        assertThat(archivedPolicy).usingRecursiveFieldByFieldElementComparator().containsExactly(policy);
+    }
+
+    @Test
+    void findPolicy_whenMultipleAgreements() {
+        var policy = createPolicy("test-policy");
+        var c1 = createContractBuilder("test-contract1").policy(policy).build();
+        var n1 = createNegotiation("id1", c1);
+        var c2 = createContractBuilder("test-contract2").policy(policy).build();
+        var n2 = createNegotiation("id2", c2);
+
+        store.save(n1);
+        store.save(n2);
+
+        var policies = store.findPolicyById("test-policy");
+        assertThat(policies).usingRecursiveFieldByFieldElementComparator().containsExactly(policy);
     }
 
     @Test
@@ -522,7 +536,7 @@ class SqlContractNegotiationStoreTest {
         store.save(n);
 
         var archivedPolicy = store.findPolicyById("test-policy");
-        assertThat(archivedPolicy).isNull();
+        assertThat(archivedPolicy).isEmpty();
         assertThat(store.findContractAgreement("test-contract")).isNotNull().extracting(ContractAgreement::getPolicy).isEqualTo(expectedPolicy);
     }
 

--- a/extensions/sql/contract-negotiation-store/src/test/resources/schema.sql
+++ b/extensions/sql/contract-negotiation-store/src/test/resources/schema.sql
@@ -71,7 +71,8 @@ CREATE TABLE IF NOT EXISTS edc_contract_agreement
     start_date        BIGINT,
     end_date          INTEGER,
     asset_id          VARCHAR NOT NULL,
-    policy_id         VARCHAR
+    policy_id         VARCHAR,
+    serialized_policy VARCHAR
 );
 
 

--- a/spi/contract-spi/build.gradle.kts
+++ b/spi/contract-spi/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 
 dependencies {
     api(project(":spi:core-spi"))
+    api(project(":spi:policy-spi"))
 }
 
 publishing {

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/store/ContractNegotiationStore.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/store/ContractNegotiationStore.java
@@ -16,6 +16,7 @@
 package org.eclipse.dataspaceconnector.spi.contract.negotiation.store;
 
 import org.eclipse.dataspaceconnector.spi.persistence.StateEntityStore;
+import org.eclipse.dataspaceconnector.spi.policy.store.PolicyArchive;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.system.Feature;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
@@ -30,7 +31,7 @@ import java.util.stream.Stream;
  * <p>
  */
 @Feature(ContractNegotiationStore.FEATURE)
-public interface ContractNegotiationStore extends StateEntityStore<ContractNegotiation> {
+public interface ContractNegotiationStore extends StateEntityStore<ContractNegotiation>, PolicyArchive {
 
     String FEATURE = "edc:core:contract:contractnegotiation:store";
 

--- a/spi/policy-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/store/PolicyArchive.java
+++ b/spi/policy-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/store/PolicyArchive.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.policy.store;
+
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+
+/**
+ * Resolves {@linkplain org.eclipse.dataspaceconnector.policy.model.Policy} objects, that are part of a contract agreement.
+ * Thus, this archive only houses policies from "foreign" EDC instances.
+ */
+
+@FunctionalInterface
+public interface PolicyArchive {
+    Policy findPolicyById(String policyId);
+}

--- a/spi/policy-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/store/PolicyArchive.java
+++ b/spi/policy-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/store/PolicyArchive.java
@@ -16,6 +16,8 @@ package org.eclipse.dataspaceconnector.spi.policy.store;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 
+import java.util.stream.Stream;
+
 /**
  * Resolves {@linkplain org.eclipse.dataspaceconnector.policy.model.Policy} objects, that are part of a contract agreement.
  * Thus, this archive only houses policies from "foreign" EDC instances.
@@ -23,5 +25,8 @@ import org.eclipse.dataspaceconnector.policy.model.Policy;
 
 @FunctionalInterface
 public interface PolicyArchive {
-    Policy findPolicyById(String policyId);
+    /**
+     * Returns a stream of distinct policies for a given ID.
+     */
+    Stream<Policy> findPolicyById(String policyId);
 }


### PR DESCRIPTION
## What this PR changes/adds

Implements a `PolicyArchive` that gives access to all policies, that have been received by "foreign" connectors, i.e. that were contained in a `ContractAgreement`.

## Why it does that

Other objects, such as the `TransferProcessManager` might need access to those policies, so they need a way to get them out of storage, but compile-time coupling to the `ContractNegotiationStore` is to be avoided for obvious reasons.

## Further notes
- In actuality, the `ContractNegotiationStore` extends the `PolicyArchive` interface. All implementors simply persist the entire `Policy`, and then provide a means to query them.

- `PolicyArchive#findbyPolicyId` returns a `Stream` now, because theoretically contracts could have policies that are (slightly) different, but share the same policy ID. This could be the case if the we ever allowed a provider to **update** their policies. The stream is guaranteed to only contain distinct elements at least.

- This PR is a "groundwork PR", it **does not include any usages** of the `PolicyArchive`.

## Linked Issue(s)

Closes #1072 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
