### PR TITLE
DataManagementApi: all API endpoints produce and consume APPLICATION_JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Restructure sql extension folder tree (#1154)
 * Extract single `PolicyArchive` implementation (#1158)
 * Replace `accessPolicy` and `contractPolicy` with `accessPolicyId` and `contractPolicyId` on `ContractDefinition` (#1144)
+* All DMgmt Api methods now produce and consume `APPLICATION_JSON` (#1175)
 
 #### Removed
 

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiController.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiController.java
@@ -47,6 +47,8 @@ import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 
+@Consumes({ MediaType.APPLICATION_JSON })
+@Produces({ MediaType.APPLICATION_JSON })
 @Path("/assets")
 public class AssetApiController implements AssetApi {
 
@@ -61,7 +63,6 @@ public class AssetApiController implements AssetApi {
     }
 
     @POST
-    @Consumes({ MediaType.APPLICATION_JSON })
     @Override
     public void createAsset(@Valid AssetEntryDto assetEntryDto) {
         var assetResult = transformerRegistry.transform(assetEntryDto.getAsset(), Asset.class);
@@ -84,7 +85,6 @@ public class AssetApiController implements AssetApi {
     }
 
     @GET
-    @Produces({ MediaType.APPLICATION_JSON })
     @Override
     public List<AssetDto> getAllAssets(@QueryParam("offset") Integer offset,
                                        @QueryParam("limit") Integer limit,
@@ -110,7 +110,6 @@ public class AssetApiController implements AssetApi {
 
     @GET
     @Path("{id}")
-    @Produces({ MediaType.APPLICATION_JSON })
     @Override
     public AssetDto getAsset(@PathParam("id") String id) {
         monitor.debug(format("Attempting to return Asset with id %s", id));

--- a/extensions/api/data-management/contractagreement/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApiController.java
+++ b/extensions/api/data-management/contractagreement/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApiController.java
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 
+@Produces({ MediaType.APPLICATION_JSON })
 @Path("/contractagreements")
 public class ContractAgreementApiController implements ContractAgreementApi {
     private final Monitor monitor;
@@ -50,7 +51,6 @@ public class ContractAgreementApiController implements ContractAgreementApi {
     }
 
     @GET
-    @Produces({ MediaType.APPLICATION_JSON })
     @Override
     public List<ContractAgreementDto> getAllAgreements(@QueryParam("offset") Integer offset,
                                                        @QueryParam("limit") Integer limit,
@@ -74,7 +74,6 @@ public class ContractAgreementApiController implements ContractAgreementApi {
 
     @GET
     @Path("{id}")
-    @Produces({ MediaType.APPLICATION_JSON })
     @Override
     public ContractAgreementDto getContractAgreement(@PathParam("id") String id) {
         monitor.debug(format("get contract agreement with ID %s", id));

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiController.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiController.java
@@ -44,6 +44,7 @@ import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 
+@Produces({ MediaType.APPLICATION_JSON })
 @Path("/contractdefinitions")
 public class ContractDefinitionApiController implements ContractDefinitionApi {
     private final Monitor monitor;
@@ -57,7 +58,6 @@ public class ContractDefinitionApiController implements ContractDefinitionApi {
     }
 
     @GET
-    @Produces({ MediaType.APPLICATION_JSON })
     @Override
     public List<ContractDefinitionDto> getAllContractDefinitions(@QueryParam("offset") Integer offset,
                                                                  @QueryParam("limit") Integer limit,
@@ -81,7 +81,6 @@ public class ContractDefinitionApiController implements ContractDefinitionApi {
 
     @GET
     @Path("{id}")
-    @Produces({ MediaType.APPLICATION_JSON })
     @Override
     public ContractDefinitionDto getContractDefinition(@PathParam("id") String id) {
         monitor.debug(format("get contract definition with ID %s", id));
@@ -95,7 +94,6 @@ public class ContractDefinitionApiController implements ContractDefinitionApi {
     }
 
     @POST
-    @Consumes({ MediaType.APPLICATION_JSON })
     @Override
     public void createContractDefinition(@Valid ContractDefinitionDto dto) {
         monitor.debug("create new contract definition");

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiController.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiController.java
@@ -16,7 +16,6 @@
 package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition;
 
 import jakarta.validation.Valid;
-import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;

--- a/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApi.java
+++ b/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApi.java
@@ -19,7 +19,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.model.ContractAgreementDto;
 import org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.model.ContractNegotiationDto;
+import org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.model.NegotiationId;
 import org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.model.NegotiationInitiateRequestDto;
+import org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.model.NegotiationState;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 
 import java.util.List;
@@ -32,11 +34,11 @@ public interface ContractNegotiationApi {
 
     ContractNegotiationDto getNegotiation(String id);
 
-    String getNegotiationState(String id);
+    NegotiationState getNegotiationState(String id);
 
     ContractAgreementDto getAgreementForNegotiation(String negotiationId);
 
-    String initiateContractNegotiation(@Valid NegotiationInitiateRequestDto initiateDto);
+    NegotiationId initiateContractNegotiation(@Valid NegotiationInitiateRequestDto initiateDto);
 
     void cancelNegotiation(String id);
 

--- a/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/model/NegotiationId.java
+++ b/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/model/NegotiationId.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.model;
+
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
+
+/**
+ * Wrapper for a {@link ContractNegotiation#getId()}. Used to format a simple string as JSON.
+ */
+public class NegotiationId {
+    private final String id;
+
+    public NegotiationId(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+}

--- a/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/model/NegotiationState.java
+++ b/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/model/NegotiationState.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.model;
+
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates;
+
+/**
+ * Wrapper for {@link ContractNegotiationStates} formatted as String. Used to format a simple string as JSON.
+ */
+public class NegotiationState {
+    private final String state;
+
+    public NegotiationState(String state) {
+        this.state = state;
+    }
+
+    public String getState() {
+        return state;
+    }
+}

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
@@ -36,7 +36,6 @@ import java.util.concurrent.CompletableFuture;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
-import static io.restassured.http.ContentType.TEXT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.TestFunctions.createOffer;
 import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.getFreePort;
@@ -110,10 +109,10 @@ class ContractNegotiationApiControllerIntegrationTest {
                 .get("/contractnegotiations/negotiationId/state")
                 .then()
                 .statusCode(200)
-                .contentType(TEXT)
+                .contentType(JSON)
                 .extract().asString();
 
-        assertThat(state).isEqualTo("REQUESTED");
+        assertThat(state).isEqualTo("{\"state\":\"REQUESTED\"}");
     }
 
     @Test

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerTest.java
@@ -137,7 +137,7 @@ class ContractNegotiationApiControllerTest {
 
         var state = controller.getNegotiationState("negotiationId");
 
-        assertThat(state).isEqualTo(REQUESTED.name());
+        assertThat(state.getState()).isEqualTo(REQUESTED.name());
     }
 
     @Test
@@ -182,7 +182,7 @@ class ContractNegotiationApiControllerTest {
 
         var negotiationId = controller.initiateContractNegotiation(request);
 
-        assertThat(negotiationId).isEqualTo("negotiationId");
+        assertThat(negotiationId.getId()).isEqualTo("negotiationId");
     }
 
     @Test

--- a/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyApiController.java
+++ b/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyApiController.java
@@ -40,6 +40,8 @@ import java.util.Optional;
 
 import static java.lang.String.format;
 
+@Produces({ MediaType.APPLICATION_JSON })
+@Consumes({ MediaType.APPLICATION_JSON })
 @Path("/policies")
 public class PolicyApiController implements PolicyApi {
 
@@ -52,7 +54,6 @@ public class PolicyApiController implements PolicyApi {
     }
 
     @GET
-    @Produces({ MediaType.APPLICATION_JSON })
     @Override
     public List<Policy> getAllPolicies(@QueryParam("offset") Integer offset,
                                        @QueryParam("limit") Integer limit,
@@ -73,7 +74,6 @@ public class PolicyApiController implements PolicyApi {
 
     @GET
     @Path("{id}")
-    @Produces({ MediaType.APPLICATION_JSON })
     @Override
     public Policy getPolicy(@PathParam("id") String id) {
         monitor.debug(format("Attempting to return policy with ID %s", id));
@@ -83,7 +83,6 @@ public class PolicyApiController implements PolicyApi {
     }
 
     @POST
-    @Consumes({ MediaType.APPLICATION_JSON })
     @Override
     public void createPolicy(Policy policy) {
 

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApi.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApi.java
@@ -17,8 +17,10 @@ package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferId;
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferProcessDto;
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferRequestDto;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferState;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 
 import java.util.List;
@@ -31,11 +33,11 @@ public interface TransferProcessApi {
 
     TransferProcessDto getTransferProcess(String id);
 
-    String getTransferProcessState(String id);
+    TransferState getTransferProcessState(String id);
 
     void cancelTransferProcess(String id);
 
     void deprovisionTransferProcess(String id);
 
-    String initiateTransfer(@Valid TransferRequestDto transferRequest);
+    TransferId initiateTransfer(@Valid TransferRequestDto transferRequest);
 }

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferId.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferId.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model;
+
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+
+/**
+ * Wrapper for a {@link TransferProcess#getId()}. Used to format a simple string as JSON.
+ */
+public class TransferId {
+    private final String id;
+
+    public TransferId(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+}

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferState.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferState.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model;
+
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
+
+/**
+ * Wrapper for {@link TransferProcessStates} formatted as String. Used to format a simple string as JSON.
+ */
+public class TransferState {
+    private final String state;
+
+    public TransferState(String state) {
+        this.state = state;
+    }
+
+    public String getState() {
+        return state;
+    }
+}

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerIntegrationTest.java
@@ -29,7 +29,6 @@ import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
-import static io.restassured.http.ContentType.TEXT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.getFreePort;
 import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.COMPLETED;
@@ -94,10 +93,10 @@ class TransferProcessApiControllerIntegrationTest {
                 .get("/transferprocess/" + PROCESS_ID + "/state")
                 .then()
                 .statusCode(200)
-                .contentType(TEXT)
+                .contentType(JSON)
                 .extract().asString();
 
-        assertThat(state).isEqualTo("PROVISIONING");
+        assertThat(state).isEqualTo("{\"state\":\"PROVISIONING\"}");
     }
 
     @Test

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerTest.java
@@ -56,11 +56,11 @@ import static org.mockito.Mockito.when;
 class TransferProcessApiControllerTest {
     public static final int OFFSET = 5;
     public static final int LIMIT = 10;
+    private static final Faker FAKER = new Faker();
     private final TransferProcessService service = mock(TransferProcessService.class);
     private final DtoTransformerRegistry transformerRegistry = mock(DtoTransformerRegistry.class);
     private final String filterExpression = "someField=value";
     private final String someField = "someField";
-    private static final Faker FAKER = new Faker();
     private TransferProcessApiController controller;
 
     @BeforeEach
@@ -118,7 +118,7 @@ class TransferProcessApiControllerTest {
 
         when(service.getState(id)).thenReturn("PROVISIONING");
 
-        assertThat(controller.getTransferProcessState(id)).isEqualTo("PROVISIONING");
+        assertThat(controller.getTransferProcessState(id).getState()).isEqualTo("PROVISIONING");
     }
 
     @Test
@@ -192,7 +192,7 @@ class TransferProcessApiControllerTest {
         when(transformerRegistry.transform(isA(TransferRequestDto.class), eq(DataRequest.class))).thenReturn(Result.success(request));
         when(service.initiateTransfer(any())).thenReturn(ServiceResult.success(processId));
 
-        String result = controller.initiateTransfer(transferReq);
+        String result = controller.initiateTransfer(transferReq).getId();
 
         var dataRequestCaptor = ArgumentCaptor.forClass(DataRequest.class);
         verify(service).initiateTransfer(dataRequestCaptor.capture());
@@ -258,28 +258,6 @@ class TransferProcessApiControllerTest {
                 .build();
     }
 
-    private static class InvalidRequestParams implements ArgumentsProvider {
-
-        @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-            return Stream.of(
-                    Arguments.of(null, "some-contract", "test-asset", "ids-multipart", DataAddress.Builder.newInstance().type("test-type").build()),
-                    Arguments.of("", "some-contract", "test-asset", "ids-multipart", DataAddress.Builder.newInstance().type("test-type").build()),
-                    Arguments.of("  ", "some-contract", "test-asset", "ids-multipart", DataAddress.Builder.newInstance().type("test-type").build()),
-                    Arguments.of("http://someurl", null, "test-asset", "ids-multipart", DataAddress.Builder.newInstance().type("test-type").build()),
-                    Arguments.of("http://someurl", "", "test-asset", "ids-multipart", DataAddress.Builder.newInstance().type("test-type").build()),
-                    Arguments.of("http://someurl", "  ", "test-asset", "ids-multipart", DataAddress.Builder.newInstance().type("test-type").build()),
-                    Arguments.of("http://someurl", "some-contract", "test-asset", null, DataAddress.Builder.newInstance().type("test-type").build()),
-                    Arguments.of("http://someurl", "some-contract", "test-asset", "", DataAddress.Builder.newInstance().type("test-type").build()),
-                    Arguments.of("http://someurl", "some-contract", "test-asset", "  ", DataAddress.Builder.newInstance().type("test-type").build()),
-                    Arguments.of("http://someurl", "some-contract", "test-asset", "ids-multipart", null),
-                    Arguments.of("http://someurl", "some-contract", null, "ids-multipart", DataAddress.Builder.newInstance().type("test-type").build()),
-                    Arguments.of("http://someurl", "some-contract", "", "ids-multipart", DataAddress.Builder.newInstance().type("test-type").build()),
-                    Arguments.of("http://someurl", "some-contract", "  ", "ids-multipart", DataAddress.Builder.newInstance().type("test-type").build())
-            );
-        }
-    }
-
     private void assertQuerySpec(int limit, int offset, SortOrder sortOrder, String sortField, Criterion... criterions) {
         ArgumentCaptor<QuerySpec> captor = ArgumentCaptor.forClass(QuerySpec.class);
         verify(service).query(captor.capture());
@@ -317,5 +295,27 @@ class TransferProcessApiControllerTest {
                 .protocol(dto.getProtocol())
                 .dataDestination(dto.getDataDestination())
                 .build();
+    }
+
+    private static class InvalidRequestParams implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    Arguments.of(null, "some-contract", "test-asset", "ids-multipart", DataAddress.Builder.newInstance().type("test-type").build()),
+                    Arguments.of("", "some-contract", "test-asset", "ids-multipart", DataAddress.Builder.newInstance().type("test-type").build()),
+                    Arguments.of("  ", "some-contract", "test-asset", "ids-multipart", DataAddress.Builder.newInstance().type("test-type").build()),
+                    Arguments.of("http://someurl", null, "test-asset", "ids-multipart", DataAddress.Builder.newInstance().type("test-type").build()),
+                    Arguments.of("http://someurl", "", "test-asset", "ids-multipart", DataAddress.Builder.newInstance().type("test-type").build()),
+                    Arguments.of("http://someurl", "  ", "test-asset", "ids-multipart", DataAddress.Builder.newInstance().type("test-type").build()),
+                    Arguments.of("http://someurl", "some-contract", "test-asset", null, DataAddress.Builder.newInstance().type("test-type").build()),
+                    Arguments.of("http://someurl", "some-contract", "test-asset", "", DataAddress.Builder.newInstance().type("test-type").build()),
+                    Arguments.of("http://someurl", "some-contract", "test-asset", "  ", DataAddress.Builder.newInstance().type("test-type").build()),
+                    Arguments.of("http://someurl", "some-contract", "test-asset", "ids-multipart", null),
+                    Arguments.of("http://someurl", "some-contract", null, "ids-multipart", DataAddress.Builder.newInstance().type("test-type").build()),
+                    Arguments.of("http://someurl", "some-contract", "", "ids-multipart", DataAddress.Builder.newInstance().type("test-type").build()),
+                    Arguments.of("http://someurl", "some-contract", "  ", "ids-multipart", DataAddress.Builder.newInstance().type("test-type").build())
+            );
+        }
     }
 }

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -9,112 +9,74 @@ info:
 servers:
 - url: /
 paths:
-  /assets:
-    get:
-      tags:
-      - Asset
-      operationId: getAllAssets
-      parameters:
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/AssetDto'
+  /identity-hub/query-commits:
     post:
       tags:
-      - Asset
-      operationId: createAsset
+      - Identity Hub
+      operationId: queryCommits
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AssetEntryDto'
-      responses:
-        default:
-          description: default response
-          content:
-            '*/*': {}
-  /assets/{id}:
-    get:
-      tags:
-      - Asset
-      operationId: getAsset
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
+              type: string
       responses:
         default:
           description: default response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AssetDto'
-    delete:
+                type: string
+  /identity-hub/query-objects:
+    post:
       tags:
-      - Asset
-      operationId: removeAsset
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
+      - Identity Hub
+      operationId: queryObjects
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
       responses:
         default:
           description: default response
           content:
-            '*/*': {}
+            application/json:
+              schema:
+                type: string
+  /identity-hub/collections:
+    post:
+      tags:
+      - Identity Hub
+      operationId: write
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
+  /identity-hub/collections-commit:
+    post:
+      tags:
+      - Identity Hub
+      operationId: writeCommit
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
   /control/catalog:
     get:
       operationId: getDescription
@@ -211,110 +173,6 @@ paths:
           content:
             application/json: {}
       deprecated: true
-  /check/health:
-    get:
-      tags:
-      - Application Observability
-      operationId: checkHealth
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /check/liveness:
-    get:
-      tags:
-      - Application Observability
-      operationId: getLiveness
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /check/readiness:
-    get:
-      tags:
-      - Application Observability
-      operationId: getReadiness
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /check/startup:
-    get:
-      tags:
-      - Application Observability
-      operationId: getStartup
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /instances:
-    get:
-      tags:
-      - Dataplane Selector
-      operationId: getAll
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/DataPlaneInstance'
-    post:
-      tags:
-      - Dataplane Selector
-      operationId: addEntry
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DataPlaneInstance'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /instances/select:
-    post:
-      tags:
-      - Dataplane Selector
-      operationId: find
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SelectionRequest'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DataPlaneInstance'
-  /catalog:
-    get:
-      tags:
-      - Catalog
-      operationId: getCatalog
-      parameters:
-      - name: providerUrl
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Catalog'
   /contractnegotiations/{id}/cancel:
     post:
       tags:
@@ -332,7 +190,7 @@ paths:
         default:
           description: default response
           content:
-            '*/*': {}
+            application/json: {}
   /contractnegotiations/{id}/decline:
     post:
       tags:
@@ -350,7 +208,7 @@ paths:
         default:
           description: default response
           content:
-            '*/*': {}
+            application/json: {}
   /contractnegotiations/{id}/agreement:
     get:
       tags:
@@ -408,9 +266,9 @@ paths:
         default:
           description: default response
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/NegotiationState'
   /contractnegotiations:
     get:
       tags:
@@ -479,60 +337,59 @@ paths:
         default:
           description: default response
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
-  /callback/{processId}/deprovision:
-    post:
-      tags:
-      - HTTP Provisioner Webhook
-      operationId: callDeprovisionWebhook
-      parameters:
-      - name: processId
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DeprovisionedResource'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /callback/{processId}/provision:
-    post:
-      tags:
-      - HTTP Provisioner Webhook
-      operationId: callProvisionWebhook
-      parameters:
-      - name: processId
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ProvisionerWebhookRequest'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /contractdefinitions:
+                $ref: '#/components/schemas/NegotiationId'
+  /instances:
     get:
       tags:
-      - Contract Definition
-      operationId: getAllContractDefinitions
+      - Dataplane Selector
+      operationId: getAll
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DataPlaneInstance'
+    post:
+      tags:
+      - Dataplane Selector
+      operationId: addEntry
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataPlaneInstance'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /instances/select:
+    post:
+      tags:
+      - Dataplane Selector
+      operationId: find
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SelectionRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataPlaneInstance'
+  /assets:
+    get:
+      tags:
+      - Asset
+      operationId: getAllAssets
       parameters:
       - name: offset
         in: query
@@ -582,200 +439,26 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ContractDefinitionDto'
+                  $ref: '#/components/schemas/AssetDto'
     post:
       tags:
-      - Contract Definition
-      operationId: createContractDefinition
+      - Asset
+      operationId: createAsset
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ContractDefinitionDto'
-      responses:
-        default:
-          description: default response
-          content:
-            '*/*': {}
-  /contractdefinitions/{id}:
-    get:
-      tags:
-      - Contract Definition
-      operationId: getContractDefinition
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ContractDefinitionDto'
-    delete:
-      tags:
-      - Contract Definition
-      operationId: deleteContractDefinition
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            '*/*': {}
-  /identity-hub/query-commits:
-    post:
-      tags:
-      - Identity Hub
-      operationId: queryCommits
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: string
-  /identity-hub/query-objects:
-    post:
-      tags:
-      - Identity Hub
-      operationId: queryObjects
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: string
-  /identity-hub/collections:
-    post:
-      tags:
-      - Identity Hub
-      operationId: write
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: string
-  /identity-hub/collections-commit:
-    post:
-      tags:
-      - Identity Hub
-      operationId: writeCommit
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              additionalProperties:
-                type: string
+              $ref: '#/components/schemas/AssetEntryDto'
       responses:
         default:
           description: default response
           content:
             application/json: {}
-  /policies:
+  /assets/{id}:
     get:
       tags:
-      - Policy
-      operationId: getAllPolicies
-      parameters:
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Policy'
-    post:
-      tags:
-      - Policy
-      operationId: createPolicy
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Policy'
-      responses:
-        default:
-          description: default response
-          content:
-            '*/*': {}
-  /policies/{id}:
-    get:
-      tags:
-      - Policy
-      operationId: getPolicy
+      - Asset
+      operationId: getAsset
       parameters:
       - name: id
         in: path
@@ -790,11 +473,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Policy'
+                $ref: '#/components/schemas/AssetDto'
     delete:
       tags:
-      - Policy
-      operationId: deletePolicy
+      - Asset
+      operationId: removeAsset
       parameters:
       - name: id
         in: path
@@ -807,7 +490,7 @@ paths:
         default:
           description: default response
           content:
-            '*/*': {}
+            application/json: {}
   /contractagreements:
     get:
       tags:
@@ -883,6 +566,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ContractAgreementDto'
+  /check/health:
+    get:
+      tags:
+      - Application Observability
+      operationId: checkHealth
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /check/liveness:
+    get:
+      tags:
+      - Application Observability
+      operationId: getLiveness
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /check/readiness:
+    get:
+      tags:
+      - Application Observability
+      operationId: getReadiness
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /check/startup:
+    get:
+      tags:
+      - Application Observability
+      operationId: getStartup
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
   /transferprocess/{id}/cancel:
     post:
       tags:
@@ -900,7 +623,7 @@ paths:
         default:
           description: default response
           content:
-            '*/*': {}
+            application/json: {}
   /transferprocess/{id}/deprovision:
     post:
       tags:
@@ -918,7 +641,7 @@ paths:
         default:
           description: default response
           content:
-            '*/*': {}
+            application/json: {}
   /transferprocess:
     get:
       tags:
@@ -987,9 +710,9 @@ paths:
         default:
           description: default response
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/TransferId'
   /transferprocess/{id}:
     get:
       tags:
@@ -1027,9 +750,286 @@ paths:
         default:
           description: default response
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/TransferState'
+  /policies:
+    get:
+      tags:
+      - Policy
+      operationId: getAllPolicies
+      parameters:
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Policy'
+    post:
+      tags:
+      - Policy
+      operationId: createPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Policy'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /policies/{id}:
+    get:
+      tags:
+      - Policy
+      operationId: getPolicy
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Policy'
+    delete:
+      tags:
+      - Policy
+      operationId: deletePolicy
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /catalog:
+    get:
+      tags:
+      - Catalog
+      operationId: getCatalog
+      parameters:
+      - name: providerUrl
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Catalog'
+  /contractdefinitions:
+    get:
+      tags:
+      - Contract Definition
+      operationId: getAllContractDefinitions
+      parameters:
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractDefinitionDto'
+    post:
+      tags:
+      - Contract Definition
+      operationId: createContractDefinition
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/ContractDefinitionDto'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /contractdefinitions/{id}:
+    get:
+      tags:
+      - Contract Definition
+      operationId: getContractDefinition
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContractDefinitionDto'
+    delete:
+      tags:
+      - Contract Definition
+      operationId: deleteContractDefinition
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /callback/{processId}/deprovision:
+    post:
+      tags:
+      - HTTP Provisioner Webhook
+      operationId: callDeprovisionWebhook
+      parameters:
+      - name: processId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeprovisionedResource'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /callback/{processId}/provision:
+    post:
+      tags:
+      - HTTP Provisioner Webhook
+      operationId: callProvisionWebhook
+      parameters:
+      - name: processId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProvisionerWebhookRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
 components:
   schemas:
     Action:
@@ -1326,6 +1326,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Criterion'
+    NegotiationId:
+      type: object
+      properties:
+        id:
+          type: string
     NegotiationInitiateRequestDto:
       required:
       - connectorAddress
@@ -1342,6 +1347,11 @@ components:
           type: string
         offer:
           $ref: '#/components/schemas/ContractOfferDescription'
+    NegotiationState:
+      type: object
+      properties:
+        state:
+          type: string
     Permission:
       type: object
       properties:
@@ -1448,6 +1458,11 @@ components:
           $ref: '#/components/schemas/DataAddress'
         strategy:
           type: string
+    TransferId:
+      type: object
+      properties:
+        id:
+          type: string
     TransferProcessDto:
       type: object
       properties:
@@ -1474,6 +1489,8 @@ components:
       properties:
         connectorAddress:
           type: string
+        id:
+          type: string
         contractId:
           type: string
         dataDestination:
@@ -1491,6 +1508,11 @@ components:
         connectorId:
           type: string
         assetId:
+          type: string
+    TransferState:
+      type: object
+      properties:
+        state:
           type: string
     TransferType:
       type: object

--- a/resources/openapi/yaml/asset.yaml
+++ b/resources/openapi/yaml/asset.yaml
@@ -53,7 +53,7 @@ paths:
         default:
           description: default response
           content:
-            '*/*': {}
+            application/json: {}
   /assets/{id}:
     get:
       tags:
@@ -86,7 +86,7 @@ paths:
         default:
           description: default response
           content:
-            '*/*': {}
+            application/json: {}
 components:
   schemas:
     AssetDto:

--- a/resources/openapi/yaml/catalog-api.yaml
+++ b/resources/openapi/yaml/catalog-api.yaml
@@ -1,92 +1,21 @@
 openapi: 3.0.1
 paths:
-  /policies:
+  /catalog:
     get:
       tags:
-      - Policy
-      operationId: getAllPolicies
+      - Catalog
+      operationId: getCatalog
       parameters:
-      - name: offset
-        in: query
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        schema:
-          type: string
-      - name: sort
-        in: query
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
+      - name: providerUrl
         in: query
         schema:
           type: string
       responses:
         default:
-          description: default response
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Policy'
-    post:
-      tags:
-      - Policy
-      operationId: createPolicy
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Policy'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /policies/{id}:
-    get:
-      tags:
-      - Policy
-      operationId: getPolicy
-      parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Policy'
-    delete:
-      tags:
-      - Policy
-      operationId: deletePolicy
-      parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
+                $ref: '#/components/schemas/Catalog'
 components:
   schemas:
     Action:
@@ -98,6 +27,22 @@ components:
           type: string
         constraint:
           $ref: '#/components/schemas/Constraint'
+    Asset:
+      type: object
+      properties:
+        properties:
+          type: object
+          additionalProperties:
+            type: object
+    Catalog:
+      type: object
+      properties:
+        id:
+          type: string
+        contractOffers:
+          type: array
+          items:
+            $ref: '#/components/schemas/ContractOffer'
     Constraint:
       required:
       - edctype
@@ -107,6 +52,37 @@ components:
           type: string
       discriminator:
         propertyName: edctype
+    ContractOffer:
+      type: object
+      properties:
+        id:
+          type: string
+        policy:
+          $ref: '#/components/schemas/Policy'
+        asset:
+          $ref: '#/components/schemas/Asset'
+        policyId:
+          type: string
+        assetId:
+          type: string
+        provider:
+          type: string
+          format: uri
+        consumer:
+          type: string
+          format: uri
+        offerStart:
+          type: string
+          format: date-time
+        offerEnd:
+          type: string
+          format: date-time
+        contractStart:
+          type: string
+          format: date-time
+        contractEnd:
+          type: string
+          format: date-time
     Duty:
       type: object
       properties:
@@ -150,10 +126,6 @@ components:
           items:
             $ref: '#/components/schemas/Duty'
     Policy:
-      required:
-      - obligations
-      - permissions
-      - prohibitions
       type: object
       properties:
         uid:

--- a/resources/openapi/yaml/contractdefinition.yaml
+++ b/resources/openapi/yaml/contractdefinition.yaml
@@ -46,14 +46,14 @@ paths:
       operationId: createContractDefinition
       requestBody:
         content:
-          application/json:
+          '*/*':
             schema:
               $ref: '#/components/schemas/ContractDefinitionDto'
       responses:
         default:
           description: default response
           content:
-            '*/*': {}
+            application/json: {}
   /contractdefinitions/{id}:
     get:
       tags:
@@ -86,7 +86,7 @@ paths:
         default:
           description: default response
           content:
-            '*/*': {}
+            application/json: {}
 components:
   schemas:
     ContractDefinitionDto:

--- a/resources/openapi/yaml/contractnegotiation.yaml
+++ b/resources/openapi/yaml/contractnegotiation.yaml
@@ -15,7 +15,7 @@ paths:
         default:
           description: default response
           content:
-            '*/*': {}
+            application/json: {}
   /contractnegotiations/{id}/decline:
     post:
       tags:
@@ -31,7 +31,7 @@ paths:
         default:
           description: default response
           content:
-            '*/*': {}
+            application/json: {}
   /contractnegotiations/{id}/agreement:
     get:
       tags:
@@ -83,9 +83,9 @@ paths:
         default:
           description: default response
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/NegotiationState'
   /contractnegotiations:
     get:
       tags:
@@ -139,9 +139,9 @@ paths:
         default:
           description: default response
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/NegotiationId'
 components:
   schemas:
     ContractAgreementDto:
@@ -186,6 +186,16 @@ components:
           enum:
           - CONSUMER
           - PROVIDER
+    NegotiationState:
+      type: object
+      properties:
+        state:
+          type: string
+    NegotiationId:
+      type: object
+      properties:
+        id:
+          type: string
     Action:
       type: object
       properties:

--- a/resources/openapi/yaml/transferprocess.yaml
+++ b/resources/openapi/yaml/transferprocess.yaml
@@ -15,7 +15,7 @@ paths:
         default:
           description: default response
           content:
-            '*/*': {}
+            application/json: {}
   /transferprocess/{id}/deprovision:
     post:
       tags:
@@ -31,7 +31,7 @@ paths:
         default:
           description: default response
           content:
-            '*/*': {}
+            application/json: {}
   /transferprocess:
     get:
       tags:
@@ -85,9 +85,9 @@ paths:
         default:
           description: default response
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/TransferId'
   /transferprocess/{id}:
     get:
       tags:
@@ -121,9 +121,9 @@ paths:
         default:
           description: default response
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/TransferState'
 components:
   schemas:
     DataRequestDto:
@@ -148,6 +148,16 @@ components:
           type: string
         dataRequest:
           $ref: '#/components/schemas/DataRequestDto'
+    TransferState:
+      type: object
+      properties:
+        state:
+          type: string
+    TransferId:
+      type: object
+      properties:
+        id:
+          type: string
     DataAddress:
       type: object
       properties:
@@ -167,6 +177,8 @@ components:
       type: object
       properties:
         connectorAddress:
+          type: string
+        id:
           type: string
         contractId:
           type: string

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/dataspaceconnector/test/e2e/Participant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/dataspaceconnector/test/e2e/Participant.java
@@ -149,7 +149,7 @@ public class Participant {
                 .post("/api/contractnegotiations")
                 .then()
                 .statusCode(200)
-                .extract().body().asString();
+                .extract().body().jsonPath().getString("id");
     }
 
     public String getContractAgreementId(String negotiationId) {
@@ -195,7 +195,7 @@ public class Participant {
                 .post("/api/transferprocess")
                 .then()
                 .statusCode(200)
-                .extract().body().asString();
+                .extract().body().jsonPath().getString("id");
     }
 
     public String getTransferProcessState(String transferProcessId) {
@@ -206,7 +206,7 @@ public class Participant {
                 .get("/api/transferprocess/{id}/state", transferProcessId)
                 .then()
                 .statusCode(200)
-                .extract().body().asString();
+                .extract().body().jsonPath().getString("state");
     }
 
     public URI backendService() {

--- a/system-tests/tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/utils/FileTransferSimulationUtils.java
+++ b/system-tests/tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/utils/FileTransferSimulationUtils.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import static io.gatling.javaapi.core.CoreDsl.StringBody;
-import static io.gatling.javaapi.core.CoreDsl.bodyString;
 import static io.gatling.javaapi.core.CoreDsl.doWhileDuring;
 import static io.gatling.javaapi.core.CoreDsl.exec;
 import static io.gatling.javaapi.core.CoreDsl.group;
@@ -76,7 +75,7 @@ public abstract class FileTransferSimulationUtils {
      * <p>
      * Saves the Contract Negotiation Request ID into the {@see CONTRACT_NEGOTIATION_REQUEST_ID} session key.
      *
-     * @param providerUrl       URL for the Provider API, as accessed from the Consumer runtime.
+     * @param providerUrl URL for the Provider API, as accessed from the Consumer runtime.
      */
     private static ChainBuilder startContractAgreement(String providerUrl) {
         var connectorAddress = format("%s/api/v1/ids/data", providerUrl);
@@ -91,7 +90,7 @@ public abstract class FileTransferSimulationUtils {
                 .body(StringBody(loadContractAgreement(connectorAddress)))
                 .header(CONTENT_TYPE, "application/json")
                 .check(status().is(200))
-                .check(bodyString()
+                .check(jmesPath("id")
                         .notNull()
                         .saveAs(CONTRACT_NEGOTIATION_REQUEST_ID));
     }
@@ -103,7 +102,6 @@ public abstract class FileTransferSimulationUtils {
      * Expects the Contract Negotiation Request ID to be provided in the {@see CONTRACT_NEGOTIATION_REQUEST_ID} session key.
      * <p>
      * Saves the Contract Agreement ID into the {@see CONTRACT_AGREEMENT_ID} session key.
-     *
      */
     private static ChainBuilder waitForContractAgreement() {
         return exec(session -> session.set("status", -1))
@@ -153,7 +151,7 @@ public abstract class FileTransferSimulationUtils {
                 .body(StringBody(session -> transferRequest(session.getString(CONTRACT_AGREEMENT_ID), destinationPath, connectorAddress)))
                 .header(CONTENT_TYPE, "application/json")
                 .check(status().is(200))
-                .check(bodyString()
+                .check(jmesPath("id")
                         .notNull()
                         .saveAs(TRANSFER_PROCESS_ID));
     }


### PR DESCRIPTION
## What this PR changes/adds

All API endpoints of the DataManagementApi now `@Produce` and `@Consume` `APPLICATION_JSON`. Those controller methods that previously returned a simple `String` now return a complex object that can be serialized to JSON in order to make things consistent.

## Why it does that

To allow easier consumption in (generated) API clients.

## Further notes

n/a

## Linked Issue(s)

Closes #1175 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
