### PR TITLE
data-plane: enable contract validation rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Dependency injection using factory/provider methods (#1056)
 * Provisioned resource information in Data Management API (#1221)
 * Add custom Jackson (de)serializer for `XMLGregorianCalendar` (#1226)
+* Add contract validation rule (#1239)
 
 #### Changed
 

--- a/extensions/data-plane-transfer/data-plane-transfer-sync/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/api/rules/ContractValidationRule.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-sync/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/api/rules/ContractValidationRule.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Amadeus - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 
@@ -22,6 +23,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.text.ParseException;
+import java.time.Instant;
 import java.util.Map;
 
 import static org.eclipse.dataspaceconnector.dataplane.spi.DataPlaneConstants.CONTRACT_ID;
@@ -55,11 +57,9 @@ public class ContractValidationRule implements TokenValidationRule {
             return Result.failure("No contract agreement found for id: " + contractId);
         }
 
-        // check contract expiration date
-        //TODO: this must be uncommented when https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/236 is solved
-        //if (Instant.now().isAfter(Instant.ofEpochSecond(contractAgreement.getContractEndDate()))) {
-        // return Result.failure("Contract has expired");
-        //}
+        if (Instant.now().isAfter(Instant.ofEpochSecond(contractAgreement.getContractEndDate()))) {
+            return Result.failure("Contract has expired");
+        }
 
         return Result.success(toVerify);
     }

--- a/extensions/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/api/rules/ContractValidationRuleTest.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/api/rules/ContractValidationRuleTest.java
@@ -1,0 +1,104 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.transfer.dataplane.sync.api.rules;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.dataplane.spi.DataPlaneConstants.CONTRACT_ID;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ContractValidationRuleTest {
+
+    private final ContractNegotiationStore contractNegotiationStore = mock(ContractNegotiationStore.class);
+    private final ContractValidationRule rule = new ContractValidationRule(contractNegotiationStore);
+
+    @Test
+    void shouldSucceedIfContractIsStillValid() {
+        var contractAgreement = createContractAgreement("contractId", Instant.now().plus(1, ChronoUnit.SECONDS));
+        when(contractNegotiationStore.findContractAgreement("contractId")).thenReturn(contractAgreement);
+        var claims = new JWTClaimsSet.Builder()
+                .claim(CONTRACT_ID, "contractId")
+                .build();
+
+        var result = rule.checkRule(createJwtWith(claims));
+
+        assertThat(result.succeeded()).isTrue();
+    }
+
+    @Test
+    void shouldFailIfContractIsExpired() {
+        var contractAgreement = createContractAgreement("contractId", Instant.now().minus(1, ChronoUnit.SECONDS));
+        when(contractNegotiationStore.findContractAgreement("contractId")).thenReturn(contractAgreement);
+        var claims = new JWTClaimsSet.Builder()
+                .claim(CONTRACT_ID, "contractId")
+                .build();
+
+        var result = rule.checkRule(createJwtWith(claims));
+
+        assertThat(result.failed()).isTrue();
+    }
+
+    @Test
+    void shouldFailIfContractIdClaimIsMissing() {
+        var claims = new JWTClaimsSet.Builder().build();
+
+        var result = rule.checkRule(createJwtWith(claims));
+
+        assertThat(result.succeeded()).isFalse();
+    }
+
+    @Test
+    void shouldFailIfContractIdContractDoesNotExist() {
+        when(contractNegotiationStore.findContractAgreement(any())).thenReturn(null);
+        var claims = new JWTClaimsSet.Builder()
+                .claim(CONTRACT_ID, "unexistentContractId")
+                .build();
+
+        var result = rule.checkRule(createJwtWith(claims));
+
+        assertThat(result.succeeded()).isFalse();
+    }
+
+    @NotNull
+    private SignedJWT createJwtWith(JWTClaimsSet claims) {
+        var jwsHeader = new JWSHeader.Builder(JWSAlgorithm.RS256).build();
+        return new SignedJWT(jwsHeader, claims);
+    }
+
+    private ContractAgreement createContractAgreement(String contractId, Instant endDate) {
+        return ContractAgreement.Builder.newInstance()
+                .id(contractId)
+                .assetId(UUID.randomUUID().toString())
+                .policyId(UUID.randomUUID().toString())
+                .contractEndDate(endDate.getEpochSecond())
+                .consumerAgentId("any")
+                .providerAgentId("any")
+                .build();
+    }
+}

--- a/extensions/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/api/rules/ContractValidationRuleTest.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/api/rules/ContractValidationRuleTest.java
@@ -24,9 +24,10 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
+import static java.time.temporal.ChronoUnit.HOURS;
+import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.dataplane.spi.DataPlaneConstants.CONTRACT_ID;
 import static org.mockito.ArgumentMatchers.any;
@@ -40,7 +41,7 @@ class ContractValidationRuleTest {
 
     @Test
     void shouldSucceedIfContractIsStillValid() {
-        var contractAgreement = createContractAgreement("contractId", Instant.now().plus(1, ChronoUnit.SECONDS));
+        var contractAgreement = createContractAgreement("contractId", Instant.now().plus(1, HOURS));
         when(contractNegotiationStore.findContractAgreement("contractId")).thenReturn(contractAgreement);
         var claims = new JWTClaimsSet.Builder()
                 .claim(CONTRACT_ID, "contractId")
@@ -53,7 +54,7 @@ class ContractValidationRuleTest {
 
     @Test
     void shouldFailIfContractIsExpired() {
-        var contractAgreement = createContractAgreement("contractId", Instant.now().minus(1, ChronoUnit.SECONDS));
+        var contractAgreement = createContractAgreement("contractId", Instant.now().minus(1, SECONDS));
         when(contractNegotiationStore.findContractAgreement("contractId")).thenReturn(contractAgreement);
         var claims = new JWTClaimsSet.Builder()
                 .claim(CONTRACT_ID, "contractId")


### PR DESCRIPTION
## What this PR changes/adds

As #1227 fixed date serdes, this PR enable `ContractValidationRule`.

## Why it does that

To verify that the contract is still valid before transferring data.

## Further notes

-

## Linked Issue(s)

Closes #1127 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
