### PR TITLE
fix: publish data-plane-azure-common artifact

### DIFF
--- a/extensions/azure/data-plane/common/build.gradle.kts
+++ b/extensions/azure/data-plane/common/build.gradle.kts
@@ -20,3 +20,12 @@ dependencies {
     api(project(":extensions:data-plane:data-plane-spi"))
     implementation(project(":common:util"))
 }
+
+publishing {
+    publications {
+        create<MavenPublication>("data-plane-azure-common") {
+            artifactId = "data-plane-azure-common"
+            from(components["java"])
+        }
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

This PR adds missing artifact publication for `data-plane-azure-common` which is required by the DPF server launcher.

## Linked Issue(s)

Closes #1168 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
