### PR TITLE
feature: Move data address resolution to the TPM and resolve policies 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ the detailed section referring to by linking pull requests or issues.
 * Add `ContractAgreement` query methods on `ContractNegotiationStore` (#1044)
 * Add `findById` method to `ContractDefinitionStore` (#967)
 * Add `PolicyArchive` for foreign policies (#1072)
+* Resolve policies using the `PolicyArchive` (#1089)
+* Resolve content addresses in the `TransferProcessManager` (#1090)
 
 #### Changed
 

--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/policy/PolicyEngineImpl.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/policy/PolicyEngineImpl.java
@@ -55,6 +55,11 @@ public class PolicyEngineImpl implements PolicyEngine {
     }
 
     @Override
+    public Policy filter(Policy policy, String scope) {
+        return scopeFilter.applyScope(policy, scope);
+    }
+
+    @Override
     public Result<Policy> evaluate(String scope, Policy policy, ParticipantAgent agent) {
         var context = new PolicyContextImpl(agent);
 

--- a/core/transfer/build.gradle.kts
+++ b/core/transfer/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
 dependencies {
     api(project(":spi:transfer-spi"))
 
+    implementation(project(":spi:policy-spi"))
     implementation(project(":common:state-machine-lib"))
     implementation(project(":common:util"))
     implementation("io.opentelemetry:opentelemetry-extension-annotations:${openTelemetryVersion}")

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
@@ -21,7 +21,7 @@ import org.eclipse.dataspaceconnector.spi.command.BoundedCommandQueue;
 import org.eclipse.dataspaceconnector.spi.command.CommandHandlerRegistry;
 import org.eclipse.dataspaceconnector.spi.command.CommandRunner;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
-import org.eclipse.dataspaceconnector.spi.policy.store.PolicyStore;
+import org.eclipse.dataspaceconnector.spi.policy.store.PolicyArchive;
 import org.eclipse.dataspaceconnector.spi.retry.ExponentialWaitStrategy;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.system.CoreExtension;
@@ -74,7 +74,7 @@ public class CoreTransferExtension implements ServiceExtension {
     private TransferProcessStore transferProcessStore;
 
     @Inject
-    private PolicyStore policyStore;
+    private PolicyArchive policyArchive;
 
     @Inject
     private CommandHandlerRegistry registry;
@@ -147,8 +147,8 @@ public class CoreTransferExtension implements ServiceExtension {
                 .commandQueue(commandQueue)
                 .commandRunner(new CommandRunner<>(registry, monitor))
                 .observable(observable)
-                .store(transferProcessStore)
-                .policyStore(policyStore)
+                .transferProcessStore(transferProcessStore)
+                .policyArchive(policyArchive)
                 .batchSize(context.getSetting(TRANSFER_STATE_MACHINE_BATCH_SIZE, 5))
                 .addressResolver(addressResolver)
                 .build();

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
@@ -21,6 +21,7 @@ import org.eclipse.dataspaceconnector.spi.command.BoundedCommandQueue;
 import org.eclipse.dataspaceconnector.spi.command.CommandHandlerRegistry;
 import org.eclipse.dataspaceconnector.spi.command.CommandRunner;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.dataspaceconnector.spi.policy.store.PolicyStore;
 import org.eclipse.dataspaceconnector.spi.retry.ExponentialWaitStrategy;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.system.CoreExtension;
@@ -71,6 +72,9 @@ public class CoreTransferExtension implements ServiceExtension {
 
     @Inject
     private TransferProcessStore transferProcessStore;
+
+    @Inject
+    private PolicyStore policyStore;
 
     @Inject
     private CommandHandlerRegistry registry;
@@ -144,6 +148,7 @@ public class CoreTransferExtension implements ServiceExtension {
                 .commandRunner(new CommandRunner<>(registry, monitor))
                 .observable(observable)
                 .store(transferProcessStore)
+                .policyStore(policyStore)
                 .batchSize(context.getSetting(TRANSFER_STATE_MACHINE_BATCH_SIZE, 5))
                 .addressResolver(addressResolver)
                 .build();

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/flow/DataFlowManagerImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/flow/DataFlowManagerImpl.java
@@ -19,6 +19,7 @@ import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowController;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowInitiateResult;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowManager;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.jetbrains.annotations.NotNull;
 
@@ -42,12 +43,12 @@ public class DataFlowManagerImpl implements DataFlowManager {
 
     @WithSpan
     @Override
-    public @NotNull DataFlowInitiateResult initiate(DataRequest dataRequest, Policy policy) {
+    public @NotNull DataFlowInitiateResult initiate(DataRequest dataRequest, DataAddress contentAddress, Policy policy) {
         try {
             return controllers.stream()
-                    .filter(controller -> controller.canHandle(dataRequest))
+                    .filter(controller -> controller.canHandle(dataRequest, contentAddress))
                     .findFirst()
-                    .map(controller -> controller.initiateFlow(dataRequest, policy))
+                    .map(controller -> controller.initiateFlow(dataRequest, contentAddress, policy))
                     .orElseGet(() -> failure(FATAL_ERROR, controllerNotFound(dataRequest.getId())));
         } catch (Exception e) {
             return failure(FATAL_ERROR, runtimeException(dataRequest.getId(), e.getLocalizedMessage()));

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/inline/InlineDataFlowController.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/inline/InlineDataFlowController.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.transfer.core.inline;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
-import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
@@ -23,6 +22,7 @@ import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowController;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowInitiateResult;
 import org.eclipse.dataspaceconnector.spi.transfer.inline.DataOperatorRegistry;
 import org.eclipse.dataspaceconnector.spi.transfer.inline.DataStreamPublisher;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.jetbrains.annotations.NotNull;
 
@@ -34,28 +34,25 @@ public class InlineDataFlowController implements DataFlowController {
     private final Vault vault;
     private final Monitor monitor;
     private final DataOperatorRegistry dataOperatorRegistry;
-    private final DataAddressResolver dataAddressResolver;
 
-    public InlineDataFlowController(Vault vault, Monitor monitor, DataOperatorRegistry dataOperatorRegistry, DataAddressResolver dataAddressResolver) {
+    public InlineDataFlowController(Vault vault, Monitor monitor, DataOperatorRegistry dataOperatorRegistry) {
         this.vault = vault;
         this.monitor = monitor;
         this.dataOperatorRegistry = dataOperatorRegistry;
-        this.dataAddressResolver = dataAddressResolver;
     }
 
     @Override
-    public boolean canHandle(DataRequest dataRequest) {
-        var sourceType = dataAddressResolver.resolveForAsset(dataRequest.getAssetId()).getType();
+    public boolean canHandle(DataRequest dataRequest, DataAddress contentAddress) {
+        var sourceType = contentAddress.getType();
         var destinationType = dataRequest.getDestinationType();
         return dataOperatorRegistry.getStreamPublisher(dataRequest) != null ||
                 (dataOperatorRegistry.getReader(sourceType) != null && dataOperatorRegistry.getWriter(destinationType) != null);
     }
 
     @Override
-    public @NotNull DataFlowInitiateResult initiateFlow(DataRequest dataRequest, Policy policy) {
-        var source = dataAddressResolver.resolveForAsset(dataRequest.getAssetId());
+    public @NotNull DataFlowInitiateResult initiateFlow(DataRequest dataRequest, DataAddress contentAddress, Policy policy) {
         var destinationType = dataRequest.getDestinationType();
-        monitor.info(format("Copying data from %s to %s", source.getType(), destinationType));
+        monitor.info(format("Copying data from %s to %s", contentAddress.getType(), destinationType));
 
         // first look for a streamer
         DataStreamPublisher streamer = dataOperatorRegistry.getStreamPublisher(dataRequest);
@@ -73,10 +70,10 @@ public class InlineDataFlowController implements DataFlowController {
 
             var secret = vault.resolveSecret(destSecretName);
             // if no copier found for this source/destination pair, then use inline read and write
-            var reader = dataOperatorRegistry.getReader(source.getType());
+            var reader = dataOperatorRegistry.getReader(contentAddress.getType());
             var writer = dataOperatorRegistry.getWriter(destinationType);
 
-            var readResult = reader.read(source);
+            var readResult = reader.read(contentAddress);
             if (readResult.failed()) {
                 return DataFlowInitiateResult.failure(ERROR_RETRY, "Failed to read data from source: " + readResult.getFailure().getMessages());
             }

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/flow/DataFlowManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/flow/DataFlowManagerImplTest.java
@@ -18,6 +18,7 @@ import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowController;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowInitiateResult;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.junit.jupiter.api.Test;
 
@@ -35,12 +36,13 @@ class DataFlowManagerImplTest {
         var controller = mock(DataFlowController.class);
         var dataRequest = DataRequest.Builder.newInstance().destinationType("type").build();
         var policy = Policy.Builder.newInstance().build();
+        var dataAddress = DataAddress.Builder.newInstance().type("test").build();
 
-        when(controller.canHandle(any())).thenReturn(true);
-        when(controller.initiateFlow(any(), any())).thenReturn(DataFlowInitiateResult.success("success"));
+        when(controller.canHandle(any(), any())).thenReturn(true);
+        when(controller.initiateFlow(any(), any(), any())).thenReturn(DataFlowInitiateResult.success("success"));
         manager.register(controller);
 
-        var response = manager.initiate(dataRequest, policy);
+        var response = manager.initiate(dataRequest, dataAddress, policy);
 
         assertThat(response.succeeded()).isTrue();
     }
@@ -50,12 +52,13 @@ class DataFlowManagerImplTest {
         var manager = new DataFlowManagerImpl();
         var controller = mock(DataFlowController.class);
         var dataRequest = DataRequest.Builder.newInstance().destinationType("type").build();
+        var dataAddress = DataAddress.Builder.newInstance().type("test").build();
         var policy = Policy.Builder.newInstance().build();
 
-        when(controller.canHandle(any())).thenReturn(false);
+        when(controller.canHandle(any(), any())).thenReturn(false);
         manager.register(controller);
 
-        var response = manager.initiate(dataRequest, policy);
+        var response = manager.initiate(dataRequest, dataAddress, policy);
 
         assertThat(response.succeeded()).isFalse();
         assertThat(response.getFailure().status()).isEqualTo(FATAL_ERROR);
@@ -66,13 +69,14 @@ class DataFlowManagerImplTest {
         var manager = new DataFlowManagerImpl();
         var controller = mock(DataFlowController.class);
         var dataRequest = DataRequest.Builder.newInstance().destinationType("type").build();
+        var dataAddress = DataAddress.Builder.newInstance().type("test").build();
         var policy = Policy.Builder.newInstance().build();
 
-        when(controller.canHandle(any())).thenReturn(true);
-        when(controller.initiateFlow(any(), any())).thenThrow(new EdcException("error"));
+        when(controller.canHandle(any(), any())).thenReturn(true);
+        when(controller.initiateFlow(any(), any(), any())).thenThrow(new EdcException("error"));
         manager.register(controller);
 
-        var response = manager.initiate(dataRequest, policy);
+        var response = manager.initiate(dataRequest, dataAddress, policy);
 
         assertThat(response.succeeded()).isFalse();
         assertThat(response.getFailure().status()).isEqualTo(FATAL_ERROR);

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplIntegrationTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplIntegrationTest.java
@@ -22,7 +22,7 @@ import org.eclipse.dataspaceconnector.spi.command.CommandQueue;
 import org.eclipse.dataspaceconnector.spi.command.CommandRunner;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.policy.store.PolicyStore;
+import org.eclipse.dataspaceconnector.spi.policy.store.PolicyArchive;
 import org.eclipse.dataspaceconnector.spi.retry.ExponentialWaitStrategy;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowManager;
 import org.eclipse.dataspaceconnector.spi.transfer.observe.TransferProcessObservable;
@@ -76,8 +76,8 @@ class TransferProcessManagerImplIntegrationTest {
         var resourceManifest = ResourceManifest.Builder.newInstance().definitions(List.of(new TestResourceDefinition())).build();
         when(manifestGenerator.generateConsumerResourceManifest(any(DataRequest.class), any(Policy.class))).thenReturn(resourceManifest);
 
-        var policyStore = mock(PolicyStore.class);
-        when(policyStore.findById(anyString())).thenReturn(Policy.Builder.newInstance().build());
+        var policyArchive = mock(PolicyArchive.class);
+        when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
 
         transferProcessManager = TransferProcessManagerImpl.Builder.newInstance()
                 .provisionManager(provisionManager)
@@ -92,8 +92,8 @@ class TransferProcessManagerImplIntegrationTest {
                 .typeManager(new TypeManager())
                 .statusCheckerRegistry(mock(StatusCheckerRegistry.class))
                 .observable(mock(TransferProcessObservable.class))
-                .store(store)
-                .policyStore(policyStore)
+                .transferProcessStore(store)
+                .policyArchive(policyArchive)
                 .addressResolver(mock(DataAddressResolver.class))
                 .build();
     }
@@ -142,6 +142,7 @@ class TransferProcessManagerImplIntegrationTest {
                 .transferType(new TransferType())
                 .managedResources(true)
                 .destinationType("test-type")
+                .contractId(UUID.randomUUID().toString())
                 .build();
 
         return TransferProcess.Builder.newInstance()

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplIntegrationTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplIntegrationTest.java
@@ -56,6 +56,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.INITIAL;
 import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.UNSAVED;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -75,6 +76,9 @@ class TransferProcessManagerImplIntegrationTest {
         var resourceManifest = ResourceManifest.Builder.newInstance().definitions(List.of(new TestResourceDefinition())).build();
         when(manifestGenerator.generateConsumerResourceManifest(any(DataRequest.class), any(Policy.class))).thenReturn(resourceManifest);
 
+        var policyStore = mock(PolicyStore.class);
+        when(policyStore.findById(anyString())).thenReturn(Policy.Builder.newInstance().build());
+
         transferProcessManager = TransferProcessManagerImpl.Builder.newInstance()
                 .provisionManager(provisionManager)
                 .dataFlowManager(mock(DataFlowManager.class))
@@ -89,7 +93,7 @@ class TransferProcessManagerImplIntegrationTest {
                 .statusCheckerRegistry(mock(StatusCheckerRegistry.class))
                 .observable(mock(TransferProcessObservable.class))
                 .store(store)
-                .policyStore(mock(PolicyStore.class))
+                .policyStore(policyStore)
                 .addressResolver(mock(DataAddressResolver.class))
                 .build();
     }

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplIntegrationTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplIntegrationTest.java
@@ -22,6 +22,7 @@ import org.eclipse.dataspaceconnector.spi.command.CommandQueue;
 import org.eclipse.dataspaceconnector.spi.command.CommandRunner;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.policy.store.PolicyStore;
 import org.eclipse.dataspaceconnector.spi.retry.ExponentialWaitStrategy;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowManager;
 import org.eclipse.dataspaceconnector.spi.transfer.observe.TransferProcessObservable;
@@ -88,6 +89,7 @@ class TransferProcessManagerImplIntegrationTest {
                 .statusCheckerRegistry(mock(StatusCheckerRegistry.class))
                 .observable(mock(TransferProcessObservable.class))
                 .store(store)
+                .policyStore(mock(PolicyStore.class))
                 .addressResolver(mock(DataAddressResolver.class))
                 .build();
     }

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
@@ -26,6 +26,7 @@ import org.eclipse.dataspaceconnector.spi.command.CommandQueue;
 import org.eclipse.dataspaceconnector.spi.command.CommandRunner;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.policy.store.PolicyStore;
 import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.retry.ExponentialWaitStrategy;
@@ -110,6 +111,7 @@ class TransferProcessManagerImplTest {
     private final StatusCheckerRegistry statusCheckerRegistry = mock(StatusCheckerRegistry.class);
     private final ResourceManifestGenerator manifestGenerator = mock(ResourceManifestGenerator.class);
     private final TransferProcessStore store = mock(TransferProcessStore.class);
+    private final PolicyStore policyStore = mock(PolicyStore.class);
     private final DataFlowManager dataFlowManager = mock(DataFlowManager.class);
     private final Vault vault = mock(Vault.class);
 
@@ -132,6 +134,7 @@ class TransferProcessManagerImplTest {
                 .statusCheckerRegistry(statusCheckerRegistry)
                 .observable(mock(TransferProcessObservable.class))
                 .store(store)
+                .policyStore(policyStore)
                 .vault(vault)
                 .addressResolver(mock(DataAddressResolver.class))
                 .build();
@@ -293,7 +296,7 @@ class TransferProcessManagerImplTest {
     void provisionedProvider_shouldTransitionToInProgress() throws InterruptedException {
         var process = createTransferProcess(PROVISIONED).toBuilder().type(PROVIDER).build();
         when(store.nextForState(eq(PROVISIONED.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(dataFlowManager.initiate(any(), any())).thenReturn(DataFlowInitiateResult.success("any"));
+        when(dataFlowManager.initiate(any(), any(), any())).thenReturn(DataFlowInitiateResult.success("any"));
         var latch = countDownOnUpdateLatch();
 
         manager.start();

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/build.gradle.kts
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     testImplementation(testFixtures(project(":common:util")))
     testImplementation(project(":core:transfer"))
     testImplementation(project(":extensions:in-memory:assetindex-memory"))
+    testImplementation(project(":extensions:in-memory:policy-store-memory"))
     testImplementation(project(":data-protocols:ids:ids-api-multipart-endpoint-v1"))
     testImplementation(project(":extensions:in-memory:negotiation-store-memory"))
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/build.gradle.kts
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     testImplementation(testFixtures(project(":common:util")))
     testImplementation(project(":core:transfer"))
     testImplementation(project(":extensions:in-memory:negotiation-store-memory"))
+    testImplementation(project(":extensions:in-memory:policy-store-memory"))
 }
 
 publishing {

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ArtifactRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ArtifactRequestHandler.java
@@ -148,7 +148,6 @@ public class ArtifactRequestHandler implements Handler {
                 .dataDestination(dataAddress)
                 .connectorId(connectorId)
                 .assetId(contractAgreement.getAssetId())
-                .policyId(contractAgreement.getPolicy().getUid())
                 .contractId(contractAgreement.getId())
                 .properties(props)
                 .connectorAddress(idsWebhookAddress)

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ArtifactRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ArtifactRequestHandler.java
@@ -148,6 +148,7 @@ public class ArtifactRequestHandler implements Handler {
                 .dataDestination(dataAddress)
                 .connectorId(connectorId)
                 .assetId(contractAgreement.getAssetId())
+                .policyId(contractAgreement.getPolicy().getUid())
                 .contractId(contractAgreement.getId())
                 .properties(props)
                 .connectorAddress(idsWebhookAddress)

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ArtifactRequestHandlerTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ArtifactRequestHandlerTest.java
@@ -96,6 +96,7 @@ class ArtifactRequestHandlerTest {
         assertThat(drCapture.getValue().getDataDestination().getKeyName()).isEqualTo(destination.getKeyName());
         assertThat(drCapture.getValue().getConnectorId()).isEqualTo(connectorId);
         assertThat(drCapture.getValue().getAssetId()).isEqualTo(agreement.getAssetId());
+        assertThat(drCapture.getValue().getPolicyId()).isEqualTo(agreement.getPolicy().getUid());
         assertThat(drCapture.getValue().getContractId()).isEqualTo(agreement.getId());
         assertThat(drCapture.getValue().getConnectorAddress()).isEqualTo(header.getProperties().get(IDS_WEBHOOK_ADDRESS_PROPERTY).toString());
         assertThat(drCapture.getValue().getProperties()).containsExactlyEntriesOf(Map.of("foo", "bar"));

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ArtifactRequestHandlerTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ArtifactRequestHandlerTest.java
@@ -96,7 +96,6 @@ class ArtifactRequestHandlerTest {
         assertThat(drCapture.getValue().getDataDestination().getKeyName()).isEqualTo(destination.getKeyName());
         assertThat(drCapture.getValue().getConnectorId()).isEqualTo(connectorId);
         assertThat(drCapture.getValue().getAssetId()).isEqualTo(agreement.getAssetId());
-        assertThat(drCapture.getValue().getPolicyId()).isEqualTo(agreement.getPolicy().getUid());
         assertThat(drCapture.getValue().getContractId()).isEqualTo(agreement.getId());
         assertThat(drCapture.getValue().getConnectorAddress()).isEqualTo(header.getProperties().get(IDS_WEBHOOK_ADDRESS_PROPERTY).toString());
         assertThat(drCapture.getValue().getProperties()).containsExactlyEntriesOf(Map.of("foo", "bar"));

--- a/extensions/api/control/build.gradle.kts
+++ b/extensions/api/control/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     testImplementation(project(":extensions:in-memory:assetindex-memory"))
     testImplementation(project(":extensions:in-memory:transfer-store-memory"))
     testImplementation(project(":extensions:in-memory:contractdefinition-store-memory"))
+    testImplementation(project(":extensions:in-memory:policy-store-memory"))
     testImplementation(project(":extensions:in-memory:assetindex-memory"))
     testImplementation(project(":data-protocols:ids"))
     testImplementation(project(":extensions:iam:iam-mock"))

--- a/extensions/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/DataPlaneTransferClientExtension.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/DataPlaneTransferClientExtension.java
@@ -76,7 +76,7 @@ public class DataPlaneTransferClientExtension implements ServiceExtension {
             client = new RemoteDataPlaneTransferClient(okHttpClient, selectorClient, selectionStrategy, retryPolicy, context.getTypeManager().getMapper());
         }
 
-        var flowController = new DataPlaneTransferFlowController(addressResolver, client);
+        var flowController = new DataPlaneTransferFlowController(client);
         flowManager.register(flowController);
     }
 }

--- a/extensions/data-plane-transfer/data-plane-transfer-sync/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/DataPlaneTransferSyncExtension.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-sync/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/DataPlaneTransferSyncExtension.java
@@ -18,7 +18,6 @@ import org.eclipse.dataspaceconnector.common.token.TokenValidationRulesRegistryI
 import org.eclipse.dataspaceconnector.common.token.TokenValidationServiceImpl;
 import org.eclipse.dataspaceconnector.spi.EdcSetting;
 import org.eclipse.dataspaceconnector.spi.WebService;
-import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
 import org.eclipse.dataspaceconnector.spi.iam.PublicKeyResolver;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
@@ -44,9 +43,6 @@ public class DataPlaneTransferSyncExtension implements ServiceExtension {
 
     @EdcSetting
     private static final String PUBLIC_KEY_ALIAS = "edc.public.key.alias";
-
-    @Inject
-    private DataAddressResolver dataAddressResolver;
 
     @Inject
     private ContractNegotiationStore contractNegotiationStore;
@@ -75,7 +71,7 @@ public class DataPlaneTransferSyncExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         registerValidationApi(context);
 
-        var flowController = new ProviderDataPlaneProxyDataFlowController(context.getConnectorId(), dispatcherRegistry, dataAddressResolver, proxyManager);
+        var flowController = new ProviderDataPlaneProxyDataFlowController(context.getConnectorId(), dispatcherRegistry, proxyManager);
         dataFlowManager.register(flowController);
     }
 

--- a/extensions/data-plane-transfer/data-plane-transfer-sync/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/flow/ProviderDataPlaneProxyDataFlowController.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-sync/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/flow/ProviderDataPlaneProxyDataFlowController.java
@@ -15,11 +15,11 @@
 package org.eclipse.dataspaceconnector.transfer.dataplane.sync.flow;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
-import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowController;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowInitiateResult;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.edr.EndpointDataReferenceMessage;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.transfer.dataplane.spi.proxy.DataPlaneProxyCreationRequest;
@@ -32,30 +32,24 @@ public class ProviderDataPlaneProxyDataFlowController implements DataFlowControl
 
     private final String connectorId;
     private final RemoteMessageDispatcherRegistry dispatcherRegistry;
-    private final DataAddressResolver resolver;
     private final DataPlaneProxyManager proxyManager;
 
-    public ProviderDataPlaneProxyDataFlowController(String connectorId,
-                                                    RemoteMessageDispatcherRegistry dispatcherRegistry,
-                                                    DataAddressResolver resolver,
-                                                    DataPlaneProxyManager proxyManager) {
+    public ProviderDataPlaneProxyDataFlowController(String connectorId, RemoteMessageDispatcherRegistry dispatcherRegistry, DataPlaneProxyManager proxyManager) {
         this.connectorId = connectorId;
         this.dispatcherRegistry = dispatcherRegistry;
-        this.resolver = resolver;
         this.proxyManager = proxyManager;
     }
 
     @Override
-    public boolean canHandle(DataRequest dataRequest) {
+    public boolean canHandle(DataRequest dataRequest, DataAddress contentAddress) {
         return SYNC.equals(dataRequest.getDestinationType());
     }
 
     @Override
-    public @NotNull DataFlowInitiateResult initiateFlow(DataRequest dataRequest, Policy policy) {
-        var address = resolver.resolveForAsset(dataRequest.getAssetId());
+    public @NotNull DataFlowInitiateResult initiateFlow(DataRequest dataRequest, DataAddress contentAddress, Policy policy) {
         var proxyCreationRequest = DataPlaneProxyCreationRequest.Builder.newInstance()
                 .id(dataRequest.getId())
-                .address(address)
+                .address(contentAddress)
                 .contractId(dataRequest.getContractId())
                 .build();
         var proxyCreationResult = proxyManager.createProxy(proxyCreationRequest);

--- a/extensions/data-plane/integration-tests/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/DataPlaneHttpIntegrationTests.java
+++ b/extensions/data-plane/integration-tests/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/DataPlaneHttpIntegrationTests.java
@@ -350,7 +350,7 @@ public class DataPlaneHttpIntegrationTests {
     /**
      * Request payload with query params to initiate DPF transfer.
      *
-     * @param processId   ProcessID of transfer.See {@link DataFlowRequest}
+     * @param processId ProcessID of transfer.See {@link DataFlowRequest}
      * @param queryParams Query params name and value as key-value entries.
      * @return JSON object. see {@link ObjectNode}.
      */
@@ -496,7 +496,7 @@ public class DataPlaneHttpIntegrationTests {
     /**
      * Mock plain text response from source.
      *
-     * @param statusCode   Response status code.
+     * @param statusCode Response status code.
      * @param responseBody Response body.
      * @return see {@link HttpResponse}
      */

--- a/extensions/http-provisioner/build.gradle.kts
+++ b/extensions/http-provisioner/build.gradle.kts
@@ -34,9 +34,11 @@ dependencies {
     implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
 
     testImplementation(testFixtures(project(":common:util")))
+    testImplementation(project(":extensions:in-memory:policy-store-memory"))
     testImplementation(project(":core:transfer"))
     testImplementation(project(":extensions:in-memory:assetindex-memory"))
     testImplementation(project(":extensions:in-memory:transfer-store-memory"))
+    testImplementation(project(":extensions:dataloading"))
     testImplementation(project(":extensions:dataloading"))
     testImplementation(testFixtures(project(":launchers:junit")))
     testImplementation("io.rest-assured:rest-assured:${restAssured}")

--- a/extensions/http-provisioner/build.gradle.kts
+++ b/extensions/http-provisioner/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
     testImplementation(project(":core:transfer"))
     testImplementation(project(":extensions:in-memory:assetindex-memory"))
     testImplementation(project(":extensions:in-memory:transfer-store-memory"))
-    testImplementation(project(":extensions:dataloading"))
+    testImplementation(project(":extensions:in-memory:negotiation-store-memory"))
     testImplementation(project(":extensions:dataloading"))
     testImplementation(testFixtures(project(":launchers:junit")))
     testImplementation("io.rest-assured:rest-assured:${restAssured}")

--- a/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderProvisioner.java
+++ b/extensions/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderProvisioner.java
@@ -89,8 +89,7 @@ public class HttpProviderProvisioner implements Provisioner<HttpProviderResource
 
     @Override
     public CompletableFuture<ProvisionResult> provision(HttpProviderResourceDefinition resourceDefinition, Policy policy) {
-        // TODO expose scope from PolicyEngine
-        var scopedPolicy = policy;
+        var scopedPolicy = policyEngine.filter(policy, policyScope);
 
         Request request;
         try {

--- a/extensions/transfer-functions/transfer-functions-core/build.gradle.kts
+++ b/extensions/transfer-functions/transfer-functions-core/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     testImplementation(project(":core:transfer"))
     testImplementation(project(":extensions:in-memory:transfer-store-memory"))
     testImplementation(project(":extensions:in-memory:policy-store-memory"))
+    testImplementation(project(":extensions:in-memory:negotiation-store-memory"))
     testImplementation(testFixtures(project(":launchers:junit")))
     testImplementation(testFixtures(project(":common:util")))
 }

--- a/extensions/transfer-functions/transfer-functions-core/build.gradle.kts
+++ b/extensions/transfer-functions/transfer-functions-core/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     // extensions needed for integration testing
     testImplementation(project(":core:transfer"))
     testImplementation(project(":extensions:in-memory:transfer-store-memory"))
+    testImplementation(project(":extensions:in-memory:policy-store-memory"))
     testImplementation(testFixtures(project(":launchers:junit")))
     testImplementation(testFixtures(project(":common:util")))
 }

--- a/extensions/transfer-functions/transfer-functions-core/src/main/java/org/eclipse/dataspaceconnector/transfer/functions/core/TransferFunctionsCoreServiceExtension.java
+++ b/extensions/transfer-functions/transfer-functions-core/src/main/java/org/eclipse/dataspaceconnector/transfer/functions/core/TransferFunctionsCoreServiceExtension.java
@@ -16,9 +16,7 @@ package org.eclipse.dataspaceconnector.transfer.functions.core;
 
 import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.spi.EdcSetting;
-import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.Provides;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
@@ -57,9 +55,6 @@ public class TransferFunctionsCoreServiceExtension implements ServiceExtension {
 
     protected Monitor monitor;
 
-    @Inject
-    protected DataAddressResolver addressResolver;
-
     private Set<String> protocols;
 
     @Override
@@ -92,7 +87,7 @@ public class TransferFunctionsCoreServiceExtension implements ServiceExtension {
                 .monitor(monitor)
                 .build();
 
-        var flowController = new HttpDataFlowController(configuration, addressResolver);
+        var flowController = new HttpDataFlowController(configuration);
         var flowManager = context.getService(DataFlowManager.class);
         flowManager.register(flowController);
 

--- a/extensions/transfer-functions/transfer-functions-core/src/test/java/org/eclipse/dataspaceconnector/transfer/functions/core/flow/http/HttpDataFlowControllerTest.java
+++ b/extensions/transfer-functions/transfer-functions-core/src/test/java/org/eclipse/dataspaceconnector/transfer/functions/core/flow/http/HttpDataFlowControllerTest.java
@@ -20,7 +20,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
-import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
@@ -36,9 +35,7 @@ import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testO
 import static org.eclipse.dataspaceconnector.spi.response.ResponseStatus.ERROR_RETRY;
 import static org.eclipse.dataspaceconnector.spi.response.ResponseStatus.FATAL_ERROR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 
 class HttpDataFlowControllerTest {
@@ -54,9 +51,7 @@ class HttpDataFlowControllerTest {
                 .monitor(mock(Monitor.class))
                 .typeManager(typeManager)
                 .build();
-        var addressResolver = mock(DataAddressResolver.class);
-        when(addressResolver.resolveForAsset(any())).thenReturn(DataAddress.Builder.newInstance().type("test").build());
-        flowController = new HttpDataFlowController(configuration, addressResolver);
+        flowController = new HttpDataFlowController(configuration);
     }
 
     @Test
@@ -70,9 +65,10 @@ class HttpDataFlowControllerTest {
         httpClient = testOkHttpClient().newBuilder().addInterceptor(delegate).build();
 
         var dataRequest = createDataRequest();
+        var contentAddress = DataAddress.Builder.newInstance().type("test").build();
         var policy = Policy.Builder.newInstance().build();
 
-        assertThat(flowController.initiateFlow(dataRequest, policy).succeeded()).isTrue();
+        assertThat(flowController.initiateFlow(dataRequest, contentAddress, policy).succeeded()).isTrue();
     }
 
     @Test
@@ -86,9 +82,10 @@ class HttpDataFlowControllerTest {
         httpClient = testOkHttpClient().newBuilder().addInterceptor(delegate).build();
 
         var dataRequest = createDataRequest();
+        var contentAddress = DataAddress.Builder.newInstance().type("test").build();
         var policy = Policy.Builder.newInstance().build();
 
-        assertEquals(ERROR_RETRY, flowController.initiateFlow(dataRequest, policy).getFailure().status());
+        assertEquals(ERROR_RETRY, flowController.initiateFlow(dataRequest, contentAddress, policy).getFailure().status());
     }
 
     @Test
@@ -102,9 +99,10 @@ class HttpDataFlowControllerTest {
         httpClient = testOkHttpClient().newBuilder().addInterceptor(delegate).build();
 
         var dataRequest = createDataRequest();
+        var contentAddress = DataAddress.Builder.newInstance().type("test").build();
         var policy = Policy.Builder.newInstance().build();
 
-        assertEquals(FATAL_ERROR, flowController.initiateFlow(dataRequest, policy).getFailure().status());
+        assertEquals(FATAL_ERROR, flowController.initiateFlow(dataRequest, contentAddress, policy).getFailure().status());
     }
 
     private DataRequest createDataRequest() {

--- a/samples/05-file-transfer-cloud/transfer-file/src/main/java/org/eclipse/dataspaceconnector/extensions/transfer/CloudTransferExtension.java
+++ b/samples/05-file-transfer-cloud/transfer-file/src/main/java/org/eclipse/dataspaceconnector/extensions/transfer/CloudTransferExtension.java
@@ -72,7 +72,7 @@ public class CloudTransferExtension implements ServiceExtension {
         dataOperatorRegistry.registerWriter(new S3BucketWriter(context.getMonitor(), context.getTypeManager(), retryPolicy, s3ClientProvider));
         dataOperatorRegistry.registerWriter(new BlobStoreWriter(context.getMonitor(), context.getTypeManager()));
 
-        dataFlowMgr.register(new InlineDataFlowController(vault, context.getMonitor(), dataOperatorRegistry, dataAddressResolver));
+        dataFlowMgr.register(new InlineDataFlowController(vault, context.getMonitor(), dataOperatorRegistry));
     }
 
     private void registerDataEntries(ServiceExtensionContext context) {

--- a/samples/other/run-from-junit/build.gradle.kts
+++ b/samples/other/run-from-junit/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     testImplementation(project(":extensions:filesystem:configuration-fs"))
     testImplementation(project(":extensions:azure:vault"))
     testImplementation("com.azure:azure-storage-blob:${storageBlobVersion}")
+    testImplementation(project(":extensions:in-memory:policy-store-memory"))
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")

--- a/samples/other/run-from-junit/src/test/java/org/eclipse/dataspaceconnector/junit/EndToEndTest.java
+++ b/samples/other/run-from-junit/src/test/java/org/eclipse/dataspaceconnector/junit/EndToEndTest.java
@@ -93,8 +93,8 @@ public class EndToEndTest {
 
         DataFlowController controllerMock = mock(DataFlowController.class);
 
-        when(controllerMock.canHandle(isA(DataRequest.class))).thenReturn(true);
-        when(controllerMock.initiateFlow(isA(DataRequest.class), isA(Policy.class))).thenAnswer(i -> {
+        when(controllerMock.canHandle(isA(DataRequest.class), isA(DataAddress.class))).thenReturn(true);
+        when(controllerMock.initiateFlow(isA(DataRequest.class), isA(DataAddress.class), isA(Policy.class))).thenAnswer(i -> {
             latch.countDown();
             return DataFlowInitiateResult.success("");
         });
@@ -115,8 +115,8 @@ public class EndToEndTest {
         processManager.initiateProviderRequest(request);
 
         assertThat(latch.await(1, TimeUnit.MINUTES)).isTrue();
-        verify(controllerMock).canHandle(isA(DataRequest.class));
-        verify(controllerMock).initiateFlow(isA(DataRequest.class), isA(Policy.class));
+        verify(controllerMock).canHandle(isA(DataRequest.class), isA(DataAddress.class));
+        verify(controllerMock).initiateFlow(isA(DataRequest.class), isA(DataAddress.class), isA(Policy.class));
     }
 
     @BeforeEach

--- a/samples/other/run-from-junit/src/test/java/org/eclipse/dataspaceconnector/junit/EndToEndTest.java
+++ b/samples/other/run-from-junit/src/test/java/org/eclipse/dataspaceconnector/junit/EndToEndTest.java
@@ -19,6 +19,7 @@ import org.eclipse.dataspaceconnector.dataloading.AssetLoader;
 import org.eclipse.dataspaceconnector.ids.spi.Protocols;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
 import org.eclipse.dataspaceconnector.spi.iam.TokenRepresentation;
@@ -37,6 +38,8 @@ import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowInitiateResult;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
 import org.eclipse.dataspaceconnector.spi.types.domain.message.RemoteMessage;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,12 +60,15 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(EdcExtension.class)
 public class EndToEndTest {
+    private static final String ASSET_ID = "test123";
+    private static final String CONTRACT_ID = "contract1";
+    private static final String POLICY_ID = "policy1";
 
     @Test
     void processConsumerRequest(TransferProcessManager processManager, RemoteMessageDispatcherRegistry dispatcherRegistry) throws InterruptedException {
-        CountDownLatch latch = new CountDownLatch(1);
+        var latch = new CountDownLatch(1);
 
-        RemoteMessageDispatcher dispatcher = mock(RemoteMessageDispatcher.class);
+        var dispatcher = mock(RemoteMessageDispatcher.class);
 
         when(dispatcher.protocol()).thenReturn(Protocols.IDS_MULTIPART);
 
@@ -73,10 +79,9 @@ public class EndToEndTest {
 
         dispatcherRegistry.register(dispatcher);
 
-        var artifactId = "test123";
         var connectorId = "https://test";
 
-        var entry = Asset.Builder.newInstance().id(artifactId).build();
+        var entry = Asset.Builder.newInstance().id(ASSET_ID).build();
         var request = DataRequest.Builder.newInstance().protocol(Protocols.IDS_MULTIPART).assetId(entry.getId())
                 .connectorId(connectorId).connectorAddress(connectorId).destinationType("S3").build();
 
@@ -88,10 +93,13 @@ public class EndToEndTest {
     }
 
     @Test
-    void processProviderRequest(TransferProcessManager processManager, DataFlowManager dataFlowManager, AssetLoader loader) throws InterruptedException {
-        CountDownLatch latch = new CountDownLatch(1);
+    void processProviderRequest(TransferProcessManager processManager,
+                                DataFlowManager dataFlowManager,
+                                ContractNegotiationStore negotiationStore,
+                                AssetLoader loader) throws InterruptedException {
+        var latch = new CountDownLatch(1);
 
-        DataFlowController controllerMock = mock(DataFlowController.class);
+        var controllerMock = mock(DataFlowController.class);
 
         when(controllerMock.canHandle(isA(DataRequest.class), isA(DataAddress.class))).thenReturn(true);
         when(controllerMock.initiateFlow(isA(DataRequest.class), isA(DataAddress.class), isA(Policy.class))).thenAnswer(i -> {
@@ -101,16 +109,23 @@ public class EndToEndTest {
 
         dataFlowManager.register(controllerMock);
 
-        var artifactId = "test123";
         var connectorId = "https://test";
 
-        var asset = Asset.Builder.newInstance().id(artifactId).build();
+        var asset = Asset.Builder.newInstance().id(ASSET_ID).build();
 
         loader.accept(asset, DataAddress.Builder.newInstance().type("test").build());
 
+        loadNegotiation(negotiationStore);
 
-        var request = DataRequest.Builder.newInstance().protocol(Protocols.IDS_MULTIPART).assetId(asset.getId())
-                .connectorId(connectorId).connectorAddress(connectorId).destinationType("S3").id(UUID.randomUUID().toString()).build();
+        var request = DataRequest.Builder.newInstance()
+                .protocol(Protocols.IDS_MULTIPART)
+                .assetId(asset.getId())
+                .contractId(CONTRACT_ID)
+                .connectorId(connectorId)
+                .connectorAddress(connectorId)
+                .destinationType("S3")
+                .id(UUID.randomUUID().toString())
+                .build();
 
         processManager.initiateProviderRequest(request);
 
@@ -123,6 +138,25 @@ public class EndToEndTest {
     void before(EdcExtension extension) {
         extension.registerSystemExtension(VaultExtension.class, new NullVaultExtension());
         extension.registerSystemExtension(ServiceExtension.class, new TestServiceExtension());
+    }
+
+    private void loadNegotiation(ContractNegotiationStore negotiationStore) {
+        var contractAgreement = ContractAgreement.Builder.newInstance()
+                .assetId(ASSET_ID)
+                .id(CONTRACT_ID)
+                .policy(Policy.Builder.newInstance().id(POLICY_ID).build())
+                .consumerAgentId("consumer")
+                .providerAgentId("provider")
+                .build();
+
+        var contractNegotiation = ContractNegotiation.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .counterPartyId(UUID.randomUUID().toString())
+                .counterPartyAddress("test")
+                .protocol("test")
+                .contractAgreement(contractAgreement)
+                .build();
+        negotiationStore.save(contractNegotiation);
     }
 
     @Provides(IdentityService.class)

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/PolicyEngine.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/PolicyEngine.java
@@ -47,6 +47,12 @@ public interface PolicyEngine {
     String DELIMITER = ".";
 
     /**
+     * Returns a filtered policy for the scope. This involves recursively removing rules and constraints not bound to the scope and returning a modified copy of the unfiltered
+     * policy.
+     */
+    Policy filter(Policy policy, String scope);
+
+    /**
      * Evaluates the given policy for an agent for the given scope.
      */
     Result<Policy> evaluate(String scope, Policy policy, ParticipantAgent agent);

--- a/spi/policy-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/store/PolicyArchive.java
+++ b/spi/policy-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/store/PolicyArchive.java
@@ -17,13 +17,12 @@ package org.eclipse.dataspaceconnector.spi.policy.store;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 
 /**
- * Resolves {@linkplain org.eclipse.dataspaceconnector.policy.model.Policy} objects, that are part of a contract agreement.
+ * Resolves {@linkplain org.eclipse.dataspaceconnector.policy.model.Policy} objects that are part of a contract agreement.
  */
-
 @FunctionalInterface
 public interface PolicyArchive {
     /**
-     * Returns a stream of distinct policies for a given ID.
+     * Returns a policy for a given id.
      */
     Policy findPolicyForContract(String contractId);
 }

--- a/spi/policy-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/store/PolicyArchive.java
+++ b/spi/policy-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/store/PolicyArchive.java
@@ -18,7 +18,6 @@ import org.eclipse.dataspaceconnector.policy.model.Policy;
 
 /**
  * Resolves {@linkplain org.eclipse.dataspaceconnector.policy.model.Policy} objects, that are part of a contract agreement.
- * Thus, this archive only houses policies from "foreign" EDC instances.
  */
 
 @FunctionalInterface

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/flow/DataFlowController.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/flow/DataFlowController.java
@@ -16,6 +16,7 @@ package org.eclipse.dataspaceconnector.spi.transfer.flow;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.jetbrains.annotations.NotNull;
 
@@ -26,8 +27,11 @@ public interface DataFlowController {
 
     /**
      * Returns true if the manager can handle the data type.
+     *
+     * @param dataRequest the request
+     * @param contentAddress the address to resolve the asset contents. This may be the original asset address or an address resolving to generated content.
      */
-    boolean canHandle(DataRequest dataRequest);
+    boolean canHandle(DataRequest dataRequest, DataAddress contentAddress);
 
     /**
      * Initiate a data flow.
@@ -36,9 +40,10 @@ public interface DataFlowController {
      * response. If an exception occurs and re-tries should not be re-attempted, set {@link ResponseStatus#FATAL_ERROR} in the response. </p>
      *
      * @param dataRequest the request
+     * @param contentAddress the address to resolve the asset contents. This may be the original asset address or an address resolving to generated content.
      * @param policy the contract agreement usage policy for the asset being transferred
      */
     @NotNull
-    DataFlowInitiateResult initiateFlow(DataRequest dataRequest, Policy policy);
+    DataFlowInitiateResult initiateFlow(DataRequest dataRequest, DataAddress contentAddress, Policy policy);
 
 }

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/flow/DataFlowManager.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/flow/DataFlowManager.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.spi.transfer.flow;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.jetbrains.annotations.NotNull;
 
@@ -32,8 +33,9 @@ public interface DataFlowManager {
      * Initiates a data flow.
      *
      * @param dataRequest the data to transfer
+     * @param contentAddress the address to resolve the asset contents. This may be the original asset address or an address resolving to generated content.
      * @param policy the contract agreement usage policy for the asset being transferred
      */
     @NotNull
-    DataFlowInitiateResult initiate(DataRequest dataRequest, Policy policy);
+    DataFlowInitiateResult initiate(DataRequest dataRequest, DataAddress contentAddress, Policy policy);
 }

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataRequest.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataRequest.java
@@ -104,7 +104,6 @@ public class DataRequest implements RemoteMessage, Polymorphic {
         return assetId;
     }
 
-
     /**
      * The id of the requested contract.
      */

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataRequest.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataRequest.java
@@ -45,8 +45,6 @@ public class DataRequest implements RemoteMessage, Polymorphic {
 
     private String contractId;
 
-    private String policyId;
-
     private DataAddress dataDestination;
 
     private boolean managedResources = true;
@@ -117,13 +115,6 @@ public class DataRequest implements RemoteMessage, Polymorphic {
     }
 
     /**
-     * Returns the policy id associated with the requested contract.
-     */
-    public String getPolicyId() {
-        return policyId;
-    }
-
-    /**
      * The type of destination the requested data should be routed to.
      */
     public String getDestinationType() {
@@ -156,7 +147,6 @@ public class DataRequest implements RemoteMessage, Polymorphic {
                 .protocol(protocol)
                 .connectorId(connectorId)
                 .assetId(assetId)
-                .policyId(policyId)
                 .contractId(contractId)
                 .dataAddress(dataDestination)
                 .transferType(transferType)
@@ -218,11 +208,6 @@ public class DataRequest implements RemoteMessage, Polymorphic {
 
         public Builder assetId(String assetId) {
             request.assetId = assetId;
-            return this;
-        }
-
-        public Builder policyId(String policyId) {
-            request.policyId = policyId;
             return this;
         }
 

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataRequest.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataRequest.java
@@ -71,7 +71,10 @@ public class DataRequest implements RemoteMessage, Polymorphic {
         return processId;
     }
 
-    void setProcessId(String processId) {
+    /**
+     * Associates the request with a process id.
+     */
+    void associateWithProcessId(String processId) {
         this.processId = processId;
     }
 

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataRequest.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataRequest.java
@@ -45,6 +45,8 @@ public class DataRequest implements RemoteMessage, Polymorphic {
 
     private String contractId;
 
+    private String policyId;
+
     private DataAddress dataDestination;
 
     private boolean managedResources = true;
@@ -115,6 +117,13 @@ public class DataRequest implements RemoteMessage, Polymorphic {
     }
 
     /**
+     * Returns the policy id associated with the requested contract.
+     */
+    public String getPolicyId() {
+        return policyId;
+    }
+
+    /**
      * The type of destination the requested data should be routed to.
      */
     public String getDestinationType() {
@@ -147,6 +156,7 @@ public class DataRequest implements RemoteMessage, Polymorphic {
                 .protocol(protocol)
                 .connectorId(connectorId)
                 .assetId(assetId)
+                .policyId(policyId)
                 .contractId(contractId)
                 .dataAddress(dataDestination)
                 .transferType(transferType)
@@ -201,13 +211,18 @@ public class DataRequest implements RemoteMessage, Polymorphic {
             return this;
         }
 
+        public Builder contractId(String contractId) {
+            request.contractId = contractId;
+            return this;
+        }
+
         public Builder assetId(String assetId) {
             request.assetId = assetId;
             return this;
         }
 
-        public Builder contractId(String contractId) {
-            request.contractId = contractId;
+        public Builder policyId(String policyId) {
+            request.policyId = policyId;
             return this;
         }
 

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcess.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcess.java
@@ -482,7 +482,7 @@ public class TransferProcess implements TraceCarrier {
             }
 
             if (process.dataRequest != null) {
-                process.dataRequest.setProcessId(process.id);
+                process.dataRequest.associateWithProcessId(process.id);
             }
             return process;
         }

--- a/system-tests/e2e-transfer-test/control-plane/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/control-plane/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     api(project(":extensions:in-memory:transfer-store-memory"))
     api(project(":extensions:in-memory:negotiation-store-memory"))
     api(project(":extensions:in-memory:contractdefinition-store-memory"))
+    api(project(":extensions:in-memory:policy-store-memory"))
 
     api(project(":extensions:data-plane-transfer:data-plane-transfer-spi"))
     api(project(":extensions:data-plane-transfer:data-plane-transfer-core"))

--- a/system-tests/runtimes/file-transfer-consumer/build.gradle.kts
+++ b/system-tests/runtimes/file-transfer-consumer/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation(project(":extensions:in-memory:transfer-store-memory"))
     implementation(project(":extensions:in-memory:negotiation-store-memory"))
     implementation(project(":extensions:in-memory:contractdefinition-store-memory"))
+    implementation(project(":extensions:in-memory:policy-store-memory"))
 
     implementation(project(":extensions:api:observability"))
 

--- a/system-tests/runtimes/file-transfer-provider/build.gradle.kts
+++ b/system-tests/runtimes/file-transfer-provider/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
     implementation(project(":extensions:in-memory:transfer-store-memory"))
     implementation(project(":extensions:in-memory:negotiation-store-memory"))
     implementation(project(":extensions:in-memory:contractdefinition-store-memory"))
+    implementation(project(":extensions:in-memory:policy-store-memory"))
 
     implementation(project(":extensions:api:observability"))
 


### PR DESCRIPTION
## What this PR changes/adds

This PR does the following:

1. It moves provider side resolution of data addresses to the TPM so that generated content addresses (e.g. from the HTTP data provisioner) can override the original asset address
2. Fixes a potential security attack vector where a client could manipulate an asset id 
3. Resolves policies during data transfer using the `PolicyArchive` 

## Why it does that

This is needed for M3 features.

## Linked Issue(s)
relates to #1089 
relates to #1090 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
