### PR TITLE
sql: Fix sql-asset-index service descriptor (fixes #1080)

### DIFF
--- a/extensions/sql/asset/index/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
+++ b/extensions/sql/asset/index/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
@@ -11,4 +11,4 @@
 #       Daimler TSS GmbH - Initial API and Implementation
 #
 #
-org.eclipse.dataspaceconnector.sql.contractdefinition.store.SqlAssetIndexServiceExtension
+org.eclipse.dataspaceconnector.sql.asset.index.SqlAssetIndexServiceExtension


### PR DESCRIPTION
## What this PR changes/adds

Change [META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension#L14](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/extensions/sql/asset/index/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension#L14) to become `org.eclipse.dataspaceconnector.sql.asset.index.SqlAssetIndexServiceExtension`

## Why it does that

sql-asset-index extension has been registered incorrectly

## Linked Issue(s)

Closes #1080

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)

<sub> Denis Neuling <denis.neuling@daimler.com>, Daimler TSS GmbH, [legal info/Impressum](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)