### PR TITLE
extensions: add custom policy field to NegotiationInitiateRequestDto

### DIFF
--- a/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/model/ContractOfferDescription.java
+++ b/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/model/ContractOfferDescription.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 
@@ -16,19 +17,23 @@ package org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.mo
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 
 public class ContractOfferDescription {
     private final String offerId;
     private final String assetId;
     private final String policyId;
+    private final Policy policy;
 
     @JsonCreator
     public ContractOfferDescription(@JsonProperty("offerId") String offerId,
                                     @JsonProperty("assetId") String assetId,
-                                    @JsonProperty("policyId") String policyId) {
+                                    @JsonProperty("policyId") String policyId,
+                                    @JsonProperty("policy") Policy policy) {
         this.offerId = offerId;
         this.assetId = assetId;
         this.policyId = policyId;
+        this.policy = policy;
     }
 
     public String getOfferId() {
@@ -41,5 +46,9 @@ public class ContractOfferDescription {
 
     public String getPolicyId() {
         return policyId;
+    }
+
+    public Policy getPolicy() {
+        return policy;
     }
 }

--- a/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformer.java
+++ b/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformer.java
@@ -41,7 +41,9 @@ public class NegotiationInitiateRequestDtoToDataRequestTransformer implements Dt
         var contractOffer = ContractOffer.Builder.newInstance()
                 .id(object.getOffer().getOfferId())
                 .asset(Asset.Builder.newInstance().id(object.getOffer().getAssetId()).build())
-                .policy(Policy.Builder.newInstance().id(object.getOffer().getPolicyId()).build()).build();
+                .policyId(object.getOffer().getPolicyId())
+                .policy(object.getOffer().getPolicy())
+                .build();
         return ContractOfferRequest.Builder.newInstance()
                 .connectorId(object.getConnectorId())
                 .connectorAddress(object.getConnectorAddress())

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/TestFunctions.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/TestFunctions.java
@@ -15,12 +15,17 @@
 package org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation;
 
 import org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.model.ContractOfferDescription;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 
 import java.util.UUID;
 
 public class TestFunctions {
     public static ContractOfferDescription createOffer(String offerId, String assetId, String policyId) {
-        return new ContractOfferDescription(offerId, assetId, policyId);
+        return new ContractOfferDescription(offerId, assetId, policyId, null);
+    }
+
+    public static ContractOfferDescription createOffer(Policy policy) {
+        return new ContractOfferDescription(UUID.randomUUID().toString(), UUID.randomUUID().toString(), null, policy);
     }
 
     public static ContractOfferDescription createOffer(String offerId) {

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformerTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformerTest.java
@@ -15,8 +15,12 @@
 package org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.transform;
 
 import org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.model.NegotiationInitiateRequestDto;
+import org.eclipse.dataspaceconnector.policy.model.Identifiable;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
 import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.TestFunctions.createOffer;
@@ -25,6 +29,7 @@ import static org.mockito.Mockito.mock;
 
 class NegotiationInitiateRequestDtoToDataRequestTransformerTest {
 
+    private final TransformerContext context = mock(TransformerContext.class);
     private final NegotiationInitiateRequestDtoToDataRequestTransformer transformer = new NegotiationInitiateRequestDtoToDataRequestTransformer();
 
     @Test
@@ -34,13 +39,12 @@ class NegotiationInitiateRequestDtoToDataRequestTransformerTest {
     }
 
     @Test
-    void transform() {
-        var context = mock(TransformerContext.class);
+    void transform_policyId() {
         var dto = NegotiationInitiateRequestDto.Builder.newInstance()
                 .connectorId("connectorId")
                 .connectorAddress("address")
                 .protocol("protocol")
-                .offerId(createOffer("offerId"))
+                .offerId(createOffer("offerId", "assetId", "policyId"))
                 .build();
 
         var request = transformer.transform(dto, context);
@@ -50,7 +54,27 @@ class NegotiationInitiateRequestDtoToDataRequestTransformerTest {
         assertThat(request.getProtocol()).isEqualTo("protocol");
         assertThat(request.getType()).isEqualTo(INITIAL);
         assertThat(request.getContractOffer().getId()).isEqualTo("offerId");
+        assertThat(request.getContractOffer().getPolicyId()).isEqualTo("policyId");
+        assertThat(request.getContractOffer().getPolicy()).isNull();
     }
 
+    @Test
+    void transform_customPolicy() {
+        var policy = Policy.Builder.newInstance().id(UUID.randomUUID().toString()).build();
+        var dto = NegotiationInitiateRequestDto.Builder.newInstance()
+                .connectorId("connectorId")
+                .connectorAddress("address")
+                .protocol("protocol")
+                .offerId(createOffer(policy))
+                .build();
 
+        var request = transformer.transform(dto, context);
+
+        assertThat(request.getConnectorId()).isEqualTo("connectorId");
+        assertThat(request.getConnectorAddress()).isEqualTo("address");
+        assertThat(request.getProtocol()).isEqualTo("protocol");
+        assertThat(request.getType()).isEqualTo(INITIAL);
+        assertThat(request.getContractOffer().getPolicyId()).isNull();
+        assertThat(request.getContractOffer().getPolicy()).extracting(Identifiable::getUid).isEqualTo(policy.getUid());
+    }
 }

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/offer/ContractOffer.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/offer/ContractOffer.java
@@ -131,7 +131,7 @@ public class ContractOffer {
         return asset;
     }
 
-    @NotNull
+    @Nullable
     public Policy getPolicy() {
         return policy;
     }


### PR DESCRIPTION
## What this PR changes/adds

Adds a `policy` field to `NegotiationInitiateRequestDto`

## Why it does that

To permit definition of custom policy on negotiation.

## Further notes

-

## Linked Issue(s)

Closes #1078 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
