### PR TITLE
DPF: fix Maven artifact names

### DIFF
--- a/extensions/data-plane-selector/selector-api/build.gradle.kts
+++ b/extensions/data-plane-selector/selector-api/build.gradle.kts
@@ -46,8 +46,8 @@ dependencies {
 
 publishing {
     publications {
-        create<MavenPublication>("data-plane-selector-spi") {
-            artifactId = "data-plane-selector-spi"
+        create<MavenPublication>("data-plane-selector-api") {
+            artifactId = "data-plane-selector-api"
             from(components["java"])
         }
     }

--- a/extensions/data-plane-selector/selector-core/build.gradle.kts
+++ b/extensions/data-plane-selector/selector-core/build.gradle.kts
@@ -25,8 +25,8 @@ dependencies {
 
 publishing {
     publications {
-        create<MavenPublication>("data-plane-selector-spi") {
-            artifactId = "data-plane-selector-spi"
+        create<MavenPublication>("data-plane-selector-core") {
+            artifactId = "data-plane-selector-core"
             from(components["java"])
         }
     }


### PR DESCRIPTION
## What this PR changes/adds

Maven artefacts for `selector-api` and `selector-core` were misnamed as `data-plane-selector-spi`. Therefore 3 artefacts used that same name.

## Why it does that

## Further notes

## Linked Issue(s)

Closes #1184

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
