### PR TITLE
Bugfix: several small fixes in Cosmos' `WhereClause`

### DIFF
--- a/extensions/azure/cosmos/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/WhereClauseTest.java
+++ b/extensions/azure/cosmos/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/WhereClauseTest.java
@@ -45,4 +45,21 @@ class WhereClauseTest {
     void whereClause_withInvalidOperator() {
         assertThatThrownBy(() -> new WhereClause(List.of(new Criterion("foo", "BEGINSWITH", "bar3")), "testobj")).isInstanceOf(IllegalArgumentException.class);
     }
+
+    @Test
+    void whereClause_withLowercaseOperator() {
+        var wc = new WhereClause(List.of(new Criterion("foo", "in", "('bar1', 'bar2')")), "testobj");
+        assertThat(wc.getWhere()).isEqualTo("WHERE testobj.foo in ('bar1', 'bar2')");
+        assertThat(wc.getParameters()).isEmpty();
+    }
+
+    @Test
+    void whereClause_withMultipleCriteria_noParams() {
+        var wc = new WhereClause(List.of(
+                new Criterion("foo", "in", "('bar1', 'bar2')"),
+                new Criterion("foo", "=", "bar")),
+                "testobj");
+        assertThat(wc.getWhere()).isEqualTo("WHERE testobj.foo in ('bar1', 'bar2') AND testobj.foo = @foo");
+        assertThat(wc.getParameters()).hasSize(1);
+    }
 }


### PR DESCRIPTION
## What this PR changes/adds

Fixes several smaller bugs in the `WhereClause` implementation

## Why it does that

So that where clauses get constructed correctly.

## Further notes

Another issue will address the problematic specifcation of lists for the IN operator, which now must be ('val1', 'val2',...). We should use prepared statements for that.

This issue will also contain the CHANGELOG entry then.

## Linked Issue(s)

Closes #1276 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
