### PR TITLE
Bugfix: changed colum name for Postgres to avoid ambiguity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ the detailed section referring to by linking pull requests or issues.
 
 #### Fixed
 
-* Hande Jakarta exception correctly (#1102)
+* Handle Jakarta exception correctly (#1102)
+* Fix Postgres column name (#1108)
 
 ## [milestone-3] - 2022-04-08
 

--- a/extensions/sql/contract-negotiation-store/docs/ddl_postgres.sql
+++ b/extensions/sql/contract-negotiation-store/docs/ddl_postgres.sql
@@ -22,7 +22,7 @@ CREATE UNIQUE INDEX lease_lease_id_uindex
 
 CREATE TABLE IF NOT EXISTS edc_contract_agreement
 (
-    id                VARCHAR NOT NULL
+    agreement_id      VARCHAR NOT NULL
         CONSTRAINT contract_agreement_pk
             PRIMARY KEY,
     provider_agent_id VARCHAR,
@@ -76,5 +76,5 @@ CREATE UNIQUE INDEX IF NOT EXISTS contract_negotiation_id_uindex
     ON edc_contract_negotiation (id);
 
 CREATE UNIQUE INDEX IF NOT EXISTS contract_agreement_id_uindex
-    ON edc_contract_agreement (id);
+    ON edc_contract_agreement (agreement_id);
 

--- a/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/ContractNegotiationStatements.java
+++ b/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/ContractNegotiationStatements.java
@@ -121,7 +121,7 @@ public interface ContractNegotiationStatements extends LeaseStatements {
     }
 
     default String getContractAgreementIdColumn() {
-        return "edc_contract_agreement.id";
+        return "agreement_id";
     }
 
     default String getAssetIdColumn() {

--- a/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/PostgresStatements.java
+++ b/extensions/sql/contract-negotiation-store/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/PostgresStatements.java
@@ -23,7 +23,7 @@ public final class PostgresStatements implements ContractNegotiationStatements {
     @Override
     public String getFindTemplate() {
         return format("SELECT * FROM %s LEFT OUTER JOIN %s ON %s.%s = %s.%s WHERE %s.%s = ?;", getContractNegotiationTable(), getContractAgreementTable(),
-                getContractNegotiationTable(), getContractAgreementIdFkColumn(), getContractAgreementTable(), getIdColumn(), getContractNegotiationTable(), getIdColumn());
+                getContractNegotiationTable(), getContractAgreementIdFkColumn(), getContractAgreementTable(), getContractAgreementIdColumn(), getContractNegotiationTable(), getIdColumn());
     }
 
     @Override
@@ -34,12 +34,12 @@ public final class PostgresStatements implements ContractNegotiationStatements {
 
     @Override
     public String getFindContractAgreementTemplate() {
-        return format("SELECT * FROM %s where %s=?;", getContractAgreementTable(), getIdColumn());
+        return format("SELECT * FROM %s where %s=?;", getContractAgreementTable(), getContractAgreementIdColumn());
     }
 
     @Override
     public String getFindContractAgreementByDefinitionIdTemplate() {
-        return format("SELECT * FROM %s where %s LIKE ?", getContractAgreementTable(), getIdColumn());
+        return format("SELECT * FROM %s where %s LIKE ?", getContractAgreementTable(), getContractAgreementIdColumn());
     }
 
     @Override
@@ -82,7 +82,7 @@ public final class PostgresStatements implements ContractNegotiationStatements {
     public String getQueryNegotiationsTemplate() {
         // todo: add WHERE ... AND ... ORDER BY... statements here
         return format("SELECT * FROM %s LEFT OUTER JOIN %s ON %s.%s = %s.%s LIMIT ? OFFSET ?;", getContractNegotiationTable(), getContractAgreementTable(),
-                getContractNegotiationTable(), getContractAgreementIdFkColumn(), getContractAgreementTable(), getIdColumn());
+                getContractNegotiationTable(), getContractAgreementIdFkColumn(), getContractAgreementTable(), getContractAgreementIdColumn());
     }
 
     @Override
@@ -94,7 +94,7 @@ public final class PostgresStatements implements ContractNegotiationStatements {
     @Override
     public String getInsertAgreementTemplate() {
         return format("INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s, %s, %s) " +
-                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);", getContractAgreementTable(), getIdColumn(), getProviderAgentColumn(), getConsumerAgentColumn(),
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);", getContractAgreementTable(), getContractAgreementIdColumn(), getProviderAgentColumn(), getConsumerAgentColumn(),
                 getSigningDateColumn(), getStartDateColumn(), getEndDateColumn(), getAssetIdColumn(), getPolicyIdColumn(), getPolicyColumnSeralized());
     }
 
@@ -106,7 +106,7 @@ public final class PostgresStatements implements ContractNegotiationStatements {
     @Override
     public String getUpdateAgreementTemplate() {
         return format("UPDATE %s SET %s=?, %s=?, %s=?, %s=?, %s=?, %s=?, %s=?, %s=? WHERE %s =?", getContractAgreementTable(), getProviderAgentColumn(), getConsumerAgentColumn(),
-                getSigningDateColumn(), getStartDateColumn(), getEndDateColumn(), getAssetIdColumn(), getPolicyIdColumn(), getPolicyColumnSeralized(), getIdColumn());
+                getSigningDateColumn(), getStartDateColumn(), getEndDateColumn(), getAssetIdColumn(), getPolicyIdColumn(), getPolicyColumnSeralized(), getContractAgreementIdColumn());
     }
 
     @Override

--- a/extensions/sql/contract-negotiation-store/src/test/resources/schema.sql
+++ b/extensions/sql/contract-negotiation-store/src/test/resources/schema.sql
@@ -34,7 +34,7 @@ CREATE UNIQUE INDEX lease_lease_id_uindex
 
 CREATE TABLE IF NOT EXISTS edc_contract_agreement
 (
-    id                VARCHAR NOT NULL
+    agreement_id      VARCHAR NOT NULL
         CONSTRAINT contract_agreement_pk
             PRIMARY KEY,
     provider_agent_id VARCHAR,
@@ -87,5 +87,5 @@ CREATE UNIQUE INDEX IF NOT EXISTS contract_negotiation_id_uindex
     ON edc_contract_negotiation (id);
 
 CREATE UNIQUE INDEX IF NOT EXISTS contract_agreement_id_uindex
-    ON edc_contract_agreement (id);
+    ON edc_contract_agreement (agreement_id);
 

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/negotiation/ContractNegotiation.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/negotiation/ContractNegotiation.java
@@ -317,7 +317,7 @@ public class ContractNegotiation implements TraceCarrier {
      */
     public void transitionConfirmed() {
         if (Type.CONSUMER == type) {
-            transition(CONFIRMED, CONSUMER_APPROVED, REQUESTED, CONSUMER_OFFERED, CONFIRMED);
+            transition(CONFIRMED, CONFIRMING, CONSUMER_APPROVED, REQUESTED, CONSUMER_OFFERED, CONFIRMED);
         } else {
             transition(CONFIRMED, CONFIRMING);
         }
@@ -367,11 +367,6 @@ public class ContractNegotiation implements TraceCarrier {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(id, correlationId, counterPartyId, protocol, traceContext, type, state, stateCount, stateTimestamp, contractAgreement, contractOffers);
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -384,6 +379,11 @@ public class ContractNegotiation implements TraceCarrier {
                 Objects.equals(correlationId, that.correlationId) && Objects.equals(counterPartyId, that.counterPartyId) &&
                 Objects.equals(protocol, that.protocol) && Objects.equals(traceContext, that.traceContext) &&
                 type == that.type && Objects.equals(contractAgreement, that.contractAgreement) && Objects.equals(contractOffers, that.contractOffers);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, correlationId, counterPartyId, protocol, traceContext, type, state, stateCount, stateTimestamp, contractAgreement, contractOffers);
     }
 
     private void checkState(int... legalStates) {


### PR DESCRIPTION
## What this PR changes/adds

In the Postgres implementation of the `ContractNegotiationStore` the column name for `ContractAgreement` was changed from `id` to `agreement_id` to avoid ambiguities when parsing the `ResultSet`. 
This never surfaced before, since all tests were done using H2, which apparently automatically prefixes the table name.

## Why it does that

Postgres seems to overwrite a `ResultSet` column when two columns (e.g. after a `JOIN`) have the same name. H2 does not have that problem, and automatically prefixes the table name in this case. Postgres does not, which caused an exception. To conquer this, the `edc_contract_agreement.id` was renamed to `edc_contract_agreement.agreement_id`. 

## Further notes

- I also discovered a problem in the contract negotiation manager: a transition from `CONFIRMING` to `CONFIRMED` was disallowed. **Is this a bug or is this intended behaviour?**

## Linked Issue(s)

Closes #1108 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
