### PR TITLE
CD: Include component tests coverage in codecov code coverage report.

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -16,4 +16,6 @@ runs:
       if: always()
       with:
         name: Test Results ${{ github.job }}
-        path: "**/test-results/**/*.xml"
+        path: |
+          **/test-results/**/*.xml
+          **/build/reports/jacoco/test/jacocoTestReport.xml

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -67,9 +67,6 @@ jobs:
         with:
           command: ./gradlew test jacocoTestReport
 
-      - name: CodeCov
-        uses: codecov/codecov-action@v2
-
   Sanity-Check:
     runs-on: ubuntu-latest
     steps:
@@ -327,6 +324,8 @@ jobs:
           path: '**/build/reports/gatling/**'
 
   Component-Tests:
+    env:
+      JACOCO: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -340,7 +339,7 @@ jobs:
       - name: Component Tests
         uses: ./.github/actions/run-tests
         with:
-          command: ./gradlew test -DincludeTags="ComponentTest"
+          command: ./gradlew test jacocoTestReport -DincludeTags="ComponentTest"
 
   OpenTelemetry-Integration-Tests:
     runs-on: ubuntu-latest
@@ -383,3 +382,19 @@ jobs:
         if: always()
         with:
           files: "**/test-results/**/*.xml"
+
+  Upload-Coverage-Report-To-Codecov:
+    needs:
+      - Unit-Tests
+      - Component-Tests
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      # Sources are needed for Codecov report
+      - uses: actions/checkout@v2
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
+      - name: CodeCov
+        uses: codecov/codecov-action@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Add custom Jackson (de)serializer for `XMLGregorianCalendar` (#1226)
 * Add contract validation rule (#1239)
 * Harmonize setting names in `data-plane-transfer` (#1164)
+* Add component tests coverage to the codecov coverage report (#1246)
 
 #### Changed
 


### PR DESCRIPTION
## What this PR changes/adds

Include component tests coverage in codecov coverage report.

## Why it does that

It makes more sense that component tests coverage is included in coverage report as they are unit tests.

## Linked Issue(s)

Closes #1217

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
