### PR TITLE
docs: provide documentation templates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,9 +146,9 @@ we would appreciate if your pull request applies to the following points:
 
 ### Add Documentation
 
-Every decision record, launcher, or extension has to provide documentation that covers at least
+Every decision record, launcher, extension, or any type of module has to provide documentation that covers at least
 one markdown file with necessary information. Please find appropriate templates that should
-be used in [this directory](docs/templates).
+be used in [the templates directory](docs/templates).
 
 ### Report on Flaky Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,8 @@ we would appreciate if your pull request applies to the following points:
 
 * Where code is not self-explanatory, add documentation providing extra clarification.
 
+* Add documentation files to new modules. See [here](#add-documentation) for more details.
+
 * Add relevant changes (e.g., no typo fixes, updated readme files, fixes of stuck test) to the 
   [changelog](CHANGELOG.md). If these refer to a new feature, add this to the `Overview` section 
   and add your changes to the `Detailed Changes` section according to the rules documented on 
@@ -141,6 +143,12 @@ we would appreciate if your pull request applies to the following points:
     * _Intellectual Property Validation_ verifying the [Eclipse CLA](#eclipse-contributor-agreement) 
       has been signed as well as commits have been signed-off and
     * _Continuous Integration_ performing various test conventions.
+
+### Add Documentation
+
+Every decision record, launcher, or extension has to provide documentation that covers at least
+one markdown file with necessary information. Please find appropriate templates that should
+be used in [this directory](docs/templates).
 
 ### Report on Flaky Tests
 

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -1,0 +1,31 @@
+# Templates
+
+Find all provided documentation templates in this folder. Please note that the cursive marked words 
+and sentences should be removed. Feel free to add additional sections and subsections, however, make sure
+that at least the not optionally marked sections of the templates are filled.
+
+## Decision Records
+
+[Link](decision-record.md) to template.
+
+Each decision record should be located [here](../developer/decision-records) and provide a separate 
+folder following a naming pattern: `YYYY-MM-DD-title-of-decision-record`. This contains all relevant 
+files, at least a `README.md` that covers the filled template and, e.g., additional images.
+
+## Extensions
+
+[Link](extension.md) to template.
+
+Every module located [here](../../extensions) has to provide documentation, e.g., about functionality, 
+implementation, or architectural details.
+The filled template has to be added as `README.md` to each module. Any additional files can be placed 
+in a dedicated `docs` directory. As defined by the template, this markdown file can hint to submodules 
+that provide the same documentation scope themselves.
+
+## Launchers
+
+[Link](launcher.md) to template.
+
+Every module located [here](../../launchers) has to provide documentation about its purpose and usage.
+The filled template has to be added as `README.md` to each module. Any additional files can be placed 
+in a dedicated `docs` directory.

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -1,31 +1,34 @@
 # Templates
 
-Find all provided documentation templates in this folder. Please note that the cursive marked words 
-and sentences should be removed. Feel free to add additional sections and subsections, however, make sure
-that at least the not optionally marked sections of the templates are filled.
+Find all provided documentation templates in this folder. Please note that the _italic text 
+and sentences_ should be removed. Feel free to add additional sections and subsections, however, make sure
+that at least the sections of the templates marked as "mandatory" are filled.
 
 ## Decision Records
 
 [Link](decision-record.md) to template.
 
-Each decision record should be located [here](../developer/decision-records) and provide a separate 
-folder following a naming pattern: `YYYY-MM-DD-title-of-decision-record`. This contains all relevant 
-files, at least a `README.md` that covers the filled template and, e.g., additional images.
+Each decision record should be put in an appropriate folder that is following a naming pattern: 
+`YYYY-MM-DD-title-of-decision-record`. This should be located at the [decision record folder](../developer/decision-records) 
+and contain all relevant files, at least a filled-out template named `README.md` and any additional images.
+
+As of now, every merged decision record is in state `accepted`. Please make sure to add a comment to
+a decision record that replaces a previous one with adding a hint: `superseded by [...]`.
 
 ## Extensions
 
 [Link](extension.md) to template.
 
-Every module located [here](../../extensions) has to provide documentation, e.g., about functionality, 
-implementation, or architectural details.
-The filled template has to be added as `README.md` to each module. Any additional files can be placed 
-in a dedicated `docs` directory. As defined by the template, this markdown file can hint to submodules 
+Every module located [in the extensions folder](../../extensions) has to provide documentation regarding its 
+functionality, implementation, or architectural details.
+The filled-out template has to be added as `README.md` to each module. Any additional files can be placed 
+in a dedicated `docs` directory. As defined by the template, this markdown file can point to submodules 
 that provide the same documentation scope themselves.
 
 ## Launchers
 
 [Link](launcher.md) to template.
 
-Every module located [here](../../launchers) has to provide documentation about its purpose and usage.
+Every module located [in the launchers folder](../../launchers) has to provide documentation regarding its purpose and usage.
 The filled template has to be added as `README.md` to each module. Any additional files can be placed 
 in a dedicated `docs` directory.

--- a/docs/templates/decision-record.md
+++ b/docs/templates/decision-record.md
@@ -2,11 +2,12 @@
 
 ## Decision
 
-_Briefly and clearly describe the topic this record covers, and what decision was made._
+_Briefly and clearly describe the topic this record covers, what decision was made and why._
 
 ## Rationale
 
-_Briefly describe the relevance of this topic and why it is important to have a decision._
+_Briefly describe the relevance of this topic and why it is important to have a decision. If applicable, 
+add an evaluation of several options (e.g., different libs)._
 
 ## Approach
 

--- a/docs/templates/decision-record.md
+++ b/docs/templates/decision-record.md
@@ -1,0 +1,14 @@
+# Title of the Decision Record
+
+## Decision
+
+_Briefly and clearly describe the topic this record covers, and what decision was made._
+
+## Rationale
+
+_Briefly describe the relevance of this topic and why it is important to have a decision._
+
+## Approach
+
+_Clearly describe the approach. Feel free to add subsections, graphics, or example code and please 
+make sure every relevant detail is explained._

--- a/docs/templates/extension.md
+++ b/docs/templates/extension.md
@@ -1,6 +1,6 @@
 # Title of the Extension
 
-_Briefly describe what functionality this extension introduces._
+_Briefly describe the functionality this extension introduces._
 
 ## Background
 
@@ -13,20 +13,26 @@ sharing scenarios._
 
 ### Use Cases
 
-_Optionally, explain one or multiple use cases that could be realized using this extension._
+_Explain one or multiple use cases that could be realized using this extension._
 
 ## Technical Details
 
 ### Interfaces
 
-_Provide a detailed description of all provided and consumed interfaces._
+_Provide a detailed description of provided and consumed interfaces, e.g., name http endpoints and values,
+or classes/methods and parameter, and add details on the purpose. You may use the table below or add an
+OpenAPI description or similar._
+
+| Interface | Parameters | Description |
+| :----| :---- | :-------------------- |
+|  |  |
 
 ### Dependencies
 
 _Provide some information about dependencies, e.g., used extensions._
 
-| Name | Description                                                                                                   |
-| :----| :---------------------------------------------------------------------------------------|
+| Name | Description |
+| :----| :-----------|
 | extensions:api:data-management | _this is an example_ |
 
 ### Configurations

--- a/docs/templates/extension.md
+++ b/docs/templates/extension.md
@@ -1,0 +1,46 @@
+# Title of the Extension
+
+_Briefly describe what functionality this extension introduces._
+
+## Background
+
+_Briefly describe the relevance and need of this extension._
+
+### Scope
+
+_Describe what this extension should be used for, e.g., for what kind of data transfers or data
+sharing scenarios._
+
+### Use Cases
+
+_Optionally, explain one or multiple use cases that could be realized using this extension._
+
+## Technical Details
+
+### Interfaces
+
+_Provide a detailed description of all provided and consumed interfaces._
+
+### Dependencies
+
+_Provide some information about dependencies, e.g., used extensions._
+
+| Name | Description                                                                                                   |
+| :----| :---------------------------------------------------------------------------------------|
+| extensions:api:data-management | _this is an example_ |
+
+### Configurations
+
+_If available, describe what configuration properties this extension comes with or expects as a prerequisite._
+
+## Terminology
+
+_If necessary, introduce important terms and concepts._
+
+## Design Principles
+
+_If available, clearly describe what design principles your implementation follows._
+
+## Decisions
+
+_Clearly describe any decisions you made regarding architectural design or similar, and try to justify them._

--- a/docs/templates/launcher.md
+++ b/docs/templates/launcher.md
@@ -1,0 +1,25 @@
+# Name of the Launcher
+
+_Briefly describe the purpose and scope of this launcher._
+
+## Prerequisites
+
+_Clearly explain what prerequisites are necessary for being able to execute this launcher, e.g. SSL certificates._
+
+## Modules
+
+The following modules are used for this launcher.
+
+| Name | Description                                                                                                   |
+| :----| :---------------------------------------------------------------------------------------|
+| extensions:api:data-management | _this is an example_ |
+
+## Configuration
+
+_Clearly describe what (especially launcher-specific) settings are used and how they are set up. You
+may use code snippets or provide example files._
+
+## Running the launcher
+
+_Clearly describe how to set up and use this launcher, e.g., how a local deployment or one with Docker
+or Kubernetes should look like. You may use code or command line snippets for guidance._

--- a/docs/templates/launcher.md
+++ b/docs/templates/launcher.md
@@ -4,22 +4,22 @@ _Briefly describe the purpose and scope of this launcher._
 
 ## Prerequisites
 
-_Clearly explain what prerequisites are necessary for being able to execute this launcher, e.g. SSL certificates._
+_Clearly explain what prerequisites are necessary for being able to execute this launcher, e.g., SSL certificates._
 
 ## Modules
 
 The following modules are used for this launcher.
 
-| Name | Description                                                                                                   |
-| :----| :---------------------------------------------------------------------------------------|
+| Name | Description |
+| :----| :-----------|
 | extensions:api:data-management | _this is an example_ |
 
 ## Configuration
 
-_Clearly describe what (especially launcher-specific) settings are used and how they are set up. You
+_Clearly describe what settings are used and how they are set up, especially if they're launcher-specific. You
 may use code snippets or provide example files._
 
 ## Running the launcher
 
-_Clearly describe how to set up and use this launcher, e.g., how a local deployment or one with Docker
+_Clearly describe how to set up and use this launcher, e.g., how a local deployment or a Docker
 or Kubernetes should look like. You may use code or command line snippets for guidance._


### PR DESCRIPTION
## What this PR changes/adds

Adds templates for documenting decision records, extensions, and launchers.

## Why it does that

Would be nice if the documentation files followed the same structure. Furthermore, it makes it easier for developers to add necessary information.

## Further notes

--

## Linked Issue(s)

Closes #1291 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
