### PR TITLE
Update DecentralizedIdentityServiceExtension.java

### DIFF
--- a/extensions/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityServiceExtension.java
+++ b/extensions/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityServiceExtension.java
@@ -28,6 +28,7 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 import static java.lang.String.format;
@@ -72,6 +73,7 @@ public class DecentralizedIdentityServiceExtension implements ServiceExtension {
             // we'll use the connector name to restore the Private Key
             var connectorName = context.getConnectorId();
             var privateKeyString = privateKeyResolver.resolvePrivateKey(connectorName, ECKey.class); //to get the private key
+            Objects.requireNonNull(privateKeyString, "Couldn't resolve private key for " + connectorName);
 
             // we cannot store the VerifiableCredential in the Vault, because it has an expiry date
             // the Issuer claim must contain the DID URL


### PR DESCRIPTION
## What this PR changes/adds

Adds a null check to ensure a clear error message is printed if a secret is missing in the vault (the DID private key).

## Why it does that

Error message appeared further in processing and was hard to trace

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
