### PR TITLE
build: introduce plugin to check duplicate module names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ in the detailed section referring to by linking pull requests or issues.
 
 * Add domain model documentation (#1158)
 * Add gradle test summary (#1148)
+* Check to avoid duplicated module names (#1190)
 
 #### Changed
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
     checkstyle
     jacoco
     id("com.rameshkp.openapi-merger-gradle-plugin") version "1.0.4"
+    id("org.eclipse.dataspaceconnector.module-names")
     id("com.autonomousapps.dependency-analysis") version "1.0.0-rc05" apply (false)
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,13 +4,21 @@ plugins {
 
 gradlePlugin {
     plugins {
-        create("DataspaceConnectorPlugin") {
+
+        create("DependencyRulesPlugin") {
             id = "org.eclipse.dataspaceconnector.dependency-rules"
             implementationClass = "org.eclipse.dataspaceconnector.gradle.DependencyRulesPlugin"
         }
+
         create("TestSummaryPlugin") {
             id = "org.eclipse.dataspaceconnector.test-summary"
             implementationClass = "org.eclipse.dataspaceconnector.gradle.TestSummaryPlugin"
         }
+
+        create("ModuleNamesPlugin") {
+            id = "org.eclipse.dataspaceconnector.module-names"
+            implementationClass = "org.eclipse.dataspaceconnector.gradle.ModuleNamesPlugin"
+        }
+
     }
 }

--- a/buildSrc/src/main/java/org/eclipse/dataspaceconnector/gradle/DependencyRulesPlugin.java
+++ b/buildSrc/src/main/java/org/eclipse/dataspaceconnector/gradle/DependencyRulesPlugin.java
@@ -26,7 +26,7 @@ public class DependencyRulesPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         var extension = project.getExtensions()
-                .create("dataspaceconnectorplugin", DependencyRulesPluginExtension.class);
+                .create("dependencyrulespluginextension", DependencyRulesPluginExtension.class);
         project.getSubprojects().forEach(p -> registerTask(p, extension));
     }
 

--- a/buildSrc/src/main/java/org/eclipse/dataspaceconnector/gradle/DependencyRulesPlugin.java
+++ b/buildSrc/src/main/java/org/eclipse/dataspaceconnector/gradle/DependencyRulesPlugin.java
@@ -25,9 +25,8 @@ public class DependencyRulesPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        var extension = project.getExtensions().create(
-                "dataspaceconnectorplugin", DependencyRulesPluginExtension.class
-        );
+        var extension = project.getExtensions()
+                .create("dataspaceconnectorplugin", DependencyRulesPluginExtension.class);
         project.getSubprojects().forEach(p -> registerTask(p, extension));
     }
 

--- a/buildSrc/src/main/java/org/eclipse/dataspaceconnector/gradle/ModuleNamesPlugin.java
+++ b/buildSrc/src/main/java/org/eclipse/dataspaceconnector/gradle/ModuleNamesPlugin.java
@@ -30,7 +30,9 @@ import static java.util.stream.Collectors.toMap;
 /**
  * Custom grade plugin to avoid module name duplications.
  * Checks between modules with a gradle build file that their names are unique in the whole project.
- * `samples` and `system-tests` modules are excluded
+ * `samples` and `system-tests` modules are excluded.
+ *
+ * Ref: https://github.com/gradle/gradle/issues/847
  */
 public class ModuleNamesPlugin implements Plugin<Project> {
 

--- a/buildSrc/src/main/java/org/eclipse/dataspaceconnector/gradle/ModuleNamesPlugin.java
+++ b/buildSrc/src/main/java/org/eclipse/dataspaceconnector/gradle/ModuleNamesPlugin.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.gradle;
+
+import org.gradle.api.Action;
+import org.gradle.api.GradleException;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toMap;
+
+/**
+ * Custom grade plugin to avoid module name duplications.
+ * Checks between modules with a gradle build file that their names are unique in the whole project.
+ * `samples` and `system-tests` modules are excluded
+ */
+public class ModuleNamesPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        project.afterEvaluate(new ModuleNamesAction());
+    }
+
+    private class ModuleNamesAction implements Action<Project> {
+
+        private final Predicate<String> isSampleModule = displayName -> displayName.startsWith("project ':samples");
+        private final Predicate<String> isSystemTestModule = displayName -> displayName.startsWith("project ':system-tests");
+        private final Predicate<String> excludeSamplesAndSystemTests = isSampleModule.or(isSystemTestModule).negate();
+
+        @Override
+        public void execute(Project project) {
+            var subprojects = project.getSubprojects().stream()
+                    .filter(it -> it.getBuildFile().exists())
+                    .map(Project::getDisplayName)
+                    .filter(excludeSamplesAndSystemTests)
+                    .collect(groupingBy(projectName));
+
+            var duplicatedSubprojects = subprojects.entrySet().stream()
+                    .filter(it -> it.getValue().size() > 1)
+                    .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+            if (!duplicatedSubprojects.isEmpty()) {
+                var message = duplicatedSubprojects.entrySet().stream()
+                        .map(it -> it.getKey() + ":\n" + it.getValue().stream().collect(joining("\n\t", "\t", "")))
+                        .collect(joining("\n"));
+
+                throw new GradleException("Duplicated module names found: \n" + message);
+            }
+        }
+
+        private final Function<String, String> projectName = it -> {
+            var split = it.replace("project '", "").replace("'", "").split(":");
+            return split[split.length - 1];
+        };
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

Adds a gradle plugin that fails if duplicate module name exists

In the case of conflict will print something like:
```
  Duplicated module names found: 
  assetindex:
        project ':extensions:in-memory:assetindex'
        project ':extensions:sql:assetindex'
```

## Why it does that

To avoid situations like the one described in #1135 to reoccur.

## Further notes

- modules existent in the `samples` and the `system-tests` folder will be excluded
- only modules with the build file will be checked

## Linked Issue(s)

Closes #1174 

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
