### PR TITLE
Bugfix: Skip authentication of OPTIONS requests

### DIFF
--- a/extensions/api/auth-spi/src/main/java/org/eclipse/dataspaceconnector/api/auth/AuthenticationRequestFilter.java
+++ b/extensions/api/auth-spi/src/main/java/org/eclipse/dataspaceconnector/api/auth/AuthenticationRequestFilter.java
@@ -23,6 +23,11 @@ import java.util.stream.Collectors;
 
 import static jakarta.ws.rs.HttpMethod.OPTIONS;
 
+/**
+ * Intercepts all requests sent to this resource and authenticates them using an {@link AuthenticationService}.
+ * In order to be able to handle CORS requests properly, OPTIONS requests are not validated as their headers usually don't
+ * contain credentials.
+ */
 public class AuthenticationRequestFilter implements ContainerRequestFilter {
     private final AuthenticationService authenticationService;
 
@@ -34,6 +39,7 @@ public class AuthenticationRequestFilter implements ContainerRequestFilter {
     public void filter(ContainerRequestContext requestContext) {
         var headers = requestContext.getHeaders();
 
+        // OPTIONS requests don't have credentials - do not authenticate
         if (!OPTIONS.equalsIgnoreCase(requestContext.getMethod())) {
             var isAuthenticated = authenticationService.isAuthenticated(headers.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
             if (!isAuthenticated) {

--- a/extensions/api/auth-spi/src/main/java/org/eclipse/dataspaceconnector/api/auth/AuthenticationRequestFilter.java
+++ b/extensions/api/auth-spi/src/main/java/org/eclipse/dataspaceconnector/api/auth/AuthenticationRequestFilter.java
@@ -21,6 +21,8 @@ import org.eclipse.dataspaceconnector.api.exception.NotAuthorizedException;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static jakarta.ws.rs.HttpMethod.OPTIONS;
+
 public class AuthenticationRequestFilter implements ContainerRequestFilter {
     private final AuthenticationService authenticationService;
 
@@ -32,10 +34,11 @@ public class AuthenticationRequestFilter implements ContainerRequestFilter {
     public void filter(ContainerRequestContext requestContext) {
         var headers = requestContext.getHeaders();
 
-        var isAuthenticated = authenticationService.isAuthenticated(headers.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-
-        if (!isAuthenticated) {
-            throw new NotAuthorizedException();
+        if (!OPTIONS.equalsIgnoreCase(requestContext.getMethod())) {
+            var isAuthenticated = authenticationService.isAuthenticated(headers.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+            if (!isAuthenticated) {
+                throw new NotAuthorizedException();
+            }
         }
     }
 }

--- a/extensions/api/auth-spi/src/test/java/org/eclipse/dataspaceconnector/api/auth/AuthenticationRequestFilterTest.java
+++ b/extensions/api/auth-spi/src/test/java/org/eclipse/dataspaceconnector/api/auth/AuthenticationRequestFilterTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -73,5 +74,14 @@ class AuthenticationRequestFilterTest {
 
         assertThatThrownBy(() -> filter.filter(contextMock)).isInstanceOf(NotAuthorizedException.class);
         verify(authSrvMock).isAuthenticated(anyMap());
+    }
+
+    @Test
+    void filter_shouldSkipOnOptions() {
+        var contextMock = mock(ContainerRequestContext.class);
+        when(contextMock.getMethod()).thenReturn("OPTIONS");
+
+        filter.filter(contextMock);
+        verify(authSrvMock, never()).isAuthenticated(anyMap());
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

the `AuthenticationRequestFilter` should skip checking auth headers for OPTIONS requests.

## Why it does that

When using the REST APIs from a browser, they usually send "preflight" requests using the `OPTIONS` method. Since it's actually the browsers sending those requests and not the frontend application, there is no way to attach any auth header, therefore the preflight requests always get rejected with a 401. 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
