### PR TITLE
Fix: adds missing SQL table column for `ContractNegotiations`

### DIFF
--- a/extensions/sql/contract-negotiation-store/docs/ddl_postgres.sql
+++ b/extensions/sql/contract-negotiation-store/docs/ddl_postgres.sql
@@ -31,7 +31,8 @@ CREATE TABLE IF NOT EXISTS edc_contract_agreement
     start_date        BIGINT,
     end_date          INTEGER,
     asset_id          VARCHAR NOT NULL,
-    policy_id         VARCHAR
+    policy_id         VARCHAR,
+    serialized_policy VARCHAR
 );
 
 


### PR DESCRIPTION
## What this PR changes/adds

adds a missing row to the DB schema for contract negotiations

## Why it does that

I forgot to add it previously

## Further notes

n/a

## Linked Issue(s)

Amends #1072 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
