### PR TITLE
Docs: adds pr etiquette document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,17 +115,7 @@ we would appreciate if your pull request applies to the following points:
   the [Developer Certificate of Origin.](https://www.eclipse.org/legal/DCO.php)
   As such, all parties involved in a contribution must have valid ECAs. Additionally, commits can 
   include a ["Signed-off-by" entry](https://wiki.eclipse.org/Development_Resources/Contributing_via_Git).
-* We prefer small changes and short living branches. Please do not combine independent things in one
-  pull request.
-
-
-* Excessive branching and merging can make git history confusing. With that in mind please
-
-    * [squash your commits](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
-      down to a few commits, or one commit, before submitting a pull request and
-    * [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your pull request changes on 
-      top of the current master. Pull requests shouldn't include merge commits.
-
+  
 * Add meaningful tests to verify your submission acts as expected.
 
 * Where code is not self-explanatory, add documentation providing extra clarification.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,8 @@ In addition to the contribution guideline made available in the
 [Eclipse project handbook](https://www.eclipse.org/projects/handbook/#contributing),
 we would appreciate if your pull request applies to the following points:
 
+* Conform to [Pull-Request Etiquette](pr_etiquette.md)
+
 * Always apply the following copyright header to specific files in your work replacing the fields 
   enclosed by curly brackets "{}" with your own identifying information. (Don't include the curly 
   brackets!) Enclose the text in the appropriate comment syntax for the file format.
@@ -144,7 +146,7 @@ we would appreciate if your pull request applies to the following points:
 * PR descriptions should use the current [PR template](.github/PULL_REQUEST_TEMPLATE.md)
 
 * Submit a draft pull request at early-stage and add people previously working on the same code as 
-  reviewer. Make sure automatically checks pass before marking it as "ready for review":
+  reviewer. Make sure automatic checks pass before marking it as "ready for review":
 
     * _Intellectual Property Validation_ verifying the [Eclipse CLA](#eclipse-contributor-agreement) 
       has been signed as well as commits have been signed-off and

--- a/pr_etiquette.md
+++ b/pr_etiquette.md
@@ -51,7 +51,7 @@ Submitting pull requests in EDC should be done while adhering to a couple of sim
 - Be civil and objective. No foul language, insulting or otherwise abusive language will be tolerated. The goal is to
   _encourage_ contributions.
 
-## The technical committers (as of May 13, 2022)
+## The technical committers (as of May 18, 2022)
 
 - @MoritzKeppler
 - @jimmarino

--- a/pr_etiquette.md
+++ b/pr_etiquette.md
@@ -11,11 +11,11 @@ Submitting pull requests in EDC should be done while adhering to a couple of sim
   may get ignored or rejected.
 - Create focused PRs: your work should be focused on one particular feature or bug. Do not create broad-scoped PRs that
   solve multiple issues as reviewers may reject those PR bombs outright.
-- Provide a clear description and motivation in the PR description in Github. This makes the reviewer's life much
+- Provide a clear description and motivation in the PR description in GitHub. This makes the reviewer's life much
   easier. It is also helpful to outline the broad changes that were made, e.g. "Changes the schema of XYZ-Entity:
-  the `age` field changed from `long` to `String`"
+  the `age` field changed from `long` to `String`".
 - If you introduce new 3rd party dependencies, be sure to note them in the PR description and explain why they are
-  necessary
+  necessary.
 - Stick to the established code style, please refer to the [styleguide document](styleguide.md).
 - All tests should be green, especially when your PR is in `"Ready for review"`
 - Mark PRs as `"Ready for review"` only when you're prepared to defend your work. By that time you have completed your
@@ -24,9 +24,9 @@ Submitting pull requests in EDC should be done while adhering to a couple of sim
   force-pushing. Do this when your PR is ready to review.
 - If you require a reviewer's input while it's still in draft, please contact the designated reviewer using
   the `@mention` feature and let them know what you'd like them to look at.
-- Request a review from one of the technical committers. Requesting a review from anyone else is still possible, and
+- Request a review from one of the [technical committers](pr_etiquette.md#the-technical-committers-as-of-may-13-2022). Requesting a review from anyone else is still possible, and
   sometimes may be advisable, but only committers can merge PRs, so be sure to include them early on.
-- Re-request reviews after all remarks have been adopted. This helps reviewers track their work in Github.
+- Re-request reviews after all remarks have been adopted. This helps reviewers track their work in GitHub.
 - If you disagree with a committer's remarks, feel free to object and argue, but if no agreement is reached, you'll have
   to either accept the decision or withdraw your PR.
 - Be civil and objective. No foul language, insulting or otherwise abusive language will be tolerated.
@@ -37,9 +37,9 @@ Submitting pull requests in EDC should be done while adhering to a couple of sim
 - If you have been requested as reviewer, but cannot do the review for any reason (time, lack of knowledge in particular
   area, etc.) please comment that in the PR and remove yourself as a reviewer, suggesting a stand-in. The [code
   owners document](CODEOWNERS) should help with that.
-- Don't be overly pedantic
+- Don't be overly pedantic.
 - Don't argue basic principles (code style, architectural decisions, etc.)
-- Use the `suggestion` feature of Github for small/simple changes.
+- Use the `suggestion` feature of GitHub for small/simple changes.
 - The following could serve you as a review checklist:
     - no unnecessary dependencies in `build.gradle.kts`
     - sensible unit tests, prefer unit tests over integration tests wherever possible (test runtime). Also check the
@@ -48,7 +48,7 @@ Submitting pull requests in EDC should be done while adhering to a couple of sim
     - simplicity and "uncluttered-ness" of the code
     - overall focus of the PR
 - Don't just wave through any PR. Please take the time to look at them carefully.
-- Be civil and objective. no foul language, insulting or otherwise abusive language will be tolerated. The goal is to
+- Be civil and objective. No foul language, insulting or otherwise abusive language will be tolerated. The goal is to
   _encourage_ contributions.
 
 ## The technical committers (as of May 13, 2022)

--- a/pr_etiquette.md
+++ b/pr_etiquette.md
@@ -1,6 +1,6 @@
 # Etiquette for pull requests
 
-## As an author (assuming non-committer)
+## As an author
 
 Submitting pull requests in EDC should be done while adhering to a couple of simple rules.
 
@@ -39,7 +39,7 @@ Submitting pull requests in EDC should be done while adhering to a couple of sim
   owners document](CODEOWNERS) should help with that.
 - Don't be overly pedantic
 - Don't argue basic principles (code style, architectural decisions, etc.)
-- Use the ````suggestion` feature of Github for small/simple changes.
+- Use the `suggestion` feature of Github for small/simple changes.
 - The following could serve you as a review checklist:
     - no unnecessary dependencies in `build.gradle.kts`
     - sensible unit tests, prefer unit tests over integration tests wherever possible (test runtime). Also check the

--- a/pr_etiquette.md
+++ b/pr_etiquette.md
@@ -29,7 +29,7 @@ Submitting pull requests in EDC should be done while adhering to a couple of sim
 - Re-request reviews after all remarks have been adopted. This helps reviewers track their work in Github.
 - If you disagree with a committer's remarks, feel free to object and argue, but if no agreement is reached, you'll have
   to either accept the decision or withdraw your PR.
-- Be civil and objective. no foul language, insulting or otherwise abusive language will be tolerated.
+- Be civil and objective. No foul language, insulting or otherwise abusive language will be tolerated.
 
 ## As a reviewer
 

--- a/pr_etiquette.md
+++ b/pr_etiquette.md
@@ -1,0 +1,62 @@
+# Etiquette for pull requests
+
+## As an author (assuming non-committer)
+
+Submitting pull requests in EDC should be done while adhering to a couple of simple rules.
+
+- Familiarize yourself with [coding style](styleguide.md), [architectural patterns](docs/architecture-principles.md) and
+  other contribution guidelines.
+- No surprise PRs please. Before you submit a PR, open a discussion or an issue outlining your planned work and give
+  people time to comment. It may even be advisable to contact committers using the `@mention` feature. Unsolicited PRs
+  may get ignored or rejected.
+- Create focused PRs: your work should be focused on one particular feature or bug. Do not create broad-scoped PRs that
+  solve multiple issues as reviewers may reject those PR bombs outright.
+- Provide a clear description and motivation in the PR description in Github. This makes the reviewer's life much
+  easier. It is also helpful to outline the broad changes that were made, e.g. "Changes the schema of XYZ-Entity:
+  the `age` field changed from `long` to `String`"
+- If you introduce new 3rd party dependencies, be sure to note them in the PR description and explain why they are
+  necessary
+- Stick to the established code style, please refer to the [styleguide document](styleguide.md).
+- All tests should be green, especially when your PR is in `"Ready for review"`
+- Mark PRs as `"Ready for review"` only when you're prepared to defend your work. By that time you have completed your
+  work and shouldn't need to push any more commits other than to incorporate review comments.
+- Merge conflicts should be resolved by squashing all commits on the PR branch, rebasing onto `main` and
+  force-pushing. Do this when your PR is ready to review.
+- If you require a reviewer's input while it's still in draft, please contact the designated reviewer using
+  the `@mention` feature and let them know what you'd like them to look at.
+- Request a review from one of the technical committers. Requesting a review from anyone else is still possible, and
+  sometimes may be advisable, but only committers can merge PRs, so be sure to include them early on.
+- Re-request reviews after all remarks have been adopted. This helps reviewers track their work in Github.
+- If you disagree with a committer's remarks, feel free to object and argue, but if no agreement is reached, you'll have
+  to either accept the decision or withdraw your PR.
+- Be civil and objective. no foul language, insulting or otherwise abusive language will be tolerated.
+
+## As a reviewer
+
+- Please complete reviews within two business days or delegate to another committer, removing yourself as a reviewer.
+- If you have been requested as reviewer, but cannot do the review for any reason (time, lack of knowledge in particular
+  area, etc.) please comment that in the PR and remove yourself as a reviewer, suggesting a stand-in. The [code
+  owners document](CODEOWNERS) should help with that.
+- Don't be overly pedantic
+- Don't argue basic principles (code style, architectural decisions, etc.)
+- Use the ````suggestion` feature of Github for small/simple changes.
+- The following could serve you as a review checklist:
+    - no unnecessary dependencies in `build.gradle.kts`
+    - sensible unit tests, prefer unit tests over integration tests wherever possible (test runtime). Also check the
+      usage of test tags.
+    - code style
+    - simplicity and "uncluttered-ness" of the code
+    - overall focus of the PR
+- Don't just wave through any PR. Please take the time to look at them carefully.
+- Be civil and objective. no foul language, insulting or otherwise abusive language will be tolerated. The goal is to
+  _encourage_ contributions.
+
+## The technical committers (as of May 13, 2022)
+
+- @MoritzKeppler
+- @jimmarino
+- @bscholtes1A
+- @ndr_brt
+- @ronjaquensel
+- @juliapampus
+- @paullatzelsperger


### PR DESCRIPTION
## What this PR changes/adds

Adds a document to outline proper PR decorum.

## Why it does that

To better shape the collaboration.

## Further notes

I created a new document and referenced it from `CONTRIBUTING.md` because there already were many bullet points and it seemed to be more readable that way.


## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
