### PR TITLE
bugfix: exclude sample and system-tests modules from module name check also if edc is loaded as submodule

### DIFF
--- a/buildSrc/src/main/java/org/eclipse/dataspaceconnector/gradle/ModuleNamesPlugin.java
+++ b/buildSrc/src/main/java/org/eclipse/dataspaceconnector/gradle/ModuleNamesPlugin.java
@@ -41,10 +41,10 @@ public class ModuleNamesPlugin implements Plugin<Project> {
         project.afterEvaluate(new ModuleNamesAction());
     }
 
-    private class ModuleNamesAction implements Action<Project> {
+    private static class ModuleNamesAction implements Action<Project> {
 
-        private final Predicate<String> isSampleModule = displayName -> displayName.startsWith("project ':samples");
-        private final Predicate<String> isSystemTestModule = displayName -> displayName.startsWith("project ':system-tests");
+        private final Predicate<String> isSampleModule = displayName -> displayName.contains(":samples:");
+        private final Predicate<String> isSystemTestModule = displayName -> displayName.contains(":system-tests:");
         private final Predicate<String> excludeSamplesAndSystemTests = isSampleModule.or(isSystemTestModule).negate();
 
         @Override


### PR DESCRIPTION
## What this PR changes/adds

Changes how the `ModuleNamePlugin` excludes `samples` ans `system-tests`

## Why it does that

To permit EDC to be loaded as submodule

## Further notes

- Tried to add unit tests, but doing it into the `buildSrc` folder [seems not so straightforward](https://github.com/gradle/gradle/issues/8224)

## Linked Issue(s)

Closes #1232

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
