### PR TITLE
fix: Prevent consumer DPF proxy to filter request arguments 

### DIFF
--- a/extensions/data-plane-transfer/data-plane-transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/core/proxy/DataPlaneTransferConsumerProxyTransformer.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/core/proxy/DataPlaneTransferConsumerProxyTransformer.java
@@ -26,6 +26,10 @@ import static org.eclipse.dataspaceconnector.dataplane.spi.DataPlaneConstants.CO
 import static org.eclipse.dataspaceconnector.spi.types.domain.http.HttpDataAddressSchema.AUTHENTICATION_CODE;
 import static org.eclipse.dataspaceconnector.spi.types.domain.http.HttpDataAddressSchema.AUTHENTICATION_KEY;
 import static org.eclipse.dataspaceconnector.spi.types.domain.http.HttpDataAddressSchema.ENDPOINT;
+import static org.eclipse.dataspaceconnector.spi.types.domain.http.HttpDataAddressSchema.PROXY_BODY;
+import static org.eclipse.dataspaceconnector.spi.types.domain.http.HttpDataAddressSchema.PROXY_METHOD;
+import static org.eclipse.dataspaceconnector.spi.types.domain.http.HttpDataAddressSchema.PROXY_PATH;
+import static org.eclipse.dataspaceconnector.spi.types.domain.http.HttpDataAddressSchema.PROXY_QUERY_PARAMS;
 import static org.eclipse.dataspaceconnector.spi.types.domain.http.HttpDataAddressSchema.TYPE;
 
 /**
@@ -72,6 +76,10 @@ public class DataPlaneTransferConsumerProxyTransformer implements EndpointDataRe
                 .property(ENDPOINT, edr.getEndpoint())
                 .property(AUTHENTICATION_KEY, edr.getAuthKey())
                 .property(AUTHENTICATION_CODE, edr.getAuthCode())
+                .property(PROXY_QUERY_PARAMS, Boolean.TRUE.toString())
+                .property(PROXY_PATH, Boolean.TRUE.toString())
+                .property(PROXY_METHOD, Boolean.TRUE.toString())
+                .property(PROXY_BODY, Boolean.TRUE.toString())
                 .build();
     }
 }

--- a/extensions/data-plane-transfer/data-plane-transfer-core/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/core/proxy/DataPlaneTransferConsumerProxyTransformerTest.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-core/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/core/proxy/DataPlaneTransferConsumerProxyTransformerTest.java
@@ -30,6 +30,10 @@ import static org.eclipse.dataspaceconnector.dataplane.spi.DataPlaneConstants.CO
 import static org.eclipse.dataspaceconnector.spi.types.domain.http.HttpDataAddressSchema.AUTHENTICATION_CODE;
 import static org.eclipse.dataspaceconnector.spi.types.domain.http.HttpDataAddressSchema.AUTHENTICATION_KEY;
 import static org.eclipse.dataspaceconnector.spi.types.domain.http.HttpDataAddressSchema.ENDPOINT;
+import static org.eclipse.dataspaceconnector.spi.types.domain.http.HttpDataAddressSchema.PROXY_BODY;
+import static org.eclipse.dataspaceconnector.spi.types.domain.http.HttpDataAddressSchema.PROXY_METHOD;
+import static org.eclipse.dataspaceconnector.spi.types.domain.http.HttpDataAddressSchema.PROXY_PATH;
+import static org.eclipse.dataspaceconnector.spi.types.domain.http.HttpDataAddressSchema.PROXY_QUERY_PARAMS;
 import static org.eclipse.dataspaceconnector.spi.types.domain.http.HttpDataAddressSchema.TYPE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -77,6 +81,10 @@ class DataPlaneTransferConsumerProxyTransformerTest {
             assertThat(address.getProperty(ENDPOINT)).isEqualTo(inputEdr.getEndpoint());
             assertThat(address.getProperty(AUTHENTICATION_KEY)).isEqualTo(inputEdr.getAuthKey());
             assertThat(address.getProperty(AUTHENTICATION_CODE)).isEqualTo(inputEdr.getAuthCode());
+            assertThat(address.getProperty(PROXY_QUERY_PARAMS)).isEqualTo(Boolean.TRUE.toString());
+            assertThat(address.getProperty(PROXY_PATH)).isEqualTo(Boolean.TRUE.toString());
+            assertThat(address.getProperty(PROXY_METHOD)).isEqualTo(Boolean.TRUE.toString());
+            assertThat(address.getProperty(PROXY_BODY)).isEqualTo(Boolean.TRUE.toString());
         });
     }
 


### PR DESCRIPTION
## What this PR changes/adds

This PR adds the boolean flags for request properties (query params, request body...) to the http `DataAddress` generated to represent the provider DPF proxy. Without these flags, all the request arguments get filtered by the consumer DPF proxy before they reach the provider DPF.  

## Why it does that

Recover proper DPF proxy behavior. 

## Linked Issue(s)

Contributes to #1180. One end-to-end test should be added in `system-tests:e2e-transfer-test` in order to close the issue. This will be done in a separated PR, once #1199 is merged. 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
