### PR TITLE
Bugfix: update `ContractAgreement`, when `ContractNegotiation` is updated

### DIFF
--- a/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/ContractNegotiationStatements.java
+++ b/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/ContractNegotiationStatements.java
@@ -37,13 +37,15 @@ public interface ContractNegotiationStatements extends LeaseStatements {
 
     String getNextForStateTemplate();
 
-    String getQueryTemplate();
+    String getQueryNegotiationsTemplate();
 
     String getQueryAgreementsTemplate();
 
     String getInsertAgreementTemplate();
 
     String getSelectByPolicyIdTemplate();
+
+    String getUpdateAgreementTemplate();
 
     @Override
     default String getLeasedByColumn() {

--- a/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/PostgresStatements.java
+++ b/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/PostgresStatements.java
@@ -45,13 +45,15 @@ public final class PostgresStatements implements ContractNegotiationStatements {
     @Override
     public String getUpdateNegotiationTemplate() {
         return format("UPDATE %s\n" +
-                "SET %s=?,\n" +
-                "    %s=?,\n" +
-                "    %s=?,\n" +
-                "    %s=?,\n" +
-                "    %s=?,\n" +
-                "    %s=?\n" +
-                "WHERE id = ?;", getContractNegotiationTable(), getStateColumn(), getStateCountColumn(), getStateTimestampColumn(), getErrorDetailColumn(), getContractOffersColumn(), getTraceContextColumn());
+                        "SET %s=?,\n" +
+                        "    %s=?,\n" +
+                        "    %s=?,\n" +
+                        "    %s=?,\n" +
+                        "    %s=?,\n" +
+                        "    %s=?,\n" +
+                        "    %s=?\n" +
+                        "WHERE id = ?;", getContractNegotiationTable(), getStateColumn(), getStateCountColumn(), getStateTimestampColumn(),
+                getErrorDetailColumn(), getContractOffersColumn(), getTraceContextColumn(), getContractAgreementIdFkColumn());
     }
 
     @Override
@@ -77,9 +79,9 @@ public final class PostgresStatements implements ContractNegotiationStatements {
     }
 
     @Override
-    public String getQueryTemplate() {
+    public String getQueryNegotiationsTemplate() {
         // todo: add WHERE ... AND ... ORDER BY... statements here
-        return format("SELECT * FROM %s LIMIT ? OFFSET ?;", getContractNegotiationTable());
+        return format("SELECT * FROM %s LEFT OUTER JOIN %s ON %s.%s = %s.%s LIMIT ? OFFSET ?;", getContractNegotiationTable(), getContractAgreementTable(), getContractNegotiationTable(), getContractAgreementIdFkColumn(), getContractAgreementTable(), getIdColumn());
     }
 
     @Override
@@ -98,6 +100,12 @@ public final class PostgresStatements implements ContractNegotiationStatements {
     @Override
     public String getSelectByPolicyIdTemplate() {
         return format("SELECT DISTINCT %s FROM %s WHERE %s = ?", getPolicyColumnSeralized(), getContractAgreementTable(), getPolicyIdColumn());
+    }
+
+    @Override
+    public String getUpdateAgreementTemplate() {
+        return format("UPDATE %s SET %s=?, %s=?, %s=?, %s=?, %s=?, %s=?, %s=?, %s=? WHERE %s =?", getContractAgreementTable(), getProviderAgentColumn(), getConsumerAgentColumn(),
+                getSigningDateColumn(), getStartDateColumn(), getEndDateColumn(), getAssetIdColumn(), getPolicyIdColumn(), getPolicyColumnSeralized(), getIdColumn());
     }
 
     @Override

--- a/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/PostgresStatements.java
+++ b/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/PostgresStatements.java
@@ -81,7 +81,8 @@ public final class PostgresStatements implements ContractNegotiationStatements {
     @Override
     public String getQueryNegotiationsTemplate() {
         // todo: add WHERE ... AND ... ORDER BY... statements here
-        return format("SELECT * FROM %s LEFT OUTER JOIN %s ON %s.%s = %s.%s LIMIT ? OFFSET ?;", getContractNegotiationTable(), getContractAgreementTable(), getContractNegotiationTable(), getContractAgreementIdFkColumn(), getContractAgreementTable(), getIdColumn());
+        return format("SELECT * FROM %s LEFT OUTER JOIN %s ON %s.%s = %s.%s LIMIT ? OFFSET ?;", getContractNegotiationTable(), getContractAgreementTable(),
+                getContractNegotiationTable(), getContractAgreementIdFkColumn(), getContractAgreementTable(), getIdColumn());
     }
 
     @Override

--- a/extensions/sql/contract-negotiation-store/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStoreTest.java
+++ b/extensions/sql/contract-negotiation-store/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStoreTest.java
@@ -76,6 +76,7 @@ class SqlContractNegotiationStoreTest {
         dataSourceRegistry = new LocalDataSourceRegistry(txManager);
         var transactionContext = (TransactionContext) txManager;
         var jdbcDataSource = new JdbcDataSource();
+//        jdbcDataSource.setURL("jdbc:h2:tcp://localhost:9092/default");
         jdbcDataSource.setURL("jdbc:h2:mem:");
 
         var connection = jdbcDataSource.getConnection();
@@ -287,6 +288,49 @@ class SqlContractNegotiationStoreTest {
     }
 
     @Test
+    @DisplayName("Should persist the agreement when a negotiation is updated")
+    void update_addsAgreement_shouldPersist() {
+        var negotiationId = "test-cn1";
+        var negotiation = createNegotiation(negotiationId);
+        store.save(negotiation);
+
+        // now add the agreement
+        var agreement = createContract("test-ca1");
+        var updatedNegotiation = createNegotiation(negotiationId, agreement);
+
+        store.save(updatedNegotiation); //should perform an update + insert
+
+        assertThat(store.queryAgreements(QuerySpec.none()))
+                .hasSize(1)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(agreement);
+
+        assertThat(Objects.requireNonNull(store.find(negotiationId)).getContractAgreement()).isEqualTo(agreement);
+    }
+
+    @Test
+    @DisplayName("Should update the agreement when a negotiation is updated")
+    void update_whenAgreementExists_shouldUpdate() {
+        var negotiationId = "test-cn1";
+        var agreement = createContract("test-ca1");
+        var negotiation = createNegotiation(negotiationId, agreement);
+        store.save(negotiation);
+        var dbNegotiation = store.find(negotiationId);
+        assertThat(dbNegotiation.getContractAgreement().getPolicy().getExtensibleProperties()).isEmpty();
+
+        // now add the agreement
+        agreement.getPolicy().getExtensibleProperties().put("somekey", "someval");
+        store.save(negotiation); //should perform an update + insert
+
+
+        var updatedNegotiation = store.find(negotiationId);
+        assertThat(updatedNegotiation).isNotNull();
+        assertThat(updatedNegotiation.getContractAgreement()).isNotNull();
+        assertThat(updatedNegotiation.getContractAgreement().getPolicy().getExtensibleProperties()).containsEntry("somekey", "someval");
+
+    }
+
+    @Test
     @DisplayName("Verify that an entity can be deleted")
     void delete() {
         var id = UUID.randomUUID().toString();
@@ -362,6 +406,27 @@ class SqlContractNegotiationStoreTest {
         var result = store.queryNegotiations(querySpec);
 
         assertThat(result).hasSize(10)
+                .extracting(ContractNegotiation::getId)
+                .map(Integer::parseInt)
+                .allMatch(i -> i > 4 && i < 15);
+    }
+
+    @Test
+    @DisplayName("Verify that paging is used")
+    void queryNegotiations_withAgreement() {
+        var querySpec = QuerySpec.Builder.newInstance().limit(10).offset(5).build();
+
+        IntStream.range(0, 100)
+                .mapToObj(i -> {
+                    var agreement = createContract("contract" + i);
+                    return createNegotiation("" + i, agreement);
+                })
+                .forEach(cn -> store.save(cn));
+
+        var result = store.queryNegotiations(querySpec);
+
+        assertThat(result).hasSize(10)
+                .allMatch(c -> c.getContractAgreement() != null)
                 .extracting(ContractNegotiation::getId)
                 .map(Integer::parseInt)
                 .allMatch(i -> i > 4 && i < 15);
@@ -538,6 +603,10 @@ class SqlContractNegotiationStoreTest {
         var archivedPolicy = store.findPolicyForContract("test-policy");
         assertThat(archivedPolicy).isNull();
         assertThat(store.findContractAgreement("test-contract")).isNotNull().extracting(ContractAgreement::getPolicy).isEqualTo(expectedPolicy);
+    }
+
+    private int count(String tableName) {
+        return executeQuery(getConnection(), "SELECT COUNT(*) FROM " + tableName);
     }
 
     private Connection getConnection() {

--- a/extensions/sql/contract-negotiation-store/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStoreTest.java
+++ b/extensions/sql/contract-negotiation-store/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStoreTest.java
@@ -76,7 +76,6 @@ class SqlContractNegotiationStoreTest {
         dataSourceRegistry = new LocalDataSourceRegistry(txManager);
         var transactionContext = (TransactionContext) txManager;
         var jdbcDataSource = new JdbcDataSource();
-//        jdbcDataSource.setURL("jdbc:h2:tcp://localhost:9092/default");
         jdbcDataSource.setURL("jdbc:h2:mem:");
 
         var connection = jdbcDataSource.getConnection();

--- a/extensions/sql/contract-negotiation-store/src/test/resources/schema.sql
+++ b/extensions/sql/contract-negotiation-store/src/test/resources/schema.sql
@@ -12,34 +12,6 @@
  *
  */
 
-/*
- *  Copyright (c) 2020 - 2022 Microsoft Corporation
- *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
- *
- *  SPDX-License-Identifier: Apache-2.0
- *
- *  Contributors:
- *       Microsoft Corporation - initial API and implementation
- *
- */
-
-/*
- *  Copyright (c) 2020 - 2022 Microsoft Corporation
- *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
- *
- *  SPDX-License-Identifier: Apache-2.0
- *
- *  Contributors:
- *       Microsoft Corporation - initial API and implementation
- *
- */
-
 CREATE TABLE IF NOT EXISTS edc_lease
 (
     leased_by      VARCHAR               NOT NULL,


### PR DESCRIPTION
## What this PR changes/adds

The `UPDATE` statement for the `ContractNegotiation` now also contains an entry for the `ContractAgreement`, so that it gets persisted as well.

## Why it does that

Was missing before.

## Further notes

the `queryNegotiations` method now also features a `JOIN` statement, so that `ContractAgreements` are fetched as well.

## Linked Issue(s)

Closes #1073 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
