### PR TITLE
Bugfix: clear FCC store before updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Make data-plane public api controller asynchronous (#1228)
 * Provide In-mem implementations by default (#1130)
 * Changed Catalog config keys and switched from minutes to seconds
+* Clean FCC store before updating
 
 #### Removed
 

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheExtension.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheExtension.java
@@ -39,6 +39,7 @@ import org.eclipse.dataspaceconnector.catalog.spi.WorkItem;
 import org.eclipse.dataspaceconnector.catalog.spi.WorkItemQueue;
 import org.eclipse.dataspaceconnector.catalog.spi.model.UpdateResponse;
 import org.eclipse.dataspaceconnector.catalog.store.InMemoryFederatedCacheStore;
+import org.eclipse.dataspaceconnector.common.concurrency.LockManager;
 import org.eclipse.dataspaceconnector.spi.WebService;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
@@ -58,12 +59,13 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 
-@Provides({ Crawler.class, LoaderManager.class, QueryEngine.class, NodeQueryAdapterRegistry.class, CacheQueryAdapterRegistry.class })
+@Provides({Crawler.class, LoaderManager.class, QueryEngine.class, NodeQueryAdapterRegistry.class, CacheQueryAdapterRegistry.class})
 public class FederatedCatalogCacheExtension implements ServiceExtension {
     public static final int DEFAULT_NUM_CRAWLERS = 1;
     private static final int DEFAULT_QUEUE_LENGTH = 50;
@@ -141,7 +143,7 @@ public class FederatedCatalogCacheExtension implements ServiceExtension {
     @Provider(isDefault = true)
     public FederatedCacheStore defaultCacheStore() {
         //todo: converts every criterion into a predicate that is always true. must be changed later!
-        return new InMemoryFederatedCacheStore(criterion -> offer -> true);
+        return new InMemoryFederatedCacheStore(criterion -> offer -> true, new LockManager(new ReentrantReadWriteLock()));
     }
 
     @Provider(isDefault = true)
@@ -152,7 +154,7 @@ public class FederatedCatalogCacheExtension implements ServiceExtension {
     @NotNull
     private LoaderManager createLoaderManager(FederatedCacheStore store) {
         return LoaderManagerImpl.Builder.newInstance()
-                .loaders(List.of(new LoaderImpl(store)))
+                .loaders(List.of(new LoaderImpl(store))) // one loader per store
                 .batchSize(partitionManagerConfig.getLoaderBatchSize(DEFAULT_BATCH_SIZE))
                 .waitStrategy(() -> partitionManagerConfig.getLoaderRetryTimeout(DEFAULT_RETRY_TIMEOUT_MILLIS))
                 .monitor(monitor)

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/LoaderImpl.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/LoaderImpl.java
@@ -30,7 +30,6 @@ public class LoaderImpl implements Loader {
 
     @Override
     public void load(Collection<UpdateResponse> responses) {
-
         for (var response : responses) {
             var catalog = response.getCatalog();
             catalog.getContractOffers().forEach(offer -> {
@@ -38,5 +37,10 @@ public class LoaderImpl implements Loader {
                 store.save(offer);
             });
         }
+    }
+
+    @Override
+    public void clear() {
+        store.deleteAll(); // delete all entries before re-populating
     }
 }

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/loader/LoaderManagerImpl.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/loader/LoaderManagerImpl.java
@@ -89,6 +89,7 @@ public class LoaderManagerImpl implements LoaderManager {
                     // take the elements out of the queue and forward to loaders
                     queue.drainTo(batch, batchSize);
                     monitor.debug(format("LoaderManager: batch full, begin loading (%s items, %s workers)", batchSize, loaders.size()));
+                    loaders.forEach(Loader::clear);
                     loaders.forEach(l -> l.load(batch));
                     monitor.debug("LoaderManager: loading complete");
                 }

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/FederatedCacheStore.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/FederatedCacheStore.java
@@ -38,4 +38,9 @@ public interface FederatedCacheStore {
      */
     Collection<ContractOffer> query(List<Criterion> query);
 
+    /**
+     * Deletes all entries from the cache
+     */
+    void deleteAll();
+
 }

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/Loader.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/Loader.java
@@ -22,7 +22,14 @@ import java.util.Collection;
  * Puts the result of a catalog request (i.e. {@link org.eclipse.dataspaceconnector.catalog.spi.model.UpdateResponse} into
  * whatever storage backend or database is used.
  */
-@FunctionalInterface
 public interface Loader {
+    /**
+     * Stores a list of {@link UpdateResponse}s in its internal database.
+     */
     void load(Collection<UpdateResponse> batch);
+
+    /**
+     * Deletes all stored entries. Typically called before loading a new batch.
+     */
+    void clear();
 }


### PR DESCRIPTION
## What this PR changes/adds

This PR cleans out the FCC cache store before re-populating it again with the results of a crawl run.

## Why it does that

To avoid having stale entries: when a connector removes a contract definition, all other connectors would still have corresponding (but invalid) offers.

## Further notes
n/a

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
