### PR TITLE
Feature: FCC node directory is queried on every plan execution

### DIFF
--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheExtension.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheExtension.java
@@ -82,7 +82,6 @@ public class FederatedCatalogCacheExtension implements ServiceExtension {
     private HealthCheckService healthCheckService;
     @Inject
     private RemoteMessageDispatcherRegistry dispatcherRegistry;
-    // protocol registry - must be supplied by another extension
     // get all known nodes from node directory - must be supplied by another extension
     @Inject
     private FederatedCacheNodeDirectory directory;

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/management/PartitionManagerImpl.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/management/PartitionManagerImpl.java
@@ -71,7 +71,7 @@ public class PartitionManagerImpl implements PartitionManager {
             monitor.debug("Partition manager: execute plan - adding workload " + currentList.size());
             workQueue.addAll(currentList);
             workQueue.unlock();
-            monitor.debug("Partition manager: execute release queue lock");
+            monitor.debug("Partition manager: unlocked queue");
         });
     }
 

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/management/PartitionManagerImpl.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/management/PartitionManagerImpl.java
@@ -63,15 +63,15 @@ public class PartitionManagerImpl implements PartitionManager {
 
     @Override
     public void schedule(ExecutionPlan executionPlan) {
-        //todo: should we really discard updates?
-        var currentList = workloadSource.get();
         executionPlan.run(() -> {
+            // obtain latest node directory contents before scheduling the work
+            var currentList = workloadSource.get();
             monitor.debug("Partition manager: execute plan - waiting for queue lock");
             workQueue.lock();
             monitor.debug("Partition manager: execute plan - adding workload " + currentList.size());
             workQueue.addAll(currentList);
-            monitor.debug("Partition manager: execute release queue lock");
             workQueue.unlock();
+            monitor.debug("Partition manager: execute release queue lock");
         });
     }
 

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/management/PartitionManagerImplTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/management/PartitionManagerImplTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -41,10 +40,9 @@ import static org.mockito.Mockito.when;
 
 public class PartitionManagerImplTest {
 
-    private PartitionManagerImpl partitionManager;
-
     private final Monitor monitorMock = mock(Monitor.class);
     private final WorkItemQueue workItemQueueMock = mock(WorkItemQueue.class);
+    private PartitionManagerImpl partitionManager;
     private List<WorkItem> staticWorkload;
 
     @BeforeEach

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/management/PartitionManagerImplTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/management/PartitionManagerImplTest.java
@@ -17,20 +17,25 @@ package org.eclipse.dataspaceconnector.catalog.cache.management;
 import org.eclipse.dataspaceconnector.catalog.spi.Crawler;
 import org.eclipse.dataspaceconnector.catalog.spi.WorkItem;
 import org.eclipse.dataspaceconnector.catalog.spi.WorkItemQueue;
+import org.eclipse.dataspaceconnector.catalog.spi.model.ExecutionPlan;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.catalog.cache.TestUtil.createWorkItem;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -74,6 +79,27 @@ public class PartitionManagerImplTest {
 
         assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
         partitionManager.stop();
+    }
+
+    @Test
+    void schedule_verifyNodeDirectoryGetsQueried() {
+        Supplier<List<WorkItem>> queueSourceMock = mock(Supplier.class);
+        when(queueSourceMock.get()).thenReturn(List.of(new WorkItem("http://some.url", "test-protocol")));
+        partitionManager = new PartitionManagerImpl(monitorMock, workItemQueueMock, workItems -> mock(Crawler.class), 5, queueSourceMock);
+
+        ExecutionPlan runMultiPlan = mock(ExecutionPlan.class);
+        doAnswer(invocation -> {
+            var runnable = (Runnable) invocation.getArgument(0);
+            runnable.run(); //run several times
+            runnable.run();
+            runnable.run();
+            return null;
+        }).when(runMultiPlan).run(any());
+
+        // schedule once, make sure multiple invocations happen
+        partitionManager.schedule(runMultiPlan);
+
+        verify(queueSourceMock, times(3)).get();
     }
 
 }

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
@@ -40,11 +40,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.getFreePort;
 import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
 import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.PROVISIONING;
 import static org.eclipse.dataspaceconnector.transfer.provision.http.HttpProvisionerFixtures.PROVISIONER_CONFIG;
@@ -60,6 +62,7 @@ public class HttpProvisionerExtensionEndToEndTest {
     private static final String ASSET_ID = "1";
     private static final String CONTRACT_ID = "2";
     private static final String POLICY_ID = "3";
+    private final int dataPort = getFreePort();
 
     private Interceptor delegate;
 
@@ -96,6 +99,10 @@ public class HttpProvisionerExtensionEndToEndTest {
 
     @BeforeEach
     void setup(EdcExtension extension) {
+        extension.setConfiguration(Map.of(
+                "web.http.data.port", String.valueOf(dataPort),
+                "web.http.data.path", "/api/v1/data"
+        ));
         delegate = mock(Interceptor.class);
         var httpClient = testOkHttpClient().newBuilder().addInterceptor(delegate).build();
 


### PR DESCRIPTION
## What this PR changes/adds

On every crawler run that the `PartitionManagerImpl` schedules, the `FederatedCacheNodeDirectory` is queried to get up-to-date information about "who is in the dataspace".

Note the periodic scheduling is implemented in the `ExecutionPlan`, or more specifically the `RecurringExecutionPlan`. This is because crawlers themselves are not scheduled in any form, they merely activate when a new `WorkItem` arrives in their queue. 

## Why it does that

To be able to react to changes in the node directory

## Further notes

- completely unrelated: the port in the http provisioner test was randomized, because I noticed that that test fails when the port is already bound.

## Linked Issue(s)

Closes #1230 

## Checklist

- [x] added appropriate tests?
- [ ] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
