### PR TITLE
logs: sanitize log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Uniform all the sql schema files as `docs/schema.sql` (#1278)
 * Clean FCC store before updating
 * Usage of `NooTransactionContext` in (SQL-)Tests (#1119)
+* Sanitize log messages (#1295)
 
 #### Removed
 

--- a/extensions/aws/s3/s3-provision/src/test/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3BucketProvisionerTest.java
+++ b/extensions/aws/s3/s3-provision/src/test/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3BucketProvisionerTest.java
@@ -68,8 +68,7 @@ class S3BucketProvisionerTest {
 
         var configuration = new S3BucketProvisionerConfiguration(2, 3600);
 
-        provisioner = new S3BucketProvisioner(clientProvider, new Monitor() {
-        }, new RetryPolicy<>(), configuration);
+        provisioner = new S3BucketProvisioner(clientProvider, mock(Monitor.class), new RetryPolicy<>(), configuration);
     }
 
     @Test

--- a/extensions/http/jetty/src/test/java/org/eclipse/dataspaceconnector/extension/jetty/JettyServiceTest.java
+++ b/extensions/http/jetty/src/test/java/org/eclipse/dataspaceconnector/extension/jetty/JettyServiceTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
+import static org.mockito.Mockito.mock;
 
 class JettyServiceTest {
     private JettyService jettyService;
@@ -50,8 +51,7 @@ class JettyServiceTest {
 
     @BeforeEach
     void setUp() {
-        monitor = new Monitor() {
-        };
+        monitor = mock(Monitor.class);
         testController = new TestController();
     }
 

--- a/extensions/iam/decentralized-identity/identity-did-service/src/test/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityServiceTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-service/src/test/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityServiceTest.java
@@ -45,9 +45,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 /**
  * Test the {@link DecentralizedIdentityService} with different key algorithms.
@@ -112,8 +114,8 @@ abstract class DecentralizedIdentityServiceTest {
         DidResolverRegistry didResolver = new TestResolverRegistry(hubUrlDid, keyPair);
 
         CredentialsVerifier verifier = (document, url) -> Result.success(Map.of("region", "eu"));
-        identityService = new DecentralizedIdentityService(() -> VerifiableCredentialFactory.create(privateKey, Map.of("region", "us"), "test-issuer"), didResolver, verifier, new Monitor() {
-        });
+        Supplier<SignedJWT> signedJwtSupplier = () -> VerifiableCredentialFactory.create(privateKey, Map.of("region", "us"), "test-issuer");
+        identityService = new DecentralizedIdentityService(signedJwtSupplier, didResolver, verifier, mock(Monitor.class));
 
     }
 

--- a/extensions/jdk-logger-monitor/src/main/java/org/eclipse/dataspaceconnector/logger/LoggerMonitor.java
+++ b/extensions/jdk-logger-monitor/src/main/java/org/eclipse/dataspaceconnector/logger/LoggerMonitor.java
@@ -18,7 +18,6 @@ import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -60,12 +59,9 @@ public class LoggerMonitor implements Monitor {
 
     private void log(final Supplier<String> supplier, final Level level, final Throwable... errors) {
         if (errors == null || errors.length == 0) {
-            LOGGER.log(level, supplier);
+            LOGGER.log(level, () -> sanitizeMessage(supplier));
         } else {
-            String logMessage = Optional.ofNullable(supplier.get())
-                    .map(msg -> msg.replaceAll("([\\r\\n])", " "))
-                    .orElse(null);
-            Arrays.stream(errors).forEach(error -> LOGGER.log(level, logMessage, error));
+            Arrays.stream(errors).forEach(error -> LOGGER.log(level, sanitizeMessage(supplier), error));
         }
     }
 }

--- a/extensions/jdk-logger-monitor/src/test/java/org/eclipse/dataspaceconnector/logger/LoggerMonitorTest.java
+++ b/extensions/jdk-logger-monitor/src/test/java/org/eclipse/dataspaceconnector/logger/LoggerMonitorTest.java
@@ -18,9 +18,11 @@ import com.github.javafaker.Faker;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -32,10 +34,8 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
-/**
- * Collection of unit tests for {@link LoggerMonitor}
- */
-public class LoggerMonitorTests {
+
+public class LoggerMonitorTest {
 
     static Faker faker = new Faker();
     final String message = faker.lorem().sentence();
@@ -53,77 +53,50 @@ public class LoggerMonitorTests {
         logger.setLevel(Level.ALL);
     }
 
-    private static Stream<Arguments> provideLogDataWithErrors() {
-        return Stream.of(
-                Arguments.of(faker.lorem().sentence(), new Throwable[]{new RuntimeException()}),
-                Arguments.of(faker.lorem().sentence(), new Throwable[]{new RuntimeException(), new Exception()})
-        );
-    }
-
     @ParameterizedTest(name = "{index} {1}")
-    @MethodSource("provideLogDataWithErrors")
+    @ArgumentsSource(ProvideLogDataWithErrors.class)
     public void loggedOnInfoLevel_WithErrors(String message, Throwable... errors) {
-
-        //Act
         sut.info(() -> message, errors);
 
-        //Assert
         assertLogWithErrors(message, Level.INFO, errors);
     }
 
     @ParameterizedTest(name = "{index} {1}")
-    @MethodSource("provideLogDataWithErrors")
+    @ArgumentsSource(ProvideLogDataWithErrors.class)
     public void loggedOnWarningLevel_WithErrors(String message, Throwable... errors) {
-
-        //Act
         sut.warning(() -> message, errors);
 
-        //Assert
         assertLogWithErrors(message, Level.WARNING, errors);
     }
 
     @ParameterizedTest(name = "{index} {1}")
-    @MethodSource("provideLogDataWithErrors")
+    @ArgumentsSource(ProvideLogDataWithErrors.class)
     public void loggedOnSevereLevel_WithErrors(String message, Throwable... errors) {
-
-        //Act
         sut.severe(() -> message, errors);
 
-        //Assert
         assertLogWithErrors(message, Level.SEVERE, errors);
     }
 
     @ParameterizedTest(name = "{index} {1}")
-    @MethodSource("provideLogDataWithErrors")
+    @ArgumentsSource(ProvideLogDataWithErrors.class)
     public void loggedOnDebugLevel_WithErrors(String message, Throwable... errors) {
-
-        //Act
         sut.debug(() -> message, errors);
 
-        //Assert
         assertLogWithErrors(message, Level.FINE, errors);
     }
 
     @Test
     public void loggedOnSevereLevel_WithParams() {
-
-        // Arrange
         Map<String, Object> errors = Map.of(message, extraParams);
-
-        //Act
         sut.severe(errors);
 
-        //Assert
-        assertThat(handler.getRecords()).extracting(
-                        LogRecord::getMessage, LogRecord::getLevel, LogRecord::getThrown, LogRecord::getParameters)
-                .containsExactly(
-                        tuple(message, Level.SEVERE, null, new Object[]{extraParams}));
+        assertThat(handler.getRecords())
+                .extracting(LogRecord::getMessage, LogRecord::getLevel, LogRecord::getThrown, LogRecord::getParameters)
+                .containsExactly(tuple(message, Level.SEVERE, null, new Object[]{extraParams}));
     }
 
     @Test
     public void loggedOnInfoLevel() {
-
-        //Act
         sut.info(() -> message);
 
         assertLog(message, Level.INFO);
@@ -131,31 +104,22 @@ public class LoggerMonitorTests {
 
     @Test
     public void loggedOnSevereLevel() {
-
-        //Act
         sut.severe(() -> message);
 
-        //Assert
         assertLog(message, Level.SEVERE);
     }
 
     @Test
     public void loggedOnWarningLevel() {
-
-        //Act
         sut.warning(() -> message);
 
-        //Assert
         assertLog(message, Level.WARNING);
     }
 
     @Test
     public void loggedOnDebugLevel() {
-
-        //Act
         sut.debug(() -> message);
 
-        //Assert
         assertLog(message, Level.FINE);
     }
 
@@ -164,25 +128,38 @@ public class LoggerMonitorTests {
      */
     @Test
     public void loggedOnSevereLevel_WithNullVarArgs() {
-
-        //Act
         sut.severe(() -> message, (Throwable) null);
 
-        //Assert
         assertLog(message, Level.SEVERE);
     }
 
+    @Test
+    void logIsSanitized() {
+        sut.debug(() -> "message\nto be\rsanitized");
+
+        assertLog("message to be sanitized", Level.FINE);
+    }
+
     private void assertLog(String message, Level level) {
-        assertThat(handler.getRecords()).extracting(
-                        LogRecord::getMessage, LogRecord::getLevel, LogRecord::getThrown)
-                .containsExactly(
-                        tuple(message, level, null));
+        assertThat(handler.getRecords())
+                .extracting(LogRecord::getMessage, LogRecord::getLevel, LogRecord::getThrown)
+                .containsExactly(tuple(message, level, null));
     }
 
     private void assertLogWithErrors(String message, Level level, Throwable... errors) {
-        assertThat(handler.getRecords()).extracting(
-                        LogRecord::getMessage, LogRecord::getLevel, LogRecord::getThrown)
-                .containsExactlyInAnyOrder(
-                        Arrays.stream(errors).map(e -> tuple(message, level, e)).toArray(Tuple[]::new));
+        assertThat(handler.getRecords())
+                .extracting(LogRecord::getMessage, LogRecord::getLevel, LogRecord::getThrown)
+                .containsExactlyInAnyOrder(Arrays.stream(errors).map(e -> tuple(message, level, e)).toArray(Tuple[]::new));
+    }
+
+    private static class ProvideLogDataWithErrors implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    Arguments.of(faker.lorem().sentence(), new Throwable[]{new RuntimeException()}),
+                    Arguments.of(faker.lorem().sentence(), new Throwable[]{new RuntimeException(), new Exception()})
+            );
+        }
     }
 }

--- a/extensions/jdk-logger-monitor/src/test/java/org/eclipse/dataspaceconnector/logger/TestLogHandler.java
+++ b/extensions/jdk-logger-monitor/src/test/java/org/eclipse/dataspaceconnector/logger/TestLogHandler.java
@@ -20,7 +20,7 @@ import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 
 /**
- * A simple log handler to validate logger under unit tests {@link org.eclipse.dataspaceconnector.logger.LoggerMonitorTests}.
+ * A simple log handler to validate logger under unit tests {@link LoggerMonitorTest}.
  */
 public class TestLogHandler extends Handler {
 

--- a/extensions/sql/lease-sql/src/test/java/org/eclipse/dataspaceconnector/sql/lease/SqlLeaseContextTest.java
+++ b/extensions/sql/lease-sql/src/test/java/org/eclipse/dataspaceconnector/sql/lease/SqlLeaseContextTest.java
@@ -34,6 +34,7 @@ import java.util.Objects;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.dataspaceconnector.sql.SqlQueryExecutor.executeQuery;
+import static org.mockito.Mockito.mock;
 
 class SqlLeaseContextTest {
 
@@ -47,9 +48,7 @@ class SqlLeaseContextTest {
 
     @BeforeEach
     void setUp() throws SQLException {
-        var monitor = new Monitor() {
-        };
-        var txManager = new LocalTransactionContext(monitor);
+        var txManager = new LocalTransactionContext(mock(Monitor.class));
         var dataSourceRegistry = new LocalDataSourceRegistry(txManager);
         transactionContext = txManager;
         var jdbcDataSource = new JdbcDataSource();

--- a/extensions/transaction/transaction-atomikos/src/test/java/org/eclipse/dataspaceconnector/transaction/atomikos/AtomikosTransactionExtensionTest.java
+++ b/extensions/transaction/transaction-atomikos/src/test/java/org/eclipse/dataspaceconnector/transaction/atomikos/AtomikosTransactionExtensionTest.java
@@ -52,8 +52,7 @@ class AtomikosTransactionExtensionTest {
 
         when(extensionContext.getConfig(isA(String.class))).thenAnswer(a -> createDataSourceConfig());
         when(extensionContext.getConfig()).thenAnswer(a -> createAtomikosConfig());
-        when(extensionContext.getMonitor()).thenReturn(new Monitor() {
-        });
+        when(extensionContext.getMonitor()).thenReturn(mock(Monitor.class));
 
         var dsRegistry = new DataSourceRegistry[1];
         doAnswer(invocation -> {

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/monitor/ConsoleMonitor.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/monitor/ConsoleMonitor.java
@@ -75,8 +75,8 @@ public class ConsoleMonitor implements Monitor {
     }
 
     private void output(String level, Supplier<String> supplier, Throwable... errors) {
-        String time = ZonedDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-        System.out.println(prefix + level + " " + time + " " + supplier.get());
+        var time = ZonedDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        System.out.println(prefix + level + " " + time + " " + sanitizeMessage(supplier));
         if (errors != null) {
             for (Throwable error : errors) {
                 if (error != null) {

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/monitor/Monitor.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/monitor/Monitor.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.spi.monitor;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
@@ -52,6 +53,12 @@ public interface Monitor {
 
     default void debug(String message, Throwable... errors) {
         debug(() -> message, errors);
+    }
+
+    default String sanitizeMessage(Supplier<String> supplier) {
+        return Optional.ofNullable(supplier.get())
+                .map(msg -> msg.replaceAll("([\\r\\n])", " "))
+                .orElse(null);
     }
 
 }

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/monitor/MultiplexingMonitor.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/monitor/MultiplexingMonitor.java
@@ -24,10 +24,7 @@ import java.util.function.Supplier;
  */
 public class MultiplexingMonitor implements Monitor {
 
-    private Collection<Monitor> internalMonitors;
-
-    public MultiplexingMonitor() {
-    }
+    private final Collection<Monitor> internalMonitors;
 
     public MultiplexingMonitor(List<Monitor> monitors) {
         internalMonitors = monitors;


### PR DESCRIPTION
## What this PR changes/adds

Sanitize log messages replacing `\n` and `\r` with a whitespace.

## Why it does that

Line breaks in logs can be used by attackers as reported here: https://www.veracode.com/security/java/cwe-117

## Further notes

- replaced anonymous class instances of `Monitor` to simplify its hierarchy

## Linked Issue(s)

Closes #1145 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
