### PR TITLE
Bugfix: also remove ContractDef from cache when deleting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Throw exception if `IdentityProviderKeyResolver` cannot get keys at startup (#1266)
 * Make all the services injectable (#1285)
 * Fix CosmosDB Integration tests (#1313)
+* Remove ContractDef from Cosmos DB cache when deleting (#1330)
 
 ## [milestone-3] - 2022-04-08
 

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreIntegrationTest.java
@@ -120,17 +120,17 @@ public class CosmosContractDefinitionStoreIntegrationTest {
     void findAll_emptyResult() {
         assertThat(store.findAll()).isNotNull().isEmpty();
     }
-    
+
     @Test
     void findById() {
         var doc = generateDocument(TEST_PARTITION_KEY);
         container.createItem(doc);
-        
+
         var result = store.findById(doc.getId());
-        
+
         assertThat(result).isNotNull().isEqualTo(doc.getWrappedInstance());
     }
-    
+
     @Test
     void findById_invalidId() {
         assertThat(store.findById("invalid-id")).isNull();
@@ -180,6 +180,17 @@ public class CosmosContractDefinitionStoreIntegrationTest {
         assertThat(allItems).hasSize(3);
         var allDefs = allItems.stream().map(this::convert);
         assertThat(allDefs).containsExactlyInAnyOrder(def1, def2, def3);
+    }
+
+    @Test
+    void save_delete_find_shouldNotExist() {
+        var def1 = generateDefinition();
+        store.save(def1);
+        assertThat(store.findAll()).containsOnly(def1);
+
+        store.deleteById(def1.getId());
+
+        assertThat(store.findAll()).doesNotContain(def1);
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

When deleting a `ContractDefintion` from a `CosmosContractDefinitionStore` it was deleted from Cosmos, but was **not** deleted from the cache.
This PR fixes that.

## Why it does that

ContractDefs were not properly deleted, which caused subsequent queries to return wrong results. The cache must be kept in sync with the actual database.

## Further notes

The current "caching" strategy is just a first version as it 1:1 mirrors the actual database, and a more elaborate strategy with proper eviction rules etc. should be devised. This will hopefully come out of #1173.

## Linked Issue(s)

n/a

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
