### PR TITLE
Feature: use @component test in sql tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     checkstyle
     jacoco
     id("com.rameshkp.openapi-merger-gradle-plugin") version "1.0.4"
-    id ("org.eclipse.dataspaceconnector.dependency-rules") apply(false)
+    id("org.eclipse.dataspaceconnector.dependency-rules") apply (false)
     id("com.autonomousapps.dependency-analysis") version "1.0.0-rc05" apply (false)
 }
 
@@ -189,29 +189,53 @@ allprojects {
             showStackTraces = true
             exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
         }
-    }
 
-    tasks.withType<Checkstyle> {
-        reports {
-            // lets not generate any reports because that is done from within the Github Actions workflow
-            html.required.set(false)
-            xml.required.set(false)
-        }
-    }
-
-    tasks.jar {
-        metaInf {
-            from("${rootProject.projectDir.path}/LICENSE")
-            from("${rootProject.projectDir.path}/NOTICE.md")
-        }
-    }
-
-    // Generate XML reports for Codecov
-    if (System.getenv("JACOCO") == "true") {
-        tasks.jacocoTestReport {
-            reports {
-                xml.required.set(true)
+        // this is the kotlin equivalent of a Groovy's "afterSuite" Closure to
+        // print a quick test summary.
+        // inspirations taken from https://stackoverflow.com/a/36130467/7079724 and
+        // https://github.com/gradle/kotlin-dsl-samples/issues/836#issuecomment-384206237
+        addTestListener(object : TestListener {
+            override fun beforeSuite(suite: TestDescriptor) {}
+            override fun beforeTest(testDescriptor: TestDescriptor) {}
+            override fun afterTest(testDescriptor: TestDescriptor, result: TestResult) {}
+            override fun afterSuite(suite: TestDescriptor, result: TestResult) {
+                if (suite.parent == null) { // will match the outermost suite
+                    val output =
+                        "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
+                    val startItem = "|  ";
+                    val endItem = "  |";
+                    val repeatLength = startItem.length + output.length + endItem.length
+                    println(
+                        '\n' + ("-".repeat(repeatLength)) + "\n" + startItem + output + endItem + "\n" + ("-".repeat(
+                            repeatLength
+                        ))
+                    )
+                }
             }
+        })
+    }
+}
+
+tasks.withType<Checkstyle> {
+    reports {
+        // lets not generate any reports because that is done from within the Github Actions workflow
+        html.required.set(false)
+        xml.required.set(false)
+    }
+}
+
+tasks.jar {
+    metaInf {
+        from("${rootProject.projectDir.path}/LICENSE")
+        from("${rootProject.projectDir.path}/NOTICE.md")
+    }
+}
+
+// Generate XML reports for Codecov
+if (System.getenv("JACOCO") == "true") {
+    tasks.jacocoTestReport {
+        reports {
+            xml.required.set(true)
         }
     }
 }
@@ -247,13 +271,13 @@ if (project.hasProperty("dependency.analysis")) {
     }
     apply(plugin = "com.autonomousapps.dependency-analysis")
     configure<com.autonomousapps.DependencyAnalysisExtension> {
-        // See https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin
+// See https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin
         issues {
             all { // all projects
                 onAny {
                     severity(project.property("dependency.analysis").toString())
                     exclude(
-                        // dependencies declared at the root level for all modules
+// dependencies declared at the root level for all modules
                         "org.jetbrains:annotations",
                         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                         "com.fasterxml.jackson.core:jackson-core",
@@ -263,7 +287,7 @@ if (project.hasProperty("dependency.analysis")) {
                 }
                 onUnusedDependencies {
                     exclude(
-                        // dependencies declared at the root level for all modules
+// dependencies declared at the root level for all modules
                         "com.github.javafaker:javafaker",
                         "org.assertj:assertj-core",
                         "org.junit.jupiter:junit-jupiter-api",
@@ -273,7 +297,7 @@ if (project.hasProperty("dependency.analysis")) {
                 }
                 onIncorrectConfiguration {
                     exclude(
-                        // some common dependencies are intentionally exported by core:base for simplicity
+// some common dependencies are intentionally exported by core:base for simplicity
                         "com.squareup.okhttp3:okhttp",
                         "net.jodah:failsafe",
                     )
@@ -286,7 +310,7 @@ if (project.hasProperty("dependency.analysis")) {
         abi {
             exclusions {
                 excludeAnnotations(
-                        "io\\.opentelemetry\\.extension\\.annotations\\.WithSpan",
+                    "io\\.opentelemetry\\.extension\\.annotations\\.WithSpan",
                 )
             }
         }

--- a/extensions/sql/asset-index-sql/build.gradle.kts
+++ b/extensions/sql/asset-index-sql/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation(project(":extensions:sql:common-sql"))
 
     testImplementation(testFixtures(project(":launchers:junit")))
+    testImplementation(testFixtures(project(":common:util")))
     testImplementation(project(":core:base"))
     testImplementation(project(":extensions:sql:pool:apache-commons-pool-sql"))
     testImplementation(project(":extensions:transaction:transaction-local"))

--- a/extensions/sql/asset-index-sql/src/test/java/org/eclipse/dataspaceconnector/sql/asset/index/SqlAssetIndexTest.java
+++ b/extensions/sql/asset-index-sql/src/test/java/org/eclipse/dataspaceconnector/sql/asset/index/SqlAssetIndexTest.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.sql.asset.index;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.dataloading.AssetEntry;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
@@ -56,7 +57,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.dataspaceconnector.sql.SqlQueryExecutor.executeQuery;
 
-public class SqlAssetIndexTest {
+@ComponentTest
+class SqlAssetIndexTest {
 
     private static final String DATASOURCE_NAME = "asset";
 

--- a/extensions/sql/contract-definition-store-sql/build.gradle.kts
+++ b/extensions/sql/contract-definition-store-sql/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation(project(":extensions:transaction:transaction-datasource-spi"))
     implementation(project(":extensions:sql:common-sql"))
 
+    testImplementation(testFixtures(project(":common:util")))
     testImplementation(testFixtures(project(":launchers:junit")))
     testImplementation(project(":core:base"))
     testImplementation(project(":extensions:sql:pool:apache-commons-pool-sql"))

--- a/extensions/sql/contract-definition-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionStoreTest.java
+++ b/extensions/sql/contract-definition-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionStoreTest.java
@@ -18,6 +18,7 @@
 package org.eclipse.dataspaceconnector.sql.contractdefinition.store;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
@@ -51,6 +52,7 @@ import java.util.stream.IntStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.sql.SqlQueryExecutor.executeQuery;
 
+@ComponentTest
 public class SqlContractDefinitionStoreTest {
 
     private static final String DATASOURCE_NAME = "contractdefinition";

--- a/extensions/sql/contract-negotiation-store-sql/build.gradle.kts
+++ b/extensions/sql/contract-negotiation-store-sql/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(project(":extensions:sql:common-sql"))
     implementation(project(":extensions:sql:lease-sql"))
 
+    testImplementation(testFixtures(project(":common:util")))
     testImplementation(testFixtures(project(":launchers:junit")))
     testImplementation(project(":core:base"))
     testImplementation(project(":core:contract"))

--- a/extensions/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStoreTest.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStoreTest.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.dataspaceconnector.sql.contractnegotiation.store;
 
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.contract.common.ContractId;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.policy.model.PolicyRegistrationTypes;
@@ -59,6 +60,7 @@ import static org.eclipse.dataspaceconnector.sql.contractnegotiation.TestFunctio
 import static org.eclipse.dataspaceconnector.sql.contractnegotiation.TestFunctions.createNegotiation;
 import static org.eclipse.dataspaceconnector.sql.contractnegotiation.TestFunctions.createPolicy;
 
+@ComponentTest
 class SqlContractNegotiationStoreTest {
 
     private static final String DATASOURCE_NAME = "contractnegotiation";

--- a/extensions/sql/policy-store-sql/build.gradle.kts
+++ b/extensions/sql/policy-store-sql/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation(project(":extensions:transaction:transaction-datasource-spi"))
     implementation(project(":extensions:sql:common-sql"))
 
+    testImplementation(testFixtures(project(":common:util")))
     testImplementation(project(":extensions:sql:pool:apache-commons-pool-sql"))
     testImplementation(project(":extensions:transaction:transaction-local"))
     testImplementation("com.h2database:h2:${h2Version}")

--- a/extensions/sql/policy-store-sql/src/test/java/org/eclipse/dataspaceconnector/slq/policy/store/SqlPolicyStoreTest.java
+++ b/extensions/sql/policy-store-sql/src/test/java/org/eclipse/dataspaceconnector/slq/policy/store/SqlPolicyStoreTest.java
@@ -14,13 +14,13 @@
 
 package org.eclipse.dataspaceconnector.slq.policy.store;
 
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.policy.model.Duty;
 import org.eclipse.dataspaceconnector.policy.model.Permission;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.policy.model.PolicyType;
 import org.eclipse.dataspaceconnector.policy.model.Prohibition;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.persistence.EdcPersistenceException;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
 import org.eclipse.dataspaceconnector.spi.transaction.datasource.DataSourceRegistry;
@@ -52,8 +52,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@ComponentTest
 class SqlPolicyStoreTest {
 
     private static final String DATASOURCE_NAME = "policy";
@@ -63,7 +63,8 @@ class SqlPolicyStoreTest {
 
     @BeforeEach
     void setUp() throws SQLException {
-        var monitor = new Monitor() {};
+        var monitor = new Monitor() {
+        };
         var txManager = new LocalTransactionContext(monitor);
         DataSourceRegistry dataSourceRegistry;
         dataSourceRegistry = new LocalDataSourceRegistry(txManager);
@@ -129,7 +130,7 @@ class SqlPolicyStoreTest {
     @Test
     @DisplayName("Find policy by ID that exists")
     void findById_whenPresent() {
-        Policy policy =  getDummyPolicy(getRandomId());
+        Policy policy = getDummyPolicy(getRandomId());
         sqlPolicyStore.save(policy);
 
         var policyFromDb = sqlPolicyStore.findById(policy.getUid());

--- a/extensions/sql/transfer-process-store-sql/build.gradle.kts
+++ b/extensions/sql/transfer-process-store-sql/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation(project(":extensions:sql:common-sql"))
     implementation(project(":extensions:sql:lease-sql"))
 
+    testImplementation(testFixtures(project(":common:util")))
     testImplementation(testFixtures(project(":launchers:junit")))
     testImplementation(testFixtures(project(":extensions:sql:lease-sql")))
     testImplementation(project(":core:base"))

--- a/extensions/sql/transfer-process-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStoreTest.java
+++ b/extensions/sql/transfer-process-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStoreTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.sql.transferprocess.store;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.transaction.datasource.DataSourceRegistry;
@@ -52,6 +53,7 @@ import static org.eclipse.dataspaceconnector.sql.transferprocess.store.TestFunct
 import static org.eclipse.dataspaceconnector.sql.transferprocess.store.TestFunctions.createTransferProcess;
 import static org.hamcrest.Matchers.hasSize;
 
+@ComponentTest
 class SqlTransferProcessStoreTest {
     private static final String DATASOURCE_NAME = "transferprocess";
     private static final String CONNECTOR_NAME = "test-connector";


### PR DESCRIPTION
## What this PR changes/adds

Adds the `@ComponentTest` annotation to all SQL-related tests.

## Why it does that

Those tests are not unit tests (the use non-mocked collaborators such as H2) and therefore should only run when triggered explicitly to reduce test runtime on local machines.

## Further notes

- I also added a short test summary to the root buildfile, which produces output such as 
  ```
  -----------------------------------------------------------------
  |  Results: SUCCESS (32 tests, 32 passed, 0 failed, 0 skipped)  |  
  -----------------------------------------------------------------
  ```

## Linked Issue(s)

Closes #1132 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
