### PR TITLE
docs: update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,35 @@
 All notable changes to this project will be documented in this file - formatted and maintained according to the rules
 documented on <http://keepachangelog.com>.
 
-This file will not cover changes about documentation, code clean-up, samples, or the CI pipeline. With each version (
-respectively milestone), the core features are highlighted. Relevant changes to existing implementations can be found in
+This file will not cover changes about documentation, code clean-up, samples, or the CI pipeline. With each version 
+(respectively milestone), the core features are highlighted. Relevant changes to existing implementations can be found in
 the detailed section referring to by linking pull requests or issues.
 
-## [Unreleased] - XXXX-XX-XX (Milestone 3)
+## [Unreleased]
+
+### Overview
+
+*
+
+### Detailed Changes
+
+#### Added
+
+*
+
+#### Changed
+
+*
+
+#### Removed
+
+*
+
+#### Fixed
+
+*
+
+## [milestone-3] - 2022-04-08
 
 ### Overview
 
@@ -79,7 +103,7 @@ the detailed section referring to by linking pull requests or issues.
 * Call the listeners before the state transition is persisted. (#876)
 * Add an overload to `TransactionContext#execute()` (#968)
 * Run CosmosDB integration tests on cloud in CI (#964)
-* Updated the ContractNegotiation service for DataManagementApi (#985)
+* Update the ContractNegotiation service for DataManagementApi (#985)
 * Set policy and rule target dynamically when generating contract offers (#609)
 * Add SQL-AssetIndex to support `QuerySpec` (#1014)
 * Improve provision signalling and align deprovisioning to handle error conditions (#992)
@@ -97,14 +121,14 @@ the detailed section referring to by linking pull requests or issues.
 #### Fixed
 
 * Flaky S3 StatusChecker Test (#794)
-* Added missing Data Management Asset controller openapi (#853)
+* Add missing Data Management Asset controller openapi (#853)
 * Policy deserialization (#898)
 * Fix extensions loading of EdcRuntimeExtension (#180)
 * Fix missing extension to register TPS (#1027)
 
 ---
 
-## [0.2.0] - 2021-02-21 (Milestone 2)
+## [milestone-2] - 2021-02-21
 
 ### Overview
 
@@ -188,7 +212,7 @@ the detailed section referring to by linking pull requests or issues.
 
 ---
 
-## [0.1.0] - 2021-12-13 (Milestone 1)
+## [milestone-1] - 2021-12-13
 
 ### Overview
 


### PR DESCRIPTION
## What this PR changes/adds

Update milestone naming and add a new (M4) section for further implementations.

## Why it does that

Provide a clean closing of the current milestone and prepare for further changes.