### PR TITLE
Observability: Trace context propagation within DPF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Http Deprovisioner Webhook endpoint (#1039)
 * Add performance test example and scheduled workflow (#1029)
 * Add basic authentication mechanism for DataManagement API (#981)
+* Trace context propagation in DPF (#1162)
 
 #### Changed
 

--- a/extensions/data-plane-transfer/data-plane-transfer-client/build.gradle.kts
+++ b/extensions/data-plane-transfer/data-plane-transfer-client/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 val httpMockServer: String by project
 val jodahFailsafeVersion: String by project
 val okHttpVersion: String by project
+val openTelemetryVersion: String by project
 val faker: String by project
 
 dependencies {
@@ -30,6 +31,7 @@ dependencies {
 
     implementation("net.jodah:failsafe:${jodahFailsafeVersion}")
     implementation("com.squareup.okhttp3:okhttp:${okHttpVersion}")
+    implementation("io.opentelemetry:opentelemetry-extension-annotations:${openTelemetryVersion}")
 
     testImplementation("org.mock-server:mockserver-netty:${httpMockServer}:shaded")
     testImplementation("org.mock-server:mockserver-client-java:${httpMockServer}:shaded")

--- a/extensions/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/client/EmbeddedDataPlaneTransferClient.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/client/EmbeddedDataPlaneTransferClient.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.transfer.dataplane.client;
 
+import io.opentelemetry.extension.annotations.WithSpan;
 import org.eclipse.dataspaceconnector.dataplane.spi.manager.DataPlaneManager;
 import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
 import org.eclipse.dataspaceconnector.spi.response.StatusResult;
@@ -31,6 +32,7 @@ public class EmbeddedDataPlaneTransferClient implements DataPlaneTransferClient 
         this.dataPlaneManager = dataPlaneManager;
     }
 
+    @WithSpan
     @Override
     public StatusResult<Void> transfer(DataFlowRequest request) {
         var result = dataPlaneManager.validate(request);

--- a/extensions/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/client/RemoteDataPlaneTransferClient.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/client/RemoteDataPlaneTransferClient.java
@@ -16,6 +16,7 @@ package org.eclipse.dataspaceconnector.transfer.dataplane.client;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opentelemetry.extension.annotations.WithSpan;
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
 import okhttp3.MediaType;
@@ -57,6 +58,7 @@ public class RemoteDataPlaneTransferClient implements DataPlaneTransferClient {
         this.mapper = mapper;
     }
 
+    @WithSpan
     @Override
     public StatusResult<Void> transfer(DataFlowRequest request) {
         var instance = selectorClient.find(request.getSourceDataAddress(), request.getDestinationDataAddress(), selectorStrategy);

--- a/extensions/data-plane/data-plane-framework/build.gradle.kts
+++ b/extensions/data-plane/data-plane-framework/build.gradle.kts
@@ -12,13 +12,17 @@
  *
  */
 
+val openTelemetryVersion: String by project
+
 plugins {
     `java-library`
 }
 
 dependencies {
+    api(project(":spi:core-spi"))
     api(project(":extensions:data-plane:data-plane-spi"))
     implementation(project(":common:util"))
+    implementation("io.opentelemetry:opentelemetry-extension-annotations:${openTelemetryVersion}")
     testImplementation(testFixtures(project(":launchers:junit")))
 }
 

--- a/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneFrameworkExtension.java
+++ b/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneFrameworkExtension.java
@@ -96,6 +96,8 @@ public class DataPlaneFrameworkExtension implements ServiceExtension {
         context.registerService(DataTransferExecutorServiceContainer.class, executorContainer);
 
         monitor = context.getMonitor();
+        var telemetry = context.getTelemetry();
+
         var queueCapacity = context.getSetting(QUEUE_CAPACITY, DEFAULT_QUEUE_CAPACITY);
         var workers = context.getSetting(WORKERS, DEFAULT_WORKERS);
         var waitTimeout = context.getSetting(WAIT_TIMEOUT, DEFAULT_WAIT_TIMEOUT);
@@ -108,7 +110,9 @@ public class DataPlaneFrameworkExtension implements ServiceExtension {
                 .pipelineService(pipelineService)
                 .transferServiceRegistry(transferServiceRegistry)
                 .store(new InMemoryDataPlaneStore(IN_MEMORY_STORE_CAPACITY))
-                .monitor(monitor).build();
+                .monitor(monitor)
+                .telemetry(telemetry)
+                .build();
 
         context.registerService(DataPlaneManager.class, dataPlaneManager);
     }

--- a/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/pipeline/PipelineServiceImpl.java
+++ b/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/pipeline/PipelineServiceImpl.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.dataplane.framework.pipeline;
 
+import io.opentelemetry.extension.annotations.WithSpan;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSink;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSinkFactory;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSource;
@@ -72,6 +73,7 @@ public class PipelineServiceImpl implements PipelineService {
         return Result.success(true);
     }
 
+    @WithSpan
     @Override
     public CompletableFuture<StatusResult<Void>> transfer(DataFlowRequest request) {
         var sourceFactory = getSourceFactory(request);

--- a/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/pipeline/PipelineServiceTransferServiceImpl.java
+++ b/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/pipeline/PipelineServiceTransferServiceImpl.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.dataplane.framework.pipeline;
 
+import io.opentelemetry.extension.annotations.WithSpan;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.PipelineService;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.TransferService;
 import org.eclipse.dataspaceconnector.spi.response.StatusResult;
@@ -43,6 +44,7 @@ public class PipelineServiceTransferServiceImpl implements TransferService {
         return pipelineService.validate(request);
     }
 
+    @WithSpan
     @Override
     public CompletableFuture<StatusResult<Void>> transfer(DataFlowRequest request) {
         return pipelineService.transfer(request);

--- a/extensions/data-plane/data-plane-spi/build.gradle.kts
+++ b/extensions/data-plane/data-plane-spi/build.gradle.kts
@@ -13,6 +13,7 @@
  */
 
 val mockitoVersion: String by project
+val openTelemetryVersion: String by project
 
 plugins {
     `java-library`
@@ -21,6 +22,7 @@ plugins {
 dependencies {
     api(project(":spi:core-spi"))
     implementation(project(":common:util"))
+    implementation("io.opentelemetry:opentelemetry-extension-annotations:${openTelemetryVersion}")
 }
 
 

--- a/extensions/data-plane/data-plane-spi/src/test/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSinkTest.java
+++ b/extensions/data-plane/data-plane-spi/src/test/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSinkTest.java
@@ -18,6 +18,7 @@ import com.github.javafaker.Faker;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
 import org.eclipse.dataspaceconnector.spi.response.StatusResult;
+import org.eclipse.dataspaceconnector.spi.telemetry.Telemetry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -48,6 +49,7 @@ class ParallelSinkTest {
     void setup() {
         fakeSink = new FakeParallelSink();
         fakeSink.monitor = monitor;
+        fakeSink.telemetry = new Telemetry(); // default noop implementation
         fakeSink.executorService = executor;
         fakeSink.requestId = UUID.randomUUID().toString();
     }

--- a/samples/04.0-file-transfer/transfer-file/build.gradle.kts
+++ b/samples/04.0-file-transfer/transfer-file/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 }
 
 val rsApi: String by project
+val openTelemetryVersion: String by project
 
 dependencies {
     api(project(":spi"))
@@ -28,6 +29,7 @@ dependencies {
     implementation(project(":extensions:data-plane-selector:selector-core"))
     implementation(project(":extensions:data-plane-selector:selector-store"))
     implementation(project(":extensions:data-plane:data-plane-framework"))
+    implementation("io.opentelemetry:opentelemetry-extension-annotations:${openTelemetryVersion}")
 
     implementation(project(":extensions:data-plane:data-plane-spi"))
     implementation(project(":extensions:in-memory:assetindex-memory"))

--- a/samples/04.0-file-transfer/transfer-file/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferDataSink.java
+++ b/samples/04.0-file-transfer/transfer-file/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferDataSink.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.extensions.api;
 
+import io.opentelemetry.extension.annotations.WithSpan;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSource;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.ParallelSink;
 import org.eclipse.dataspaceconnector.spi.response.StatusResult;
@@ -29,6 +30,7 @@ import static org.eclipse.dataspaceconnector.spi.response.ResponseStatus.ERROR_R
 class FileTransferDataSink extends ParallelSink {
     private File file;
 
+    @WithSpan
     @Override
     protected StatusResult<Void> transferParts(List<DataSource.Part> parts) {
         for (DataSource.Part part : parts) {

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/telemetry/InMemoryTraceCarrier.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/telemetry/InMemoryTraceCarrier.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.telemetry;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Simple {@link TraceCarrier} to use in situations where no entity is persisted (e.g. asynchronous processing)
+ */
+class InMemoryTraceCarrier implements TraceCarrier {
+
+    private final Map<String, String> traceContext;
+
+    InMemoryTraceCarrier(Map<String, String> traceContext) {
+        this.traceContext = Collections.unmodifiableMap(traceContext);
+    }
+
+    @Override
+    public Map<String, String> getTraceContext() {
+        return traceContext;
+    }
+}

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/telemetry/Telemetry.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/telemetry/Telemetry.java
@@ -21,7 +21,9 @@ import io.opentelemetry.context.propagation.TextMapGetter;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * System observability interface for tracing and metrics
@@ -51,6 +53,15 @@ public class Telemetry {
     }
 
     /**
+     * Returns a trace carrier object containing the trace context from the current thread
+     *
+     * @return The trace carrier
+     */
+    public TraceCarrier getTraceCarrierWithCurrentContext() {
+        return new InMemoryTraceCarrier(getCurrentTraceContext());
+    }
+
+    /**
      * Wraps a function with a middleware to propagate the trace context present in the carrier to the executing thread
      *
      * @param delegate The wrapped function
@@ -60,6 +71,35 @@ public class Telemetry {
         return (t) -> {
             try (Scope scope = propagateTraceContext(t)) {
                 return delegate.apply(t);
+            }
+        };
+    }
+
+    /**
+     * Wraps a consumer with a middleware to propagate the trace context present in the carrier to the executing thread
+     *
+     * @param delegate The wrapped consumer
+     * @return The resulting function with the context propagation middleware
+     */
+    public <T extends TraceCarrier> Consumer<T> contextPropagationMiddleware(Consumer<T> delegate) {
+        return (t) -> {
+            try (Scope scope = propagateTraceContext(t)) {
+                delegate.accept(t);
+            }
+        };
+    }
+
+    /**
+     * Wraps a supplier with a middleware to propagate the trace context present in the carrier to the executing thread
+     *
+     * @param delegate The wrapped supplier
+     * @param traceCarrier The trace carrier
+     * @return The resulting function with the context propagation middleware
+     */
+    public <T> Supplier<T> contextPropagationMiddleware(Supplier<T> delegate, TraceCarrier traceCarrier) {
+        return () -> {
+            try (Scope scope = propagateTraceContext(traceCarrier)) {
+                return delegate.get();
             }
         };
     }

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/telemetry/TraceCarrier.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/telemetry/TraceCarrier.java
@@ -15,12 +15,11 @@
 package org.eclipse.dataspaceconnector.spi.telemetry;
 
 import java.util.Map;
-import java.util.function.Function;
 
 /**
  * Interface for trace context carrier entities.
  *
- * Use in combination with {@link Telemetry#contextPropagationMiddleware(Function)} to propagate the tracing context stored in the entity to the current thread.
+ * Use in combination with the various overloads of {@link Telemetry#contextPropagationMiddleware} to propagate the tracing context stored in the entity to the current thread.
  */
 public interface TraceCarrier {
 

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataFlowRequest.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataFlowRequest.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.dataspaceconnector.spi.telemetry.TraceCarrier;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.Polymorphic;
 
@@ -29,7 +30,7 @@ import java.util.Objects;
  */
 @JsonTypeName("dataspaceconnector:dataflowrequest")
 @JsonDeserialize(builder = DataFlowRequest.Builder.class)
-public class DataFlowRequest implements Polymorphic {
+public class DataFlowRequest implements Polymorphic, TraceCarrier {
     private String id;
     private String processId;
 
@@ -39,6 +40,7 @@ public class DataFlowRequest implements Polymorphic {
     private boolean trackable;
 
     private Map<String, String> properties = Map.of();
+    private Map<String, String> traceContext = Map.of();
 
     private DataFlowRequest() {
     }
@@ -85,12 +87,31 @@ public class DataFlowRequest implements Polymorphic {
         return properties;
     }
 
+    /**
+     * Trace context for this request
+     */
+    @Override
+    public Map<String, String> getTraceContext() {
+        return traceContext;
+    }
+
+    /**
+     * A builder initialized with the current DataFlowRequest
+     */
+    public Builder toBuilder() {
+        return new Builder(this);
+    }
+
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder {
         private final DataFlowRequest request;
 
         private Builder() {
-            request = new DataFlowRequest();
+            this(new DataFlowRequest());
+        }
+
+        private Builder(DataFlowRequest request) {
+            this.request = request;
         }
 
         @JsonCreator
@@ -137,10 +158,16 @@ public class DataFlowRequest implements Polymorphic {
             return this;
         }
 
+        public Builder traceContext(Map<String, String> value) {
+            request.traceContext = value;
+            return this;
+        }
+
         public DataFlowRequest build() {
             Objects.requireNonNull(request.processId, "processId");
             Objects.requireNonNull(request.sourceDataAddress, "sourceDataAddress");
             Objects.requireNonNull(request.destinationDataAddress, "destinationDataAddress");
+            Objects.requireNonNull(request.traceContext, "traceContext");
             return request;
         }
 

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataFlowRequestTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataFlowRequestTest.java
@@ -36,11 +36,13 @@ class DataFlowRequestTest {
                 .processId(UUID.randomUUID().toString())
                 .destinationType("test")
                 .properties(Map.of("key", "value"))
+                .traceContext(Map.of("key2", "value2"))
                 .build();
         var serialized = mapper.writeValueAsString(request);
         var deserialized = mapper.readValue(serialized, DataFlowRequest.class);
 
         assertThat(deserialized).isNotNull();
         assertThat(deserialized.getProperties().get("key")).isEqualTo("value");
+        assertThat(deserialized.getTraceContext().get("key2")).isEqualTo("value2");
     }
 }

--- a/system-tests/runtimes/file-transfer-provider/build.gradle.kts
+++ b/system-tests/runtimes/file-transfer-provider/build.gradle.kts
@@ -13,6 +13,8 @@
  *
  */
 
+val openTelemetryVersion: String by project
+
 plugins {
     `java-library`
     id("application")
@@ -38,6 +40,7 @@ dependencies {
     api(project(":extensions:dataloading"))
 
     implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
+    implementation("io.opentelemetry:opentelemetry-extension-annotations:${openTelemetryVersion}")
 
     implementation(project(":core"))
 

--- a/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferDataSink.java
+++ b/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferDataSink.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.extensions.api;
 
+import io.opentelemetry.extension.annotations.WithSpan;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSource;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.ParallelSink;
 import org.eclipse.dataspaceconnector.spi.response.StatusResult;
@@ -29,6 +30,7 @@ import static org.eclipse.dataspaceconnector.spi.response.ResponseStatus.ERROR_R
 class FileTransferDataSink extends ParallelSink {
     private File file;
 
+    @WithSpan
     @Override
     protected StatusResult<Void> transferParts(List<DataSource.Part> parts) {
         for (DataSource.Part part : parts) {

--- a/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferDataSinkFactory.java
+++ b/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferDataSinkFactory.java
@@ -18,6 +18,7 @@ import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSink;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSinkFactory;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.eclipse.dataspaceconnector.spi.telemetry.Telemetry;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
 import org.jetbrains.annotations.NotNull;
 
@@ -26,11 +27,13 @@ import java.util.concurrent.ExecutorService;
 
 class FileTransferDataSinkFactory implements DataSinkFactory {
     private final Monitor monitor;
+    private final Telemetry telemetry;
     private final ExecutorService executorService;
     private final int partitionSize;
 
-    FileTransferDataSinkFactory(Monitor monitor, ExecutorService executorService, int partitionSize) {
+    FileTransferDataSinkFactory(Monitor monitor, Telemetry telemetry, ExecutorService executorService, int partitionSize) {
         this.monitor = monitor;
+        this.telemetry = telemetry;
         this.executorService = executorService;
         this.partitionSize = partitionSize;
     }
@@ -60,6 +63,7 @@ class FileTransferDataSinkFactory implements DataSinkFactory {
                 .partitionSize(partitionSize)
                 .executorService(executorService)
                 .monitor(monitor)
+                .telemetry(telemetry)
                 .build();
     }
 }

--- a/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferExtension.java
+++ b/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferExtension.java
@@ -50,11 +50,12 @@ public class FileTransferExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var monitor = context.getMonitor();
+        var telemetry = context.getTelemetry();
 
         var sourceFactory = new FileTransferDataSourceFactory();
         pipelineService.registerFactory(sourceFactory);
 
-        var sinkFactory = new FileTransferDataSinkFactory(monitor, executorContainer.getExecutorService(), 5);
+        var sinkFactory = new FileTransferDataSinkFactory(monitor, telemetry, executorContainer.getExecutorService(), 5);
         pipelineService.registerFactory(sinkFactory);
 
         var policy = createPolicy();

--- a/system-tests/tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/local/TracingIntegrationTest.java
+++ b/system-tests/tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/local/TracingIntegrationTest.java
@@ -62,15 +62,20 @@ public class TracingIntegrationTest extends FileTransferEdcRuntime {
     static ClientAndServer traceCollectorServer;
 
     List<String> contractNegotiationSpanNames = List.of(
-            "ConsumerContractNegotiationManagerImpl.initiate",
-            "ProviderContractNegotiationManagerImpl.requested",
-            "ConsumerContractNegotiationManagerImpl.confirmed");
+            "ConsumerContractNegotiationManagerImpl.initiate", // initial API request
+            "ProviderContractNegotiationManagerImpl.requested", // verify context propagation in ProviderContractNegotiationManagerImpl
+            "ConsumerContractNegotiationManagerImpl.confirmed" // verify context propagation in ConsumerContractNegotiationManagerImpl
+    );
 
     List<String> transferProcessSpanNames = List.of(
-            "TransferProcessManagerImpl.initiateConsumerRequest",
-            "TransferProcessManagerImpl.processInitial",
-            "TransferProcessManagerImpl.processProvisioned",
-            "TransferProcessManagerImpl.initiateProviderRequest");
+            "TransferProcessManagerImpl.initiateConsumerRequest", // initial API request
+            "TransferProcessManagerImpl.processInitial", // verify context propagation in TransferProcessManagerImpl
+            "TransferProcessManagerImpl.initiateProviderRequest", // verify context propagation in TransferProcessManagerImpl
+            "TransferProcessManagerImpl.processProvisioned", // verify context propagation in TransferProcessManagerImpl
+            "EmbeddedDataPlaneTransferClient.transfer", // DPF call
+            "PipelineServiceImpl.transfer", // verify context propagation in DataPlaneManagerImpl
+            "FileTransferDataSink.transferParts" // verify context propagation in ParallelSink
+    );
 
     @BeforeAll
     public static void setUp() {


### PR DESCRIPTION
## What this PR changes/adds

Add trace context propagation at different points within DPF:
- `DataPlaneManagerImpl`: trace context is propagated to the corresponding async worker threads through the "DataFlowRequest" entities stored in the processing queue.
- `ParallelSink`: trace context is propagated to the async workers that process parts. No entity is persisted in this case, the trace context is propagated in memory.

Additionally `TracingIntegrationTest` was extended to verify traces propagation within DPF is working properly.

## Why it does that

In order to have traces spanning across asynchronous calls it is required to propagate the tracing context to worker threads. See resulting trace visualization in Jaeger:

<img width="1266" alt="trace" src="https://user-images.githubusercontent.com/5342234/163671282-2133753b-f0c3-4c55-b799-a12975d74ffa.png">


## Linked Issue(s)

Closes #936 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
