### PR TITLE
bugfix: get vault through context

### DIFF
--- a/extensions/azure/cosmos/policy-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/cosmos/policy/store/CosmosPolicyStoreExtension.java
+++ b/extensions/azure/cosmos/policy-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/cosmos/policy/store/CosmosPolicyStoreExtension.java
@@ -29,8 +29,6 @@ public class CosmosPolicyStoreExtension implements ServiceExtension {
 
     @Inject
     private RetryPolicy retryPolicy;
-    @Inject
-    private Vault vault;
 
     @Override
     public String name() {
@@ -40,6 +38,8 @@ public class CosmosPolicyStoreExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var configuration = new CosmosPolicyStoreConfig(context);
+
+        var vault = context.getService(Vault.class);
 
         var cosmosDbApi = new CosmosDbApiImpl(vault, configuration);
 


### PR DESCRIPTION
## What this PR changes/adds

Currently `Vault` is not injectable. 
#1285 should fix the problem but we need a fast (and simpler) resolution for this specific bug.

## Why it does that

See #1272 

## Further notes

-

## Linked Issue(s)

Closes #1272 

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
