### PR TITLE
Fix: corrects content types in DataManagementApi controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ in the detailed section referring to by linking pull requests or issues.
 ## [Unreleased]
 
 ### Overview
-
+Bugfixing DataManagementApi
 *
 
 ### Detailed Changes
@@ -31,6 +31,7 @@ in the detailed section referring to by linking pull requests or issues.
 
 * Handle Jakarta exception correctly (#1102)
 * Fix Postgres column name (#1108)
+* Fixed DMgmtApi content types (#1126)
 
 ## [milestone-3] - 2022-04-08
 

--- a/common/state-machine-lib/src/main/java/org/eclipse/dataspaceconnector/common/statemachine/StateMachine.java
+++ b/common/state-machine-lib/src/main/java/org/eclipse/dataspaceconnector/common/statemachine/StateMachine.java
@@ -50,7 +50,7 @@ public class StateMachine {
         this.name = name;
         this.monitor = monitor;
         this.waitStrategy = waitStrategy;
-        this.executor = instrumentation.instrument(
+        executor = instrumentation.instrument(
                 Executors.newSingleThreadScheduledExecutor(r -> {
                     var thread = Executors.defaultThreadFactory().newThread(r);
                     thread.setName("StateMachine-" + name);
@@ -68,17 +68,11 @@ public class StateMachine {
         return submit(0L);
     }
 
-    @NotNull
-    private Future<?> submit(long delayMillis) {
-        monitor.debug(format("StateMachine [%s] delaying for %d ms", name, delayMillis));
-        return executor.schedule(loop(), delayMillis, MILLISECONDS);
-    }
-
     /**
      * Stop the loop gracefully
      *
      * @return a future that will complete when the loop is fully stopped.
-     *         The content of the future will be true if stop happened before the timeout, false elsewhere.
+     * The content of the future will be true if stop happened before the timeout, false elsewhere.
      */
     public CompletableFuture<Boolean> stop() {
         active.set(false);
@@ -100,6 +94,12 @@ public class StateMachine {
      */
     public boolean isActive() {
         return active.get();
+    }
+
+    @NotNull
+    private Future<?> submit(long delayMillis) {
+//        monitor.debug(format("StateMachine [%s] delaying for %d ms", name, delayMillis));
+        return executor.schedule(loop(), delayMillis, MILLISECONDS);
     }
 
     private Runnable loop() {
@@ -139,7 +139,7 @@ public class StateMachine {
         private final StateMachine loop;
 
         private Builder(String name, Monitor monitor, ExecutorInstrumentation instrumentation, WaitStrategy waitStrategy) {
-            this.loop = new StateMachine(name, monitor, instrumentation, waitStrategy);
+            loop = new StateMachine(name, monitor, instrumentation, waitStrategy);
         }
 
         public static Builder newInstance(String name, Monitor monitor, ExecutorInstrumentation instrumentation, WaitStrategy waitStrategy) {

--- a/common/state-machine-lib/src/main/java/org/eclipse/dataspaceconnector/common/statemachine/StateMachine.java
+++ b/common/state-machine-lib/src/main/java/org/eclipse/dataspaceconnector/common/statemachine/StateMachine.java
@@ -71,8 +71,7 @@ public class StateMachine {
     /**
      * Stop the loop gracefully
      *
-     * @return a future that will complete when the loop is fully stopped.
-     * The content of the future will be true if stop happened before the timeout, false elsewhere.
+     * @return a future that will complete when the loop is fully stopped. The content of the future will be true if stop happened before the timeout, false elsewhere.
      */
     public CompletableFuture<Boolean> stop() {
         active.set(false);
@@ -98,7 +97,6 @@ public class StateMachine {
 
     @NotNull
     private Future<?> submit(long delayMillis) {
-//        monitor.debug(format("StateMachine [%s] delaying for %d ms", name, delayMillis));
         return executor.schedule(loop(), delayMillis, MILLISECONDS);
     }
 

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiController.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiController.java
@@ -46,8 +46,6 @@ import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 
-@Consumes({ MediaType.APPLICATION_JSON })
-@Produces({ MediaType.APPLICATION_JSON })
 @Path("/assets")
 public class AssetApiController implements AssetApi {
 
@@ -62,6 +60,7 @@ public class AssetApiController implements AssetApi {
     }
 
     @POST
+    @Consumes({ MediaType.APPLICATION_JSON })
     @Override
     public void createAsset(AssetEntryDto assetEntryDto) {
         var assetResult = transformerRegistry.transform(assetEntryDto.getAsset(), Asset.class);
@@ -84,6 +83,7 @@ public class AssetApiController implements AssetApi {
     }
 
     @GET
+    @Produces({ MediaType.APPLICATION_JSON })
     @Override
     public List<AssetDto> getAllAssets(@QueryParam("offset") Integer offset,
                                        @QueryParam("limit") Integer limit,
@@ -109,6 +109,7 @@ public class AssetApiController implements AssetApi {
 
     @GET
     @Path("{id}")
+    @Produces({ MediaType.APPLICATION_JSON })
     @Override
     public AssetDto getAsset(@PathParam("id") String id) {
         monitor.debug(format("Attempting to return Asset with id %s", id));
@@ -135,9 +136,12 @@ public class AssetApiController implements AssetApi {
 
     private void handleFailedResult(ServiceResult<Asset> result, String id) {
         switch (result.reason()) {
-            case NOT_FOUND: throw new ObjectNotFoundException(Asset.class, id);
-            case CONFLICT: throw new ObjectExistsException(Asset.class, id);
-            default: throw new EdcException("unexpected error");
+            case NOT_FOUND:
+                throw new ObjectNotFoundException(Asset.class, id);
+            case CONFLICT:
+                throw new ObjectExistsException(Asset.class, id);
+            default:
+                throw new EdcException("unexpected error");
         }
     }
 

--- a/extensions/api/data-management/contractagreement/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApiController.java
+++ b/extensions/api/data-management/contractagreement/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApiController.java
@@ -15,7 +15,6 @@
 
 package org.eclipse.dataspaceconnector.api.datamanagement.contractagreement;
 
-import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -38,8 +37,6 @@ import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 
-@Consumes({ MediaType.APPLICATION_JSON })
-@Produces({ MediaType.APPLICATION_JSON })
 @Path("/contractagreements")
 public class ContractAgreementApiController implements ContractAgreementApi {
     private final Monitor monitor;
@@ -53,6 +50,7 @@ public class ContractAgreementApiController implements ContractAgreementApi {
     }
 
     @GET
+    @Produces({ MediaType.APPLICATION_JSON })
     @Override
     public List<ContractAgreementDto> getAllAgreements(@QueryParam("offset") Integer offset,
                                                        @QueryParam("limit") Integer limit,
@@ -76,6 +74,7 @@ public class ContractAgreementApiController implements ContractAgreementApi {
 
     @GET
     @Path("{id}")
+    @Produces({ MediaType.APPLICATION_JSON })
     @Override
     public ContractAgreementDto getContractAgreement(@PathParam("id") String id) {
         monitor.debug(format("get contract agreement with ID %s", id));

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiController.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiController.java
@@ -43,8 +43,6 @@ import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 
-@Consumes({ MediaType.APPLICATION_JSON })
-@Produces({ MediaType.APPLICATION_JSON })
 @Path("/contractdefinitions")
 public class ContractDefinitionApiController implements ContractDefinitionApi {
     private final Monitor monitor;
@@ -58,6 +56,7 @@ public class ContractDefinitionApiController implements ContractDefinitionApi {
     }
 
     @GET
+    @Produces({ MediaType.APPLICATION_JSON })
     @Override
     public List<ContractDefinitionDto> getAllContractDefinitions(@QueryParam("offset") Integer offset,
                                                                  @QueryParam("limit") Integer limit,
@@ -81,6 +80,7 @@ public class ContractDefinitionApiController implements ContractDefinitionApi {
 
     @GET
     @Path("{id}")
+    @Produces({ MediaType.APPLICATION_JSON })
     @Override
     public ContractDefinitionDto getContractDefinition(@PathParam("id") String id) {
         monitor.debug(format("get contract definition with ID %s", id));
@@ -94,6 +94,7 @@ public class ContractDefinitionApiController implements ContractDefinitionApi {
     }
 
     @POST
+    @Consumes({ MediaType.APPLICATION_JSON })
     @Override
     public void createContractDefinition(ContractDefinitionDto dto) {
         monitor.debug("create new contract definition");
@@ -127,9 +128,12 @@ public class ContractDefinitionApiController implements ContractDefinitionApi {
 
     private void handleFailedResult(ServiceResult<ContractDefinition> result, String id) {
         switch (result.reason()) {
-            case NOT_FOUND: throw new ObjectNotFoundException(ContractDefinition.class, id);
-            case CONFLICT: throw new ObjectExistsException(ContractDefinition.class, id);
-            default: throw new EdcException("unexpected error");
+            case NOT_FOUND:
+                throw new ObjectNotFoundException(ContractDefinition.class, id);
+            case CONFLICT:
+                throw new ObjectExistsException(ContractDefinition.class, id);
+            default:
+                throw new EdcException("unexpected error");
         }
     }
 

--- a/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiController.java
+++ b/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiController.java
@@ -48,8 +48,6 @@ import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 
-@Consumes({ MediaType.APPLICATION_JSON })
-@Produces({ MediaType.APPLICATION_JSON })
 @Path("/contractnegotiations")
 public class ContractNegotiationApiController implements ContractNegotiationApi {
     private final Monitor monitor;
@@ -63,6 +61,7 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
     }
 
     @GET
+    @Produces({ MediaType.APPLICATION_JSON })
     @Override
     public List<ContractNegotiationDto> getNegotiations(@QueryParam("offset") Integer offset,
                                                         @QueryParam("limit") Integer limit,
@@ -88,6 +87,7 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
 
     @GET
     @Path("/{id}")
+    @Produces({ MediaType.APPLICATION_JSON })
     @Override
     public ContractNegotiationDto getNegotiation(@PathParam("id") String id) {
         monitor.debug(format("Get contract negotiation with id %s", id));
@@ -102,6 +102,7 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
 
     @GET
     @Path("/{id}/state")
+    @Produces({ MediaType.TEXT_PLAIN })
     @Override
     public String getNegotiationState(@PathParam("id") String id) {
         monitor.debug(format("Get contract negotiation state with id %s", id));
@@ -112,6 +113,7 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
 
     @GET
     @Path("/{id}/agreement")
+    @Produces({ MediaType.APPLICATION_JSON })
     @Override
     public ContractAgreementDto getAgreementForNegotiation(@PathParam("id") String negotiationId) {
         monitor.debug(format("Get contract agreement of negotiation with id %s", negotiationId));
@@ -125,6 +127,8 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
     }
 
     @POST
+    @Consumes({ MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_PLAIN })
     @Override
     public String initiateContractNegotiation(NegotiationInitiateRequestDto initiateDto) {
         if (!isValid(initiateDto)) {

--- a/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformer.java
+++ b/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformer.java
@@ -16,7 +16,7 @@ package org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.tr
 
 import org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.model.NegotiationInitiateRequestDto;
 import org.eclipse.dataspaceconnector.api.transformer.DtoTransformer;
-import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractOfferRequest;
@@ -25,6 +25,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.net.URI;
+
+import java.net.URISyntaxException;
 
 public class NegotiationInitiateRequestDtoToDataRequestTransformer implements DtoTransformer<NegotiationInitiateRequestDto, ContractOfferRequest> {
     @Override
@@ -44,9 +46,9 @@ public class NegotiationInitiateRequestDtoToDataRequestTransformer implements Dt
                 .id(object.getOffer().getOfferId())
                 .asset(Asset.Builder.newInstance().id(object.getOffer().getAssetId()).build())
                 .policyId(object.getOffer().getPolicyId())
+                .consumer(uri("urn:connector:consumer"))
+                .provider(uri("urn:connector:provider"))
                 .policy(object.getOffer().getPolicy())
-                .consumer(URI.create("http://localhost")) // TODO: this needs to be obtained
-                .provider(URI.create("http://localhost")) // TODO: this needs to be obtained
                 .build();
         return ContractOfferRequest.Builder.newInstance()
                 .connectorId(object.getConnectorId())
@@ -55,5 +57,13 @@ public class NegotiationInitiateRequestDtoToDataRequestTransformer implements Dt
                 .contractOffer(contractOffer)
                 .type(ContractOfferRequest.Type.INITIAL)
                 .build();
+    }
+
+    private URI uri(String s) {
+        try {
+            return new URI(s);
+        } catch (URISyntaxException e) {
+            throw new EdcException(e);
+        }
     }
 }

--- a/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformer.java
+++ b/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformer.java
@@ -25,7 +25,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.net.URI;
-
 import java.net.URISyntaxException;
 
 public class NegotiationInitiateRequestDtoToDataRequestTransformer implements DtoTransformer<NegotiationInitiateRequestDto, ContractOfferRequest> {
@@ -46,6 +45,7 @@ public class NegotiationInitiateRequestDtoToDataRequestTransformer implements Dt
                 .id(object.getOffer().getOfferId())
                 .asset(Asset.Builder.newInstance().id(object.getOffer().getAssetId()).build())
                 .policyId(object.getOffer().getPolicyId())
+                // TODO: this is a workaround for the bug described in https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/753
                 .consumer(uri("urn:connector:consumer"))
                 .provider(uri("urn:connector:provider"))
                 .policy(object.getOffer().getPolicy())

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
@@ -23,11 +23,8 @@ import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNeg
 import org.eclipse.dataspaceconnector.spi.message.MessageContext;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcher;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
-import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
-import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractOfferRequest;
-import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.eclipse.dataspaceconnector.spi.types.domain.message.RemoteMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,6 +36,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.TEXT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.TestFunctions.createOffer;
 import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.getFreePort;
@@ -112,7 +110,7 @@ class ContractNegotiationApiControllerIntegrationTest {
                 .get("/contractnegotiations/negotiationId/state")
                 .then()
                 .statusCode(200)
-                .contentType(JSON)
+                .contentType(TEXT)
                 .extract().asString();
 
         assertThat(state).isEqualTo("REQUESTED");

--- a/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyApiController.java
+++ b/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyApiController.java
@@ -34,14 +34,12 @@ import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 
-@Consumes({ MediaType.APPLICATION_JSON })
-@Produces({ MediaType.APPLICATION_JSON })
 @Path("/policies")
 public class PolicyApiController implements PolicyApi {
 
@@ -54,6 +52,7 @@ public class PolicyApiController implements PolicyApi {
     }
 
     @GET
+    @Produces({ MediaType.APPLICATION_JSON })
     @Override
     public List<Policy> getAllPolicies(@QueryParam("offset") Integer offset,
                                        @QueryParam("limit") Integer limit,
@@ -68,13 +67,13 @@ public class PolicyApiController implements PolicyApi {
                 .sortOrder(sortOrder).build();
         monitor.debug(format("get all policys %s", spec));
 
-        return policyService.query(spec).stream()
-                .collect(Collectors.toList());
+        return new ArrayList<>(policyService.query(spec));
 
     }
 
     @GET
     @Path("{id}")
+    @Produces({ MediaType.APPLICATION_JSON })
     @Override
     public Policy getPolicy(@PathParam("id") String id) {
         monitor.debug(format("Attempting to return policy with ID %s", id));
@@ -84,6 +83,7 @@ public class PolicyApiController implements PolicyApi {
     }
 
     @POST
+    @Consumes({ MediaType.APPLICATION_JSON })
     @Override
     public void createPolicy(Policy policy) {
 

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerIntegrationTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.TEXT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.getFreePort;
 import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.COMPLETED;
@@ -93,7 +94,7 @@ class TransferProcessApiControllerIntegrationTest {
                 .get("/transferprocess/" + PROCESS_ID + "/state")
                 .then()
                 .statusCode(200)
-                .contentType(JSON)
+                .contentType(TEXT)
                 .extract().asString();
 
         assertThat(state).isEqualTo("PROVISIONING");

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -93,6 +93,7 @@ paths:
           description: default response
           content:
             application/json: {}
+      deprecated: true
   /control/transfer:
     post:
       operationId: addTransfer
@@ -106,6 +107,7 @@ paths:
           description: default response
           content:
             application/json: {}
+      deprecated: true
   /control/agreement/{id}:
     get:
       operationId: getAgreementById
@@ -122,6 +124,7 @@ paths:
           description: default response
           content:
             application/json: {}
+      deprecated: true
   /control/negotiation/{id}:
     get:
       operationId: getNegotiationById
@@ -138,6 +141,7 @@ paths:
           description: default response
           content:
             application/json: {}
+      deprecated: true
   /control/negotiation/{id}/state:
     get:
       operationId: getNegotiationStateById
@@ -154,6 +158,7 @@ paths:
           description: default response
           content:
             application/json: {}
+      deprecated: true
   /control/negotiation:
     post:
       operationId: initiateNegotiation
@@ -167,6 +172,7 @@ paths:
           description: default response
           content:
             application/json: {}
+      deprecated: true
   /contractnegotiations/{id}/cancel:
     post:
       tags:

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -9,107 +9,69 @@ info:
 servers:
 - url: /
 paths:
-  /assets:
-    get:
-      tags:
-      - Asset
-      operationId: getAllAssets
-      parameters:
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/AssetDto'
+  /identity-hub/query-commits:
     post:
       tags:
-      - Asset
-      operationId: createAsset
+      - Identity Hub
+      operationId: queryCommits
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AssetEntryDto'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /assets/{id}:
-    get:
-      tags:
-      - Asset
-      operationId: getAsset
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
+              type: string
       responses:
         default:
           description: default response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AssetDto'
-    delete:
+                type: string
+  /identity-hub/query-objects:
+    post:
       tags:
-      - Asset
-      operationId: removeAsset
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
+      - Identity Hub
+      operationId: queryObjects
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
+  /identity-hub/collections:
+    post:
+      tags:
+      - Identity Hub
+      operationId: write
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
+  /identity-hub/collections-commit:
+    post:
+      tags:
+      - Identity Hub
+      operationId: writeCommit
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
       responses:
         default:
           description: default response
@@ -131,7 +93,6 @@ paths:
           description: default response
           content:
             application/json: {}
-      deprecated: true
   /control/transfer:
     post:
       operationId: addTransfer
@@ -145,7 +106,6 @@ paths:
           description: default response
           content:
             application/json: {}
-      deprecated: true
   /control/agreement/{id}:
     get:
       operationId: getAgreementById
@@ -162,7 +122,6 @@ paths:
           description: default response
           content:
             application/json: {}
-      deprecated: true
   /control/negotiation/{id}:
     get:
       operationId: getNegotiationById
@@ -179,7 +138,6 @@ paths:
           description: default response
           content:
             application/json: {}
-      deprecated: true
   /control/negotiation/{id}/state:
     get:
       operationId: getNegotiationStateById
@@ -196,7 +154,6 @@ paths:
           description: default response
           content:
             application/json: {}
-      deprecated: true
   /control/negotiation:
     post:
       operationId: initiateNegotiation
@@ -210,92 +167,6 @@ paths:
           description: default response
           content:
             application/json: {}
-      deprecated: true
-  /check/health:
-    get:
-      tags:
-      - Application Observability
-      operationId: checkHealth
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /check/liveness:
-    get:
-      tags:
-      - Application Observability
-      operationId: getLiveness
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /check/readiness:
-    get:
-      tags:
-      - Application Observability
-      operationId: getReadiness
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /check/startup:
-    get:
-      tags:
-      - Application Observability
-      operationId: getStartup
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /instances:
-    get:
-      tags:
-      - Dataplane Selector
-      operationId: getAll
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/DataPlaneInstance'
-    post:
-      tags:
-      - Dataplane Selector
-      operationId: addEntry
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DataPlaneInstance'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /instances/select:
-    post:
-      tags:
-      - Dataplane Selector
-      operationId: find
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SelectionRequest'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DataPlaneInstance'
   /contractnegotiations/{id}/cancel:
     post:
       tags:
@@ -313,7 +184,7 @@ paths:
         default:
           description: default response
           content:
-            application/json: {}
+            '*/*': {}
   /contractnegotiations/{id}/decline:
     post:
       tags:
@@ -331,7 +202,7 @@ paths:
         default:
           description: default response
           content:
-            application/json: {}
+            '*/*': {}
   /contractnegotiations/{id}/agreement:
     get:
       tags:
@@ -389,7 +260,7 @@ paths:
         default:
           description: default response
           content:
-            application/json:
+            text/plain:
               schema:
                 type: string
   /contractnegotiations:
@@ -460,60 +331,59 @@ paths:
         default:
           description: default response
           content:
-            application/json:
+            text/plain:
               schema:
                 type: string
-  /callback/{processId}/deprovision:
-    post:
-      tags:
-      - HTTP Provisioner Webhook
-      operationId: callDeprovisionWebhook
-      parameters:
-      - name: processId
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DeprovisionedResource'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /callback/{processId}/provision:
-    post:
-      tags:
-      - HTTP Provisioner Webhook
-      operationId: callProvisionWebhook
-      parameters:
-      - name: processId
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ProvisionerWebhookRequest'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /contractdefinitions:
+  /instances:
     get:
       tags:
-      - Contract Definition
-      operationId: getAllContractDefinitions
+      - Dataplane Selector
+      operationId: getAll
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DataPlaneInstance'
+    post:
+      tags:
+      - Dataplane Selector
+      operationId: addEntry
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataPlaneInstance'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /instances/select:
+    post:
+      tags:
+      - Dataplane Selector
+      operationId: find
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SelectionRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataPlaneInstance'
+  /assets:
+    get:
+      tags:
+      - Asset
+      operationId: getAllAssets
       parameters:
       - name: offset
         in: query
@@ -563,26 +433,26 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ContractDefinitionDto'
+                  $ref: '#/components/schemas/AssetDto'
     post:
       tags:
-      - Contract Definition
-      operationId: createContractDefinition
+      - Asset
+      operationId: createAsset
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ContractDefinitionDto'
+              $ref: '#/components/schemas/AssetEntryDto'
       responses:
         default:
           description: default response
           content:
-            application/json: {}
-  /contractdefinitions/{id}:
+            '*/*': {}
+  /assets/{id}:
     get:
       tags:
-      - Contract Definition
-      operationId: getContractDefinition
+      - Asset
+      operationId: getAsset
       parameters:
       - name: id
         in: path
@@ -597,11 +467,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContractDefinitionDto'
+                $ref: '#/components/schemas/AssetDto'
     delete:
       tags:
-      - Contract Definition
-      operationId: deleteContractDefinition
+      - Asset
+      operationId: removeAsset
       parameters:
       - name: id
         in: path
@@ -614,198 +484,7 @@ paths:
         default:
           description: default response
           content:
-            application/json: {}
-  /identity-hub/query-commits:
-    post:
-      tags:
-      - Identity Hub
-      operationId: queryCommits
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: string
-  /identity-hub/query-objects:
-    post:
-      tags:
-      - Identity Hub
-      operationId: queryObjects
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: string
-  /identity-hub/collections:
-    post:
-      tags:
-      - Identity Hub
-      operationId: write
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: string
-  /identity-hub/collections-commit:
-    post:
-      tags:
-      - Identity Hub
-      operationId: writeCommit
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              additionalProperties:
-                type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /catalog:
-    post:
-      operationId: getCatalog
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/FederatedCatalogCacheQuery'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ContractOffer'
-  /policies:
-    get:
-      tags:
-      - Policy
-      operationId: getAllPolicies
-      parameters:
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Policy'
-    post:
-      tags:
-      - Policy
-      operationId: createPolicy
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Policy'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /policies/{id}:
-    get:
-      tags:
-      - Policy
-      operationId: getPolicy
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Policy'
-    delete:
-      tags:
-      - Policy
-      operationId: deletePolicy
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
+            '*/*': {}
   /contractagreements:
     get:
       tags:
@@ -881,6 +560,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ContractAgreementDto'
+  /check/health:
+    get:
+      tags:
+      - Application Observability
+      operationId: checkHealth
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /check/liveness:
+    get:
+      tags:
+      - Application Observability
+      operationId: getLiveness
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /check/readiness:
+    get:
+      tags:
+      - Application Observability
+      operationId: getReadiness
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /check/startup:
+    get:
+      tags:
+      - Application Observability
+      operationId: getStartup
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
   /transferprocess/{id}/cancel:
     post:
       tags:
@@ -898,7 +617,7 @@ paths:
         default:
           description: default response
           content:
-            application/json: {}
+            '*/*': {}
   /transferprocess/{id}/deprovision:
     post:
       tags:
@@ -916,7 +635,7 @@ paths:
         default:
           description: default response
           content:
-            application/json: {}
+            '*/*': {}
   /transferprocess:
     get:
       tags:
@@ -985,7 +704,7 @@ paths:
         default:
           description: default response
           content:
-            application/json:
+            text/plain:
               schema:
                 type: string
   /transferprocess/{id}:
@@ -1025,9 +744,284 @@ paths:
         default:
           description: default response
           content:
-            application/json:
+            text/plain:
               schema:
                 type: string
+  /policies:
+    get:
+      tags:
+      - Policy
+      operationId: getAllPolicies
+      parameters:
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Policy'
+    post:
+      tags:
+      - Policy
+      operationId: createPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Policy'
+      responses:
+        default:
+          description: default response
+          content:
+            '*/*': {}
+  /policies/{id}:
+    get:
+      tags:
+      - Policy
+      operationId: getPolicy
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Policy'
+    delete:
+      tags:
+      - Policy
+      operationId: deletePolicy
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            '*/*': {}
+  /catalog:
+    post:
+      operationId: getCatalog
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FederatedCatalogCacheQuery'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractOffer'
+  /contractdefinitions:
+    get:
+      tags:
+      - Contract Definition
+      operationId: getAllContractDefinitions
+      parameters:
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractDefinitionDto'
+    post:
+      tags:
+      - Contract Definition
+      operationId: createContractDefinition
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ContractDefinitionDto'
+      responses:
+        default:
+          description: default response
+          content:
+            '*/*': {}
+  /contractdefinitions/{id}:
+    get:
+      tags:
+      - Contract Definition
+      operationId: getContractDefinition
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContractDefinitionDto'
+    delete:
+      tags:
+      - Contract Definition
+      operationId: deleteContractDefinition
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            '*/*': {}
+  /callback/{processId}/deprovision:
+    post:
+      tags:
+      - HTTP Provisioner Webhook
+      operationId: callDeprovisionWebhook
+      parameters:
+      - name: processId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeprovisionedResource'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /callback/{processId}/provision:
+    post:
+      tags:
+      - HTTP Provisioner Webhook
+      operationId: callProvisionWebhook
+      parameters:
+      - name: processId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProvisionerWebhookRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
 components:
   schemas:
     Action:

--- a/resources/openapi/yaml/asset.yaml
+++ b/resources/openapi/yaml/asset.yaml
@@ -53,7 +53,7 @@ paths:
         default:
           description: default response
           content:
-            application/json: {}
+            '*/*': {}
   /assets/{id}:
     get:
       tags:
@@ -86,7 +86,7 @@ paths:
         default:
           description: default response
           content:
-            application/json: {}
+            '*/*': {}
 components:
   schemas:
     AssetDto:

--- a/resources/openapi/yaml/contractdefinition.yaml
+++ b/resources/openapi/yaml/contractdefinition.yaml
@@ -53,7 +53,7 @@ paths:
         default:
           description: default response
           content:
-            application/json: {}
+            '*/*': {}
   /contractdefinitions/{id}:
     get:
       tags:
@@ -86,7 +86,7 @@ paths:
         default:
           description: default response
           content:
-            application/json: {}
+            '*/*': {}
 components:
   schemas:
     ContractDefinitionDto:

--- a/resources/openapi/yaml/contractnegotiation.yaml
+++ b/resources/openapi/yaml/contractnegotiation.yaml
@@ -15,7 +15,7 @@ paths:
         default:
           description: default response
           content:
-            application/json: {}
+            '*/*': {}
   /contractnegotiations/{id}/decline:
     post:
       tags:
@@ -31,7 +31,7 @@ paths:
         default:
           description: default response
           content:
-            application/json: {}
+            '*/*': {}
   /contractnegotiations/{id}/agreement:
     get:
       tags:
@@ -83,7 +83,7 @@ paths:
         default:
           description: default response
           content:
-            application/json:
+            text/plain:
               schema:
                 type: string
   /contractnegotiations:
@@ -139,7 +139,7 @@ paths:
         default:
           description: default response
           content:
-            application/json:
+            text/plain:
               schema:
                 type: string
 components:

--- a/resources/openapi/yaml/policydefinition.yaml
+++ b/resources/openapi/yaml/policydefinition.yaml
@@ -53,7 +53,7 @@ paths:
         default:
           description: default response
           content:
-            application/json: {}
+            '*/*': {}
   /policies/{id}:
     get:
       tags:
@@ -86,7 +86,7 @@ paths:
         default:
           description: default response
           content:
-            application/json: {}
+            '*/*': {}
 components:
   schemas:
     Action:

--- a/resources/openapi/yaml/transferprocess.yaml
+++ b/resources/openapi/yaml/transferprocess.yaml
@@ -15,7 +15,7 @@ paths:
         default:
           description: default response
           content:
-            application/json: {}
+            '*/*': {}
   /transferprocess/{id}/deprovision:
     post:
       tags:
@@ -31,7 +31,7 @@ paths:
         default:
           description: default response
           content:
-            application/json: {}
+            '*/*': {}
   /transferprocess:
     get:
       tags:
@@ -85,7 +85,7 @@ paths:
         default:
           description: default response
           content:
-            application/json:
+            text/plain:
               schema:
                 type: string
   /transferprocess/{id}:
@@ -121,7 +121,7 @@ paths:
         default:
           description: default response
           content:
-            application/json:
+            text/plain:
               schema:
                 type: string
 components:


### PR DESCRIPTION
## What this PR changes/adds

Adapts the `@Produces` and `@Consumes` annotations on all DataManagementAPI controller such that they reflect what the methods actually consume/produce.

## Why it does that

Wrong content types may cause problems when generating client SDKs from the OpenApi spec.

## Further notes

- fixed a wrong validity check in the `ContractNegotiationApiController`
- added default `provider` and `consumer` fields in the transformer.
- removed a logline from `StateMachine` that spammed the log every couple of seconds.

## Linked Issue(s)

Closes #1126 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
