### PR TITLE
Fix: broken CosmosDB tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Fix Azure storage transfer (#1245)
 * Throw exception if `IdentityProviderKeyResolver` cannot get keys at startup (#1266)
 * Make all the services injectable (#1285)
+* Fix CosmosDB Integration tests (#1313)
 
 ## [milestone-3] - 2022-04-08
 

--- a/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetQueryBuilderTest.java
+++ b/extensions/azure/cosmos/assetindex-cosmos/src/test/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetQueryBuilderTest.java
@@ -74,6 +74,6 @@ class CosmosAssetQueryBuilderTest {
                 .build();
 
         assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> builder.from(expression.getCriteria()))
-                .withMessage("Cannot build WHERE clause, reason: The \"in\" operator requires the right-hand operand to be of type interface java.lang.Iterable");
+                .withMessage("Cannot build WHERE clause, reason: The \"in\" operator requires the right-hand operand to be of type interface java.lang.Iterable but was actually class java.lang.String");
     }
 }

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/QuerySpec.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/QuerySpec.java
@@ -67,6 +67,7 @@ public class QuerySpec {
     }
 
     public static final class Builder {
+        private static final String EQUALS_EXPRESSION_PATTERN = "[^\\s\\\\]*(\\s*)=(\\s*)[^\\s\\\\]*";
         private final QuerySpec querySpec;
         private boolean equalsAsContains = false;
 
@@ -127,7 +128,7 @@ public class QuerySpec {
         public Builder filter(String filterExpression) {
 
             if (filterExpression != null) {
-                if (Pattern.matches("[^\\s\\\\]*(\\s*)=(\\s*)[^\\s\\\\]*", filterExpression)) { // something like X = Y
+                if (Pattern.matches(EQUALS_EXPRESSION_PATTERN, filterExpression)) { // something like X = Y
                     // remove whitespaces
                     filterExpression = filterExpression.replace(" ", "");
                     // we'll interpret the "=" as "contains"


### PR DESCRIPTION
## What this PR changes/adds

This PR fixes failing integration tests for the AssetIndex based on CosmosDB. The test code previously still used the "old" formatted string format, which is obsolete since the introduction of the `CosmosConditionExpression`.

## Why it does that

Some test code still used the old format.

## Further notes

Added a feature to `CosmosConditionExpression` that tries to reinterpret/parse a `Criterion` based on the operator and right-hand operand.


## Linked Issue(s)

Closes #1313

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
