### PR TITLE
docs: update sample 04.0 README

### DIFF
--- a/samples/04.0-file-transfer/transfer-file/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferExtension.java
+++ b/samples/04.0-file-transfer/transfer-file/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferExtension.java
@@ -67,7 +67,6 @@ public class FileTransferExtension implements ServiceExtension {
     }
 
     private Policy createPolicy() {
-
         var usePermission = Permission.Builder.newInstance()
                 .action(Action.Builder.newInstance().type("USE").build())
                 .build();
@@ -95,12 +94,13 @@ public class FileTransferExtension implements ServiceExtension {
     }
 
     private void registerContractDefinition(String uid) {
-
         var contractDefinition = ContractDefinition.Builder.newInstance()
                 .id("1")
                 .accessPolicyId(uid)
                 .contractPolicyId(uid)
-                .selectorExpression(AssetSelectorExpression.Builder.newInstance().whenEquals(Asset.PROPERTY_ID, "test-document").build())
+                .selectorExpression(AssetSelectorExpression.Builder.newInstance()
+                        .whenEquals(Asset.PROPERTY_ID, "test-document")
+                        .build())
                 .build();
 
         contractStore.save(contractDefinition);


### PR DESCRIPTION
## What this PR changes/adds

It updates the `README` of sample `04.0-file-transfer`.

## Why it does that

The `README` was not up to date. It e.g. still mentioned the control API, which is not used in the sample anymore.

## Linked Issue(s)

Closes #1256 

## Checklist

- [X] added/updated relevant documentation?
- [X] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [X] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
