### PR TITLE
catalog: Fix interference between Catalog API based on same path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Fixed DMgmtApi content types (#1126)
 * Fix HTTPS termination in Jetty (#1133)
 * Break lease after TransferProcessManager status check (#1214)
+* Fix path conflicts between `CatalogApiController` and `FederatedCatalogApiController` (#1225)
 
 ## [milestone-3] - 2022-04-08
 

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheExtension.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheExtension.java
@@ -15,7 +15,7 @@
 package org.eclipse.dataspaceconnector.catalog.cache;
 
 import net.jodah.failsafe.RetryPolicy;
-import org.eclipse.dataspaceconnector.catalog.cache.controller.CatalogController;
+import org.eclipse.dataspaceconnector.catalog.cache.controller.FederatedCatalogApiController;
 import org.eclipse.dataspaceconnector.catalog.cache.crawler.CrawlerImpl;
 import org.eclipse.dataspaceconnector.catalog.cache.crawler.NodeQueryAdapterRegistryImpl;
 import org.eclipse.dataspaceconnector.catalog.cache.loader.LoaderManagerImpl;
@@ -96,7 +96,7 @@ public class FederatedCatalogCacheExtension implements ServiceExtension {
         var queryEngine = new QueryEngineImpl(queryAdapterRegistry);
         context.registerService(QueryEngine.class, queryEngine);
         monitor = context.getMonitor();
-        var catalogController = new CatalogController(monitor, queryEngine);
+        var catalogController = new FederatedCatalogApiController(monitor, queryEngine);
         webService.registerResource(catalogController);
 
         // contribute to the liveness probe

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/controller/FederatedCatalogApiController.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/controller/FederatedCatalogApiController.java
@@ -29,21 +29,20 @@ import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOf
 
 import java.util.Collection;
 
-@Consumes({ MediaType.APPLICATION_JSON })
-@Produces({ MediaType.APPLICATION_JSON })
-@Path("/")
-public class CatalogController {
+@Consumes({MediaType.APPLICATION_JSON})
+@Produces({MediaType.APPLICATION_JSON})
+@Path("/federatedcatalog")
+public class FederatedCatalogApiController {
 
     private final Monitor monitor;
     private final QueryEngine queryEngine;
 
-    public CatalogController(Monitor monitor, QueryEngine queryEngine) {
+    public FederatedCatalogApiController(Monitor monitor, QueryEngine queryEngine) {
         this.monitor = monitor;
         this.queryEngine = queryEngine;
     }
 
     @POST
-    @Path("catalog")
     public Collection<ContractOffer> getCatalog(FederatedCatalogCacheQuery federatedCatalogCacheQuery) {
         monitor.info("Received a catalog request");
         var queryResponse = queryEngine.getCatalog(federatedCatalogCacheQuery);

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheEndToEndTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheEndToEndTest.java
@@ -79,7 +79,7 @@ class FederatedCatalogCacheEndToEndTest {
         // here the content of the catalog cache store can be queried through http://localhost:8181/api/catalog
         RequestBody body = RequestBody.create("{}", MediaType.parse("application/json"));
         Request request = new Request.Builder()
-                .url("http://localhost:" + PORT + "/api/catalog")
+                .url("http://localhost:" + PORT + "/api/federatedcatalog")
                 .post(body)
                 .build();
 


### PR DESCRIPTION
## What this PR changes/adds

This PR modifies the previous path `/catalog` for the Federated Catalog API controller to `/federatedcatalog`.

## Why it does that

In case Data Management API are registered on the default context, there is a conflict between the endpoints respectively defined in `CatalogApiController` and in `CatalogController`, as both are registered on the same path `/catalog`.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
