### PR TITLE
sql: Fix sql-policy-store service descriptor (fixes #1081)

### DIFF
--- a/extensions/sql/policy/store/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
+++ b/extensions/sql/policy/store/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
@@ -9,6 +9,7 @@
 #
 #  Contributors:
 #       ZF Friedrichshafen AG - Initial API and Implementation
+#       Dailer TSS GmbH - Correct ServiceExtension name
 #
 #
-org.eclipse.dataspaceconnector.sql.policy.store.SqlPolicyStoreServiceExtension
+org.eclipse.dataspaceconnector.sql.policy.SqlPolicyStoreExtension


### PR DESCRIPTION
## What this PR changes/adds

Change [META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension#L14](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/extensions/sql/policy/store/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension#L14) to become `org.eclipse.dataspaceconnector.sql.policy.SqlPolicyStoreExtension`

## Why it does that

sql-policy-store extension has been registered incorrectly

## Linked Issue(s)

Closes #1081

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)

<sub> Denis Neuling <denis.neuling@daimler.com>, Daimler TSS GmbH, [legal info/Impressum](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)