### PR TITLE
bugfix: throws exception if `IdentityProviderKeyResolver` cannot get keys at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Fix path conflicts between `CatalogApiController` and `FederatedCatalogApiController` (#1225)
 * Always use configured IDS API path in IDS webhook address (#1249)
 * Fix Azure storage transfer (#1245)
+* Throw exception if `IdentityProviderKeyResolver` cannot get keys at startup (#1266)
 
 ## [milestone-3] - 2022-04-08
 

--- a/extensions/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/identity/IdentityProviderKeyResolverConfiguration.java
+++ b/extensions/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/identity/IdentityProviderKeyResolverConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
+ *
+ */
+
+package org.eclipse.dataspaceconnector.iam.oauth2.core.identity;
+
+public class IdentityProviderKeyResolverConfiguration {
+    private final String jwksUrl;
+    private final long keyRefreshInterval;
+
+    public IdentityProviderKeyResolverConfiguration(String jwksUrl, long keyRefreshInterval) {
+        this.jwksUrl = jwksUrl;
+        this.keyRefreshInterval = keyRefreshInterval;
+    }
+
+    public String getJwksUrl() {
+        return jwksUrl;
+    }
+
+    public long getKeyRefreshInterval() {
+        return keyRefreshInterval;
+    }
+}

--- a/extensions/iam/oauth2/oauth2-core/src/test/java/org/eclipse/dataspaceconnector/iam/oauth2/core/identity/IdentityProviderKeyResolverTest.java
+++ b/extensions/iam/oauth2/oauth2-core/src/test/java/org/eclipse/dataspaceconnector/iam/oauth2/core/identity/IdentityProviderKeyResolverTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2021 Microsoft Corporation
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -9,53 +9,114 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 
 package org.eclipse.dataspaceconnector.iam.oauth2.core.identity;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.javafaker.Faker;
+import okhttp3.Interceptor;
+import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 import org.eclipse.dataspaceconnector.iam.oauth2.core.jwt.JwkKeys;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.security.interfaces.RSAPublicKey;
 import java.util.Map;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class IdentityProviderKeyResolverTest {
-    private static final String JWKS_URL = "https://login.microsoftonline.com/common/discovery/v2.0/keys";
+
+    private static final Faker FAKER = Faker.instance();
+    private static final String JWKS_URL = "https://" + FAKER.internet().url();
     private static final String JWKS_FILE = "jwks_response.json";
+    private final Interceptor interceptor = mock(Interceptor.class);
+    private final TypeManager typeManager = new TypeManager();
+    private final OkHttpClient okHttpClient = new OkHttpClient.Builder().addInterceptor(interceptor).build();
+    private JwkKeys testKeys;
     private IdentityProviderKeyResolver resolver;
-    private JwkKeys keys;
-
-    @Test
-    void verifyJwksDeserialization() {
-        assertThat(keys.getKeys()).isNotNull();
-        Map<String, RSAPublicKey> keyCache = resolver.deserializeKeys(keys.getKeys());
-
-        assertThat(keyCache)
-                .hasSize(5)
-                .containsKey("nOo3ZDrODXEK1jKWhXslHR_KXEg");
-    }
 
     @BeforeEach
     void setUp() {
-        resolver = new IdentityProviderKeyResolver(JWKS_URL, new Monitor() {
-        }, mock(OkHttpClient.class), new TypeManager());
+        resolver = new IdentityProviderKeyResolver(mock(Monitor.class), okHttpClient, typeManager, new IdentityProviderKeyResolverConfiguration(JWKS_URL, 1));
 
-        try (InputStream in = getClass().getClassLoader().getResourceAsStream(JWKS_FILE)) {
-            keys = new ObjectMapper().readValue(in, JwkKeys.class);
+        try (var stream = getClass().getClassLoader().getResourceAsStream(JWKS_FILE)) {
+            testKeys = new ObjectMapper().readValue(stream, JwkKeys.class);
         } catch (IOException e) {
             throw new EdcException("Failed to load keys from file");
         }
+    }
+
+    @Test
+    void getKeys_shouldGetUpdatedKeys() throws IOException {
+        when(interceptor.intercept(any())).thenReturn(response(200, testKeys));
+
+        var result = resolver.getKeys();
+
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent()).hasSize(5).containsKey("nOo3ZDrODXEK1jKWhXslHR_KXEg");
+    }
+
+    @Test
+    void getKeys_shouldReturnFailureIfServerReturnsError() throws IOException {
+        when(interceptor.intercept(any())).thenReturn(response(500, emptyMap()));
+
+        var result = resolver.getKeys();
+
+        assertThat(result.failed()).isTrue();
+    }
+
+    @Test
+    void getKeys_shouldReturnFailureIfBodyCannotBeDeserialized() throws IOException {
+        when(interceptor.intercept(any())).thenReturn(response(200, null));
+
+        var result = resolver.getKeys();
+
+        assertThat(result.failed()).isTrue();
+    }
+
+    @Test
+    void getKeys_shouldReturnFailureIfNoKeysAreContainedInTheResult() throws IOException {
+        when(interceptor.intercept(any())).thenReturn(response(200, Map.of("keys", emptyList())));
+
+        var result = resolver.getKeys();
+
+        assertThat(result.failed()).isTrue();
+    }
+
+    @Test
+    void start_shouldThrowExceptionIfItFailsToLoadKeysTheFirstTime() throws IOException {
+        when(interceptor.intercept(any())).thenReturn(response(500, emptyMap()));
+
+        assertThatThrownBy(() -> resolver.start()).isInstanceOf(EdcException.class);
+    }
+
+    @NotNull
+    private Response response(int code, Object body) {
+        return new Response.Builder()
+                .code(code)
+                .body(ResponseBody.create(typeManager.writeValueAsString(body), MediaType.get("application/json")))
+                .message(FAKER.twinPeaks().quote())
+                .protocol(Protocol.HTTP_1_1)
+                .request(new Request.Builder().url("http://" + FAKER.internet().url()).build())
+                .build();
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Make `IdentityProviderKeyResolver` throw exception if it's not able to get the keys at startup

## Why it does that

This will avoid EDC starting without having keys loaded

## Further notes

- Enclose the `ExecutorService` inside the key resolver and exposing only a `start` and a `stop` method to give to the resolver full control of the cache refresh mechanism
- Introduce a `IdentityProviderKeyResolverConfiguration` pojo
- In the related issue we were talking about a retry mechanism, but since it's a topic that was already discussed in (#336) as "short retry" probably we need to reason about it at the http client level. will open an issue about

## Linked Issue(s)

Closes #1262

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
