### PR TITLE
extensions: handle jakarta exceptions correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ the detailed section referring to by linking pull requests or issues.
 
 #### Fixed
 
-*
+* Hande Jakarta exception correctly (#1102)
 
 ## [milestone-3] - 2022-04-08
 

--- a/extensions/api/api-core/src/test/java/org/eclipse/dataspaceconnector/api/exception/mappers/EdcApiExceptionMapperTest.java
+++ b/extensions/api/api-core/src/test/java/org/eclipse/dataspaceconnector/api/exception/mappers/EdcApiExceptionMapperTest.java
@@ -9,51 +9,75 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 
 package org.eclipse.dataspaceconnector.api.exception.mappers;
 
-import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.NotAcceptableException;
+import jakarta.ws.rs.NotAllowedException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.NotSupportedException;
 import org.eclipse.dataspaceconnector.api.exception.AuthenticationFailedException;
 import org.eclipse.dataspaceconnector.api.exception.NotAuthorizedException;
 import org.eclipse.dataspaceconnector.api.exception.ObjectExistsException;
 import org.eclipse.dataspaceconnector.api.exception.ObjectNotFoundException;
 import org.eclipse.dataspaceconnector.api.exception.ObjectNotModifiableException;
 import org.eclipse.dataspaceconnector.spi.EdcException;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class EdcApiExceptionMapperTest {
-    private EdcApiExceptionMapper mapper;
 
-    public static Stream<Arguments> getArgs() {
-        return Stream.of(Arguments.of(new ObjectNotModifiableException("1234", "test-type"), 423),
-                Arguments.of(new AuthenticationFailedException(), 401),
-                Arguments.of(new ObjectExistsException(Object.class, "test-object-id"), 409),
-                Arguments.of(new ObjectNotFoundException(Object.class, "test-object-id"), 404),
-                Arguments.of(new IllegalStateException("foo"), 503),
-                Arguments.of(new IllegalArgumentException("foo"), 400),
-                Arguments.of(new UnsupportedOperationException("foo"), 501),
-                Arguments.of(new NullPointerException("foo"), 400),
-                Arguments.of(new EdcException("foo"), 503),
-                Arguments.of(new NotAuthorizedException(), 403));
-    }
-
-    @BeforeEach
-    void setUp() {
-        mapper = new EdcApiExceptionMapper();
-    }
+    private final EdcApiExceptionMapper mapper = new EdcApiExceptionMapper();
 
     @ParameterizedTest
-    @MethodSource("getArgs")
+    @ArgumentsSource(EdcApiExceptions.class)
+    @ArgumentsSource(JakartaApiExceptions.class)
     void toResponse(Throwable throwable, int expectedCode) {
-        assertThat(mapper.toResponse(throwable)).extracting(Response::getStatus).isEqualTo(expectedCode);
+        var response = mapper.toResponse(throwable);
+
+        assertThat(response.getStatus()).isEqualTo(expectedCode);
+        assertThat(response.getStatusInfo().getReasonPhrase()).isNotBlank();
+    }
+
+    private static class EdcApiExceptions implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    Arguments.of(new ObjectNotModifiableException("1234", "test-type"), 409),
+                    Arguments.of(new AuthenticationFailedException(), 401),
+                    Arguments.of(new ObjectExistsException(Object.class, "test-object-id"), 409),
+                    Arguments.of(new ObjectNotFoundException(Object.class, "test-object-id"), 404),
+                    Arguments.of(new IllegalStateException("foo"), 503),
+                    Arguments.of(new IllegalArgumentException("foo"), 400),
+                    Arguments.of(new UnsupportedOperationException("foo"), 501),
+                    Arguments.of(new NullPointerException("foo"), 400),
+                    Arguments.of(new EdcException("foo"), 503),
+                    Arguments.of(new NotAuthorizedException(), 403)
+            );
+        }
+    }
+
+    private static class JakartaApiExceptions implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    Arguments.of(new NotAcceptableException("Not acceptable"), 406),
+                    Arguments.of(new NotFoundException(), 404),
+                    Arguments.of(new NotSupportedException(), 415),
+                    Arguments.of(new NotAllowedException("any"), 405)
+            );
+        }
     }
 }

--- a/extensions/data-plane-selector/selector-api/src/test/java/org/eclipse/dataspaceconnector/dataplane/selector/api/DataplaneSelectorApiControllerIntegrationTest.java
+++ b/extensions/data-plane-selector/selector-api/src/test/java/org/eclipse/dataspaceconnector/dataplane/selector/api/DataplaneSelectorApiControllerIntegrationTest.java
@@ -232,7 +232,6 @@ class DataplaneSelectorApiControllerIntegrationTest {
         var body = RequestBody.create(objectMapper.writeValueAsString(rq), JSON_TYPE);
         try (var response = post(basePath() + "/select", body)) {
             assertThat(response.code()).isEqualTo(400);
-            assertThat(response.body().string()).isEqualTo("Strategy non-exist was not found"); //should be equal to the exception text
         }
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Makes `EdcApiExceptionMapper` handle `jakarta.ws.rs` exceptions correctly

## Why it does that

To avoid unclear `503` status response (see #1101 )

## Further notes

- The mapper now does not return the exception message as the body, because it's not a secure behavior, it's always better to hide exception details to the outside, or at least report them in a way that is not related to the exception itself (e.g. the `EdcApiException` could have an optional field that brings an object that should be used as body for the response.
- A status description is added as `reasonPhrase` to detail the error type.
- The `ObjectNotModifiableException` (that's currently not used anywhere in the application) has been switched to `409` because `423` is not a state described by the jakarta's `Status` enum and it's also not mentioned in the [mozilla http status list](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status) or by [w3c](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html) so probably is not a standard one.
- Removed the body assertion on `DataplaneSelectorApiControllerIntegrationTest.select_selectionStrategyNotFound` because as I reported before, this is a practice that needs to be standardized avoiding the use of the exception message.

## Linked Issue(s)

Closes #1101 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
