### PR TITLE
fix: IDS date serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Add strict body validation for REST endpoints (#1128)
 * Dependency injection using factory/provider methods (#1056)
 * Provisioned resource information in Data Management API (#1221)
+* Add custom Jackson (de)serializer for `XMLGregorianCalendar` (#1226)
 
 #### Changed
 

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/IdsMultipartDispatcherServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/IdsMultipartDispatcherServiceExtension.java
@@ -29,6 +29,7 @@ import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.Multip
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.MultipartDescriptionRequestSender;
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.MultipartEndpointDataReferenceRequestSender;
 import org.eclipse.dataspaceconnector.ids.core.policy.IdsConstraintImpl;
+import org.eclipse.dataspaceconnector.ids.core.serialization.XmlGregorianCalendarModule;
 import org.eclipse.dataspaceconnector.ids.spi.IdsId;
 import org.eclipse.dataspaceconnector.ids.spi.IdsIdParser;
 import org.eclipse.dataspaceconnector.ids.spi.IdsType;
@@ -89,6 +90,7 @@ public class IdsMultipartDispatcherServiceExtension implements ServiceExtension 
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         objectMapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
         objectMapper.registerSubtypes(IdsConstraintImpl.class);
+        objectMapper.registerModule(new XmlGregorianCalendarModule());
 
         String idsWebhookAddress = getSetting(context, IDS_WEBHOOK_ADDRESS, DEFAULT_IDS_WEBHOOK_ADDRESS);
         String idsApiPath = idsApiConfiguration.getPath();

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/IdsMultipartDispatcherServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/IdsMultipartDispatcherServiceExtension.java
@@ -14,11 +14,6 @@
 
 package org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.ids.api.configuration.IdsApiConfiguration;
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.MultipartArtifactRequestSender;
@@ -28,8 +23,7 @@ import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.Multip
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.MultipartContractRejectionSender;
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.MultipartDescriptionRequestSender;
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.MultipartEndpointDataReferenceRequestSender;
-import org.eclipse.dataspaceconnector.ids.core.policy.IdsConstraintImpl;
-import org.eclipse.dataspaceconnector.ids.core.serialization.XmlGregorianCalendarModule;
+import org.eclipse.dataspaceconnector.ids.core.serialization.ObjectMapperFactory;
 import org.eclipse.dataspaceconnector.ids.spi.IdsId;
 import org.eclipse.dataspaceconnector.ids.spi.IdsIdParser;
 import org.eclipse.dataspaceconnector.ids.spi.IdsType;
@@ -45,7 +39,6 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.jetbrains.annotations.NotNull;
 
-import java.text.SimpleDateFormat;
 import java.util.Objects;
 
 public class IdsMultipartDispatcherServiceExtension implements ServiceExtension {
@@ -67,6 +60,8 @@ public class IdsMultipartDispatcherServiceExtension implements ServiceExtension 
     private IdsTransformerRegistry transformerRegistry;
     @Inject
     private IdsApiConfiguration idsApiConfiguration;
+    @Inject
+    private ObjectMapperFactory objectMapperFactory;
 
     @Override
     public String name() {
@@ -82,15 +77,7 @@ public class IdsMultipartDispatcherServiceExtension implements ServiceExtension 
 
         // TODO ObjectMapper needs to be replaced by one capable to write proper IDS JSON-LD
         //      once https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/236 is done
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-        objectMapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"));
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        objectMapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
-        objectMapper.registerSubtypes(IdsConstraintImpl.class);
-        objectMapper.registerModule(new XmlGregorianCalendarModule());
+        var objectMapper = objectMapperFactory.getObjectMapper();
 
         String idsWebhookAddress = getSetting(context, IDS_WEBHOOK_ADDRESS, DEFAULT_IDS_WEBHOOK_ADDRESS);
         String idsApiPath = idsApiConfiguration.getPath();

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/AbstractMultipartDispatcherIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/AbstractMultipartDispatcherIntegrationTest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.eclipse.dataspaceconnector.ids.api.multipart.controller.MultipartController;
 import org.eclipse.dataspaceconnector.ids.core.policy.IdsConstraintImpl;
+import org.eclipse.dataspaceconnector.ids.core.serialization.XmlGregorianCalendarModule;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
@@ -61,6 +62,7 @@ abstract class AbstractMultipartDispatcherIntegrationTest {
         OBJECT_MAPPER.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         OBJECT_MAPPER.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
         OBJECT_MAPPER.registerSubtypes(IdsConstraintImpl.class);
+        OBJECT_MAPPER.registerModule(new XmlGregorianCalendarModule());
     }
 
     protected IdentityService identityService;

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/AbstractMultipartDispatcherIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/AbstractMultipartDispatcherIntegrationTest.java
@@ -42,13 +42,13 @@ import static org.mockito.Mockito.when;
 abstract class AbstractMultipartDispatcherIntegrationTest {
     // TODO needs to be replaced by an objectmapper capable to understand IDS JSON-LD
     //      once https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/236 is done
-    protected static ObjectMapper OBJECT_MAPPER;
+    protected static ObjectMapper objectMapper;
     private static final AtomicReference<Integer> PORT = new AtomicReference<>();
     private static final AtomicReference<Integer> IDS_PORT = new AtomicReference<>();
     private static final List<Asset> ASSETS = new LinkedList<>();
 
     static {
-        OBJECT_MAPPER = new ObjectMapperFactory().getObjectMapper();
+        objectMapper = new ObjectMapperFactory().getObjectMapper();
     }
 
     protected IdentityService identityService;

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/AbstractMultipartDispatcherIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/AbstractMultipartDispatcherIntegrationTest.java
@@ -14,14 +14,9 @@
 
 package org.eclipse.dataspaceconnector.ids.api.multipart.client;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.eclipse.dataspaceconnector.ids.api.multipart.controller.MultipartController;
-import org.eclipse.dataspaceconnector.ids.core.policy.IdsConstraintImpl;
-import org.eclipse.dataspaceconnector.ids.core.serialization.XmlGregorianCalendarModule;
+import org.eclipse.dataspaceconnector.ids.core.serialization.ObjectMapperFactory;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
@@ -33,7 +28,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.text.SimpleDateFormat;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -48,21 +42,13 @@ import static org.mockito.Mockito.when;
 abstract class AbstractMultipartDispatcherIntegrationTest {
     // TODO needs to be replaced by an objectmapper capable to understand IDS JSON-LD
     //      once https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/236 is done
-    protected static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    protected static ObjectMapper OBJECT_MAPPER;
     private static final AtomicReference<Integer> PORT = new AtomicReference<>();
     private static final AtomicReference<Integer> IDS_PORT = new AtomicReference<>();
     private static final List<Asset> ASSETS = new LinkedList<>();
 
     static {
-        OBJECT_MAPPER.registerModule(new JavaTimeModule());
-        OBJECT_MAPPER.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"));
-        OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        OBJECT_MAPPER.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-        OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        OBJECT_MAPPER.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
-        OBJECT_MAPPER.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
-        OBJECT_MAPPER.registerSubtypes(IdsConstraintImpl.class);
-        OBJECT_MAPPER.registerModule(new XmlGregorianCalendarModule());
+        OBJECT_MAPPER = new ObjectMapperFactory().getObjectMapper();
     }
 
     protected IdentityService identityService;

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.ids.api.multipart.client;
 
 import kotlin.NotImplementedError;
 import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
+import org.eclipse.dataspaceconnector.ids.core.serialization.ObjectMapperFactory;
 import org.eclipse.dataspaceconnector.policy.model.Action;
 import org.eclipse.dataspaceconnector.policy.model.Permission;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
@@ -73,7 +74,8 @@ import static org.mockito.Mockito.mock;
 @Provides({
         AssetIndex.class, TransferProcessStore.class, ContractDefinitionStore.class, IdentityService.class,
         ContractNegotiationManager.class, ConsumerContractNegotiationManager.class, ProviderContractNegotiationManager.class,
-        ContractOfferService.class, ContractValidationService.class, PolicyArchive.class
+        ContractOfferService.class, ContractValidationService.class, PolicyArchive.class,
+        ObjectMapperFactory.class
 })
 class IdsApiMultipartDispatcherV1IntegrationTestServiceExtension implements ServiceExtension {
     private final List<Asset> assets;
@@ -118,6 +120,7 @@ class IdsApiMultipartDispatcherV1IntegrationTestServiceExtension implements Serv
         context.registerService(ProviderContractNegotiationManager.class, new FakeProviderContractNegotiationManager());
         context.registerService(ConsumerContractNegotiationManager.class, new FakeConsumerContractNegotiationManager());
         context.registerService(PolicyArchive.class, mock(PolicyArchive.class));
+        context.registerService(ObjectMapperFactory.class, new ObjectMapperFactory());
     }
 
     private static class FakeAssetIndex implements AssetIndex {

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/MultipartDispatcherIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/MultipartDispatcherIntegrationTest.java
@@ -88,12 +88,12 @@ class MultipartDispatcherIntegrationTest extends AbstractMultipartDispatcherInte
         var idsApiPath = "/api";
 
         multipartDispatcher = new IdsMultipartRemoteMessageDispatcher();
-        multipartDispatcher.register(new MultipartDescriptionRequestSender(CONNECTOR_ID, httpClient, OBJECT_MAPPER, monitor, identityService, transformerRegistry));
-        multipartDispatcher.register(new MultipartArtifactRequestSender(CONNECTOR_ID, httpClient, OBJECT_MAPPER, monitor, vault, identityService, transformerRegistry, idsWebhookAddress, idsApiPath));
-        multipartDispatcher.register(new MultipartContractOfferSender(CONNECTOR_ID, httpClient, OBJECT_MAPPER, monitor, identityService, transformerRegistry, idsWebhookAddress, idsApiPath));
-        multipartDispatcher.register(new MultipartContractAgreementSender(CONNECTOR_ID, httpClient, OBJECT_MAPPER, monitor, identityService, transformerRegistry, idsWebhookAddress, idsApiPath));
-        multipartDispatcher.register(new MultipartContractRejectionSender(CONNECTOR_ID, httpClient, OBJECT_MAPPER, monitor, identityService, transformerRegistry));
-        multipartDispatcher.register(new MultipartCatalogDescriptionRequestSender(CONNECTOR_ID, httpClient, OBJECT_MAPPER, monitor, identityService, transformerRegistry));
+        multipartDispatcher.register(new MultipartDescriptionRequestSender(CONNECTOR_ID, httpClient, objectMapper, monitor, identityService, transformerRegistry));
+        multipartDispatcher.register(new MultipartArtifactRequestSender(CONNECTOR_ID, httpClient, objectMapper, monitor, vault, identityService, transformerRegistry, idsWebhookAddress, idsApiPath));
+        multipartDispatcher.register(new MultipartContractOfferSender(CONNECTOR_ID, httpClient, objectMapper, monitor, identityService, transformerRegistry, idsWebhookAddress, idsApiPath));
+        multipartDispatcher.register(new MultipartContractAgreementSender(CONNECTOR_ID, httpClient, objectMapper, monitor, identityService, transformerRegistry, idsWebhookAddress, idsApiPath));
+        multipartDispatcher.register(new MultipartContractRejectionSender(CONNECTOR_ID, httpClient, objectMapper, monitor, identityService, transformerRegistry));
+        multipartDispatcher.register(new MultipartCatalogDescriptionRequestSender(CONNECTOR_ID, httpClient, objectMapper, monitor, identityService, transformerRegistry));
     }
 
     @Test

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsMultipartApiServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsMultipartApiServiceExtension.java
@@ -41,6 +41,7 @@ import org.eclipse.dataspaceconnector.ids.api.multipart.handler.description.Repr
 import org.eclipse.dataspaceconnector.ids.api.multipart.handler.description.ResourceDescriptionRequestHandler;
 import org.eclipse.dataspaceconnector.ids.api.multipart.message.ids.IdsResponseMessageFactory;
 import org.eclipse.dataspaceconnector.ids.core.policy.IdsConstraintImpl;
+import org.eclipse.dataspaceconnector.ids.core.serialization.XmlGregorianCalendarModule;
 import org.eclipse.dataspaceconnector.ids.spi.IdsId;
 import org.eclipse.dataspaceconnector.ids.spi.IdsIdParser;
 import org.eclipse.dataspaceconnector.ids.spi.IdsType;
@@ -147,6 +148,7 @@ public final class IdsMultipartApiServiceExtension implements ServiceExtension {
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         objectMapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
         objectMapper.registerSubtypes(IdsConstraintImpl.class);
+        objectMapper.registerModule(new XmlGregorianCalendarModule());
 
         // create request handler
         var descriptionHandler = new DescriptionHandler(

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsMultipartApiServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsMultipartApiServiceExtension.java
@@ -16,11 +16,6 @@
 
 package org.eclipse.dataspaceconnector.ids.api.multipart;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import de.fraunhofer.iais.eis.ParticipantUpdateMessage;
 import org.eclipse.dataspaceconnector.ids.api.configuration.IdsApiConfiguration;
 import org.eclipse.dataspaceconnector.ids.api.multipart.controller.MultipartController;
@@ -40,8 +35,7 @@ import org.eclipse.dataspaceconnector.ids.api.multipart.handler.description.Data
 import org.eclipse.dataspaceconnector.ids.api.multipart.handler.description.RepresentationDescriptionRequestHandler;
 import org.eclipse.dataspaceconnector.ids.api.multipart.handler.description.ResourceDescriptionRequestHandler;
 import org.eclipse.dataspaceconnector.ids.api.multipart.message.ids.IdsResponseMessageFactory;
-import org.eclipse.dataspaceconnector.ids.core.policy.IdsConstraintImpl;
-import org.eclipse.dataspaceconnector.ids.core.serialization.XmlGregorianCalendarModule;
+import org.eclipse.dataspaceconnector.ids.core.serialization.ObjectMapperFactory;
 import org.eclipse.dataspaceconnector.ids.spi.IdsId;
 import org.eclipse.dataspaceconnector.ids.spi.IdsIdParser;
 import org.eclipse.dataspaceconnector.ids.spi.IdsType;
@@ -68,7 +62,6 @@ import org.eclipse.dataspaceconnector.spi.transfer.edr.EndpointDataReferenceRece
 import org.eclipse.dataspaceconnector.spi.transfer.edr.EndpointDataReferenceTransformerRegistry;
 import org.jetbrains.annotations.NotNull;
 
-import java.text.SimpleDateFormat;
 import java.util.LinkedList;
 import java.util.Objects;
 
@@ -112,6 +105,8 @@ public final class IdsMultipartApiServiceExtension implements ServiceExtension {
     private EndpointDataReferenceTransformerRegistry endpointDataReferenceTransformerRegistry;
     @Inject
     private IdsApiConfiguration idsApiConfiguration;
+    @Inject
+    private ObjectMapperFactory objectMapperFactory;
 
     @Override
     public String name() {
@@ -140,15 +135,7 @@ public final class IdsMultipartApiServiceExtension implements ServiceExtension {
         // create & register controller
         // TODO ObjectMapper needs to be replaced by one capable to write proper IDS JSON-LD
         //      once https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/236 is done
-        var objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-        objectMapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"));
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        objectMapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
-        objectMapper.registerSubtypes(IdsConstraintImpl.class);
-        objectMapper.registerModule(new XmlGregorianCalendarModule());
+        var objectMapper = objectMapperFactory.getObjectMapper();
 
         // create request handler
         var descriptionHandler = new DescriptionHandler(

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ContractAgreementHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ContractAgreementHandler.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.ids.api.multipart.handler;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.fraunhofer.iais.eis.ContractAgreementMessage;
 import de.fraunhofer.iais.eis.Message;
@@ -31,7 +30,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
-import java.util.Map;
 import java.util.Objects;
 
 import static org.eclipse.dataspaceconnector.ids.api.multipart.util.RejectionMessageUtil.badParameters;
@@ -76,12 +74,7 @@ public class ContractAgreementHandler implements Handler {
 
         de.fraunhofer.iais.eis.ContractAgreement contractAgreement;
         try {
-            var map = objectMapper.readValue(multipartRequest.getPayload(), new TypeReference<Map<String, Object>>() {
-            });
-            map.remove("ids:contractEnd");
-            map.remove("ids:contractStart");
-            map.remove("ids:contractDate");
-            contractAgreement = objectMapper.convertValue(map, de.fraunhofer.iais.eis.ContractAgreement.class);
+            contractAgreement = objectMapper.readValue(multipartRequest.getPayload(), de.fraunhofer.iais.eis.ContractAgreement.class);
         } catch (IOException e) {
             monitor.severe("ContractAgreementHandler: Contract Agreement is invalid", e);
             return createBadParametersErrorMultipartResponse(message);

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/AbstractMultipartControllerIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/AbstractMultipartControllerIntegrationTest.java
@@ -16,11 +16,7 @@
 
 package org.eclipse.dataspaceconnector.ids.api.multipart;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import de.fraunhofer.iais.eis.Contract;
 import de.fraunhofer.iais.eis.ContractAgreementMessage;
 import de.fraunhofer.iais.eis.ContractAgreementMessageBuilder;
@@ -45,8 +41,7 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.eclipse.dataspaceconnector.ids.api.multipart.controller.MultipartController;
 import org.eclipse.dataspaceconnector.ids.api.multipart.message.MultipartResponse;
-import org.eclipse.dataspaceconnector.ids.core.policy.IdsConstraintImpl;
-import org.eclipse.dataspaceconnector.ids.core.serialization.XmlGregorianCalendarModule;
+import org.eclipse.dataspaceconnector.ids.core.serialization.ObjectMapperFactory;
 import org.eclipse.dataspaceconnector.ids.spi.IdsId;
 import org.eclipse.dataspaceconnector.ids.spi.IdsIdParser;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
@@ -54,12 +49,12 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.net.URI;
 import java.net.http.HttpHeaders;
-import java.text.SimpleDateFormat;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -75,20 +70,13 @@ abstract class AbstractMultipartControllerIntegrationTest {
     public static final String PAYLOAD = "payload";
     // TODO needs to be replaced by an objectmapper capable to understand IDS JSON-LD
     //      once https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/236 is done
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static ObjectMapper OBJECT_MAPPER;
     private static final AtomicReference<Integer> PORT = new AtomicReference<>();
     private static final AtomicReference<Integer> IDS_PORT = new AtomicReference<>();
     private static final List<Asset> ASSETS = new LinkedList<>();
-
+    
     static {
-        OBJECT_MAPPER.registerModule(new JavaTimeModule());
-        OBJECT_MAPPER.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"));
-        OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        OBJECT_MAPPER.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-        OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        OBJECT_MAPPER.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
-        OBJECT_MAPPER.registerSubtypes(IdsConstraintImpl.class);
-        OBJECT_MAPPER.registerModule(new XmlGregorianCalendarModule());
+        OBJECT_MAPPER = new ObjectMapperFactory().getObjectMapper();
     }
 
     @AfterEach

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/AbstractMultipartControllerIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/AbstractMultipartControllerIntegrationTest.java
@@ -49,7 +49,6 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -70,13 +69,13 @@ abstract class AbstractMultipartControllerIntegrationTest {
     public static final String PAYLOAD = "payload";
     // TODO needs to be replaced by an objectmapper capable to understand IDS JSON-LD
     //      once https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/236 is done
-    private static ObjectMapper OBJECT_MAPPER;
+    private static ObjectMapper objectMapper;
     private static final AtomicReference<Integer> PORT = new AtomicReference<>();
     private static final AtomicReference<Integer> IDS_PORT = new AtomicReference<>();
     private static final List<Asset> ASSETS = new LinkedList<>();
     
     static {
-        OBJECT_MAPPER = new ObjectMapperFactory().getObjectMapper();
+        objectMapper = new ObjectMapperFactory().getObjectMapper();
     }
 
     @AfterEach
@@ -126,11 +125,11 @@ abstract class AbstractMultipartControllerIntegrationTest {
     }
 
     protected String toJson(Message message) throws Exception {
-        return OBJECT_MAPPER.writeValueAsString(message);
+        return objectMapper.writeValueAsString(message);
     }
 
     protected String toJson(Contract contract) throws Exception {
-        return OBJECT_MAPPER.writeValueAsString(contract);
+        return objectMapper.writeValueAsString(contract);
     }
 
     protected DescriptionRequestMessage getDescriptionRequestMessage() {
@@ -242,7 +241,7 @@ abstract class AbstractMultipartControllerIntegrationTest {
                 }
 
                 if (multipartName.equalsIgnoreCase(HEADER)) {
-                    header = OBJECT_MAPPER.readValue(part.body().inputStream(), Message.class);
+                    header = objectMapper.readValue(part.body().inputStream(), Message.class);
                 } else if (multipartName.equalsIgnoreCase(PAYLOAD)) {
                     payload = part.body().readByteArray();
                 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/AbstractMultipartControllerIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/AbstractMultipartControllerIntegrationTest.java
@@ -46,6 +46,7 @@ import okhttp3.Response;
 import org.eclipse.dataspaceconnector.ids.api.multipart.controller.MultipartController;
 import org.eclipse.dataspaceconnector.ids.api.multipart.message.MultipartResponse;
 import org.eclipse.dataspaceconnector.ids.core.policy.IdsConstraintImpl;
+import org.eclipse.dataspaceconnector.ids.core.serialization.XmlGregorianCalendarModule;
 import org.eclipse.dataspaceconnector.ids.spi.IdsId;
 import org.eclipse.dataspaceconnector.ids.spi.IdsIdParser;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
@@ -87,6 +88,7 @@ abstract class AbstractMultipartControllerIntegrationTest {
         OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         OBJECT_MAPPER.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
         OBJECT_MAPPER.registerSubtypes(IdsConstraintImpl.class);
+        OBJECT_MAPPER.registerModule(new XmlGregorianCalendarModule());
     }
 
     @AfterEach

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
@@ -18,6 +18,7 @@ package org.eclipse.dataspaceconnector.ids.api.multipart;
 
 import kotlin.NotImplementedError;
 import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
+import org.eclipse.dataspaceconnector.ids.core.serialization.ObjectMapperFactory;
 import org.eclipse.dataspaceconnector.policy.model.Action;
 import org.eclipse.dataspaceconnector.policy.model.Permission;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
@@ -84,7 +85,8 @@ import static org.mockito.Mockito.mock;
         ProviderContractNegotiationManager.class,
         ContractOfferService.class,
         ContractValidationService.class,
-        PolicyArchive.class
+        PolicyArchive.class,
+        ObjectMapperFactory.class
 })
 class IdsApiMultipartEndpointV1IntegrationTestServiceExtension implements ServiceExtension {
     private final List<Asset> assets;
@@ -129,6 +131,7 @@ class IdsApiMultipartEndpointV1IntegrationTestServiceExtension implements Servic
         context.registerService(ProviderContractNegotiationManager.class, new FakeProviderContractNegotiationManager());
         context.registerService(ConsumerContractNegotiationManager.class, new FakeConsumerContractNegotiationManager());
         context.registerService(PolicyArchive.class, mock(PolicyArchive.class));
+        context.registerService(ObjectMapperFactory.class, new ObjectMapperFactory());
     }
 
     private static class FakeIdentityService implements IdentityService {

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/IdsCoreServiceExtension.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/IdsCoreServiceExtension.java
@@ -16,6 +16,7 @@ package org.eclipse.dataspaceconnector.ids.core;
 
 import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.ids.core.descriptor.IdsDescriptorServiceImpl;
+import org.eclipse.dataspaceconnector.ids.core.serialization.ObjectMapperFactory;
 import org.eclipse.dataspaceconnector.ids.core.service.CatalogServiceImpl;
 import org.eclipse.dataspaceconnector.ids.core.service.ConnectorServiceImpl;
 import org.eclipse.dataspaceconnector.ids.core.service.ConnectorServiceSettings;
@@ -46,7 +47,7 @@ import java.util.List;
  * Implements the IDS Controller REST API.
  */
 @Provides({ ConnectorVersionProvider.class, CatalogService.class, ConnectorService.class, IdsDescriptorService.class,
-        CatalogService.class, ConnectorService.class, IdsTransformerRegistry.class })
+        CatalogService.class, ConnectorService.class, IdsTransformerRegistry.class, ObjectMapperFactory.class })
 public class IdsCoreServiceExtension implements ServiceExtension {
 
     @EdcSetting
@@ -106,7 +107,11 @@ public class IdsCoreServiceExtension implements ServiceExtension {
 
         ConnectorService connectorService = createConnectorService(connectorServiceSettings, connectorVersionProvider, dataCatalogService);
         serviceExtensionContext.registerService(ConnectorService.class, connectorService);
-
+        
+        //TODO remove once IDS serializer is integrated (#236)
+        var objectMapperFactory = new ObjectMapperFactory();
+        serviceExtensionContext.registerService(ObjectMapperFactory.class, objectMapperFactory);
+        
         registerOther(serviceExtensionContext);
     }
 

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/serialization/ObjectMapperFactory.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/serialization/ObjectMapperFactory.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2022 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.ids.core.serialization;
+
+import java.text.SimpleDateFormat;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.eclipse.dataspaceconnector.ids.core.policy.IdsConstraintImpl;
+
+/**
+ * Creates and returns the ObjectMapper for IDS (de)serialization.
+ */
+public class ObjectMapperFactory {
+
+    private final ObjectMapper objectMapper;
+    
+    public ObjectMapperFactory() {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"));
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        objectMapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+        objectMapper.registerSubtypes(IdsConstraintImpl.class);
+        objectMapper.registerModule(new XmlGregorianCalendarModule());
+    }
+    
+    public ObjectMapper getObjectMapper() {
+        return objectMapper;
+    }
+
+}

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/serialization/ObjectMapperFactory.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/serialization/ObjectMapperFactory.java
@@ -14,14 +14,14 @@
 
 package org.eclipse.dataspaceconnector.ids.core.serialization;
 
-import java.text.SimpleDateFormat;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.eclipse.dataspaceconnector.ids.core.policy.IdsConstraintImpl;
+
+import java.text.SimpleDateFormat;
 
 /**
  * Creates and returns the ObjectMapper for IDS (de)serialization.

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/serialization/XmlGregorianCalendarDeserializer.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/serialization/XmlGregorianCalendarDeserializer.java
@@ -18,12 +18,12 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeFactory;
-import javax.xml.datatype.XMLGregorianCalendar;
 import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.util.GregorianCalendar;
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
 
 /**
  * Custom Jackson deserializer for objects of type XMLGregorianCalendar. Serves as a workaround

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/serialization/XmlGregorianCalendarDeserializer.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/serialization/XmlGregorianCalendarDeserializer.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2022 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.ids.core.serialization;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.util.GregorianCalendar;
+
+/**
+ * Custom Jackson deserializer for objects of type XMLGregorianCalendar. Serves as a workaround
+ * for date deserialization until integration of the IDS Information Model Serializer.
+ */
+public class XmlGregorianCalendarDeserializer extends StdDeserializer<XMLGregorianCalendar> {
+    
+    public XmlGregorianCalendarDeserializer() {
+        super(XMLGregorianCalendar.class);
+    }
+    
+    @Override
+    public XMLGregorianCalendar deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+        try {
+            return DatatypeFactory.newInstance().newXMLGregorianCalendar(GregorianCalendar.from(ZonedDateTime.parse(jsonParser.getValueAsString())));
+        } catch (DatatypeConfigurationException e) {
+            return null;
+        }
+    }
+    
+}

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/serialization/XmlGregorianCalendarModule.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/serialization/XmlGregorianCalendarModule.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2022 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.ids.core.serialization;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+/**
+ * Custom Jackson module for the ObjectMapper, that contains custom (de)serializers for objects of
+ * type XMLGregorianCalendar. Serves as a workaround for date (de)serialization until integration
+ * of the IDS Information Model Serializer.
+ */
+public class XmlGregorianCalendarModule extends SimpleModule {
+    
+    public XmlGregorianCalendarModule() {
+        this.addSerializer(XMLGregorianCalendar.class, new XmlGregorianCalendarSerializer());
+        this.addDeserializer(XMLGregorianCalendar.class, new XmlGregorianCalendarDeserializer());
+    }
+    
+}

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/serialization/XmlGregorianCalendarSerializer.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/serialization/XmlGregorianCalendarSerializer.java
@@ -18,9 +18,9 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
-import javax.xml.datatype.XMLGregorianCalendar;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
+import javax.xml.datatype.XMLGregorianCalendar;
 
 /**
  * Custom Jackson serializer for objects of type XMLGregorianCalendar. Serves as a workaround

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/serialization/XmlGregorianCalendarSerializer.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/serialization/XmlGregorianCalendarSerializer.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2022 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.ids.core.serialization;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+
+/**
+ * Custom Jackson serializer for objects of type XMLGregorianCalendar. Serves as a workaround
+ * for date serialization until integration of the IDS Information Model Serializer.
+ */
+public class XmlGregorianCalendarSerializer extends StdSerializer<XMLGregorianCalendar> {
+    
+    public XmlGregorianCalendarSerializer() {
+        super(XMLGregorianCalendar.class);
+    }
+    
+    @Override
+    public void serialize(XMLGregorianCalendar xmlGregorianCalendar,
+                          JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        var sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+        var formatted = sdf.format(xmlGregorianCalendar.toGregorianCalendar().getTime());
+        jsonGenerator.writeString(formatted);
+    }
+    
+}

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/util/CalendarUtil.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/util/CalendarUtil.java
@@ -9,12 +9,14 @@
  *
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - added method
  *
  */
 
 package org.eclipse.dataspaceconnector.ids.core.util;
 
 import java.time.ZonedDateTime;
+import java.util.Date;
 import java.util.GregorianCalendar;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
@@ -29,5 +31,18 @@ public final class CalendarUtil {
         } catch (DatatypeConfigurationException e) {
             throw new RuntimeException(e);
         }
+    }
+    
+    /**
+     * Creates an XMLGregorianCalendar from an epoch seconds timestamp.
+     *
+     * @param timestamp the timestamp.
+     * @return XMLGregorianCalendar representation of the timestamp.
+     * @throws DatatypeConfigurationException if the timestamp cannot be parsed.
+     */
+    public static XMLGregorianCalendar gregorianFromEpochSeconds(long timestamp) throws DatatypeConfigurationException {
+        var gregCal = new GregorianCalendar();
+        gregCal.setTime(new Date(timestamp * 1000));
+        return DatatypeFactory.newInstance().newXMLGregorianCalendar(gregCal);
     }
 }

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/serialization/XmlGregorianCalendarModuleTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/serialization/XmlGregorianCalendarModuleTest.java
@@ -14,11 +14,6 @@
 
 package org.eclipse.dataspaceconnector.ids.core.serialization;
 
-import java.io.IOException;
-import java.text.SimpleDateFormat;
-
-import javax.xml.datatype.XMLGregorianCalendar;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import de.fraunhofer.iais.eis.ContractAgreement;
@@ -27,9 +22,13 @@ import org.eclipse.dataspaceconnector.ids.core.util.CalendarUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import javax.xml.datatype.XMLGregorianCalendar;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
-class XmlGregorianCalendarTest {
+class XmlGregorianCalendarModuleTest {
     
     private ObjectMapper objectMapper;
     

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/serialization/XmlGregorianCalendarTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/serialization/XmlGregorianCalendarTest.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2022 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.ids.core.serialization;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import de.fraunhofer.iais.eis.ContractAgreement;
+import de.fraunhofer.iais.eis.ContractAgreementBuilder;
+import org.eclipse.dataspaceconnector.ids.core.util.CalendarUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class XmlGregorianCalendarTest {
+    
+    private ObjectMapper objectMapper;
+    
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        objectMapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"));
+        objectMapper.registerModule(new XmlGregorianCalendarModule());
+    }
+    
+    @Test
+    void serializeAndDeserializeDate() {
+        var xmlGregorian = CalendarUtil.gregorianNow();
+        
+        try {
+            var serialized = objectMapper.writeValueAsString(xmlGregorian);
+            var xmlGregorianDeserialized = objectMapper.readValue(serialized, XMLGregorianCalendar.class);
+            
+            assertThat(xmlGregorian).isEqualTo(xmlGregorianDeserialized);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    @Test
+    void serializeAndDeserializeAgreement() {
+        var xmlGregorian = CalendarUtil.gregorianNow();
+        
+        var agreement = new ContractAgreementBuilder()
+                ._contractDate_(xmlGregorian)
+                ._contractStart_(xmlGregorian)
+                ._contractEnd_(xmlGregorian)
+                .build();
+    
+        try {
+            var serialized = objectMapper.writeValueAsString(agreement);
+            var agreementDeserialized = objectMapper.readValue(serialized, ContractAgreement.class);
+        
+            assertThat(agreement).isEqualTo(agreementDeserialized);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+}

--- a/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/dataspaceconnector/ids/transform/ContractAgreementRequestToIdsContractAgreementTransformer.java
+++ b/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/dataspaceconnector/ids/transform/ContractAgreementRequestToIdsContractAgreementTransformer.java
@@ -19,6 +19,7 @@ import de.fraunhofer.iais.eis.ContractAgreementBuilder;
 import de.fraunhofer.iais.eis.Duty;
 import de.fraunhofer.iais.eis.Permission;
 import de.fraunhofer.iais.eis.Prohibition;
+import org.eclipse.dataspaceconnector.ids.core.util.CalendarUtil;
 import org.eclipse.dataspaceconnector.ids.spi.IdsId;
 import org.eclipse.dataspaceconnector.ids.spi.IdsType;
 import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTypeTransformer;
@@ -33,7 +34,6 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeFactory;
 
 public class ContractAgreementRequestToIdsContractAgreementTransformer  implements IdsTypeTransformer<ContractAgreementRequest, de.fraunhofer.iais.eis.ContractAgreement> {
 
@@ -94,21 +94,21 @@ public class ContractAgreementRequestToIdsContractAgreementTransformer  implemen
         } catch (NullPointerException e) {
             context.reportProblem("cannot convert empty providerId string to URI");
         }
-
+    
         try {
-            builder._contractStart_(DatatypeFactory.newInstance().newXMLGregorianCalendar(String.valueOf(agreement.getContractStartDate())));
+            builder._contractStart_(CalendarUtil.gregorianFromEpochSeconds(agreement.getContractStartDate()));
         } catch (DatatypeConfigurationException e) {
             context.reportProblem("cannot convert contract start time to XMLGregorian");
         }
-
+    
         try {
-            builder._contractEnd_(DatatypeFactory.newInstance().newXMLGregorianCalendar(String.valueOf(agreement.getContractEndDate())));
+            builder._contractEnd_(CalendarUtil.gregorianFromEpochSeconds(agreement.getContractEndDate()));
         } catch (DatatypeConfigurationException e) {
             context.reportProblem("cannot convert contract end time to XMLGregorian");
         }
-
+    
         try {
-            builder._contractDate_(DatatypeFactory.newInstance().newXMLGregorianCalendar(String.valueOf(agreement.getContractSigningDate())));
+            builder._contractDate_(CalendarUtil.gregorianFromEpochSeconds(agreement.getContractSigningDate()));
         } catch (DatatypeConfigurationException e) {
             context.reportProblem("cannot convert contract signing time to XMLGregorian");
         }


### PR DESCRIPTION
## What this PR changes/adds

It add a custom serializer and deserializer to the `ObjectMappers` in the `ids` modules.

## Why it does that

Enables serialization and deserialization of `XMLGregorianCalendar` instances. Thus, the dates in `ContractAgreements` can be mapped correctly.

## Further notes

Once the IDS Information Model serializer is integrated, this solution should be deprecated.

## Linked Issue(s)

Closes #1226 

## Checklist

- [X] added appropriate tests?
- [ ] performed checkstyle check locally?
- [X] added/updated copyright headers?
- [X] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [X] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [X] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
