### PR TITLE
Bugfix: improve Cosmos DB statement parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Uniform all the sql schema files as `docs/schema.sql` (#1278)
 * Clean FCC store before updating
 * Usage of `NooTransactionContext` in (SQL-)Tests (#1119)
+* Improve CosmosDB statement parser (#1282)
 
 #### Removed
 

--- a/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexTest.java
+++ b/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndexTest.java
@@ -144,7 +144,7 @@ class CosmosAssetIndexTest {
         var queryCapture = ArgumentCaptor.forClass(SqlQuerySpec.class);
         when(api.queryItems(queryCapture.capture())).thenReturn(Stream.of(createDocument(id1), createDocument(id2)));
 
-        var inExpr = "(" + String.join(",", List.of(id1, id2)) + ")";
+        var inExpr = List.of(id1, id2);
         var selector = AssetSelectorExpression.Builder.newInstance()
                 .constraint(Asset.PROPERTY_ID, "IN", inExpr)
                 .build();
@@ -154,7 +154,7 @@ class CosmosAssetIndexTest {
         assertThat(assets).hasSize(2)
                 .anyMatch(asset -> asset.getId().equals(id1))
                 .anyMatch(asset -> asset.getId().equals(id2));
-        assertThat(queryCapture.getValue().getQueryText()).contains("WHERE AssetDocument.wrappedInstance.asset_prop_id IN (" + id1 + "," + id2 + ")");
+        assertThat(queryCapture.getValue().getQueryText()).contains("WHERE AssetDocument.wrappedInstance.asset_prop_id IN (@asset_prop_id0, @asset_prop_id1)");
         verify(api).queryItems(queryCapture.capture());
         verifyNoMoreInteractions(api);
     }

--- a/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetQueryBuilderTest.java
+++ b/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetQueryBuilderTest.java
@@ -74,6 +74,6 @@ class CosmosAssetQueryBuilderTest {
                 .build();
 
         assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> builder.from(expression.getCriteria()))
-                .withMessage("Cannot build SqlParameter for operator: in");
+                .withMessage("Cannot build WHERE clause, reason: The \"in\" operator requires the right-hand operand to be of type interface java.lang.Iterable");
     }
 }

--- a/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/CosmosConditionExpression.java
+++ b/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/CosmosConditionExpression.java
@@ -1,0 +1,138 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.azure.cosmos.dialect;
+
+import com.azure.cosmos.models.SqlParameter;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.StreamSupport;
+
+import static java.lang.String.format;
+import static org.eclipse.dataspaceconnector.azure.cosmos.CosmosDocument.sanitize;
+
+public class CosmosConditionExpression {
+    private static final String IN_OPERATOR = "in";
+    private static final String EQUALS_OPERATOR = "=";
+    private static final List<String> SUPPORTED_PREPARED_STATEMENT_OPERATORS = List.of(EQUALS_OPERATOR, IN_OPERATOR);
+    private static final String PREPARED_STATEMENT_PLACEHOLDER = "@";
+    private final Criterion criterion;
+    private final String objectPrefix;
+
+    CosmosConditionExpression(Criterion criterion) {
+        this(criterion, null);
+    }
+
+    CosmosConditionExpression(Criterion criterion, String objectPrefix) {
+        this.criterion = criterion;
+        this.objectPrefix = objectPrefix;
+    }
+
+    /**
+     * Checks whether the given {@link Criterion} is valid or not, i.e. if its {@linkplain Criterion#getOperator()} is in the list
+     * of supported operators, and whether the {@linkplain Criterion#getOperandRight()} has the correct type.
+     */
+    public Result<Void> isValidExpression() {
+        var isSupportedOperator = SUPPORTED_PREPARED_STATEMENT_OPERATORS.contains(criterion.getOperator().toLowerCase());
+        if (!isSupportedOperator) {
+            return Result.failure("unsupported operator " + criterion.getOperator());
+        }
+
+        if (Objects.equals(IN_OPERATOR, criterion.getOperator()) && !(criterion.getOperandRight() instanceof Iterable)) {
+            return Result.failure(format("The \"%s\" operator requires the right-hand operand to be of type %s", IN_OPERATOR, Iterable.class));
+        }
+        return Result.success();
+    }
+
+    /**
+     * Converts the {@link Criterion#getOperandRight()} to a {@link List} of {@link SqlParameter}
+     * which can then be used to execute prepared statements against CosmosDB.
+     */
+    public List<SqlParameter> getParameters() {
+
+        var operandRight = criterion.getOperandRight();
+
+        if (operandRight instanceof Iterable) {
+            var iterable = (Iterable) operandRight;
+            var placeHolders = getPlaceholderValues();
+
+            var iterator = iterable.iterator();
+            return placeHolders.stream().map(ph -> new SqlParameter(ph, iterator.next())).collect(Collectors.toList());
+        } else {
+            var name = getName();
+            return List.of(new SqlParameter(generateParameter(name), criterion.getOperandRight()));
+        }
+    }
+
+    /**
+     * Converts the {@link Criterion} into a string representation, that uses statement placeholders ("@xyz").
+     * The corresponding parameters are available using {@link CosmosConditionExpression#getParameters()}.
+     */
+    public String toExpressionString() {
+        var operandLeft = sanitize(criterion.getOperandLeft().toString());
+        return objectPrefix != null ?
+                String.format(" %s.%s %s %s", objectPrefix, operandLeft, criterion.getOperator(), toValuePlaceholder()) :
+                String.format(" %s %s %s", operandLeft, criterion.getOperator(), toValuePlaceholder());
+    }
+
+    /**
+     * Converts a right-operand into a simple Cosmos SQL statement placeholder ("@example"), or, if the operand is actually a list, converts
+     * it into "(@val1, @val2,...)", with as many placeholders as there are list items.
+     * The resulting String does not include the left-operand or the operator.
+     */
+    private String toValuePlaceholder() {
+        var name = getName();
+        var operandRight = criterion.getOperandRight();
+        if (operandRight instanceof Iterable) {
+            return "(" + String.join(", ", getPlaceholderValues()) + ")";
+        }
+        return PREPARED_STATEMENT_PLACEHOLDER + name;
+    }
+
+    private String getName() {
+        return criterion.getOperandLeft().toString()
+                .replace(":", "_")
+                .replace(".", "_");
+    }
+
+    /**
+     * Converts the right-operand into a set of SQL parameter placeholders, e.g. converts {@code foo IN ["bar", "baz"]} into a List containing
+     * {@code ["@foo0", "@foo1"]}.
+     * If the right-operand is not a list-type object, it would simply return a singleton list
+     */
+    private List<String> getPlaceholderValues() {
+        var operandRight = criterion.getOperandRight();
+        var name = getName();
+        if (operandRight instanceof Iterable) {
+            var size = (int) StreamSupport.stream(((Iterable) operandRight).spliterator(), false).count();
+            return IntStream.range(0, size)
+                    .mapToObj(i -> format("%s%s%s", PREPARED_STATEMENT_PLACEHOLDER, name, i))
+                    .collect(Collectors.toList());
+        } else {
+            return Collections.singletonList(generateParameter(name));
+        }
+    }
+
+    @NotNull
+    private String generateParameter(String name) {
+        return PREPARED_STATEMENT_PLACEHOLDER + name;
+    }
+}

--- a/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/WhereClause.java
+++ b/extensions/azure/cosmos/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/WhereClause.java
@@ -21,8 +21,6 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.eclipse.dataspaceconnector.azure.cosmos.CosmosDocument.sanitize;
-
 /**
  * Represents in a structural way a WHERE clause in an SQL statement. Attempts to use parameterized statements using
  * {@link SqlParameter} if possible. Currently, this is only implemented for the equals-operator ("=").
@@ -38,9 +36,6 @@ import static org.eclipse.dataspaceconnector.azure.cosmos.CosmosDocument.sanitiz
  * In this case the {@code orderPrefix} would have to be {@code "YourDocument.Header"}.
  */
 class WhereClause implements Clause {
-    public static final String EQUALS_OPERATOR = "=";
-    public static final String IN_OPERATOR = "IN";
-    private static final List<String> SUPPORTED_OPERATOR = List.of(EQUALS_OPERATOR, IN_OPERATOR);
     private final String objectPrefix;
     private final List<SqlParameter> parameters = new ArrayList<>();
     private String where = "";
@@ -48,7 +43,7 @@ class WhereClause implements Clause {
     WhereClause(List<Criterion> criteria, String objectPrefix) {
         this.objectPrefix = objectPrefix;
         if (criteria != null) {
-            criteria.stream().distinct().forEach(this::criterion);
+            criteria.stream().distinct().forEach(this::parse);
         }
     }
 
@@ -70,32 +65,16 @@ class WhereClause implements Clause {
         return where;
     }
 
-    private void criterion(Criterion criterion) {
-        if (!SUPPORTED_OPERATOR.contains(criterion.getOperator())) {
-            throw new IllegalArgumentException("Cannot build SqlParameter for operator: " + criterion.getOperator());
+    private void parse(Criterion criterion) {
+        var expr = new CosmosConditionExpression(criterion, objectPrefix);
+        var exprResult = expr.isValidExpression();
+        if (exprResult.failed()) {
+            throw new IllegalArgumentException("Cannot build WHERE clause, reason: " + String.join(", ", exprResult.getFailureMessages()));
         }
-        var operandLeft = sanitize(criterion.getOperandLeft().toString());
-        var operandRight = criterion.getOperandRight().toString();
-        var queryParam = createQueryParam(operandLeft, criterion.getOperator(), operandRight);
-        String param = queryParam.isEmpty() ? operandRight : sanitizedParameterName(operandLeft);
-        where += parameters.isEmpty() ? "WHERE" : " AND";
-        parameters.addAll(queryParam);
-        where += String.format(" %s.%s %s %s", objectPrefix, operandLeft, criterion.getOperator(), param);
-    }
 
-    private List<SqlParameter> createQueryParam(String opLeft, String operator, String opRight) {
-        switch (operator) {
-            case EQUALS_OPERATOR:
-                return List.of(new SqlParameter(sanitizedParameterName(opLeft), opRight));
-            case IN_OPERATOR:
-                return List.of();
-            default: //not actually needed, but it's good style to have a default case
-                throw new IllegalArgumentException("Cannot build SqlParameter for operator: " + operator);
-        }
-    }
-
-    private String sanitizedParameterName(String operandLeft) {
-        return "@" + operandLeft.replaceAll("\\.", "");
+        where += where.startsWith("WHERE") ? " AND" : "WHERE"; //if we have a chained WHERE ... AND ... statement
+        parameters.addAll(expr.getParameters());
+        where += expr.toExpressionString();
     }
 
 }

--- a/extensions/azure/cosmos/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/CosmosConditionExpressionTest.java
+++ b/extensions/azure/cosmos/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/CosmosConditionExpressionTest.java
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.azure.cosmos.dialect;
+
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CosmosConditionExpressionTest {
+
+
+    private final String objectPrefix = "test";
+
+    @Test
+    void isValidExpression() {
+        var expr = new CosmosConditionExpression(new Criterion("foo", "in", List.of("bar")), objectPrefix);
+        assertThat(expr.isValidExpression().succeeded()).isTrue();
+
+    }
+
+    @Test
+    void isValidExpression_wrongOperand() {
+        var expr = new CosmosConditionExpression(new Criterion("foo", "in", "bar"), objectPrefix);
+        assertThat(expr.isValidExpression().succeeded()).isFalse();
+
+    }
+
+    @Test
+    void isValidExpression_invalidOperator() {
+        var expr2 = new CosmosConditionExpression(new Criterion("foo", "is_subset_of", List.of("bar")), objectPrefix);
+        assertThat(expr2.isValidExpression().succeeded()).isFalse();
+    }
+
+    @Test
+    void toExpressionString_withList() {
+        var expr = new CosmosConditionExpression(new Criterion("foo", "in", List.of("bar", "baz")), objectPrefix);
+        assertThat(expr.toExpressionString()).isEqualToIgnoringWhitespace("test.foo in (@foo0, @foo1)");
+    }
+
+    @Test
+    void toExpressionString() {
+        var expr = new CosmosConditionExpression(new Criterion("foo", "=", "baz"), objectPrefix);
+        assertThat(expr.toExpressionString()).isEqualToIgnoringWhitespace("test.foo = @foo");
+    }
+
+    @Test
+    void toExpressionString_withList_noPrefix() {
+        var expr = new CosmosConditionExpression(new Criterion("foo", "in", List.of("bar", "baz")));
+        assertThat(expr.toExpressionString()).isEqualToIgnoringWhitespace("foo in (@foo0, @foo1)");
+    }
+
+    @Test
+    void toExpressionString_noPrefix() {
+        var expr = new CosmosConditionExpression(new Criterion("foo", "=", "baz"));
+        assertThat(expr.toExpressionString()).isEqualToIgnoringWhitespace("foo = @foo");
+    }
+
+    @Test
+    void toParameters() {
+        var expr = new CosmosConditionExpression(new Criterion("foo", "=", "baz"), objectPrefix);
+        assertThat(expr.getParameters()).hasSize(1).allSatisfy(c -> {
+            assertThat(c.getName()).isEqualTo("@foo");
+            assertThat(c.getValue(String.class)).isEqualTo("baz");
+        });
+    }
+
+    @Test
+    void toParameters_list() {
+        var expr = new CosmosConditionExpression(new Criterion("foo", "in", List.of("bar", "baz")), objectPrefix);
+        assertThat(expr.getParameters()).hasSize(2)
+                .anySatisfy(c -> {
+                    assertThat(c.getName()).isEqualTo("@foo0");
+                    assertThat(c.getValue(String.class)).isEqualTo("bar");
+                })
+                .anySatisfy(c -> {
+                    assertThat(c.getName()).isEqualTo("@foo1");
+                    assertThat(c.getValue(String.class)).isEqualTo("baz");
+                });
+    }
+}

--- a/extensions/azure/cosmos/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/WhereClauseTest.java
+++ b/extensions/azure/cosmos/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/WhereClauseTest.java
@@ -36,13 +36,51 @@ class WhereClauseTest {
 
     @Test
     void whereClause_withIn() {
-        var wc = new WhereClause(List.of(new Criterion("foo", "IN", "('bar1', 'bar2')")), "testobj");
-        assertThat(wc.getWhere()).isEqualTo("WHERE testobj.foo IN ('bar1', 'bar2')");
-        assertThat(wc.getParameters()).isEmpty();
+        var wc = new WhereClause(List.of(new Criterion("foo", "IN", List.of("bar1", "bar2"))), "testobj");
+        assertThat(wc.getWhere()).isEqualTo("WHERE testobj.foo IN (@foo0, @foo1)");
+        assertThat(wc.getParameters()).hasSize(2)
+                .anyMatch(p -> p.getName().equals("@foo0") && p.getValue(String.class).equals("bar1"))
+                .anyMatch(p -> p.getName().equals("@foo1") && p.getValue(String.class).equals("bar2"));
     }
 
     @Test
     void whereClause_withInvalidOperator() {
         assertThatThrownBy(() -> new WhereClause(List.of(new Criterion("foo", "BEGINSWITH", "bar3")), "testobj")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void whereClause_withLowercaseOperator() {
+        var wc = new WhereClause(List.of(new Criterion("foo", "in", List.of("bar1", "bar2"))), "testobj");
+        assertThat(wc.getWhere()).isEqualTo("WHERE testobj.foo in (@foo0, @foo1)");
+        assertThat(wc.getParameters()).hasSize(2)
+                .anyMatch(p -> p.getName().equals("@foo0") && p.getValue(String.class).equals("bar1"))
+                .anyMatch(p -> p.getName().equals("@foo1") && p.getValue(String.class).equals("bar2"));
+    }
+
+    @Test
+    void whereClause_withMultipleCriteria_withParams() {
+        var wc = new WhereClause(List.of(
+                new Criterion("foo", "in", List.of("bar1", "bar2")),
+                new Criterion("foo", "=", "barbaz")),
+                "testobj");
+        assertThat(wc.getWhere()).isEqualTo("WHERE testobj.foo in (@foo0, @foo1) AND testobj.foo = @foo");
+        assertThat(wc.getParameters()).hasSize(3)
+                .anyMatch(p -> p.getName().equals("@foo0") && p.getValue(String.class).equals("bar1"))
+                .anyMatch(p -> p.getName().equals("@foo1") && p.getValue(String.class).equals("bar2"))
+                .anyMatch(p -> p.getName().equals("@foo") && p.getValue(String.class).equals("barbaz"));
+    }
+
+    @Test
+    void whereClause_withMultipleInStatements() {
+        var wc = new WhereClause(List.of(
+                new Criterion("foo", "in", List.of("bar1", "bar2")),
+                new Criterion("foo", "in", List.of("blubb", "blabb"))),
+                "testobj");
+        assertThat(wc.getWhere()).isEqualTo("WHERE testobj.foo in (@foo0, @foo1) AND testobj.foo in (@foo0, @foo1)");
+        assertThat(wc.getParameters()).hasSize(4)
+                .anyMatch(p -> p.getName().equals("@foo0") && p.getValue(String.class).equals("bar1"))
+                .anyMatch(p -> p.getName().equals("@foo1") && p.getValue(String.class).equals("bar2"))
+                .anyMatch(p -> p.getName().equals("@foo0") && p.getValue(String.class).equals("blubb"))
+                .anyMatch(p -> p.getName().equals("@foo1") && p.getValue(String.class).equals("blabb"));
     }
 }

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -9,107 +9,69 @@ info:
 servers:
 - url: /
 paths:
-  /assets:
-    get:
-      tags:
-      - Asset
-      operationId: getAllAssets
-      parameters:
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/AssetDto'
+  /identity-hub/query-commits:
     post:
       tags:
-      - Asset
-      operationId: createAsset
+      - Identity Hub
+      operationId: queryCommits
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AssetEntryDto'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /assets/{id}:
-    get:
-      tags:
-      - Asset
-      operationId: getAsset
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
+              type: string
       responses:
         default:
           description: default response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AssetDto'
-    delete:
+                type: string
+  /identity-hub/query-objects:
+    post:
       tags:
-      - Asset
-      operationId: removeAsset
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
+      - Identity Hub
+      operationId: queryObjects
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
+  /identity-hub/collections:
+    post:
+      tags:
+      - Identity Hub
+      operationId: write
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
+  /identity-hub/collections-commit:
+    post:
+      tags:
+      - Identity Hub
+      operationId: writeCommit
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
       responses:
         default:
           description: default response
@@ -211,111 +173,6 @@ paths:
           content:
             application/json: {}
       deprecated: true
-  /catalog:
-    get:
-      tags:
-      - Catalog
-      operationId: getCatalog
-      parameters:
-      - name: providerUrl
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: Gets contract offers (=catalog) of a single connector
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Catalog'
-  /check/health:
-    get:
-      tags:
-      - Application Observability
-      operationId: checkHealth
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /check/liveness:
-    get:
-      tags:
-      - Application Observability
-      operationId: getLiveness
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /check/readiness:
-    get:
-      tags:
-      - Application Observability
-      operationId: getReadiness
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /check/startup:
-    get:
-      tags:
-      - Application Observability
-      operationId: getStartup
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /instances:
-    get:
-      tags:
-      - Dataplane Selector
-      operationId: getAll
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/DataPlaneInstance'
-    post:
-      tags:
-      - Dataplane Selector
-      operationId: addEntry
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DataPlaneInstance'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /instances/select:
-    post:
-      tags:
-      - Dataplane Selector
-      operationId: find
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SelectionRequest'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DataPlaneInstance'
   /contractnegotiations/{id}/cancel:
     post:
       tags:
@@ -483,57 +340,56 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NegotiationId'
-  /callback/{processId}/deprovision:
-    post:
-      tags:
-      - HTTP Provisioner Webhook
-      operationId: callDeprovisionWebhook
-      parameters:
-      - name: processId
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DeprovisionedResource'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /callback/{processId}/provision:
-    post:
-      tags:
-      - HTTP Provisioner Webhook
-      operationId: callProvisionWebhook
-      parameters:
-      - name: processId
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ProvisionerWebhookRequest'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /contractdefinitions:
+  /instances:
     get:
       tags:
-      - Contract Definition
-      operationId: getAllContractDefinitions
+      - Dataplane Selector
+      operationId: getAll
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DataPlaneInstance'
+    post:
+      tags:
+      - Dataplane Selector
+      operationId: addEntry
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataPlaneInstance'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /instances/select:
+    post:
+      tags:
+      - Dataplane Selector
+      operationId: find
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SelectionRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataPlaneInstance'
+  /assets:
+    get:
+      tags:
+      - Asset
+      operationId: getAllAssets
       parameters:
       - name: offset
         in: query
@@ -583,26 +439,26 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ContractDefinitionDto'
+                  $ref: '#/components/schemas/AssetDto'
     post:
       tags:
-      - Contract Definition
-      operationId: createContractDefinition
+      - Asset
+      operationId: createAsset
       requestBody:
         content:
-          '*/*':
+          application/json:
             schema:
-              $ref: '#/components/schemas/ContractDefinitionDto'
+              $ref: '#/components/schemas/AssetEntryDto'
       responses:
         default:
           description: default response
           content:
             application/json: {}
-  /contractdefinitions/{id}:
+  /assets/{id}:
     get:
       tags:
-      - Contract Definition
-      operationId: getContractDefinition
+      - Asset
+      operationId: getAsset
       parameters:
       - name: id
         in: path
@@ -617,202 +473,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContractDefinitionDto'
+                $ref: '#/components/schemas/AssetDto'
     delete:
       tags:
-      - Contract Definition
-      operationId: deleteContractDefinition
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /identity-hub/query-commits:
-    post:
-      tags:
-      - Identity Hub
-      operationId: queryCommits
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: string
-  /identity-hub/query-objects:
-    post:
-      tags:
-      - Identity Hub
-      operationId: queryObjects
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: string
-  /identity-hub/collections:
-    post:
-      tags:
-      - Identity Hub
-      operationId: write
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: string
-  /identity-hub/collections-commit:
-    post:
-      tags:
-      - Identity Hub
-      operationId: writeCommit
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              additionalProperties:
-                type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /federatedcatalog:
-    post:
-      operationId: getCachedCatalog
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/FederatedCatalogCacheQuery'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ContractOffer'
-  /policies:
-    get:
-      tags:
-      - Policy
-      operationId: getAllPolicies
-      parameters:
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Policy'
-    post:
-      tags:
-      - Policy
-      operationId: createPolicy
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Policy'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /policies/{id}:
-    get:
-      tags:
-      - Policy
-      operationId: getPolicy
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Policy'
-    delete:
-      tags:
-      - Policy
-      operationId: deletePolicy
+      - Asset
+      operationId: removeAsset
       parameters:
       - name: id
         in: path
@@ -901,6 +566,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ContractAgreementDto'
+  /check/health:
+    get:
+      tags:
+      - Application Observability
+      operationId: checkHealth
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /check/liveness:
+    get:
+      tags:
+      - Application Observability
+      operationId: getLiveness
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /check/readiness:
+    get:
+      tags:
+      - Application Observability
+      operationId: getReadiness
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /check/startup:
+    get:
+      tags:
+      - Application Observability
+      operationId: getStartup
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
   /transferprocess/{id}/cancel:
     post:
       tags:
@@ -1048,6 +753,301 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TransferState'
+  /policies:
+    get:
+      tags:
+      - Policy
+      operationId: getAllPolicies
+      parameters:
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Policy'
+    post:
+      tags:
+      - Policy
+      operationId: createPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Policy'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /policies/{id}:
+    get:
+      tags:
+      - Policy
+      operationId: getPolicy
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Policy'
+    delete:
+      tags:
+      - Policy
+      operationId: deletePolicy
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /catalog:
+    get:
+      tags:
+      - Catalog
+      operationId: getCatalog
+      parameters:
+      - name: providerUrl
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        default:
+          description: Gets contract offers (=catalog) of a single connector
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Catalog'
+  /federatedcatalog:
+    post:
+      operationId: getCachedCatalog
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FederatedCatalogCacheQuery'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractOffer'
+  /contractdefinitions:
+    get:
+      tags:
+      - Contract Definition
+      operationId: getAllContractDefinitions
+      parameters:
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractDefinitionDto'
+    post:
+      tags:
+      - Contract Definition
+      operationId: createContractDefinition
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/ContractDefinitionDto'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /contractdefinitions/{id}:
+    get:
+      tags:
+      - Contract Definition
+      operationId: getContractDefinition
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContractDefinitionDto'
+    delete:
+      tags:
+      - Contract Definition
+      operationId: deleteContractDefinition
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /callback/{processId}/deprovision:
+    post:
+      tags:
+      - HTTP Provisioner Webhook
+      operationId: callDeprovisionWebhook
+      parameters:
+      - name: processId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeprovisionedResource'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /callback/{processId}/provision:
+    post:
+      tags:
+      - HTTP Provisioner Webhook
+      operationId: callProvisionWebhook
+      parameters:
+      - name: processId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProvisionerWebhookRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
 components:
   schemas:
     Action:


### PR DESCRIPTION
## What this PR changes/adds

Properly interprets the SQL-statements based on the right-hand operand of the `Criterion` and adds statement placeholders as needed.

## Why it does that

To make the statement interpreter more robust and avoid SQL injection attacks.


## Linked Issue(s)

Closes #1282 
Closes #1002 

## Checklist

- [x] added appropriate tests?
- [ ] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
