### PR TITLE
Catalog: fixes property names and period time unit 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ in the detailed section referring to by linking pull requests or issues.
 ## [Unreleased]
 
 ### Overview
+
 * Bugfixing DataManagementApi
 * Build improvements
 * Improvements to Dependency Resolution
@@ -38,6 +39,7 @@ in the detailed section referring to by linking pull requests or issues.
 * All DMgmt Api methods now produce and consume `APPLICATION_JSON` (#1175)
 * Make data-plane public api controller asynchronous (#1228)
 * Provide In-mem implementations by default (#1130)
+* Changed Catalog config keys and switched from minutes to seconds
 
 #### Removed
 

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/PartitionConfiguration.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/PartitionConfiguration.java
@@ -16,6 +16,7 @@ package org.eclipse.dataspaceconnector.catalog.spi;
 
 import org.eclipse.dataspaceconnector.catalog.spi.model.ExecutionPlan;
 import org.eclipse.dataspaceconnector.catalog.spi.model.RecurringExecutionPlan;
+import org.eclipse.dataspaceconnector.spi.EdcSetting;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
 import java.time.Duration;
@@ -28,12 +29,19 @@ import java.util.Random;
  */
 public class PartitionConfiguration {
 
-    private static final String PART_WORK_ITEM_QUEUE_SIZE_SETTING = "edc.catalog.cache.partition.queue-size";
-    private static final String PART_NUM_CRAWLER_SETTING = "edc.catalog.cache.partition.num-crawlers";
-    private static final String PART_LOADER_BATCH_SIZE_SETTING = "edc.catalog.cache.loader.batch-size";
-    private static final String PART_LOADER_RETRY_TIMEOUT = "edc.catalog.cache.loader.timeout-millis";
-    private static final String PART_EXECUTION_PLAN_PERIOD_MINUTES = "edc.catalog.cache.execution.period-minutes";
-    private static final String PART_EXECUTION_PLAN_DELAY_SECONDS = "edc.catalog.cache.execution.delay-seconds";
+    @EdcSetting
+    private static final String PART_WORK_ITEM_QUEUE_SIZE_SETTING = "edc.catalog.cache.partition.queue.size";
+    @EdcSetting
+    private static final String PART_NUM_CRAWLER_SETTING = "edc.catalog.cache.partition.num.crawlers";
+    @EdcSetting
+    private static final String PART_LOADER_BATCH_SIZE_SETTING = "edc.catalog.cache.loader.batch.size";
+    @EdcSetting
+    private static final String PART_LOADER_RETRY_TIMEOUT = "edc.catalog.cache.loader.timeout.millis";
+    @EdcSetting
+    private static final String PART_EXECUTION_PLAN_PERIOD_SECONDS = "edc.catalog.cache.execution.period.seconds";
+    @EdcSetting
+    private static final String PART_EXECUTION_PLAN_DELAY_SECONDS = "edc.catalog.cache.execution.delay.seconds";
+    private static final int DEFAULT_EXECUTION_PERIOD_SECONDS = 60;
     private final ServiceExtensionContext context;
 
     public PartitionConfiguration(ServiceExtensionContext context) {
@@ -57,7 +65,7 @@ public class PartitionConfiguration {
     }
 
     public ExecutionPlan getExecutionPlan() {
-        var minutes = context.getSetting(PART_EXECUTION_PLAN_PERIOD_MINUTES, 10);
+        var periodSeconds = context.getSetting(PART_EXECUTION_PLAN_PERIOD_SECONDS, DEFAULT_EXECUTION_PERIOD_SECONDS);
         var setting = context.getSetting(PART_EXECUTION_PLAN_DELAY_SECONDS, null);
         int initialDelaySeconds;
         if ("random".equals(setting) || setting == null) {
@@ -69,7 +77,7 @@ public class PartitionConfiguration {
                 initialDelaySeconds = 0;
             }
         }
-        return new RecurringExecutionPlan(Duration.ofMinutes(minutes), Duration.ofSeconds(initialDelaySeconds));
+        return new RecurringExecutionPlan(Duration.ofSeconds(periodSeconds), Duration.ofSeconds(initialDelaySeconds));
     }
 
     private int randomSeconds() {


### PR DESCRIPTION
## What this PR changes/adds

This PR does two things:
1. changes the scheduler period from minutes to seconds 
2. changes the configuration keys to be more shell-friendly by replacing `"-"` with `"."`

**please update your configs accordingly!**

## Why it does that

improve debugability and shell-friendliness

## Further notes

also added the `@EdcSetting` annotation, which has no functional impact as of now.


## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
