### PR TITLE
ids: IDS policy fixes

### DIFF
--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/policy/IdsConstraintTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/policy/IdsConstraintTest.java
@@ -23,156 +23,152 @@ import de.fraunhofer.iais.eis.ConstraintImpl;
 import de.fraunhofer.iais.eis.Permission;
 import de.fraunhofer.iais.eis.PermissionBuilder;
 import de.fraunhofer.iais.eis.util.RdfResource;
+import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.net.URI;
+import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class IdsConstraintTest {
 
-    URI id = URI.create("id");
-    String leftOperand = "leftOperand";
-    BinaryOperator operator = BinaryOperator.AFTER;
-    RdfResource rightOperand = new RdfResource("test", URI.create("http://www.w3.org/2001/XMLSchema#string"));
-    URI reference = URI.create("reference");
-    URI unit = URI.create("unit");
-    URI endpoint = URI.create("endpoint");
+    private static final URI ID = URI.create("id");
+    private static final String LEFT_OPERAND = "leftOperand";
+    private static final BinaryOperator OPERATOR = BinaryOperator.AFTER;
+    private static final RdfResource RIGHT_OPERAND = new RdfResource("test", URI.create("http://www.w3.org/2001/XMLSchema#string"));
+    private static final URI REFERENCE = URI.create("reference");
+    private static final URI UNIT = URI.create("unit");
+    private static final URI ENDPOINT = URI.create("endpoint");
 
     @Test
     void setId() {
         /* ACT */
-        var result = new IdsConstraintBuilder(id).build();
+        var result = new IdsConstraintBuilder(ID).build();
 
         /* ASSERT */
         var value = result.getId();
-        assertNotNull(value);
-        assertEquals(id, value);
+        assertThat(value).isNotNull().isEqualTo(ID);
     }
 
     @Test
     void setLeftOperand() {
         /* ACT */
-        var result = (IdsConstraintImpl) new IdsConstraintBuilder().leftOperand(leftOperand).build();
+        var result = (IdsConstraintImpl) new IdsConstraintBuilder().leftOperand(LEFT_OPERAND).build();
 
         /* ASSERT */
         var value = result.getLeftOperandAsString();
-        assertNotNull(value);
-        assertNull(result.getLeftOperand());
-        assertEquals(leftOperand, value);
+        assertThat(value).isNotNull();
+        assertThat(result.getLeftOperand()).isNull();
+        assertThat(value).isEqualTo(LEFT_OPERAND);
     }
 
     @Test
     void setOperator() {
         /* ACT */
-        var result = new IdsConstraintBuilder().operator(operator).build();
+        var result = new IdsConstraintBuilder().operator(OPERATOR).build();
 
         /* ASSERT */
         var value = result.getOperator();
-        assertNotNull(value);
-        assertEquals(operator, value);
+        assertThat(value).isNotNull().isEqualTo(OPERATOR);
     }
 
     @Test
     void setRightOperand() {
         /* ACT */
-        var result = new IdsConstraintBuilder().rightOperand(rightOperand).build();
+        var result = new IdsConstraintBuilder().rightOperand(RIGHT_OPERAND).build();
 
         /* ASSERT */
         var value = result.getRightOperand();
-        assertNotNull(value);
-        assertEquals(rightOperand, value);
+        assertThat(value).isNotNull().isEqualTo(RIGHT_OPERAND);
     }
 
     @Test
     void setRightOperandReference() {
         /* ACT */
-        var result = new IdsConstraintBuilder().rightOperandReference(reference).build();
+        var result = new IdsConstraintBuilder().rightOperandReference(REFERENCE).build();
 
         /* ASSERT */
         var value = result.getRightOperandReference();
-        assertNotNull(value);
-        assertEquals(reference, value);
+        assertThat(value).isNotNull().isEqualTo(REFERENCE);
     }
 
     @Test
     void setUnit() {
         /* ACT */
-        var result = new IdsConstraintBuilder().unit(unit).build();
+        var result = new IdsConstraintBuilder().unit(UNIT).build();
 
         /* ASSERT */
         var value = result.getUnit();
-        assertNotNull(value);
-        assertEquals(unit, value);
+        assertThat(value).isNotNull().isEqualTo(UNIT);
     }
 
     @Test
     void setPipEndpoint() {
         /* ACT */
-        var result = new IdsConstraintBuilder().pipEndpoint(endpoint).build();
+        var result = new IdsConstraintBuilder().pipEndpoint(ENDPOINT).build();
 
         /* ASSERT */
         var value = result.getPipEndpoint();
-        assertNotNull(value);
-        assertEquals(endpoint, value);
+        assertThat(value).isNotNull().isEqualTo(ENDPOINT);
     }
 
     @Test
     void build() {
         /* ACT */
-        var result = (IdsConstraintImpl) new IdsConstraintBuilder(id)
-                .leftOperand(leftOperand)
-                .operator(operator)
-                .rightOperand(rightOperand)
-                .rightOperandReference(reference)
-                .unit(unit)
-                .pipEndpoint(endpoint)
+        var result = (IdsConstraintImpl) new IdsConstraintBuilder(ID)
+                .leftOperand(LEFT_OPERAND)
+                .operator(OPERATOR)
+                .rightOperand(RIGHT_OPERAND)
+                .rightOperandReference(REFERENCE)
+                .unit(UNIT)
+                .pipEndpoint(ENDPOINT)
                 .build();
 
         /* ASSERT */
-        assertNotNull(result);
-        assertEquals(result.getId(), id);
-        assertEquals(result.getLeftOperandAsString(), leftOperand);
-        assertEquals(result.getOperator(), operator);
-        assertEquals(result.getRightOperand(), rightOperand);
-        assertEquals(result.getRightOperandReference(), reference);
-        assertEquals(result.getUnit(), unit);
-        assertEquals(result.getPipEndpoint(), endpoint);
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(ID);
+        assertThat(result.getLeftOperandAsString()).isEqualTo(LEFT_OPERAND);
+        assertThat(result.getOperator()).isEqualTo(OPERATOR);
+        assertThat(result.getRightOperand()).isEqualTo(RIGHT_OPERAND);
+        assertThat(result.getRightOperandReference()).isEqualTo(REFERENCE);
+        assertThat(result.getUnit()).isEqualTo(UNIT);
+        assertThat(result.getPipEndpoint()).isEqualTo(ENDPOINT);
     }
 
     @Test
     void serialize() throws JsonProcessingException {
         /* ARRANGE */
-        var constraint = (IdsConstraintImpl) new IdsConstraintBuilder(id)
-                .leftOperand(leftOperand)
-                .operator(operator)
-                .rightOperand(rightOperand)
-                .rightOperandReference(reference)
-                .unit(unit)
-                .pipEndpoint(endpoint)
+        var constraint = (IdsConstraintImpl) new IdsConstraintBuilder(ID)
+                .leftOperand(LEFT_OPERAND)
+                .operator(OPERATOR)
+                .rightOperand(RIGHT_OPERAND)
+                .rightOperandReference(REFERENCE)
+                .unit(UNIT)
+                .pipEndpoint(ENDPOINT)
                 .build();
 
         /* ACT */
         var result = new ObjectMapper().writeValueAsString(constraint);
 
         /* ASSERT */
-        assertNotEquals("", result);
+        assertThat(result).isNotBlank();
     }
 
     @Test
     void failedConstraintDeserialization() throws JsonProcessingException {
         /* ARRANGE */
-        var constraint = (IdsConstraintImpl) new IdsConstraintBuilder(id)
-                .leftOperand(leftOperand)
-                .operator(operator)
-                .rightOperand(rightOperand)
-                .rightOperandReference(reference)
-                .unit(unit)
-                .pipEndpoint(endpoint)
+        var constraint = (IdsConstraintImpl) new IdsConstraintBuilder(ID)
+                .leftOperand(LEFT_OPERAND)
+                .operator(OPERATOR)
+                .rightOperand(RIGHT_OPERAND)
+                .rightOperandReference(REFERENCE)
+                .unit(UNIT)
+                .pipEndpoint(ENDPOINT)
                 .build();
         var objectMapper = new ObjectMapper();
         var constraintAsString = objectMapper.writeValueAsString(constraint);
@@ -181,21 +177,21 @@ class IdsConstraintTest {
         var result = objectMapper.readValue(constraintAsString, Constraint.class);
 
         /* ASSERT */
-        assertNotNull(result);
-        assertTrue(result instanceof ConstraintImpl);
-        assertNull(result.getLeftOperand());
+        assertThat(result)
+                .isNotNull()
+                .isInstanceOf(ConstraintImpl.class);
+        assertThat(result.getLeftOperand()).isNull();
     }
 
     @Test
-    void deserializeConstraint() throws JsonProcessingException {
+    void deserializeConstraintWithRightOperand() throws JsonProcessingException {
         /* ARRANGE */
-        var constraint = (IdsConstraintImpl) new IdsConstraintBuilder(id)
-                .leftOperand(leftOperand)
-                .operator(operator)
-                .rightOperand(rightOperand)
-                .rightOperandReference(reference)
-                .unit(unit)
-                .pipEndpoint(endpoint)
+        var constraint = (IdsConstraintImpl) new IdsConstraintBuilder(ID)
+                .leftOperand(LEFT_OPERAND)
+                .operator(OPERATOR)
+                .rightOperand(RIGHT_OPERAND)
+                .unit(UNIT)
+                .pipEndpoint(ENDPOINT)
                 .build();
 
         var objectMapper = new ObjectMapper();
@@ -206,29 +202,90 @@ class IdsConstraintTest {
         var result = objectMapper.readValue(constraintAsString, Constraint.class);
 
         /* ASSERT */
-        assertNotNull(result);
-        assertTrue(result instanceof IdsConstraintImpl);
-        assertNull(result.getLeftOperand());
-        assertEquals(id, result.getId());
-        assertEquals(leftOperand, ((IdsConstraintImpl) result).getLeftOperandAsString());
-        assertEquals(operator, result.getOperator());
-        assertEquals(endpoint, result.getPipEndpoint());
-        assertEquals(rightOperand.getType(), result.getRightOperand().getType());
-        assertEquals(rightOperand.getValue(), result.getRightOperand().getValue());
-        assertEquals(reference, result.getRightOperandReference());
-        assertEquals(unit, result.getUnit());
+        assertThat(result).isNotNull().isInstanceOf(IdsConstraintImpl.class);
+        assertThat(result.getLeftOperand()).isNull();
+        assertThat(result.getId()).isEqualTo(ID);
+        assertThat(((IdsConstraintImpl) result).getLeftOperandAsString()).isEqualTo(LEFT_OPERAND);
+        assertThat(result.getOperator()).isEqualTo(OPERATOR);
+        assertThat(result.getPipEndpoint()).isEqualTo(ENDPOINT);
+        assertThat(result.getRightOperand().getType()).isEqualTo(RIGHT_OPERAND.getType());
+        assertThat(result.getRightOperand().getValue()).isEqualTo(RIGHT_OPERAND.getValue());
+        assertThat(result.getRightOperandReference()).isNull();
+        assertThat(result.getUnit()).isEqualTo(UNIT);
     }
+
+    @Test
+    void deserializeConstraintWithRightOperandReference() throws JsonProcessingException {
+        /* ARRANGE */
+        var constraint = (IdsConstraintImpl) new IdsConstraintBuilder(ID)
+                .leftOperand(LEFT_OPERAND)
+                .operator(OPERATOR)
+                .rightOperandReference(REFERENCE)
+                .unit(UNIT)
+                .pipEndpoint(ENDPOINT)
+                .build();
+
+        var objectMapper = new ObjectMapper();
+        objectMapper.registerSubtypes(IdsConstraintImpl.class);
+        var constraintAsString = objectMapper.writeValueAsString(constraint);
+
+        /* ACT */
+        var result = objectMapper.readValue(constraintAsString, Constraint.class);
+
+        /* ASSERT */
+        assertThat(result).isNotNull().isInstanceOf(IdsConstraintImpl.class);
+        assertThat(result.getLeftOperand()).isNull();
+        assertThat(result.getId()).isEqualTo(ID);
+        assertThat(((IdsConstraintImpl) result).getLeftOperandAsString()).isEqualTo(LEFT_OPERAND);
+        assertThat(result.getOperator()).isEqualTo(OPERATOR);
+        assertThat(result.getPipEndpoint()).isEqualTo(ENDPOINT);
+        assertThat(result.getRightOperand()).isNull();
+        assertThat(result.getRightOperandReference()).isEqualTo(REFERENCE);
+        assertThat(result.getUnit()).isEqualTo(UNIT);
+    }
+
+    /**
+     * Ensure proper {@link Constraint} mapping even if optional properties "unit" and "pipEndpoint" are not provided.
+     */
+    @Test
+    void deserializeConstraintWithoutOptionalFields() throws JsonProcessingException {
+        /* ARRANGE */
+        var constraint = (IdsConstraintImpl) new IdsConstraintBuilder(ID)
+                .leftOperand(LEFT_OPERAND)
+                .operator(OPERATOR)
+                .rightOperand(RIGHT_OPERAND)
+                .build();
+
+        var objectMapper = new ObjectMapper();
+        objectMapper.registerSubtypes(IdsConstraintImpl.class);
+        var constraintAsString = objectMapper.writeValueAsString(constraint);
+
+        /* ACT */
+        var result = objectMapper.readValue(constraintAsString, Constraint.class);
+
+        /* ASSERT */
+        assertThat(result).isNotNull().isInstanceOf(IdsConstraintImpl.class);
+        assertThat(result.getLeftOperand()).isNull();
+        assertThat(result.getId()).isEqualTo(ID);
+        assertThat(((IdsConstraintImpl) result).getLeftOperandAsString()).isEqualTo(LEFT_OPERAND);
+        assertThat(result.getOperator()).isEqualTo(OPERATOR);
+        assertThat(result.getRightOperand().getType()).isEqualTo(RIGHT_OPERAND.getType());
+        assertThat(result.getRightOperand().getValue()).isEqualTo(RIGHT_OPERAND.getValue());
+        assertThat(result.getUnit()).isNull();
+        assertThat(result.getPipEndpoint()).isNull();
+    }
+
 
     @Test
     void deserializePermission() throws JsonProcessingException {
         /* ARRANGE */
-        var constraint = (IdsConstraintImpl) new IdsConstraintBuilder(id)
-                .leftOperand(leftOperand)
-                .operator(operator)
-                .rightOperand(rightOperand)
-                .rightOperandReference(reference)
-                .unit(unit)
-                .pipEndpoint(endpoint)
+        var constraint = (IdsConstraintImpl) new IdsConstraintBuilder(ID)
+                .leftOperand(LEFT_OPERAND)
+                .operator(OPERATOR)
+                .rightOperand(RIGHT_OPERAND)
+                .rightOperandReference(REFERENCE)
+                .unit(UNIT)
+                .pipEndpoint(ENDPOINT)
                 .build();
         var permission = new PermissionBuilder()
                 ._action_(Action.USE)
@@ -246,20 +303,56 @@ class IdsConstraintTest {
         var result = objectMapper.readValue(permissionAsString, Permission.class);
 
         /* ASSERT */
-        assertNotNull(result);
-        assertNotNull(result.getConstraint());
+        assertThat(result).isNotNull();
+        assertThat(result.getConstraint()).isNotNull();
 
         var resultConstraint = (Constraint) result.getConstraint().get(0);
-        assertNotNull(resultConstraint);
-        assertTrue(resultConstraint instanceof IdsConstraintImpl);
-        assertNull(resultConstraint.getLeftOperand());
-        assertEquals(id, resultConstraint.getId());
-        assertEquals(leftOperand, ((IdsConstraintImpl) resultConstraint).getLeftOperandAsString());
-        assertEquals(operator, resultConstraint.getOperator());
-        assertEquals(endpoint, resultConstraint.getPipEndpoint());
-        assertEquals(rightOperand.getType(), resultConstraint.getRightOperand().getType());
-        assertEquals(rightOperand.getValue(), resultConstraint.getRightOperand().getValue());
-        assertEquals(reference, resultConstraint.getRightOperandReference());
-        assertEquals(unit, resultConstraint.getUnit());
+        assertThat(resultConstraint).isNotNull().isInstanceOf(IdsConstraintImpl.class);
+        assertThat(resultConstraint.getLeftOperand()).isNull();
+        assertThat(resultConstraint.getId()).isEqualTo(ID);
+        assertThat(((IdsConstraintImpl) resultConstraint).getLeftOperandAsString()).isEqualTo(LEFT_OPERAND);
+        assertThat(resultConstraint.getOperator()).isEqualTo(OPERATOR);
+        assertThat(resultConstraint.getPipEndpoint()).isEqualTo(ENDPOINT);
+        assertThat(resultConstraint.getRightOperand().getType()).isEqualTo(RIGHT_OPERAND.getType());
+        assertThat(resultConstraint.getRightOperand().getValue()).isEqualTo(RIGHT_OPERAND.getValue());
+        assertThat(resultConstraint.getRightOperandReference()).isNull(); // reference is ignored when right operand is provided
+        assertThat(resultConstraint.getUnit()).isEqualTo(UNIT);
+    }
+
+    @ParameterizedTest(name = "{index} {0}")
+    @MethodSource("provideInvalidConstraints")
+    void deserializeFailureIfIncorrectInput_shouldThrowEdcException(String name, Constraint constraint) throws JsonProcessingException {
+        /* ARRANGE */
+        var idsConstraint = (IdsConstraintImpl) constraint;
+
+        var objectMapper = new ObjectMapper();
+        objectMapper.registerSubtypes(IdsConstraintImpl.class);
+        var constraintAsString = objectMapper.writeValueAsString(idsConstraint);
+
+        /* ASSERT */
+        assertThatExceptionOfType(EdcException.class).isThrownBy(() -> objectMapper.readValue(constraintAsString, Constraint.class));
+    }
+
+    private static Stream<Arguments> provideInvalidConstraints() {
+        var noLeftOperand = (IdsConstraintImpl) new IdsConstraintBuilder(ID)
+                .operator(OPERATOR)
+                .rightOperand(RIGHT_OPERAND)
+                .build();
+
+        var noOperator = (IdsConstraintImpl) new IdsConstraintBuilder(ID)
+                .leftOperand(LEFT_OPERAND)
+                .rightOperand(RIGHT_OPERAND)
+                .build();
+
+        var noRightOperandOrReference = (IdsConstraintImpl) new IdsConstraintBuilder(ID)
+                .leftOperand(LEFT_OPERAND)
+                .operator(OPERATOR)
+                .build();
+
+        return Stream.of(
+                Arguments.of("NO LEFT OPERAND", noLeftOperand),
+                Arguments.of("NO OPERATOR", noOperator),
+                Arguments.of("NO RIGHT OPERAND OR REFERENCE", noRightOperandOrReference)
+        );
     }
 }

--- a/extensions/policy/ids-policy/src/main/java/org/eclipse/dataspaceconnector/ids/policy/IdsPolicyExtension.java
+++ b/extensions/policy/ids-policy/src/main/java/org/eclipse/dataspaceconnector/ids/policy/IdsPolicyExtension.java
@@ -16,10 +16,12 @@ package org.eclipse.dataspaceconnector.ids.policy;
 
 import org.eclipse.dataspaceconnector.policy.model.Permission;
 import org.eclipse.dataspaceconnector.spi.policy.PolicyEngine;
+import org.eclipse.dataspaceconnector.spi.policy.RuleBindingRegistry;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
+import static org.eclipse.dataspaceconnector.ids.spi.policy.IdsPolicyActions.USE;
 import static org.eclipse.dataspaceconnector.spi.policy.PolicyEngine.ALL_SCOPES;
 
 /**
@@ -27,8 +29,12 @@ import static org.eclipse.dataspaceconnector.spi.policy.PolicyEngine.ALL_SCOPES;
  */
 public class IdsPolicyExtension implements ServiceExtension {
 
-    public static String ABS_SPATIAL_POSITION = "ids:absoluteSpatialPosition";
-    public static String PARTNER_LEVEL = "ids:partnerLevel";
+    private static final String ABS_SPATIAL_POSITION = "ids:absoluteSpatialPosition";
+    private static final String PARTNER_LEVEL = "ids:partnerLevel";
+
+    @Inject
+    private RuleBindingRegistry ruleBindingRegistry;
+
     @Inject
     private PolicyEngine policyEngine;
 
@@ -39,9 +45,9 @@ public class IdsPolicyExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
+        ruleBindingRegistry.bind(USE, ALL_SCOPES);
 
         policyEngine.registerFunction(ALL_SCOPES, Permission.class, ABS_SPATIAL_POSITION, new AbsSpatialPositionConstraintFunction());
         policyEngine.registerFunction(ALL_SCOPES, Permission.class, PARTNER_LEVEL, new PartnerLevelConstraintFunction());
     }
-
 }


### PR DESCRIPTION

## What this PR changes/adds

This PR brings two fixes for IDS policies:
 - add binding for _USE_ action to _ALL_SCOPE_ (otherwise, policy constraints are never evaluated)
 - improve resiliency of CustomIdsConstraintDeserializer as it was not properly checking potentially null values before using them.

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
