### PR TITLE
CI: add checkstyle rule for RedundantModifier

### DIFF
--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/policy/PolicyEngineImpl.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/policy/PolicyEngineImpl.java
@@ -142,7 +142,7 @@ public class PolicyEngineImpl implements PolicyEngine {
         String key;
         AtomicConstraintFunction<R> function;
 
-        public ConstraintFunctionEntry(Class<R> type, String key, AtomicConstraintFunction<R> function) {
+        ConstraintFunctionEntry(Class<R> type, String key, AtomicConstraintFunction<R> function) {
             this.type = type;
             this.key = key;
             this.function = function;
@@ -153,7 +153,7 @@ public class PolicyEngineImpl implements PolicyEngine {
         Class<R> type;
         RuleFunction<R> function;
 
-        public RuleFunctionEntry(Class<R> type, RuleFunction<R> function) {
+        RuleFunctionEntry(Class<R> type, RuleFunction<R> function) {
             this.type = type;
             this.function = function;
         }

--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/monitor/MonitorProvider.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/monitor/MonitorProvider.java
@@ -64,7 +64,7 @@ public class MonitorProvider implements SLF4JServiceProvider {
     }
 
     private static class MonitorLogger extends AbstractLogger {
-        public MonitorLogger() {
+        MonitorLogger() {
             name = getClass().getSimpleName();
         }
 

--- a/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/ReflectiveObjectFactoryTest.java
+++ b/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/ReflectiveObjectFactoryTest.java
@@ -75,7 +75,7 @@ class ReflectiveObjectFactoryTest {
         @Inject
         private SomeService obj;
 
-        public NoDefaultCtor(String id) {
+        NoDefaultCtor(String id) {
             this.id = id;
         }
 

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/command/ContractNegotiationCommandQueueIntegrationTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/command/ContractNegotiationCommandQueueIntegrationTest.java
@@ -151,7 +151,7 @@ class ContractNegotiationCommandQueueIntegrationTest {
      * Example Command implementation for this test.
      */
     private static class TestCommand extends SingleContractNegotiationCommand {
-        public TestCommand(String negotiationId) {
+        TestCommand(String negotiationId) {
             super(negotiationId);
         }
     }
@@ -165,7 +165,7 @@ class ContractNegotiationCommandQueueIntegrationTest {
         private CountDownLatch countDownLatch;
         private String errorDetail;
 
-        public TestCommandHandler(ContractNegotiationStore store, CountDownLatch countDownLatch, String errorDetail) {
+        TestCommandHandler(ContractNegotiationStore store, CountDownLatch countDownLatch, String errorDetail) {
             super(store);
             this.countDownLatch = countDownLatch;
             this.errorDetail = errorDetail;

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
@@ -733,7 +733,7 @@ class TransferProcessManagerImplTest {
     }
 
     private static class TokenTestProvisionResource extends TestProvisionedDataDestinationResource {
-        public TokenTestProvisionResource(String resourceName, String id) {
+        TokenTestProvisionResource(String resourceName, String id) {
             super(resourceName, id);
             this.hasToken = true;
         }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
@@ -80,7 +80,7 @@ class IdsApiMultipartDispatcherV1IntegrationTestServiceExtension implements Serv
 
     private final IdentityService identityService;
 
-    public IdsApiMultipartDispatcherV1IntegrationTestServiceExtension(List<Asset> assets, IdentityService identityService) {
+    IdsApiMultipartDispatcherV1IntegrationTestServiceExtension(List<Asset> assets, IdentityService identityService) {
         this.assets = Objects.requireNonNull(assets);
         this.identityService = identityService;
     }
@@ -226,7 +226,7 @@ class IdsApiMultipartDispatcherV1IntegrationTestServiceExtension implements Serv
 
         private final List<ContractDefinition> contractDefinitions = new ArrayList<>();
 
-        public FakeContractDefinitionStore() {
+        FakeContractDefinitionStore() {
             Policy publicPolicy = Policy.Builder.newInstance()
                     .permission(Permission.Builder.newInstance()
                             .target("2")

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/AbstractDescriptionRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/AbstractDescriptionRequestHandler.java
@@ -40,7 +40,7 @@ abstract class AbstractDescriptionRequestHandler<T, S> implements DescriptionReq
     protected final IdsType targetIdsType;
     protected final Class<S> resultType;
 
-    public AbstractDescriptionRequestHandler(
+    AbstractDescriptionRequestHandler(
             @NotNull String connectorId,
             @NotNull Monitor monitor,
             @NotNull IdsTransformerRegistry transformerRegistry,

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/AbstractMultipartControllerIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/AbstractMultipartControllerIntegrationTest.java
@@ -321,7 +321,7 @@ abstract class AbstractMultipartControllerIntegrationTest {
         private final String name;
         private final byte[] content;
 
-        public NamedMultipartContent(String name, byte[] content) {
+        NamedMultipartContent(String name, byte[] content) {
             this.name = name;
             this.content = content;
         }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
@@ -89,7 +89,7 @@ import static org.mockito.Mockito.mock;
 class IdsApiMultipartEndpointV1IntegrationTestServiceExtension implements ServiceExtension {
     private final List<Asset> assets;
 
-    public IdsApiMultipartEndpointV1IntegrationTestServiceExtension(List<Asset> assets) {
+    IdsApiMultipartEndpointV1IntegrationTestServiceExtension(List<Asset> assets) {
         this.assets = Objects.requireNonNull(assets);
     }
 

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/transform/IdsTransformerRegistryImpl.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/transform/IdsTransformerRegistryImpl.java
@@ -84,7 +84,7 @@ public class IdsTransformerRegistryImpl implements IdsTransformerRegistry {
         private final Class<?> input;
         private final Class<?> output;
 
-        public TransformKey(Class<?> input, Class<?> output) {
+        TransformKey(Class<?> input, Class<?> output) {
             Objects.requireNonNull(input);
             Objects.requireNonNull(output);
             this.input = input;
@@ -121,7 +121,7 @@ public class IdsTransformerRegistryImpl implements IdsTransformerRegistry {
         private final List<String> problems = new ArrayList<>();
         private final IdsTransformerRegistryImpl registry;
 
-        public TransformerContextImpl(IdsTransformerRegistryImpl registry) {
+        TransformerContextImpl(IdsTransformerRegistryImpl registry) {
             this.registry = registry;
         }
 

--- a/data-protocols/ids/ids-spi/src/test/java/org/eclipse/dataspaceconnector/ids/IdsIdParserTest.java
+++ b/data-protocols/ids/ids-spi/src/test/java/org/eclipse/dataspaceconnector/ids/IdsIdParserTest.java
@@ -71,7 +71,7 @@ class IdsIdParserTest {
     }
 
     static class IllegalIdsArgumentsProvider implements ArgumentsProvider {
-        public IllegalIdsArgumentsProvider() {
+        IllegalIdsArgumentsProvider() {
         }
 
         @Override
@@ -82,7 +82,7 @@ class IdsIdParserTest {
     }
 
     static class LegalIdsArgumentsProvider implements ArgumentsProvider {
-        public LegalIdsArgumentsProvider() {
+        LegalIdsArgumentsProvider() {
         }
 
         @Override

--- a/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/dataspaceconnector/ids/transform/IdsTransformServiceExtensionTest.java
+++ b/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/dataspaceconnector/ids/transform/IdsTransformServiceExtensionTest.java
@@ -130,7 +130,7 @@ class IdsTransformServiceExtensionTest {
     private static class TestTransformerRegistry implements IdsTransformerRegistry {
         private final Map<Class<?>, List<Class<?>>> knownConvertibles;
 
-        public TestTransformerRegistry(Map<Class<?>, List<Class<?>>> knownConvertibles) {
+        TestTransformerRegistry(Map<Class<?>, List<Class<?>>> knownConvertibles) {
             this.knownConvertibles = knownConvertibles;
         }
 

--- a/extensions/api/auth-basic/src/main/java/org/eclipse/dataspaceconnector/api/auth/BasicAuthenticationService.java
+++ b/extensions/api/auth-basic/src/main/java/org/eclipse/dataspaceconnector/api/auth/BasicAuthenticationService.java
@@ -111,7 +111,7 @@ public class BasicAuthenticationService implements AuthenticationService {
         String username;
         String password;
 
-        public BasicAuthCredentials(String username, String password) {
+        BasicAuthCredentials(String username, String password) {
             this.username = username;
             this.password = password;
         }

--- a/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/HttpApiKeyAuthContainerRequestFilter.java
+++ b/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/HttpApiKeyAuthContainerRequestFilter.java
@@ -45,7 +45,7 @@ class HttpApiKeyAuthContainerRequestFilter implements ContainerRequestFilter {
      */
     private final String expectedHeaderValue;
 
-    public HttpApiKeyAuthContainerRequestFilter(
+    HttpApiKeyAuthContainerRequestFilter(
             @NotNull String expectedHeaderName,
             @NotNull String expectedHeaderValue,
             @NotNull Predicate<ContainerRequestContext> containerRequestContextPredicate) {

--- a/extensions/aws/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataSource.java
+++ b/extensions/aws/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataSource.java
@@ -40,7 +40,7 @@ class S3DataSource implements DataSource {
         private final String keyName;
         private final String bucketName;
 
-        public S3Part(S3Client client, String keyName, String bucketName) {
+        S3Part(S3Client client, String keyName, String bucketName) {
             this.client = client;
             this.keyName = keyName;
             this.bucketName = bucketName;

--- a/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/LimitClause.java
+++ b/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/LimitClause.java
@@ -22,7 +22,7 @@ class LimitClause implements Clause {
 
     private final Integer limit;
 
-    public LimitClause(Integer limit) {
+    LimitClause(Integer limit) {
         this.limit = limit;
     }
 

--- a/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/OffsetClause.java
+++ b/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/OffsetClause.java
@@ -24,7 +24,7 @@ class OffsetClause implements Clause {
 
     private final Integer offset;
 
-    public OffsetClause(Integer offset) {
+    OffsetClause(Integer offset) {
         this.offset = offset;
     }
 

--- a/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/OrderByClause.java
+++ b/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/OrderByClause.java
@@ -35,14 +35,14 @@ class OrderByClause implements Clause {
     private final boolean sortAsc;
     private final String objectPrefix;
 
-    public OrderByClause(String orderField, boolean sortAsc, String objectPrefix) {
+    OrderByClause(String orderField, boolean sortAsc, String objectPrefix) {
 
         this.orderField = orderField;
         this.sortAsc = sortAsc;
         this.objectPrefix = objectPrefix;
     }
 
-    public OrderByClause(String orderField, boolean sortAsc) {
+    OrderByClause(String orderField, boolean sortAsc) {
         this(orderField, sortAsc, null);
     }
 

--- a/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/WhereClause.java
+++ b/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/WhereClause.java
@@ -45,7 +45,7 @@ class WhereClause implements Clause {
     private final List<SqlParameter> parameters = new ArrayList<>();
     private String where = "";
 
-    public WhereClause(List<Criterion> criteria, String objectPrefix) {
+    WhereClause(List<Criterion> criteria, String objectPrefix) {
         this.objectPrefix = objectPrefix;
         if (criteria != null) {
             criteria.stream().distinct().forEach(this::criterion);

--- a/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSource.java
+++ b/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSource.java
@@ -125,7 +125,7 @@ public class AzureStorageDataSource implements DataSource {
     private static class AzureStoragePart implements Part {
         private final BlobAdapter adapter;
 
-        public AzureStoragePart(BlobAdapter adapter) {
+        AzureStoragePart(BlobAdapter adapter) {
             this.adapter = adapter;
         }
 

--- a/extensions/azure/events/src/main/java/org/eclipse/dataspaceconnector/events/azure/AzureEventGridPublisher.java
+++ b/extensions/azure/events/src/main/java/org/eclipse/dataspaceconnector/events/azure/AzureEventGridPublisher.java
@@ -33,7 +33,7 @@ class AzureEventGridPublisher implements TransferProcessListener {
     private final String eventTypeMetadata = "dataspaceconnector/metadata/store";
     private final String connectorId;
 
-    public AzureEventGridPublisher(String connectorId, Monitor monitor, EventGridPublisherAsyncClient<EventGridEvent> client) {
+    AzureEventGridPublisher(String connectorId, Monitor monitor, EventGridPublisherAsyncClient<EventGridEvent> client) {
         this.connectorId = connectorId;
         this.monitor = monitor;
         this.client = client;

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/management/PartitionManagerImplIntegrationTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/management/PartitionManagerImplIntegrationTest.java
@@ -134,7 +134,7 @@ class PartitionManagerImplIntegrationTest {
     private static class SignalingWorkItemQueue extends DefaultWorkItemQueue {
         private final WorkQueueListener listener;
 
-        public SignalingWorkItemQueue(int cap, WorkQueueListener listener) {
+        SignalingWorkItemQueue(int cap, WorkQueueListener listener) {
             super(cap);
             this.listener = listener;
         }
@@ -170,7 +170,7 @@ class PartitionManagerImplIntegrationTest {
      */
     private static class RunOnceExecutionPlan implements ExecutionPlan {
 
-        public RunOnceExecutionPlan() {
+        RunOnceExecutionPlan() {
         }
 
         @Override

--- a/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/e2e/EndToEndTest.java
+++ b/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/e2e/EndToEndTest.java
@@ -57,7 +57,7 @@ public class EndToEndTest {
         private final ByteArrayOutputStream stream;
         private final OutputStreamDataSink sink;
 
-        public FixedEndpoint(Monitor monitor) {
+        FixedEndpoint(Monitor monitor) {
             stream = new ByteArrayOutputStream();
             sink = new OutputStreamDataSink(stream, Executors.newFixedThreadPool(1), monitor);
         }

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpDataSource.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpDataSource.java
@@ -177,7 +177,7 @@ public class HttpDataSource implements DataSource {
         private final String name;
         private final byte[] content;
 
-        public HttpPart(String name, byte[] content) {
+        HttpPart(String name, byte[] content) {
             this.name = name;
             this.content = content;
         }

--- a/extensions/data-plane/integration-tests/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/DataPlaneHttpPullIntegrationTests.java
+++ b/extensions/data-plane/integration-tests/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/DataPlaneHttpPullIntegrationTests.java
@@ -173,7 +173,7 @@ public class DataPlaneHttpPullIntegrationTests {
         private final RequestSpecification dataplaneRequest;
         private final HttpRequest expectedSourceRequest;
 
-        public TestInstance(String method) {
+        TestInstance(String method) {
             this.method = method;
             dataplaneRequest = givenDpfRequest(token);
             expectedSourceRequest = new HttpRequest();

--- a/extensions/dataloading/src/test/java/org/eclipse/dataspaceconnector/dataloading/TestEntity.java
+++ b/extensions/dataloading/src/test/java/org/eclipse/dataspaceconnector/dataloading/TestEntity.java
@@ -18,7 +18,7 @@ class TestEntity {
     private final String description;
     private final int index;
 
-    public TestEntity(String description, int index) {
+    TestEntity(String description, int index) {
         this.description = description;
         this.index = index;
     }

--- a/extensions/iam/daps/src/test/java/org/eclipse/dataspaceconnector/iam/daps/TestExtensions.java
+++ b/extensions/iam/daps/src/test/java/org/eclipse/dataspaceconnector/iam/daps/TestExtensions.java
@@ -29,7 +29,7 @@ public class TestExtensions {
     private static class MockHttpExtension implements ServiceExtension {
         private final OkHttpClient client;
 
-        public MockHttpExtension(OkHttpClient client) {
+        MockHttpExtension(OkHttpClient client) {
             this.client = client;
         }
 

--- a/extensions/iam/decentralized-identity/identity-did-service/src/test/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityServiceTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-service/src/test/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityServiceTest.java
@@ -148,7 +148,7 @@ abstract class DecentralizedIdentityServiceTest {
         private String hubUrlDid;
         private JWK keyPair;
 
-        public TestResolverRegistry(String hubUrlDid, JWK keyPair) {
+        TestResolverRegistry(String hubUrlDid, JWK keyPair) {
             this.hubUrlDid = hubUrlDid;
             this.keyPair = keyPair;
         }

--- a/extensions/in-memory/did-document-store-inmem/src/main/java/org/eclipse/dataspaceconnector/samples/identity/did/InMemoryDidDocumentStore.java
+++ b/extensions/in-memory/did-document-store-inmem/src/main/java/org/eclipse/dataspaceconnector/samples/identity/did/InMemoryDidDocumentStore.java
@@ -87,7 +87,7 @@ public class InMemoryDidDocumentStore implements DidStore {
         private final Instant createTime = Instant.now();
         private final T payload;
 
-        public Entity(T payload) {
+        Entity(T payload) {
             this.payload = payload;
         }
 

--- a/extensions/policy/ids-policy/src/test/java/org/eclipse/dataspaceconnector/ids/policy/MockPolicyContext.java
+++ b/extensions/policy/ids-policy/src/test/java/org/eclipse/dataspaceconnector/ids/policy/MockPolicyContext.java
@@ -25,7 +25,7 @@ class MockPolicyContext implements PolicyContext {
     private final ParticipantAgent agent;
     private final List<String> problems = new ArrayList<>();
 
-    public MockPolicyContext(ParticipantAgent agent) {
+    MockPolicyContext(ParticipantAgent agent) {
         this.agent = agent;
     }
 

--- a/extensions/sql/asset-index-sql/src/main/java/org/eclipse/dataspaceconnector/sql/asset/index/SqlConditionExpression.java
+++ b/extensions/sql/asset-index-sql/src/main/java/org/eclipse/dataspaceconnector/sql/asset/index/SqlConditionExpression.java
@@ -38,7 +38,7 @@ class SqlConditionExpression {
     private static final String PREPARED_STATEMENT_PLACEHOLDER = "?";
     private final Criterion criterion;
 
-    public SqlConditionExpression(Criterion criterion) {
+    SqlConditionExpression(Criterion criterion) {
 
         this.criterion = criterion;
     }

--- a/extensions/sql/asset-index-sql/src/test/java/org/eclipse/dataspaceconnector/sql/asset/index/SqlAssetIndexTest.java
+++ b/extensions/sql/asset-index-sql/src/test/java/org/eclipse/dataspaceconnector/sql/asset/index/SqlAssetIndexTest.java
@@ -447,13 +447,13 @@ class SqlAssetIndexTest {
         private int someNumber;
         private boolean someBoolean;
 
-        public TestObject(String text, int number, boolean bool) {
+        TestObject(String text, int number, boolean bool) {
             someText = text;
             someNumber = number;
             someBoolean = bool;
         }
 
-        public TestObject() {
+        TestObject() {
         }
 
         public String getSomeText() {

--- a/extensions/sql/common-sql/src/main/java/org/eclipse/dataspaceconnector/sql/datasource/PooledDataSourceConnection.java
+++ b/extensions/sql/common-sql/src/main/java/org/eclipse/dataspaceconnector/sql/datasource/PooledDataSourceConnection.java
@@ -46,7 +46,7 @@ class PooledDataSourceConnection implements Connection {
     private final Connection connection;
     private final ConnectionPool connectionPool;
 
-    public PooledDataSourceConnection(Connection connection, ConnectionPool connectionPool) {
+    PooledDataSourceConnection(Connection connection, ConnectionPool connectionPool) {
         this.connectionPool = Objects.requireNonNull(connectionPool);
         this.connection = Objects.requireNonNull(connection);
     }

--- a/extensions/sql/common-sql/src/test/java/org/eclipse/dataspaceconnector/sql/SqlQueryExecutorIntegrationTest.java
+++ b/extensions/sql/common-sql/src/test/java/org/eclipse/dataspaceconnector/sql/SqlQueryExecutorIntegrationTest.java
@@ -110,7 +110,7 @@ public class SqlQueryExecutorIntegrationTest {
         final String key;
         final String value;
 
-        public Kv(String key, String value) {
+        Kv(String key, String value) {
             this.key = key;
             this.value = value;
         }

--- a/extensions/sql/lease-sql/src/test/java/org/eclipse/dataspaceconnector/sql/lease/SqlLeaseContextTest.java
+++ b/extensions/sql/lease-sql/src/test/java/org/eclipse/dataspaceconnector/sql/lease/SqlLeaseContextTest.java
@@ -183,7 +183,7 @@ class SqlLeaseContextTest {
         private final String id;
         private final String leaseId;
 
-        public TestEntity(String id, String leaseId) {
+        TestEntity(String id, String leaseId) {
             this.id = id;
             this.leaseId = leaseId;
         }

--- a/extensions/sql/pool/apache-commons-pool-sql/src/main/java/org/eclipse/dataspaceconnector/sql/pool/commons/CommonsConnectionPool.java
+++ b/extensions/sql/pool/apache-commons-pool-sql/src/main/java/org/eclipse/dataspaceconnector/sql/pool/commons/CommonsConnectionPool.java
@@ -85,7 +85,7 @@ public final class CommonsConnectionPool implements ConnectionPool, AutoCloseabl
         private final String testQuery;
         private final DataSource dataSource;
 
-        public PooledConnectionObjectFactory(@NotNull DataSource dataSource, @NotNull String testQuery) {
+        PooledConnectionObjectFactory(@NotNull DataSource dataSource, @NotNull String testQuery) {
             this.dataSource = Objects.requireNonNull(dataSource);
             this.testQuery = Objects.requireNonNull(testQuery);
         }

--- a/extensions/transaction/transaction-local/src/main/java/org/eclipse/dataspaceconnector/transaction/local/ConnectionWrapper.java
+++ b/extensions/transaction/transaction-local/src/main/java/org/eclipse/dataspaceconnector/transaction/local/ConnectionWrapper.java
@@ -40,7 +40,7 @@ import java.util.concurrent.Executor;
 class ConnectionWrapper implements Connection {
     private final Connection delegate;
 
-    public ConnectionWrapper(Connection delegate) {
+    ConnectionWrapper(Connection delegate) {
         this.delegate = delegate;
     }
 

--- a/launchers/junit/src/testFixtures/java/org/eclipse/dataspaceconnector/junit/launcher/EdcExtension.java
+++ b/launchers/junit/src/testFixtures/java/org/eclipse/dataspaceconnector/junit/launcher/EdcExtension.java
@@ -146,7 +146,7 @@ public class EdcExtension extends BaseRuntime implements BeforeTestExecutionCall
         private final ServiceLocator delegate = new ServiceLocatorImpl();
         private final LinkedHashMap<Class<? extends SystemExtension>, List<SystemExtension>> systemExtensions;
 
-        public MultiSourceServiceLocator() {
+        MultiSourceServiceLocator() {
             this.systemExtensions  = new LinkedHashMap<>();
         }
 

--- a/resources/edc-checkstyle-config.xml
+++ b/resources/edc-checkstyle-config.xml
@@ -431,5 +431,6 @@
     <!-- Require both @deprecated Javadoc tag and @Deprecated annotation -->
     <module name="MissingDeprecated"/>
     <module name="UnusedImports"/>
+    <module name="RedundantModifier"/>
   </module>
 </module>

--- a/samples/04.0-file-transfer/transfer-file/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferDataSinkFactory.java
+++ b/samples/04.0-file-transfer/transfer-file/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferDataSinkFactory.java
@@ -29,7 +29,7 @@ class FileTransferDataSinkFactory implements DataSinkFactory {
     private final ExecutorService executorService;
     private final int partitionSize;
 
-    public FileTransferDataSinkFactory(Monitor monitor, ExecutorService executorService, int partitionSize) {
+    FileTransferDataSinkFactory(Monitor monitor, ExecutorService executorService, int partitionSize) {
         this.monitor = monitor;
         this.executorService = executorService;
         this.partitionSize = partitionSize;

--- a/samples/04.0-file-transfer/transfer-file/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferDataSource.java
+++ b/samples/04.0-file-transfer/transfer-file/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferDataSource.java
@@ -27,7 +27,7 @@ class FileTransferDataSource implements DataSource {
 
     private final File file;
 
-    public FileTransferDataSource(File file) {
+    FileTransferDataSource(File file) {
         this.file = file;
     }
 

--- a/samples/other/custom-runtime/src/main/java/org/eclipse/dataspaceconnector/demo/runtime/CustomRuntime.java
+++ b/samples/other/custom-runtime/src/main/java/org/eclipse/dataspaceconnector/demo/runtime/CustomRuntime.java
@@ -55,7 +55,7 @@ public class CustomRuntime extends BaseRuntime {
     }
 
     private static class SuperCustomExtensionContext extends DefaultServiceExtensionContext {
-        public SuperCustomExtensionContext(TypeManager typeManager, Monitor monitor, Telemetry telemetry, List<ConfigurationExtension> configurationExtensions) {
+        SuperCustomExtensionContext(TypeManager typeManager, Monitor monitor, Telemetry telemetry, List<ConfigurationExtension> configurationExtensions) {
             super(typeManager, monitor, telemetry, configurationExtensions);
         }
     }

--- a/samples/other/run-from-junit/src/test/java/org/eclipse/dataspaceconnector/junit/TestExtensions.java
+++ b/samples/other/run-from-junit/src/test/java/org/eclipse/dataspaceconnector/junit/TestExtensions.java
@@ -29,7 +29,7 @@ public class TestExtensions {
     private static class MockIamExtension implements ServiceExtension {
         private final IdentityService identityService;
 
-        public MockIamExtension(IdentityService identityService) {
+        MockIamExtension(IdentityService identityService) {
             this.identityService = identityService;
         }
 

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/command/BoundedCommandQueueTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/command/BoundedCommandQueueTest.java
@@ -117,7 +117,7 @@ class BoundedCommandQueueTest {
     }
 
     private static class BoundedTestCommandQueue extends BoundedCommandQueue<TestCommand> {
-        public BoundedTestCommandQueue(int bound) {
+        BoundedTestCommandQueue(int bound) {
             super(bound);
         }
     }

--- a/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferDataSinkFactory.java
+++ b/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferDataSinkFactory.java
@@ -29,7 +29,7 @@ class FileTransferDataSinkFactory implements DataSinkFactory {
     private final ExecutorService executorService;
     private final int partitionSize;
 
-    public FileTransferDataSinkFactory(Monitor monitor, ExecutorService executorService, int partitionSize) {
+    FileTransferDataSinkFactory(Monitor monitor, ExecutorService executorService, int partitionSize) {
         this.monitor = monitor;
         this.executorService = executorService;
         this.partitionSize = partitionSize;

--- a/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferDataSource.java
+++ b/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferDataSource.java
@@ -27,7 +27,7 @@ class FileTransferDataSource implements DataSource {
 
     private final File file;
 
-    public FileTransferDataSource(File file) {
+    FileTransferDataSource(File file) {
         this.file = file;
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Add a rule for checkstyle check [RedundantModifier](https://checkstyle.sourceforge.io/config_modifier.html#RedundantModifier).
Checks for redundant modifiers, such as usage of public and abstract for method declarations in interfaces, or public constructor in private static classes.

## Why it does that

Improve code consistency and reduce spurious PR diffs.

## Further notes

## Linked Issue(s)

Relates to #991 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
