### PR TITLE
Build: adds plugin that prints a small summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,15 @@ in the detailed section referring to by linking pull requests or issues.
 ## [Unreleased]
 
 ### Overview
-Bugfixing DataManagementApi
-*
+* Bugfixing DataManagementApi
+* Build improvements
 
 ### Detailed Changes
 
 #### Added
 
 * Add domain model documentation (#1158)
+* Add gradle test summary (#1148)
 
 #### Changed
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -191,30 +191,30 @@ allprojects {
         }
     }
 
-tasks.withType<Checkstyle> {
-    reports {
-        // lets not generate any reports because that is done from within the Github Actions workflow
-        html.required.set(false)
-        xml.required.set(false)
+    tasks.withType<Checkstyle> {
+        reports {
+            // lets not generate any reports because that is done from within the Github Actions workflow
+            html.required.set(false)
+            xml.required.set(false)
+        }
     }
-}
 
-tasks.jar {
-    metaInf {
-        from("${rootProject.projectDir.path}/LICENSE")
-        from("${rootProject.projectDir.path}/NOTICE.md")
+    tasks.jar {
+        metaInf {
+            from("${rootProject.projectDir.path}/LICENSE")
+            from("${rootProject.projectDir.path}/NOTICE.md")
+        }
     }
-}
 
 // Generate XML reports for Codecov
-if (System.getenv("JACOCO") == "true") {
-    tasks.jacocoTestReport {
-        reports {
-            xml.required.set(true)
+    if (System.getenv("JACOCO") == "true") {
+        tasks.jacocoTestReport {
+            reports {
+                xml.required.set(true)
+            }
         }
     }
 }
-
 openApiMerger {
     val yamlDirectory = file("${rootProject.projectDir.path}/resources/openapi/yaml")
 
@@ -285,9 +285,10 @@ if (project.hasProperty("dependency.analysis")) {
         abi {
             exclusions {
                 excludeAnnotations(
-                        "io\\.opentelemetry\\.extension\\.annotations\\.WithSpan",
+                    "io\\.opentelemetry\\.extension\\.annotations\\.WithSpan",
                 )
             }
         }
     }
 }
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,6 @@ plugins {
     checkstyle
     jacoco
     id("com.rameshkp.openapi-merger-gradle-plugin") version "1.0.4"
-    id("org.eclipse.dataspaceconnector.dependency-rules") apply (false)
     id("com.autonomousapps.dependency-analysis") version "1.0.0-rc05" apply (false)
 }
 
@@ -71,6 +70,7 @@ allprojects {
     apply(plugin = "maven-publish")
     apply(plugin = "checkstyle")
     apply(plugin = "java")
+    apply(plugin = "org.eclipse.dataspaceconnector.test-summary")
 
     if (System.getenv("JACOCO") == "true") {
         apply(plugin = "jacoco")
@@ -189,32 +189,7 @@ allprojects {
             showStackTraces = true
             exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
         }
-
-        // this is the kotlin equivalent of a Groovy's "afterSuite" Closure to
-        // print a quick test summary.
-        // inspirations taken from https://stackoverflow.com/a/36130467/7079724 and
-        // https://github.com/gradle/kotlin-dsl-samples/issues/836#issuecomment-384206237
-        addTestListener(object : TestListener {
-            override fun beforeSuite(suite: TestDescriptor) {}
-            override fun beforeTest(testDescriptor: TestDescriptor) {}
-            override fun afterTest(testDescriptor: TestDescriptor, result: TestResult) {}
-            override fun afterSuite(suite: TestDescriptor, result: TestResult) {
-                if (suite.parent == null) { // will match the outermost suite
-                    val output =
-                        "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
-                    val startItem = "|  ";
-                    val endItem = "  |";
-                    val repeatLength = startItem.length + output.length + endItem.length
-                    println(
-                        '\n' + ("-".repeat(repeatLength)) + "\n" + startItem + output + endItem + "\n" + ("-".repeat(
-                            repeatLength
-                        ))
-                    )
-                }
-            }
-        })
     }
-}
 
 tasks.withType<Checkstyle> {
     reports {
@@ -271,13 +246,13 @@ if (project.hasProperty("dependency.analysis")) {
     }
     apply(plugin = "com.autonomousapps.dependency-analysis")
     configure<com.autonomousapps.DependencyAnalysisExtension> {
-// See https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin
+        // See https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin
         issues {
             all { // all projects
                 onAny {
                     severity(project.property("dependency.analysis").toString())
                     exclude(
-// dependencies declared at the root level for all modules
+                        // dependencies declared at the root level for all modules
                         "org.jetbrains:annotations",
                         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                         "com.fasterxml.jackson.core:jackson-core",
@@ -287,7 +262,7 @@ if (project.hasProperty("dependency.analysis")) {
                 }
                 onUnusedDependencies {
                     exclude(
-// dependencies declared at the root level for all modules
+                        // dependencies declared at the root level for all modules
                         "com.github.javafaker:javafaker",
                         "org.assertj:assertj-core",
                         "org.junit.jupiter:junit-jupiter-api",
@@ -297,7 +272,7 @@ if (project.hasProperty("dependency.analysis")) {
                 }
                 onIncorrectConfiguration {
                     exclude(
-// some common dependencies are intentionally exported by core:base for simplicity
+                        // some common dependencies are intentionally exported by core:base for simplicity
                         "com.squareup.okhttp3:okhttp",
                         "net.jodah:failsafe",
                     )
@@ -310,7 +285,7 @@ if (project.hasProperty("dependency.analysis")) {
         abi {
             exclusions {
                 excludeAnnotations(
-                    "io\\.opentelemetry\\.extension\\.annotations\\.WithSpan",
+                        "io\\.opentelemetry\\.extension\\.annotations\\.WithSpan",
                 )
             }
         }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,5 +8,9 @@ gradlePlugin {
             id = "org.eclipse.dataspaceconnector.dependency-rules"
             implementationClass = "org.eclipse.dataspaceconnector.gradle.DependencyRulesPlugin"
         }
+        create("TestSummaryPlugin") {
+            id = "org.eclipse.dataspaceconnector.test-summary"
+            implementationClass = "org.eclipse.dataspaceconnector.gradle.TestSummaryPlugin"
+        }
     }
 }

--- a/buildSrc/src/main/java/org/eclipse/dataspaceconnector/gradle/SummaryPrinterAdapter.java
+++ b/buildSrc/src/main/java/org/eclipse/dataspaceconnector/gradle/SummaryPrinterAdapter.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.gradle;
+
+import org.gradle.api.tasks.testing.TestDescriptor;
+import org.gradle.api.tasks.testing.TestListener;
+import org.gradle.api.tasks.testing.TestResult;
+
+/**
+ * Adapter for the {@link TestListener}, that allows overriding just one method.
+ * Currently, only the {@link TestListener#afterSuite(TestDescriptor, TestResult)} is used.
+ */
+public abstract class SummaryPrinterAdapter implements TestListener {
+    @Override
+    public void beforeSuite(TestDescriptor suite) {
+
+    }
+
+    @Override
+    public void afterSuite(TestDescriptor suite, TestResult result) {
+
+    }
+
+    @Override
+    public void beforeTest(TestDescriptor testDescriptor) {
+
+    }
+
+    @Override
+    public void afterTest(TestDescriptor testDescriptor, TestResult result) {
+
+    }
+}

--- a/buildSrc/src/main/java/org/eclipse/dataspaceconnector/gradle/TestSummaryPlugin.java
+++ b/buildSrc/src/main/java/org/eclipse/dataspaceconnector/gradle/TestSummaryPlugin.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.gradle;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.tasks.testing.Test;
+import org.gradle.api.tasks.testing.TestDescriptor;
+import org.gradle.api.tasks.testing.TestListener;
+import org.gradle.api.tasks.testing.TestResult;
+
+import static java.lang.String.format;
+
+/**
+ * Plugin that adds a {@link TestListener} to each "test" task in the project, that prints a little summary.
+ */
+public class TestSummaryPlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project target) {
+        var testTasks = target.getTasks().getByName("test");
+        if (testTasks instanceof Test) {
+            ((Test) testTasks).addTestListener(new AfterSuitePrinter(target.getLogger()));
+        }
+    }
+
+    private class AfterSuitePrinter extends SummaryPrinterAdapter {
+        private final Logger logger;
+
+        public AfterSuitePrinter(Logger logger) {
+            this.logger = logger;
+        }
+
+        @Override
+        public void afterSuite(TestDescriptor suite, TestResult result) {
+            if (suite.getParent() == null) { // will match the outermost suite
+                var output = format("Results: %s (%d tests, %d passed, %d failed, %d skipped)", result.getResultType().toString(),
+                        result.getTestCount(), result.getSuccessfulTestCount(), result.getFailedTestCount(), result.getSkippedTestCount());
+                var startItem = "|  ";
+                var endItem = "  |";
+                var repeatLength = startItem.length() + output.length() + endItem.length();
+                logger.lifecycle(format("\n%s\n%s%s%s\n%s%n", "-".repeat(repeatLength), startItem, output, endItem, "-".repeat(repeatLength)));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

This PR adds a gradle plugin that prints a small test summar

## Why it does that

Un-clutter the root `build.gradle.kts`

## Further notes

Should be merged after #1143, and the test listener code from there (in `build.gradle.kts`) should be removed before merging this.

## Linked Issue(s)

Closes #1148 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
