### PR TITLE
Bugfix: fixed more Cosmos DB tests

### DIFF
--- a/extensions/azure/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStoreIntegrationTest.java
@@ -169,7 +169,7 @@ class CosmosTransferProcessStoreIntegrationTest {
         String id1 = UUID.randomUUID().toString();
         var tp = createTransferProcess(id1, TransferProcessStates.INITIAL);
         TransferProcessDocument item = new TransferProcessDocument(tp, partitionKey);
-        Duration leaseDuration = Duration.ofSeconds(2);
+        Duration leaseDuration = Duration.ofSeconds(10);
         item.acquireLease("another-connector", leaseDuration);
         container.upsertItem(item);
 
@@ -177,7 +177,7 @@ class CosmosTransferProcessStoreIntegrationTest {
         assertThat(processesBeforeLeaseBreak).isEmpty();
 
         await()
-                .atMost(Duration.ofSeconds(10))
+                .atMost(Duration.ofSeconds(20))
                 .pollInterval(Duration.ofMillis(500))
                 .pollDelay(leaseDuration) //give the lease time to expire
                 .untilAsserted(() -> {
@@ -564,7 +564,7 @@ class CosmosTransferProcessStoreIntegrationTest {
 
         var query = QuerySpec.Builder.newInstance().filter("something contains other").build();
 
-        assertThatThrownBy(() -> store.findAll(query)).isInstanceOfAny(IllegalArgumentException.class).hasMessage("Cannot build SqlParameter for operator: contains");
+        assertThatThrownBy(() -> store.findAll(query)).isInstanceOfAny(IllegalArgumentException.class).hasMessage("Cannot build WHERE clause, reason: unsupported operator contains");
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

fixes more CosmosDB tests, which were not caught by the previous PR #1315 

## Why it does that

_Briefly state why the change was necessary._

## Further notes

There seems to be a functional difference between the Cosmos Emulator (which I used for testing locally) and the actual CosmosDB instance: when sorting based on a non-existing field, the cosmos emulator returns an empty list, whereas on the "real" cosmos does not affect the result.

## Linked Issue(s)

Closes #1313

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
