### PR TITLE
CI: add checkstyle rule for Java file headers

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -18,14 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
-
       # lets run Checkstyle explicitly (as opposed to within gradle) due to better reporting capabilities
       - name: Run Checkstyle
+        if: github.event_name == 'pull_request'
         uses: nikitasavinov/checkstyle-action@0.4.0
         with:
           checkstyle_config: resources/edc-checkstyle-config.xml
@@ -33,8 +28,10 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tool_name: 'checkstyle'
           checkstyle_version: '9.0'
-          reporter: 'github-check'
-          filter_mode: 'nofilter'
+          # Filtering does not work on github-check, needs github-pr-check
+          reporter: 'github-pr-check'
+          # Include only violations on added or modified files
+          filter_mode: 'file'
 
   Dependency-analysis:
     runs-on: ubuntu-latest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,8 +79,7 @@ allprojects {
     checkstyle {
         toolVersion = "9.0"
         configFile = rootProject.file("resources/edc-checkstyle-config.xml")
-        maxErrors = 0 // does not tolerate errors ...
-        maxWarnings = 0 // ... or warnings
+        maxErrors = 0 // does not tolerate errors
     }
 
     java {

--- a/buildSrc/src/main/java/org/eclipse/dataspaceconnector/gradle/DependencyRulesPlugin.java
+++ b/buildSrc/src/main/java/org/eclipse/dataspaceconnector/gradle/DependencyRulesPlugin.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.gradle;
 
 import org.gradle.api.Plugin;

--- a/buildSrc/src/main/java/org/eclipse/dataspaceconnector/gradle/DependencyRulesPluginExtension.java
+++ b/buildSrc/src/main/java/org/eclipse/dataspaceconnector/gradle/DependencyRulesPluginExtension.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.gradle;
 
 import org.gradle.api.provider.Property;

--- a/buildSrc/src/main/java/org/eclipse/dataspaceconnector/gradle/DependencyRulesTask.java
+++ b/buildSrc/src/main/java/org/eclipse/dataspaceconnector/gradle/DependencyRulesTask.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.gradle;
 
 import org.gradle.api.DefaultTask;

--- a/common/util/src/test/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctionsTest.java
+++ b/common/util/src/test/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctionsTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.common.configuration;
 
 import org.junit.jupiter.api.AfterEach;

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
  */
 
 package org.eclipse.dataspaceconnector.contract.negotiation;

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/SendRetryManager.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/SendRetryManager.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.transfer.core.transfer;
 
 /**

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessSendRetryManager.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessSendRetryManager.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.transfer.core.transfer;
 
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessSendRetryManagerTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessSendRetryManagerTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.transfer.core.transfer;
 
 import com.github.javafaker.Faker;

--- a/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/exception/mappers/EdcApiExceptionMapper.java
+++ b/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/exception/mappers/EdcApiExceptionMapper.java
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
+ *
  */
 
 package org.eclipse.dataspaceconnector.api.exception.mappers;

--- a/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/service/PolicyService.java
+++ b/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/service/PolicyService.java
@@ -1,14 +1,15 @@
 /*
- * Copyright (c) 2022 ZF Friedrichshafen AG
+ *  Copyright (c) 2022 ZF Friedrichshafen AG
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * Contributors:
- *    ZF Friedrichshafen AG - Initial API and Implementation
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial API and Implementation
+ *
  */
 
 package org.eclipse.dataspaceconnector.api.datamanagement.policy.service;

--- a/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/service/PolicyServiceImpl.java
+++ b/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/service/PolicyServiceImpl.java
@@ -1,14 +1,15 @@
 /*
- * Copyright (c) 2022 ZF Friedrichshafen AG
+ *  Copyright (c) 2022 ZF Friedrichshafen AG
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * Contributors:
- *    ZF Friedrichshafen AG - Initial API and Implementation
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial API and Implementation
+ *
  */
 
 package org.eclipse.dataspaceconnector.api.datamanagement.policy.service;

--- a/extensions/api/data-management/policydefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/TestFunctions.java
+++ b/extensions/api/data-management/policydefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/TestFunctions.java
@@ -1,14 +1,15 @@
 /*
- * Copyright (c) 2022 ZF Friedrichshafen AG
+ *  Copyright (c) 2022 ZF Friedrichshafen AG
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * Contributors:
- *    ZF Friedrichshafen AG - Initial API and Implementation
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial API and Implementation
+ *
  */
 
 package org.eclipse.dataspaceconnector.api.datamanagement.policy;

--- a/extensions/api/data-management/policydefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/service/PolicyServiceImplTest.java
+++ b/extensions/api/data-management/policydefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/service/PolicyServiceImplTest.java
@@ -1,14 +1,15 @@
 /*
- * Copyright (c) 2022 ZF Friedrichshafen AG
+ *  Copyright (c) 2022 ZF Friedrichshafen AG
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * Contributors:
- *    ZF Friedrichshafen AG - Initial API and Implementation
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial API and Implementation
+ *
  */
 
 package org.eclipse.dataspaceconnector.api.datamanagement.policy.service;

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferRequestDtoToDataRequestTransformerTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferRequestDtoToDataRequestTransformerTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform;
 
 import com.github.javafaker.Faker;

--- a/extensions/aws/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/DataPlaneS3Extension.java
+++ b/extensions/aws/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/DataPlaneS3Extension.java
@@ -11,6 +11,7 @@
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
+
 package org.eclipse.dataspaceconnector.aws.dataplane.s3;
 
 import org.eclipse.dataspaceconnector.aws.s3.core.S3ClientProvider;

--- a/extensions/aws/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataSink.java
+++ b/extensions/aws/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataSink.java
@@ -11,6 +11,7 @@
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
+
 package org.eclipse.dataspaceconnector.aws.dataplane.s3;
 
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSource;

--- a/extensions/aws/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataSinkFactory.java
+++ b/extensions/aws/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataSinkFactory.java
@@ -11,6 +11,7 @@
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
+
 package org.eclipse.dataspaceconnector.aws.dataplane.s3;
 
 import org.eclipse.dataspaceconnector.aws.dataplane.s3.validation.S3DataAddressCredentialsValidationRule;

--- a/extensions/aws/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataSource.java
+++ b/extensions/aws/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataSource.java
@@ -11,6 +11,7 @@
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
+
 package org.eclipse.dataspaceconnector.aws.dataplane.s3;
 
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSource;

--- a/extensions/aws/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataSourceFactory.java
+++ b/extensions/aws/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataSourceFactory.java
@@ -11,6 +11,7 @@
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
+
 package org.eclipse.dataspaceconnector.aws.dataplane.s3;
 
 import org.eclipse.dataspaceconnector.aws.dataplane.s3.validation.S3DataAddressCredentialsValidationRule;

--- a/extensions/aws/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/validation/CompositeValidationRule.java
+++ b/extensions/aws/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/validation/CompositeValidationRule.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.aws.dataplane.s3.validation;
 
 import org.eclipse.dataspaceconnector.spi.result.Result;

--- a/extensions/aws/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/validation/EmptyValueValidationRule.java
+++ b/extensions/aws/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/validation/EmptyValueValidationRule.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.aws.dataplane.s3.validation;
 
 import org.eclipse.dataspaceconnector.common.string.StringUtils;

--- a/extensions/aws/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/validation/S3DataAddressCredentialsValidationRule.java
+++ b/extensions/aws/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/validation/S3DataAddressCredentialsValidationRule.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.aws.dataplane.s3.validation;
 
 import org.eclipse.dataspaceconnector.spi.result.Result;

--- a/extensions/aws/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/validation/S3DataAddressValidationRule.java
+++ b/extensions/aws/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/validation/S3DataAddressValidationRule.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.aws.dataplane.s3.validation;
 
 import org.eclipse.dataspaceconnector.spi.result.Result;

--- a/extensions/aws/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/validation/ValidationRule.java
+++ b/extensions/aws/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/validation/ValidationRule.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.aws.dataplane.s3.validation;
 
 import org.eclipse.dataspaceconnector.spi.result.Result;

--- a/extensions/aws/data-plane-s3/src/test/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/DataPlaneS3ExtensionTest.java
+++ b/extensions/aws/data-plane-s3/src/test/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/DataPlaneS3ExtensionTest.java
@@ -11,6 +11,7 @@
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
+
 package org.eclipse.dataspaceconnector.aws.dataplane.s3;
 
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.PipelineService;

--- a/extensions/aws/data-plane-s3/src/test/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataPlaneIntegrationTest.java
+++ b/extensions/aws/data-plane-s3/src/test/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataPlaneIntegrationTest.java
@@ -11,6 +11,7 @@
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
+
 package org.eclipse.dataspaceconnector.aws.dataplane.s3;
 
 import com.github.javafaker.Faker;

--- a/extensions/aws/data-plane-s3/src/test/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataSinkFactoryTest.java
+++ b/extensions/aws/data-plane-s3/src/test/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataSinkFactoryTest.java
@@ -11,6 +11,7 @@
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
+
 package org.eclipse.dataspaceconnector.aws.dataplane.s3;
 
 import org.eclipse.dataspaceconnector.aws.s3.core.AwsSecretToken;

--- a/extensions/aws/data-plane-s3/src/test/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataSourceFactoryTest.java
+++ b/extensions/aws/data-plane-s3/src/test/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataSourceFactoryTest.java
@@ -11,6 +11,7 @@
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
+
 package org.eclipse.dataspaceconnector.aws.dataplane.s3;
 
 import org.eclipse.dataspaceconnector.aws.s3.core.S3BucketSchema;

--- a/extensions/aws/data-plane-s3/src/test/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/TestFunctions.java
+++ b/extensions/aws/data-plane-s3/src/test/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/TestFunctions.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.aws.dataplane.s3;
 
 import org.eclipse.dataspaceconnector.aws.s3.core.S3BucketSchema;

--- a/extensions/aws/data-plane-s3/src/test/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/validation/ValidationRuleTest.java
+++ b/extensions/aws/data-plane-s3/src/test/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/validation/ValidationRuleTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.aws.dataplane.s3.validation;
 
 import org.eclipse.dataspaceconnector.spi.result.Result;

--- a/extensions/aws/s3/s3-core/src/main/java/org/eclipse/dataspaceconnector/aws/s3/core/S3CoreExtension.java
+++ b/extensions/aws/s3/s3-core/src/main/java/org/eclipse/dataspaceconnector/aws/s3/core/S3CoreExtension.java
@@ -11,6 +11,7 @@
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
+
 package org.eclipse.dataspaceconnector.aws.s3.core;
 
 import org.eclipse.dataspaceconnector.spi.system.Provides;

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/TestFunctions.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/TestFunctions.java
@@ -11,7 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *       Daimler TSS GmbH - fixed contract dates to epoch seconds
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - add functionalities
-  *
+ *
  */
 
 package org.eclipse.dataspaceconnector.contract.negotiation.store;

--- a/extensions/azure/cosmos/cosmos-common/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/cosmos/util/StoredProcedureTestUtils.java
+++ b/extensions/azure/cosmos/cosmos-common/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/cosmos/util/StoredProcedureTestUtils.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.azure.cosmos.util;
 
 import com.azure.cosmos.CosmosContainer;

--- a/extensions/data-plane/integration-tests/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/DataPlaneHttpPullIntegrationTests.java
+++ b/extensions/data-plane/integration-tests/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/DataPlaneHttpPullIntegrationTests.java
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Amadeus - initial API and implementation
  *       Mercedes Benz Tech Innovation - add toggles for proxy behavior
+ *
  */
 
 package org.eclipse.dataspaceconnector.dataplane.http;

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/config/ConfigParserTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/config/ConfigParserTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.provision.http.config;
 
 import org.eclipse.dataspaceconnector.spi.system.configuration.ConfigFactory;

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderProvisionerTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderProvisionerTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.provision.http.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderResourceDefinitionGeneratorTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderResourceDefinitionGeneratorTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.provision.http.impl;
 
 

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderResourceDefinitionTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderResourceDefinitionTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.provision.http.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.provision.http.impl;
 
 import okhttp3.Interceptor;

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProvisionerRequestTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProvisionerRequestTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.transfer.provision.http.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/resources/edc-checkstyle-config.xml
+++ b/resources/edc-checkstyle-config.xml
@@ -19,7 +19,7 @@
 <module name = "Checker">
   <property name="charset" value="UTF-8"/>
 
-  <property name="severity" value="warning"/>
+  <property name="severity" value="error"/>
 
   <property name="fileExtensions" value="java, properties, xml"/>
   <!-- Excludes all 'module-info.java' files              -->
@@ -44,6 +44,15 @@
     <property name="fileExtensions" value="java"/>
     <property name="max" value="250"/>
     <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+  </module>
+
+  <!-- Checks for header format                                   -->
+  <!-- See https://checkstyle.org/config_header.html#RegexpHeader -->
+  <module name="RegexpHeader">
+    <property name="severity" value="warning"/>
+    <property name="fileExtensions" value="java"/>
+    <property name="header" value="^/\*$\n^ \*  Copyright \(c\) 20\d\d((,| -) 20\d{2})? [A-Za-z].+\S$\n^ \*$\n^ \*  This program and the accompanying materials are made available under the$\n^ \*  terms of the Apache License, Version 2\.0 which is available at$\n^ \*  https://www\.apache\.org/licenses/LICENSE-2\.0$\n^ \*$\n^ \*  SPDX-License-Identifier: Apache-2\.0$\n^ \*$\n^ \*  Contributors:$\n^ \*       \S.*\S$\n^ \*$\n^ \*/$\n^$\n^package"/>
+    <property name="multiLines" value="11"/>
   </module>
 
   <module name="TreeWalker">

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/result/ResultTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/result/ResultTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.result;
 
 import org.junit.jupiter.api.Test;

--- a/spi/policy-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/store/PolicyStore.java
+++ b/spi/policy-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/store/PolicyStore.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *
  */
+
 package org.eclipse.dataspaceconnector.spi.policy.store;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;


### PR DESCRIPTION
## What this PR changes/adds

An added or modified file with a missing or wrong header causes a PR to fail, e.g. https://github.com/agera-edc/DataSpaceConnector/pull/184/checks?check_run_id=5732607179:

<img width="1322" alt="image" src="https://user-images.githubusercontent.com/22099722/160553529-850f62e1-b389-48dc-bd9e-b44d5b73327a.png">

## Why it does that

Improve code consistency and reduce spurious PR diffs.

## Further notes

This was previously introduced in #997 but later reversed since there were many PRs in flight that would have had to be rebased before the milestone. With #1042 and #1043 having already fixed headers in most files, this should not be an issue this time, also given only modified files result in PR check fails.

To make this check not blocking, also when running checkstyle gradle task:
- Changed the severity of all pre-existing checkstyle checks to *error*
- Set the checkstyle gradle task not to fail on *warning*
- Set the severity of the new checkstyle check  (for file header) to *warning*
- Changed the CI task to fail only on warnings/errors on changed files. For this to work properly, set the step to run only on PRs (not push)

Note that the header regex is quite hard to read in the XML definition. While it could be moved to a file, we would need to resolve the absolute path to it from submodules. This would require the root folder to be a a property, that devs would have to set in the IDE Plugin configuration. It seems easier to avoid this.

## Linked Issue(s)

Relates to #991 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
