### PR TITLE
TransferProcessManager: Break lease after status check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Fix problem with interpreting contractId/negotiationId (#1140)
 * Fixed DMgmtApi content types (#1126)
 * Fix HTTPS termination in Jetty (#1133)
+* Break lease after TransferProcessManager status check (#1214)
 
 ## [milestone-3] - 2022-04-08
 

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
@@ -350,6 +350,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
             } else {
                 // Process is not finished yet, so it stays in the IN_PROGRESS state
                 monitor.info(format("Transfer process %s not COMPLETED yet. The process will not advance to the COMPLETED state.", process.getId()));
+                breakLease(process);
                 return false;
             }
         }
@@ -583,8 +584,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
     private boolean processConsumerRequest(TransferProcess process, DataRequest dataRequest) {
 
         if (sendRetryManager.shouldDelay(process)) {
-            // Break lease
-            transferProcessStore.update(process);
+            breakLease(process);
             return false;
         }
 
@@ -631,6 +631,10 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
     private void updateTransferProcess(TransferProcess transferProcess, Consumer<TransferProcessListener> observe) {
         observable.invokeForEach(observe);
         transferProcessStore.update(transferProcess);
+    }
+
+    private void breakLease(TransferProcess process) {
+        transferProcessStore.update(process);
     }
 
     public static class Builder {

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
@@ -454,7 +454,7 @@ class TransferProcessManagerImplTest {
         process.getProvisionedResourceSet().addResource(provisionedDataDestinationResource());
 
         when(transferProcessStore.nextForState(eq(IN_PROGRESS.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(statusCheckerRegistry.resolve(anyString())).thenReturn((i, l) -> true);
+        when(statusCheckerRegistry.resolve(anyString())).thenReturn((tp, resources) -> true);
 
         var latch = countDownOnUpdateLatch();
 
@@ -473,7 +473,7 @@ class TransferProcessManagerImplTest {
         process.getProvisionedResourceSet().addResource(provisionedDataDestinationResource());
 
         when(transferProcessStore.nextForState(eq(IN_PROGRESS.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(statusCheckerRegistry.resolve(anyString())).thenReturn((i, l) -> true);
+        when(statusCheckerRegistry.resolve(anyString())).thenReturn((tp, resources) -> true);
         var latch = countDownOnUpdateLatch();
 
         manager.start();
@@ -484,26 +484,21 @@ class TransferProcessManagerImplTest {
     }
 
     @Test
-    @DisplayName("checkComplete: should not transition process if checker returns not yet completed")
+    @DisplayName("checkComplete: should break lease and not transition process if checker returns not yet completed")
     void verifyCompleted_notAllYetCompleted() throws InterruptedException {
         var process = createTransferProcess(IN_PROGRESS);
         process.getProvisionedResourceSet().addResource(provisionedDataDestinationResource());
         process.getProvisionedResourceSet().addResource(provisionedDataDestinationResource());
 
-        var latch = new CountDownLatch(1);
+        var latch = countDownOnUpdateLatch();
 
-        when(transferProcessStore.nextForState(eq(IN_PROGRESS.code()), anyInt())).thenAnswer(i -> {
-            latch.countDown();
-            return List.of(process);
-        });
-        doThrow(new AssertionError("update() should not be called as process was not updated"))
-                .when(transferProcessStore).update(process);
+        when(transferProcessStore.nextForState(eq(IN_PROGRESS.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
+        when(statusCheckerRegistry.resolve(anyString())).thenReturn((tp, resources) -> false);
 
         manager.start();
 
         assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-        verify(transferProcessStore, atLeastOnce()).nextForState(anyInt(), anyInt());
-        verify(transferProcessStore, never()).update(any());
+        verify(transferProcessStore).update(argThat(p -> p.getState() == IN_PROGRESS.code()));
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

For consumer-side transfers that are `IN_PROGRESS`, a `StatusChecker` (when provided) should execute on every `TransferProcessManagerImpl` (every 5 seconds) to check if e.g. the destination blob has been produced.

## Why it does that

Following refactoring of the lease mechanism (probably with changes in #724), when the `StatusChecker` reports that the transfer is not completed, the lease was not broken after a Status check resulting in the output being incomplete. Therefore the status checker was only run again at lease timeout (every 60 seconds).

## Further notes

## Linked Issue(s)

Closes #1206 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
