### PR TITLE
DPF Azure storage: Write ".complete" blob

### DIFF
--- a/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSink.java
+++ b/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSink.java
@@ -66,7 +66,7 @@ public class AzureStorageDataSink extends ParallelSink {
     protected StatusResult<Void> complete() {
         try {
             // Write an empty blob to indicate completion
-            blobAdapterFactory.getBlobAdapter(accountName, containerName, COMPLETE_BLOB_NAME, sharedKey)
+            blobStoreApi.getBlobAdapter(accountName, containerName, COMPLETE_BLOB_NAME, sharedKey)
                     .getOutputStream().close();
         } catch (Exception e) {
             return getTransferResult(e, "Error creating blob %s on account %s", COMPLETE_BLOB_NAME, accountName);

--- a/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureDataSourceToDataSinkTest.java
+++ b/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureDataSourceToDataSinkTest.java
@@ -35,6 +35,8 @@ import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -44,6 +46,7 @@ class AzureDataSourceToDataSinkTest {
     Monitor monitor = mock(Monitor.class);
     FakeBlobAdapter fakeSource = new FakeBlobAdapter();
     FakeBlobAdapter fakeSink = new FakeBlobAdapter();
+    FakeBlobAdapter fakeCompletionMarker = new FakeBlobAdapter();
     String sourceAccountName = AzureStorageTestFixtures.createAccountName();
     String sourceContainerName = AzureStorageTestFixtures.createContainerName();
     String sourceSharedKey = AzureStorageTestFixtures.createSharedKey();
@@ -84,6 +87,12 @@ class AzureDataSourceToDataSinkTest {
                 fakeSource.name,
                 sinkSharedKey
         )).thenReturn(fakeSink);
+        when(fakeSinkFactory.getBlobAdapter(
+                eq(sinkAccountName),
+                eq(sinkContainerName),
+                argThat(name -> name.endsWith(".complete")),
+                eq(sinkSharedKey)
+        )).thenReturn(fakeCompletionMarker);
 
         var dataSink = AzureStorageDataSink.Builder.newInstance()
                 .accountName(sinkAccountName)

--- a/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSinkTest.java
+++ b/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSinkTest.java
@@ -42,12 +42,6 @@ import static org.eclipse.dataspaceconnector.azure.blob.core.AzureStorageTestFix
 import static org.eclipse.dataspaceconnector.azure.blob.core.AzureStorageTestFixtures.createContainerName;
 import static org.eclipse.dataspaceconnector.azure.blob.core.AzureStorageTestFixtures.createRequest;
 import static org.eclipse.dataspaceconnector.azure.blob.core.AzureStorageTestFixtures.createSharedKey;
-import static org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline.AzureStorageTestFixtures.TestCustomException;
-import static org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline.AzureStorageTestFixtures.createAccountName;
-import static org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline.AzureStorageTestFixtures.createBlobName;
-import static org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline.AzureStorageTestFixtures.createContainerName;
-import static org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline.AzureStorageTestFixtures.createRequest;
-import static org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline.AzureStorageTestFixtures.createSharedKey;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -96,7 +90,7 @@ class AzureStorageDataSinkTest {
                 .thenReturn(destination);
 
         when(completionMarker.getOutputStream()).thenReturn(completionMarkerOutput);
-        when(blobAdapterFactory.getBlobAdapter(
+        when(blobStoreApi.getBlobAdapter(
                 eq(accountName),
                 eq(containerName),
                 argThat(s -> s.endsWith(".complete")),
@@ -149,7 +143,7 @@ class AzureStorageDataSinkTest {
     @Test
     void complete() throws IOException {
         dataSink.complete();
-        verify(blobAdapterFactory).getBlobAdapter(
+        verify(blobStoreApi).getBlobAdapter(
                 eq(accountName),
                 eq(containerName),
                 argThat(s -> s.endsWith(".complete")),

--- a/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSink.java
+++ b/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSink.java
@@ -74,6 +74,13 @@ public abstract class ParallelSink implements DataSink {
 
     protected abstract StatusResult<Void> transferParts(List<DataSource.Part> parts);
 
+    /**
+     * Called after all parallel parts are transferred, only if all parts were successfully transferred.
+     * <p>
+     * Implementations may override this method to perform completion logic, such as writing a completion marker.
+     *
+     * @return status result to be returned to caller.
+     */
     protected StatusResult<Void> complete() {
         return StatusResult.success();
     }

--- a/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSink.java
+++ b/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSink.java
@@ -58,7 +58,7 @@ public abstract class ParallelSink implements DataSink {
                             .filter(AbstractResult::failed)
                             .findFirst()
                             .map(r -> StatusResult.<Void>failure(ERROR_RETRY, String.join(",", r.getFailureMessages())))
-                            .orElseGet(StatusResult::success))
+                            .orElseGet(this::complete))
                     .exceptionally(throwable -> StatusResult.failure(ERROR_RETRY, "Unhandled exception raised when transferring data: " + throwable.getMessage()));
         } catch (Exception e) {
             monitor.severe("Error processing data transfer request: " + requestId, e);
@@ -73,6 +73,10 @@ public abstract class ParallelSink implements DataSink {
     }
 
     protected abstract StatusResult<Void> transferParts(List<DataSource.Part> parts);
+
+    protected StatusResult<Void> complete() {
+        return StatusResult.success();
+    }
 
     protected abstract static class Builder<B extends Builder<B, T>, T extends ParallelSink> {
         protected T sink;

--- a/extensions/data-plane/data-plane-spi/src/test/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSinkTest.java
+++ b/extensions/data-plane/data-plane-spi/src/test/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSinkTest.java
@@ -89,8 +89,6 @@ class ParallelSinkTest {
     void transfer_whenFailureDuringTransfer_fails() {
         fakeSink.transferResultSupplier = () -> StatusResult.failure(ResponseStatus.FATAL_ERROR, errorMessage);
 
-        var dataSource = new InputStreamDataSource(dataSourceName, new ByteArrayInputStream(dataSourceContent.getBytes()));
-
         assertThat(fakeSink.transfer(dataSource)).succeedsWithin(500, TimeUnit.MILLISECONDS)
                 .satisfies(transferResult -> assertThat(transferResult.failed()).isTrue())
                 .satisfies(transferResult -> assertThat(transferResult.getFailure().status()).isEqualTo(ResponseStatus.ERROR_RETRY))
@@ -105,7 +103,6 @@ class ParallelSinkTest {
         fakeSink.transferResultSupplier = () -> {
             throw new RuntimeException(errorMessage);
         };
-        var dataSource = new InputStreamDataSource(dataSourceName, new ByteArrayInputStream(dataSourceContent.getBytes()));
 
         assertThat(fakeSink.transfer(dataSource)).succeedsWithin(500, TimeUnit.MILLISECONDS)
                 .satisfies(transferResult -> assertThat(transferResult.failed()).isTrue())

--- a/extensions/data-plane/data-plane-spi/src/test/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSinkTest.java
+++ b/extensions/data-plane/data-plane-spi/src/test/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSinkTest.java
@@ -42,6 +42,9 @@ class ParallelSinkTest {
     String dataSourceName = faker.lorem().word();
     String dataSourceContent = faker.lorem().characters();
     String errorMessage = faker.lorem().sentence();
+    InputStreamDataSource dataSource = new InputStreamDataSource(
+            dataSourceName,
+            new ByteArrayInputStream(dataSourceContent.getBytes()));
 
     FakeParallelSink fakeSink;
 
@@ -56,12 +59,18 @@ class ParallelSinkTest {
 
     @Test
     void transfer_succeeds() {
-        var dataSource = new InputStreamDataSource(dataSourceName, new ByteArrayInputStream(dataSourceContent.getBytes()));
-
         assertThat(fakeSink.transfer(dataSource)).succeedsWithin(500, TimeUnit.MILLISECONDS)
                 .satisfies(transferResult -> assertThat(transferResult.succeeded()).isTrue());
 
         assertThat(fakeSink.parts).containsExactly(dataSource);
+        assertThat(fakeSink.complete).isEqualTo(1);
+    }
+
+    @Test
+    void transfer_whenCompleteFails_fails() {
+        fakeSink.completeResponse = StatusResult.failure(ResponseStatus.ERROR_RETRY);
+        assertThat(fakeSink.transfer(dataSource)).succeedsWithin(500, TimeUnit.MILLISECONDS)
+                .isEqualTo(fakeSink.completeResponse);
     }
 
     @Test
@@ -71,8 +80,9 @@ class ParallelSinkTest {
         when(dataSourceMock.openPartStream()).thenThrow(new RuntimeException(errorMessage));
 
         assertThat(fakeSink.transfer(dataSourceMock)).succeedsWithin(500, TimeUnit.MILLISECONDS)
-            .satisfies(transferResult -> assertThat(transferResult.failed()).isTrue())
-            .satisfies(transferResult -> assertThat(transferResult.getFailureMessages()).containsExactly("Error processing data transfer request"));
+                .satisfies(transferResult -> assertThat(transferResult.failed()).isTrue())
+                .satisfies(transferResult -> assertThat(transferResult.getFailureMessages()).containsExactly("Error processing data transfer request"));
+        assertThat(fakeSink.complete).isEqualTo(0);
     }
 
     @Test
@@ -82,11 +92,12 @@ class ParallelSinkTest {
         var dataSource = new InputStreamDataSource(dataSourceName, new ByteArrayInputStream(dataSourceContent.getBytes()));
 
         assertThat(fakeSink.transfer(dataSource)).succeedsWithin(500, TimeUnit.MILLISECONDS)
-            .satisfies(transferResult -> assertThat(transferResult.failed()).isTrue())
+                .satisfies(transferResult -> assertThat(transferResult.failed()).isTrue())
                 .satisfies(transferResult -> assertThat(transferResult.getFailure().status()).isEqualTo(ResponseStatus.ERROR_RETRY))
-            .satisfies(transferResult -> assertThat(transferResult.getFailureMessages()).containsExactly(errorMessage));
+                .satisfies(transferResult -> assertThat(transferResult.getFailureMessages()).containsExactly(errorMessage));
 
         assertThat(fakeSink.parts).containsExactly(dataSource);
+        assertThat(fakeSink.complete).isEqualTo(0);
     }
 
     @Test
@@ -103,17 +114,26 @@ class ParallelSinkTest {
                         .containsExactly("Unhandled exception raised when transferring data: java.lang.RuntimeException: " + errorMessage));
 
         assertThat(fakeSink.parts).containsExactly(dataSource);
+        assertThat(fakeSink.complete).isEqualTo(0);
     }
 
     private static class FakeParallelSink extends ParallelSink {
 
         List<DataSource.Part> parts;
         Supplier<StatusResult<Void>> transferResultSupplier = StatusResult::success;
+        private int complete;
+        private StatusResult<Void> completeResponse = StatusResult.success();
 
         @Override
         protected StatusResult<Void> transferParts(List<DataSource.Part> parts) {
             this.parts = parts;
             return transferResultSupplier.get();
+        }
+
+        @Override
+        protected StatusResult<Void> complete() {
+            complete++;
+            return completeResponse;
         }
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

AzureStorageDataSink writes a blob named `.complete` after all parts are transferred

## Why it does that

End-to-end flow for blob storage transfers across EDC and DPF is not working (#1183). This is one of multiple PRs to solve several issues causing the problem.

When a data transfer target is an Azure Storage container, the consumer did not detect transfer completion. 

`ObjectContainerStatusChecker` polls for a blob called `*.complete` in the destination storage container to determine if a transfer has completed on the provider side. As `AzureStorageDataSink` did not currently write this file, transfer completion was never detected.

## Further notes


## Linked Issue(s)

Closes #1210 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)

