### PR TITLE
fix: always use configured IDS API path in webhook address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Fix HTTPS termination in Jetty (#1133)
 * Break lease after TransferProcessManager status check (#1214)
 * Fix path conflicts between `CatalogApiController` and `FederatedCatalogApiController` (#1225)
+* Always use configured IDS API path in IDS webhook address (#1249)
 
 ## [milestone-3] - 2022-04-08
 

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/IdsMultipartDispatcherServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/IdsMultipartDispatcherServiceExtension.java
@@ -79,14 +79,16 @@ public class IdsMultipartDispatcherServiceExtension implements ServiceExtension 
         //      once https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/236 is done
         var objectMapper = objectMapperFactory.getObjectMapper();
 
-        String idsWebhookAddress = getSetting(context, IDS_WEBHOOK_ADDRESS, DEFAULT_IDS_WEBHOOK_ADDRESS);
-        String idsApiPath = idsApiConfiguration.getPath();
+        var idsWebhookAddress = getSetting(context, IDS_WEBHOOK_ADDRESS, DEFAULT_IDS_WEBHOOK_ADDRESS);
+        var idsApiPath = idsApiConfiguration.getPath();
+        var webhookPath = idsApiPath + (idsApiPath.endsWith("/") ? "data" : "/data");
+        idsWebhookAddress = idsWebhookAddress + webhookPath;
 
         var multipartDispatcher = new IdsMultipartRemoteMessageDispatcher();
-        multipartDispatcher.register(new MultipartArtifactRequestSender(connectorId, httpClient, objectMapper, monitor, context.getService(Vault.class), identityService, transformerRegistry, idsWebhookAddress, idsApiPath));
+        multipartDispatcher.register(new MultipartArtifactRequestSender(connectorId, httpClient, objectMapper, monitor, context.getService(Vault.class), identityService, transformerRegistry, idsWebhookAddress));
         multipartDispatcher.register(new MultipartDescriptionRequestSender(connectorId, httpClient, objectMapper, monitor, identityService, transformerRegistry));
-        multipartDispatcher.register(new MultipartContractOfferSender(connectorId, httpClient, objectMapper, monitor, identityService, transformerRegistry, idsWebhookAddress, idsApiPath));
-        multipartDispatcher.register(new MultipartContractAgreementSender(connectorId, httpClient, objectMapper, monitor, identityService, transformerRegistry, idsWebhookAddress, idsApiPath));
+        multipartDispatcher.register(new MultipartContractOfferSender(connectorId, httpClient, objectMapper, monitor, identityService, transformerRegistry, idsWebhookAddress));
+        multipartDispatcher.register(new MultipartContractAgreementSender(connectorId, httpClient, objectMapper, monitor, identityService, transformerRegistry, idsWebhookAddress));
         multipartDispatcher.register(new MultipartContractRejectionSender(connectorId, httpClient, objectMapper, monitor, identityService, transformerRegistry));
         multipartDispatcher.register(new MultipartCatalogDescriptionRequestSender(connectorId, httpClient, objectMapper, monitor, identityService, transformerRegistry));
         multipartDispatcher.register(new MultipartEndpointDataReferenceRequestSender(connectorId, httpClient, objectMapper, monitor, identityService, transformerRegistry));

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartArtifactRequestSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartArtifactRequestSender.java
@@ -48,7 +48,6 @@ public class MultipartArtifactRequestSender extends IdsMultipartSender<DataReque
 
     private final Vault vault;
     private final String idsWebhookAddress;
-    private final String idsApiPath;
 
     public MultipartArtifactRequestSender(@NotNull String connectorId,
                                           @NotNull OkHttpClient httpClient,
@@ -57,12 +56,10 @@ public class MultipartArtifactRequestSender extends IdsMultipartSender<DataReque
                                           @NotNull Vault vault,
                                           @NotNull IdentityService identityService,
                                           @NotNull IdsTransformerRegistry transformerRegistry,
-                                          @NotNull String idsWebhookAddress,
-                                          @NotNull String idsApiPath) {
+                                          @NotNull String idsWebhookAddress) {
         super(connectorId, httpClient, objectMapper, monitor, identityService, transformerRegistry);
         this.vault = Objects.requireNonNull(vault);
         this.idsWebhookAddress = idsWebhookAddress;
-        this.idsApiPath = idsApiPath;
     }
 
     @Override
@@ -110,8 +107,7 @@ public class MultipartArtifactRequestSender extends IdsMultipartSender<DataReque
                 ._transferContract_(contractId)
                 .build();
 
-        var webhookPath = idsApiPath + (idsApiPath.endsWith("/") ? "data" : "/data");
-        message.setProperty(IDS_WEBHOOK_ADDRESS_PROPERTY, idsWebhookAddress + webhookPath);
+        message.setProperty(IDS_WEBHOOK_ADDRESS_PROPERTY, idsWebhookAddress);
 
         request.getProperties().forEach(message::setProperty);
         return message;

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartArtifactRequestSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartArtifactRequestSender.java
@@ -110,8 +110,8 @@ public class MultipartArtifactRequestSender extends IdsMultipartSender<DataReque
                 ._transferContract_(contractId)
                 .build();
 
-        var path = idsApiPath + (idsApiPath.endsWith("/") ? "data" : "/data");
-        message.setProperty(IDS_WEBHOOK_ADDRESS_PROPERTY, idsWebhookAddress + path);
+        var webhookPath = idsApiPath + (idsApiPath.endsWith("/") ? "data" : "/data");
+        message.setProperty(IDS_WEBHOOK_ADDRESS_PROPERTY, idsWebhookAddress + webhookPath);
 
         request.getProperties().forEach(message::setProperty);
         return message;

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractAgreementSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractAgreementSender.java
@@ -87,8 +87,8 @@ public class MultipartContractAgreementSender extends IdsMultipartSender<Contrac
                 ._recipientConnector_(Collections.singletonList(URI.create(request.getConnectorId())))
                 ._transferContract_(URI.create(request.getCorrelationId()))
                 .build();
-        var path = idsApiPath + (idsApiPath.endsWith("/") ? "data" : "/data");
-        message.setProperty(IDS_WEBHOOK_ADDRESS_PROPERTY, idsWebhookAddress + path);
+        var webhookPath = idsApiPath + (idsApiPath.endsWith("/") ? "data" : "/data");
+        message.setProperty(IDS_WEBHOOK_ADDRESS_PROPERTY, idsWebhookAddress + webhookPath);
 
         return message;
     }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractAgreementSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractAgreementSender.java
@@ -43,7 +43,6 @@ import static org.eclipse.dataspaceconnector.ids.spi.IdsConstants.IDS_WEBHOOK_AD
 public class MultipartContractAgreementSender extends IdsMultipartSender<ContractAgreementRequest, MultipartMessageProcessedResponse> {
 
     private final String idsWebhookAddress;
-    private final String idsApiPath;
 
     public MultipartContractAgreementSender(@NotNull String connectorId,
                                             @NotNull OkHttpClient httpClient,
@@ -51,12 +50,10 @@ public class MultipartContractAgreementSender extends IdsMultipartSender<Contrac
                                             @NotNull Monitor monitor,
                                             @NotNull IdentityService identityService,
                                             @NotNull IdsTransformerRegistry transformerRegistry,
-                                            @NotNull String idsWebhookAddress,
-                                            @NotNull String idsApiPath) {
+                                            @NotNull String idsWebhookAddress) {
         super(connectorId, httpClient, objectMapper, monitor, identityService, transformerRegistry);
 
         this.idsWebhookAddress = idsWebhookAddress;
-        this.idsApiPath = idsApiPath;
     }
 
     @Override
@@ -87,8 +84,8 @@ public class MultipartContractAgreementSender extends IdsMultipartSender<Contrac
                 ._recipientConnector_(Collections.singletonList(URI.create(request.getConnectorId())))
                 ._transferContract_(URI.create(request.getCorrelationId()))
                 .build();
-        var webhookPath = idsApiPath + (idsApiPath.endsWith("/") ? "data" : "/data");
-        message.setProperty(IDS_WEBHOOK_ADDRESS_PROPERTY, idsWebhookAddress + webhookPath);
+
+        message.setProperty(IDS_WEBHOOK_ADDRESS_PROPERTY, idsWebhookAddress);
 
         return message;
     }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractOfferSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractOfferSender.java
@@ -72,6 +72,8 @@ public class MultipartContractOfferSender extends IdsMultipartSender<ContractOff
 
     @Override
     protected Message buildMessageHeader(ContractOfferRequest request, DynamicAttributeToken token) {
+        var webhookPath = idsApiPath + (idsApiPath.endsWith("/") ? "data" : "/data");
+        
         if (request.getType() == ContractOfferRequest.Type.INITIAL) {
             var message = new ContractRequestMessageBuilder()
                     ._modelVersion_(IdsProtocol.INFORMATION_MODEL_VERSION)
@@ -82,8 +84,7 @@ public class MultipartContractOfferSender extends IdsMultipartSender<ContractOff
                     ._recipientConnector_(Collections.singletonList(URI.create(request.getConnectorId())))
                     ._transferContract_(URI.create(request.getCorrelationId()))
                     .build();
-            var path = idsApiPath + (idsApiPath.endsWith("/") ? "data" : "/data");
-            message.setProperty(IDS_WEBHOOK_ADDRESS_PROPERTY, idsWebhookAddress + path);
+            message.setProperty(IDS_WEBHOOK_ADDRESS_PROPERTY, idsWebhookAddress + webhookPath);
 
             return message;
         } else {
@@ -96,7 +97,7 @@ public class MultipartContractOfferSender extends IdsMultipartSender<ContractOff
                     ._recipientConnector_(Collections.singletonList(URI.create(request.getConnectorId())))
                     ._transferContract_(URI.create(request.getCorrelationId()))
                     .build();
-            message.setProperty(IDS_WEBHOOK_ADDRESS_PROPERTY, idsWebhookAddress + "/api/v1/ids/data");
+            message.setProperty(IDS_WEBHOOK_ADDRESS_PROPERTY, idsWebhookAddress + webhookPath);
 
             return message;
         }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractOfferSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractOfferSender.java
@@ -44,7 +44,6 @@ import static org.eclipse.dataspaceconnector.ids.spi.IdsConstants.IDS_WEBHOOK_AD
 public class MultipartContractOfferSender extends IdsMultipartSender<ContractOfferRequest, MultipartRequestInProcessResponse> {
 
     private final String idsWebhookAddress;
-    private final String idsApiPath;
 
     public MultipartContractOfferSender(@NotNull String connectorId,
                                         @NotNull OkHttpClient httpClient,
@@ -52,12 +51,10 @@ public class MultipartContractOfferSender extends IdsMultipartSender<ContractOff
                                         @NotNull Monitor monitor,
                                         @NotNull IdentityService identityService,
                                         @NotNull IdsTransformerRegistry transformerRegistry,
-                                        @NotNull String idsWebhookAddress,
-                                        @NotNull String idsApiPath) {
+                                        @NotNull String idsWebhookAddress) {
         super(connectorId, httpClient, objectMapper, monitor, identityService, transformerRegistry);
 
         this.idsWebhookAddress = idsWebhookAddress;
-        this.idsApiPath = idsApiPath;
     }
 
     @Override
@@ -72,8 +69,6 @@ public class MultipartContractOfferSender extends IdsMultipartSender<ContractOff
 
     @Override
     protected Message buildMessageHeader(ContractOfferRequest request, DynamicAttributeToken token) {
-        var webhookPath = idsApiPath + (idsApiPath.endsWith("/") ? "data" : "/data");
-        
         if (request.getType() == ContractOfferRequest.Type.INITIAL) {
             var message = new ContractRequestMessageBuilder()
                     ._modelVersion_(IdsProtocol.INFORMATION_MODEL_VERSION)
@@ -84,7 +79,7 @@ public class MultipartContractOfferSender extends IdsMultipartSender<ContractOff
                     ._recipientConnector_(Collections.singletonList(URI.create(request.getConnectorId())))
                     ._transferContract_(URI.create(request.getCorrelationId()))
                     .build();
-            message.setProperty(IDS_WEBHOOK_ADDRESS_PROPERTY, idsWebhookAddress + webhookPath);
+            message.setProperty(IDS_WEBHOOK_ADDRESS_PROPERTY, idsWebhookAddress);
 
             return message;
         } else {
@@ -97,7 +92,7 @@ public class MultipartContractOfferSender extends IdsMultipartSender<ContractOff
                     ._recipientConnector_(Collections.singletonList(URI.create(request.getConnectorId())))
                     ._transferContract_(URI.create(request.getCorrelationId()))
                     .build();
-            message.setProperty(IDS_WEBHOOK_ADDRESS_PROPERTY, idsWebhookAddress + webhookPath);
+            message.setProperty(IDS_WEBHOOK_ADDRESS_PROPERTY, idsWebhookAddress);
 
             return message;
         }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/MultipartDispatcherIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/MultipartDispatcherIntegrationTest.java
@@ -84,14 +84,13 @@ class MultipartDispatcherIntegrationTest extends AbstractMultipartDispatcherInte
         Vault vault = mock(Vault.class);
         var httpClient = testOkHttpClient();
 
-        var idsWebhookAddress = "http://webhook";
-        var idsApiPath = "/api";
+        var idsWebhookAddress = "http://webhook/api";
 
         multipartDispatcher = new IdsMultipartRemoteMessageDispatcher();
         multipartDispatcher.register(new MultipartDescriptionRequestSender(CONNECTOR_ID, httpClient, objectMapper, monitor, identityService, transformerRegistry));
-        multipartDispatcher.register(new MultipartArtifactRequestSender(CONNECTOR_ID, httpClient, objectMapper, monitor, vault, identityService, transformerRegistry, idsWebhookAddress, idsApiPath));
-        multipartDispatcher.register(new MultipartContractOfferSender(CONNECTOR_ID, httpClient, objectMapper, monitor, identityService, transformerRegistry, idsWebhookAddress, idsApiPath));
-        multipartDispatcher.register(new MultipartContractAgreementSender(CONNECTOR_ID, httpClient, objectMapper, monitor, identityService, transformerRegistry, idsWebhookAddress, idsApiPath));
+        multipartDispatcher.register(new MultipartArtifactRequestSender(CONNECTOR_ID, httpClient, objectMapper, monitor, vault, identityService, transformerRegistry, idsWebhookAddress));
+        multipartDispatcher.register(new MultipartContractOfferSender(CONNECTOR_ID, httpClient, objectMapper, monitor, identityService, transformerRegistry, idsWebhookAddress));
+        multipartDispatcher.register(new MultipartContractAgreementSender(CONNECTOR_ID, httpClient, objectMapper, monitor, identityService, transformerRegistry, idsWebhookAddress));
         multipartDispatcher.register(new MultipartContractRejectionSender(CONNECTOR_ID, httpClient, objectMapper, monitor, identityService, transformerRegistry));
         multipartDispatcher.register(new MultipartCatalogDescriptionRequestSender(CONNECTOR_ID, httpClient, objectMapper, monitor, identityService, transformerRegistry));
     }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartArtifactRequestSenderTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartArtifactRequestSenderTest.java
@@ -57,9 +57,8 @@ class MultipartArtifactRequestSenderTest {
         var identityService = mock(IdentityService.class);
         String connectorId = UUID.randomUUID().toString();
         transformerRegistry = mock(IdsTransformerRegistry.class);
-        idsWebhookAddress = UUID.randomUUID().toString();
-        idsApiPath = "/api/v1/ids";
-        sender = new MultipartArtifactRequestSender(connectorId, httpClient, mapper, monitor, vault, identityService, transformerRegistry, idsWebhookAddress, idsApiPath);
+        idsWebhookAddress = UUID.randomUUID() + "/api/v1/ids/data";
+        sender = new MultipartArtifactRequestSender(connectorId, httpClient, mapper, monitor, vault, identityService, transformerRegistry, idsWebhookAddress);
     }
 
     @Test
@@ -87,7 +86,7 @@ class MultipartArtifactRequestSenderTest {
                     assertThat(msg.getProperties())
                             .hasSize(request.getProperties().size() + 1)
                             .containsAllEntriesOf(request.getProperties())
-                            .containsEntry(IDS_WEBHOOK_ADDRESS_PROPERTY, idsWebhookAddress + "/api/v1/ids/data");
+                            .containsEntry(IDS_WEBHOOK_ADDRESS_PROPERTY, idsWebhookAddress);
                 });
     }
 


### PR DESCRIPTION
## What this PR changes/adds

It dynamically sets the webhook address path from the configured IDS API path in the `MultipartContractOfferSender`.

## Why it does that

The path was previously hardcoded, leading to an error if the path was configured to anything else than the default.

## Linked Issue(s)

Closes #1249

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [X] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [X] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
