### PR TITLE
Build: adds property to skip signing jars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,13 +33,14 @@ in the detailed section referring to by linking pull requests or issues.
 * Add Blob transfer Architectural Decision Record (#1259)
 * Add component tests coverage to the codecov coverage report (#1246)
 * Postgresql end to end test (#1278)
-* * Add signing/publishing config (#1147)
+* Add signing/publishing config (#1147)
 
 #### Changed
 
 * Restructure sql extension folder tree (#1154)
 * Extract single `PolicyArchive` implementation (#1158)
-* Replace `accessPolicy` and `contractPolicy` with `accessPolicyId` and `contractPolicyId` on `ContractDefinition` (#1144)
+* Replace `accessPolicy` and `contractPolicy` with `accessPolicyId` and `contractPolicyId` on `ContractDefinition` (
+  #1144)
 * Replace `policy` with `policyId` on `ContractAgreement` (#1220)
 * All DMgmt Api methods now produce and consume `APPLICATION_JSON` (#1175)
 * Make data-plane public api controller asynchronous (#1228)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,7 +78,7 @@ allprojects {
     apply(plugin = "maven-publish")
     apply(plugin = "checkstyle")
     apply(plugin = "java")
-    apply(plugin = "signing")
+
 
     apply(plugin = "org.eclipse.dataspaceconnector.test-summary")
 
@@ -132,51 +132,56 @@ allprojects {
             testImplementation("com.github.javafaker:javafaker:${faker}")
         }
 
-        publishing {
-            repositories {
-                maven {
-                    name = "OSSRH"
-                    setUrl("https://oss.sonatype.org/service/local/staging/deploy/maven2")
-                    credentials {
-                        username = System.getenv("OSSRH_USER") ?: return@credentials
-                        password = System.getenv("OSSRH_PASSWORD") ?: return@credentials
-                    }
-                }
-            }
-            publications {
-                create<MavenPublication>("mavenJava") {
-                    java {
-                        withJavadocJar()
-                        withSourcesJar()
-                    }
-                    pom {
-                        name.set(project.name)
-                        description.set("edc :: ${project.name}")
-                        url.set(edcWebsiteUrl)
-                        licenses {
-                            license {
-                                name.set("The Apache License, Version 2.0")
-                                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                            }
-                            developers {
-                                developer {
-                                    id.set(edcDeveloperId)
-                                    name.set(edcDeveloperName)
-                                    email.set(edcDeveloperEmail)
-                                }
-                            }
-                            scm {
-                                connection.set(edcScmConnection)
-                                url.set(edcScmUrl)
-                            }
+        if (!project.hasProperty("skip.signing")) {
+
+            apply(plugin = "signing")
+            publishing {
+                repositories {
+                    maven {
+                        name = "OSSRH"
+                        setUrl("https://oss.sonatype.org/service/local/staging/deploy/maven2")
+                        credentials {
+                            username = System.getenv("OSSRH_USER") ?: return@credentials
+                            password = System.getenv("OSSRH_PASSWORD") ?: return@credentials
                         }
                     }
                 }
+                publications {
+                    create<MavenPublication>("mavenJava") {
+                        java {
+                            withJavadocJar()
+                            withSourcesJar()
+                        }
+                        pom {
+                            name.set(project.name)
+                            description.set("edc :: ${project.name}")
+                            url.set(edcWebsiteUrl)
+                            
+                            licenses {
+                                license {
+                                    name.set("The Apache License, Version 2.0")
+                                    url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                                }
+                                developers {
+                                    developer {
+                                        id.set(edcDeveloperId)
+                                        name.set(edcDeveloperName)
+                                        email.set(edcDeveloperEmail)
+                                    }
+                                }
+                                scm {
+                                    connection.set(edcScmConnection)
+                                    url.set(edcScmUrl)
+                                }
+                            }
+                        }
+                    }
 
-            }
+                }
 
-            signing {
-                sign(publishing.publications)
+                signing {
+                    sign(publishing.publications)
+                }
             }
         }
 
@@ -332,7 +337,7 @@ if (project.hasProperty("dependency.analysis")) {
         abi {
             exclusions {
                 excludeAnnotations(
-                        "io\\.opentelemetry\\.extension\\.annotations\\.WithSpan",
+                    "io\\.opentelemetry\\.extension\\.annotations\\.WithSpan",
                 )
             }
         }

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ExecutorInstrumentation.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ExecutorInstrumentation.java
@@ -22,10 +22,21 @@ import java.util.concurrent.ScheduledExecutorService;
  * collect execution metrics when available.
  * <p>
  * The default implementation does not provide any instrumentation. Extension
- * modules can provide implementations of the {@link ExecutorInstrumentationImplementation} sub-interface,
+ * modules can provide implementations of the {@link ExecutorInstrumentation} sub-interface,
  * such as for collecting metrics.
  */
 public interface ExecutorInstrumentation {
+    /**
+     * Default implementation that does not provide any instrumentation. Extension
+     * modules can provide implementations, such as for collecting metrics.
+     *
+     * @return a default {@link ExecutorInstrumentation} implementation.
+     */
+    static ExecutorInstrumentation noop() {
+        return new ExecutorInstrumentation() {
+        };
+    }
+
     /**
      * Instrument a {@link ScheduledExecutorService}.
      *
@@ -46,16 +57,5 @@ public interface ExecutorInstrumentation {
      */
     default ExecutorService instrument(ExecutorService target, String name) {
         return target;
-    }
-
-    /**
-     * Default implementation that does not provide any instrumentation. Extension
-     * modules can provide implementations, such as for collecting metrics.
-     *
-     * @return a default {@link ExecutorInstrumentation} implementation.
-     */
-    static ExecutorInstrumentation noop() {
-        return new ExecutorInstrumentation() {
-        };
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Adds a property `skip.signing` that foregoes the Gradle signing plugin. This is an addendum to #1147. 

## Why it does that

This could be very handy when publishing to a local or private Maven repository, when there are either no GPG keys available, or having to sign every time is just too time consuming.

## Further notes

Usage: `./gradlew clean publishToMavenLocal -Pskip.signing`

## Linked Issue(s)
n/a

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
