### PR TITLE
CI: add checkstyle rule for MissingDeprecated

### DIFF
--- a/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/response/NegotiationStatusResponse.java
+++ b/extensions/api/control/src/main/java/org/eclipse/dataspaceconnector/api/control/response/NegotiationStatusResponse.java
@@ -19,6 +19,8 @@ import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.Cont
 
 /**
  * Response for requesting the status of a {@link ContractNegotiation}.
+ *
+ * @deprecated Control API is deprecated, use Data Management API instead.
  */
 @Deprecated
 public class NegotiationStatusResponse {

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/IdentityHub.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/hub/IdentityHub.java
@@ -32,6 +32,8 @@ public interface IdentityHub {
 
     /**
      * Workaround for Hackathon .NET client
+     *
+     * @deprecated use {@link #write(String)}
      */
     @Deprecated
     void write(Commit commit);

--- a/resources/edc-checkstyle-config.xml
+++ b/resources/edc-checkstyle-config.xml
@@ -427,5 +427,7 @@
     </module>
     <module name="TypecastParenPad"/>
     <module name="InnerAssignment"/>
+    <!-- Require both @deprecated Javadoc tag and @Deprecated annotation -->
+    <module name="MissingDeprecated"/>
   </module>
 </module>


### PR DESCRIPTION
## What this PR changes/adds

Add a rule for checkstyle check [MissingDeprecated](https://checkstyle.sourceforge.io/config_annotation.html#MissingDeprecated).

Verifies that the annotation @Deprecated and the Javadoc tag @deprecated are both present when either of them is present.

## Why it does that

Improve code consistency and reduce spurious PR diffs.

## Further notes

## Linked Issue(s)

Relates to #991 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
