### PR TITLE
DM API: Add timestamps in TransferProcess DTO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Make `ContractDefinitionService` get definition by its id (#1325)
 * Update the CodeQL version from v1 to v2
 * Update `slf4j-api` to `2.0.0-alpha7` (#1328)
+* Added timestamps to TransferProcess DTO (#1350)
 
 #### Removed
 

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
@@ -52,6 +52,7 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.command.TransferProcessCommand;
 
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -114,6 +115,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
     private DataAddressResolver addressResolver;
     private PolicyArchive policyArchive;
     private SendRetryManager<TransferProcess> sendRetryManager;
+    protected Clock clock = Clock.systemUTC();
 
     private TransferProcessManagerImpl() {
     }
@@ -190,8 +192,13 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
             return StatusResult.success(processId);
         }
         var id = randomUUID().toString();
-        var process = TransferProcess.Builder.newInstance().id(id).dataRequest(dataRequest).type(type)
-                .traceContext(telemetry.getCurrentTraceContext()).build();
+        var process = TransferProcess.Builder.newInstance()
+                .id(id)
+                .dataRequest(dataRequest)
+                .type(type)
+                .createdTimestamp(clock.millis())
+                .traceContext(telemetry.getCurrentTraceContext())
+                .build();
         if (process.getState() == TransferProcessStates.UNSAVED.code()) {
             process.transitionInitial();
         }

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferProcessDto.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferProcessDto.java
@@ -23,6 +23,8 @@ public class TransferProcessDto {
     private String id;
     private String type;
     private String state;
+    private Long stateTimestamp;
+    private Long createdTimestamp;
     private String errorDetail;
     private DataRequestDto dataRequest;
     private DataAddressInformationDto dataDestination;
@@ -40,6 +42,14 @@ public class TransferProcessDto {
 
     public String getState() {
         return state;
+    }
+
+    public Long getStateTimestamp() {
+        return stateTimestamp;
+    }
+
+    public Long getCreatedTimestamp() {
+        return createdTimestamp;
     }
 
     public String getErrorDetail() {
@@ -79,6 +89,16 @@ public class TransferProcessDto {
 
         public Builder state(String state) {
             transferProcessDto.state = state;
+            return this;
+        }
+
+        public Builder stateTimestamp(Long stateTimestamp) {
+            transferProcessDto.stateTimestamp = stateTimestamp;
+            return this;
+        }
+
+        public Builder createdTimestamp(Long createdTimestamp) {
+            transferProcessDto.createdTimestamp = createdTimestamp;
             return this;
         }
 

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessToTransferProcessDtoTransformer.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessToTransferProcessDtoTransformer.java
@@ -45,6 +45,8 @@ public class TransferProcessToTransferProcessDtoTransformer implements DtoTransf
                 .id(object.getId())
                 .type(object.getType().name())
                 .state(getState(object.getState(), context))
+                .stateTimestamp(object.getStateTimestamp())
+                .createdTimestamp(object.getCreatedTimestamp())
                 .errorDetail(object.getErrorDetail())
                 .dataRequest(context.transform(object.getDataRequest(), DataRequestDto.class))
                 .dataDestination(

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessToTransferProcessDtoTransformerTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessToTransferProcessDtoTransformerTest.java
@@ -73,12 +73,15 @@ class TransferProcessToTransferProcessDtoTransformerTest {
         data.entity = TransferProcess.Builder.newInstance()
                 .id(data.id)
                 .type(data.type)
+                .stateTimestamp(data.stateTimestamp)
                 .dataRequest(data.dataRequest);
         data.dto
                 .dataDestination(
                         DataAddressInformationDto.Builder.newInstance()
                                 .properties(Map.of("type", data.dataDestinationType))
                                 .build())
+                .stateTimestamp(data.stateTimestamp)
+                .createdTimestamp(0L)
                 .errorDetail(null);
 
         assertThatEntityTransformsToDto();

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessTransformerTestData.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessTransformerTestData.java
@@ -39,6 +39,8 @@ public class TransferProcessTransformerTestData {
     String id = faker.lorem().word();
     TransferProcess.Type type = faker.options().option(TransferProcess.Type.class);
     TransferProcessStates state = faker.options().option(TransferProcessStates.class);
+    long stateTimestamp = faker.random().nextLong();
+    long createdTimestamp = faker.random().nextLong();
     String errorDetail = faker.lorem().word();
 
     Map<String, String> dataDestinationProperties = Map.of(faker.lorem().word(), faker.lorem().word());
@@ -53,6 +55,8 @@ public class TransferProcessTransformerTestData {
             .id(id)
             .type(type)
             .state(state.code())
+            .stateTimestamp(stateTimestamp)
+            .createdTimestamp(createdTimestamp)
             .errorDetail(errorDetail)
             .dataRequest(dataRequest);
 
@@ -60,6 +64,8 @@ public class TransferProcessTransformerTestData {
             .id(id)
             .type(type.name())
             .state(state.name())
+            .stateTimestamp(stateTimestamp)
+            .createdTimestamp(createdTimestamp)
             .errorDetail(errorDetail)
             .dataRequest(dataRequestDto)
             .dataDestination(

--- a/extensions/sql/transfer-process-store-sql/docs/schema.sql
+++ b/extensions/sql/transfer-process-store-sql/docs/schema.sql
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS edc_transfer_process
     state                    INTEGER           NOT NULL,
     state_count              INTEGER DEFAULT 0 NOT NULL,
     state_time_stamp         BIGINT,
+    created_time_stamp       BIGINT,
     trace_context            VARCHAR,
     error_detail             VARCHAR,
     resource_manifest        VARCHAR,

--- a/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/PostgresStatements.java
+++ b/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/PostgresStatements.java
@@ -44,8 +44,9 @@ public class PostgresStatements implements TransferProcessStoreStatements {
 
     @Override
     public String getInsertStatement() {
-        return format("INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
+        return format("INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
                 getTableName(), getIdColumn(), getStateColumn(), getStateCountColumn(), getStateTimestampColumn(),
+                getCreatedTimestampColumn(),
                 getTraceContextColumn(), getErrorDetailColumn(), getResourceManifestColumn(),
                 getProvisionedResourcesetColumn(), getContentDataAddressColumn(), getTypeColumn());
     }

--- a/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStore.java
+++ b/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStore.java
@@ -217,6 +217,7 @@ public class SqlTransferProcessStore implements TransferProcessStore {
                         process.getState(),
                         process.getStateCount(),
                         process.getStateTimestamp(),
+                        process.getCreatedTimestamp(),
                         toJson(process.getTraceContext()),
                         process.getErrorDetail(),
                         toJson(process.getResourceManifest()),
@@ -250,6 +251,7 @@ public class SqlTransferProcessStore implements TransferProcessStore {
         return TransferProcess.Builder.newInstance()
                 .id(resultSet.getString(statements.getIdColumn()))
                 .type(TransferProcess.Type.valueOf(resultSet.getString(statements.getTypeColumn())))
+                .createdTimestamp(resultSet.getLong(statements.getCreatedTimestampColumn()))
                 .state(resultSet.getInt(statements.getStateColumn()))
                 .stateTimestamp(resultSet.getLong(statements.getStateTimestampColumn()))
                 .stateCount(resultSet.getInt(statements.getStateCountColumn()))

--- a/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/TransferProcessStoreStatements.java
+++ b/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/TransferProcessStoreStatements.java
@@ -74,6 +74,10 @@ public interface TransferProcessStoreStatements extends LeaseStatements {
         return "type";
     }
 
+    default String getCreatedTimestampColumn() {
+        return "created_time_stamp";
+    }
+
     default String getContentDataAddressColumn() {
         return "content_data_address";
     }

--- a/extensions/sql/transfer-process-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/TestFunctions.java
+++ b/extensions/sql/transfer-process-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/TestFunctions.java
@@ -59,6 +59,7 @@ class TestFunctions {
         return TransferProcess.Builder.newInstance()
                 .id(processId)
                 .state(state.code())
+                .createdTimestamp(12314)
                 .type(TransferProcess.Type.CONSUMER)
                 .dataRequest(createDataRequest())
                 .contentDataAddress(DataAddress.Builder.newInstance().type("any").build())

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -217,6 +217,102 @@ paths:
           description: default response
           content:
             application/json: {}
+  /contractnegotiations/{id}/cancel:
+    post:
+      tags:
+      - Contract Negotiation
+      operationId: cancelNegotiation
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /contractnegotiations/{id}/decline:
+    post:
+      tags:
+      - Contract Negotiation
+      operationId: declineNegotiation
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /contractnegotiations/{id}/agreement:
+    get:
+      tags:
+      - Contract Negotiation
+      operationId: getAgreementForNegotiation
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContractAgreementDto'
+  /contractnegotiations/{id}:
+    get:
+      tags:
+      - Contract Negotiation
+      operationId: getNegotiation
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContractNegotiationDto'
+  /contractnegotiations/{id}/state:
+    get:
+      tags:
+      - Contract Negotiation
+      operationId: getNegotiationState
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NegotiationState'
   /contractnegotiations:
     get:
       tags:
@@ -288,51 +384,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NegotiationId'
-  /contractnegotiations/{id}:
-    get:
-      tags:
-      - Contract Negotiation
-      operationId: getNegotiation
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ContractNegotiationDto'
-  /contractnegotiations/{id}/agreement:
-    get:
-      tags:
-      - Contract Negotiation
-      operationId: getAgreementForNegotiation
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ContractAgreementDto'
-  /contractnegotiations/{id}/cancel:
+  /transferprocess/{id}/cancel:
     post:
       tags:
-      - Contract Negotiation
-      operationId: cancelNegotiation
+      - Transfer Process
+      operationId: cancelTransferProcess
       parameters:
       - name: id
         in: path
@@ -346,11 +402,11 @@ paths:
           description: default response
           content:
             application/json: {}
-  /contractnegotiations/{id}/decline:
+  /transferprocess/{id}/deprovision:
     post:
       tags:
-      - Contract Negotiation
-      operationId: declineNegotiation
+      - Transfer Process
+      operationId: deprovisionTransferProcess
       parameters:
       - name: id
         in: path
@@ -364,26 +420,6 @@ paths:
           description: default response
           content:
             application/json: {}
-  /contractnegotiations/{id}/state:
-    get:
-      tags:
-      - Contract Negotiation
-      operationId: getNegotiationState
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NegotiationState'
   /transferprocess:
     get:
       tags:
@@ -475,42 +511,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TransferProcessDto'
-  /transferprocess/{id}/cancel:
-    post:
-      tags:
-      - Transfer Process
-      operationId: cancelTransferProcess
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /transferprocess/{id}/deprovision:
-    post:
-      tags:
-      - Transfer Process
-      operationId: deprovisionTransferProcess
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
   /transferprocess/{id}/state:
     get:
       tags:
@@ -637,40 +637,6 @@ paths:
           description: default response
           content:
             application/json: {}
-  /identity-hub/collections:
-    post:
-      tags:
-      - Identity Hub
-      operationId: write
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: string
-  /identity-hub/collections-commit:
-    post:
-      tags:
-      - Identity Hub
-      operationId: writeCommit
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              additionalProperties:
-                type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
   /identity-hub/query-commits:
     post:
       tags:
@@ -705,6 +671,40 @@ paths:
             application/json:
               schema:
                 type: string
+  /identity-hub/collections:
+    post:
+      tags:
+      - Identity Hub
+      operationId: write
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
+  /identity-hub/collections-commit:
+    post:
+      tags:
+      - Identity Hub
+      operationId: writeCommit
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
   /assets:
     get:
       tags:
@@ -952,17 +952,113 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Catalog'
+  /control/catalog:
+    get:
+      operationId: getDescription
+      parameters:
+      - name: provider
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      deprecated: true
+  /control/transfer:
+    post:
+      operationId: addTransfer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      deprecated: true
+  /control/agreement/{id}:
+    get:
+      operationId: getAgreementById
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      deprecated: true
+  /control/negotiation/{id}:
+    get:
+      operationId: getNegotiationById
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      deprecated: true
+  /control/negotiation/{id}/state:
+    get:
+      operationId: getNegotiationStateById
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      deprecated: true
+  /control/negotiation:
+    post:
+      operationId: initiateNegotiation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ContractOfferRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      deprecated: true
 components:
   schemas:
     Action:
       type: object
       properties:
-        constraint:
-          $ref: '#/components/schemas/Constraint'
-        includedIn:
-          type: string
         type:
           type: string
+        includedIn:
+          type: string
+        constraint:
+          $ref: '#/components/schemas/Constraint'
     Asset:
       type: object
       properties:
@@ -992,12 +1088,12 @@ components:
     Catalog:
       type: object
       properties:
+        id:
+          type: string
         contractOffers:
           type: array
           items:
             $ref: '#/components/schemas/ContractOffer'
-        id:
-          type: string
     Constraint:
       required:
       - edctype
@@ -1010,24 +1106,24 @@ components:
     ContractAgreementDto:
       type: object
       properties:
-        assetId:
+        id:
+          type: string
+        providerAgentId:
           type: string
         consumerAgentId:
           type: string
-        contractEndDate:
-          type: integer
-          format: int64
         contractSigningDate:
           type: integer
           format: int64
         contractStartDate:
           type: integer
           format: int64
-        id:
+        contractEndDate:
+          type: integer
+          format: int64
+        assetId:
           type: string
         policyId:
-          type: string
-        providerAgentId:
           type: string
     ContractDefinitionDto:
       required:
@@ -1070,48 +1166,66 @@ components:
     ContractOffer:
       type: object
       properties:
+        id:
+          type: string
+        policy:
+          $ref: '#/components/schemas/Policy'
         asset:
           $ref: '#/components/schemas/Asset'
+        policyId:
+          type: string
         assetId:
           type: string
+        provider:
+          type: string
+          format: uri
         consumer:
           type: string
           format: uri
-        contractEnd:
+        offerStart:
+          type: string
+          format: date-time
+        offerEnd:
           type: string
           format: date-time
         contractStart:
           type: string
           format: date-time
-        id:
-          type: string
-        offerEnd:
+        contractEnd:
           type: string
           format: date-time
-        offerStart:
-          type: string
-          format: date-time
-        policy:
-          $ref: '#/components/schemas/Policy'
-        policyId:
-          type: string
-        provider:
-          type: string
-          format: uri
     ContractOfferDescription:
       required:
       - assetId
       - offerId
       type: object
       properties:
+        offerId:
+          type: string
         assetId:
           type: string
-        offerId:
+        policyId:
           type: string
         policy:
           $ref: '#/components/schemas/Policy'
-        policyId:
+    ContractOfferRequest:
+      type: object
+      properties:
+        type:
           type: string
+          enum:
+          - INITIAL
+          - COUNTER_OFFER
+        protocol:
+          type: string
+        connectorId:
+          type: string
+        connectorAddress:
+          type: string
+        correlationId:
+          type: string
+        contractOffer:
+          $ref: '#/components/schemas/ContractOffer'
     Criterion:
       type: object
       properties:
@@ -1145,62 +1259,91 @@ components:
     DataPlaneInstance:
       type: object
       properties:
-        id:
-          type: string
         lastActive:
           type: integer
           format: int64
-        properties:
-          type: object
-          additionalProperties:
-            type: object
         turnCount:
           type: integer
           format: int32
         url:
           type: string
           format: url
+        properties:
+          type: object
+          additionalProperties:
+            type: object
+        id:
+          type: string
+    DataRequest:
+      type: object
+      properties:
+        id:
+          type: string
+        processId:
+          type: string
+        connectorAddress:
+          type: string
+        protocol:
+          type: string
+        connectorId:
+          type: string
+        assetId:
+          type: string
+        contractId:
+          type: string
+        dataDestination:
+          $ref: '#/components/schemas/DataAddress'
+        managedResources:
+          type: boolean
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+        transferType:
+          $ref: '#/components/schemas/TransferType'
+        destinationType:
+          type: string
     DataRequestDto:
       type: object
       properties:
         assetId:
           type: string
-        connectorId:
-          type: string
         contractId:
+          type: string
+        connectorId:
           type: string
     DeprovisionedResource:
       type: object
       properties:
+        provisionedResourceId:
+          type: string
+        inProcess:
+          type: boolean
         error:
           type: boolean
         errorMessage:
           type: string
-        inProcess:
-          type: boolean
-        provisionedResourceId:
-          type: string
     Duty:
       type: object
       properties:
+        uid:
+          type: string
+        target:
+          type: string
         action:
           $ref: '#/components/schemas/Action'
         assignee:
           type: string
         assigner:
           type: string
-        consequence:
-          $ref: '#/components/schemas/Duty'
         constraints:
           type: array
           items:
             $ref: '#/components/schemas/Constraint'
         parentPermission:
           $ref: '#/components/schemas/Permission'
-        target:
-          type: string
-        uid:
-          type: string
+        consequence:
+          $ref: '#/components/schemas/Duty'
     FederatedCatalogCacheQuery:
       type: object
       properties:
@@ -1223,12 +1366,12 @@ components:
       properties:
         connectorAddress:
           type: string
+        protocol:
+          type: string
         connectorId:
           type: string
         offer:
           $ref: '#/components/schemas/ContractOfferDescription'
-        protocol:
-          type: string
     NegotiationState:
       type: object
       properties:
@@ -1237,6 +1380,10 @@ components:
     Permission:
       type: object
       properties:
+        uid:
+          type: string
+        target:
+          type: string
         action:
           $ref: '#/components/schemas/Action'
         assignee:
@@ -1251,33 +1398,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Duty'
-        target:
-          type: string
-        uid:
-          type: string
     Policy:
       type: object
       properties:
-        '@type':
+        uid:
           type: string
-          enum:
-          - SET
-          - OFFER
-          - CONTRACT
-        assignee:
-          type: string
-        assigner:
-          type: string
-        extensibleProperties:
-          type: object
-          additionalProperties:
-            type: object
-        inheritsFrom:
-          type: string
-        obligations:
-          type: array
-          items:
-            $ref: '#/components/schemas/Duty'
         permissions:
           type: array
           items:
@@ -1286,13 +1411,35 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Prohibition'
+        obligations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Duty'
+        extensibleProperties:
+          type: object
+          additionalProperties:
+            type: object
+        inheritsFrom:
+          type: string
+        assigner:
+          type: string
+        assignee:
+          type: string
         target:
           type: string
-        uid:
+        '@type':
           type: string
+          enum:
+          - SET
+          - OFFER
+          - CONTRACT
     Prohibition:
       type: object
       properties:
+        uid:
+          type: string
+        target:
+          type: string
         action:
           $ref: '#/components/schemas/Action'
         assignee:
@@ -1303,10 +1450,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Constraint'
-        target:
-          type: string
-        uid:
-          type: string
     ProvisionerWebhookRequest:
       required:
       - assetId
@@ -1315,24 +1458,24 @@ components:
       - resourceName
       type: object
       properties:
-        apiToken:
+        resourceDefinitionId:
           type: string
         assetId:
           type: string
-        contentDataAddress:
-          $ref: '#/components/schemas/DataAddress'
-        hasToken:
-          type: boolean
-        resourceDefinitionId:
-          type: string
         resourceName:
           type: string
+        contentDataAddress:
+          $ref: '#/components/schemas/DataAddress'
+        apiToken:
+          type: string
+        hasToken:
+          type: boolean
     SelectionRequest:
       type: object
       properties:
-        destination:
-          $ref: '#/components/schemas/DataAddress'
         source:
+          $ref: '#/components/schemas/DataAddress'
+        destination:
           $ref: '#/components/schemas/DataAddress'
         strategy:
           type: string
@@ -1344,18 +1487,24 @@ components:
     TransferProcessDto:
       type: object
       properties:
-        dataDestination:
-          $ref: '#/components/schemas/DataAddressInformationDto'
-        dataRequest:
-          $ref: '#/components/schemas/DataRequestDto'
-        errorDetail:
-          type: string
         id:
-          type: string
-        state:
           type: string
         type:
           type: string
+        state:
+          type: string
+        stateTimestamp:
+          type: integer
+          format: int64
+        createdTimestamp:
+          type: integer
+          format: int64
+        errorDetail:
+          type: string
+        dataRequest:
+          $ref: '#/components/schemas/DataRequestDto'
+        dataDestination:
+          $ref: '#/components/schemas/DataAddressInformationDto'
     TransferRequestDto:
       required:
       - assetId
@@ -1368,28 +1517,28 @@ components:
       - transferType
       type: object
       properties:
-        assetId:
-          type: string
         connectorAddress:
           type: string
-        connectorId:
+        id:
           type: string
         contractId:
           type: string
         dataDestination:
           $ref: '#/components/schemas/DataAddress'
-        id:
-          type: string
         managedResources:
           type: boolean
         properties:
           type: object
           additionalProperties:
             type: string
-        protocol:
-          type: string
         transferType:
           $ref: '#/components/schemas/TransferType'
+        protocol:
+          type: string
+        connectorId:
+          type: string
+        assetId:
+          type: string
     TransferState:
       type: object
       properties:

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -217,102 +217,6 @@ paths:
           description: default response
           content:
             application/json: {}
-  /contractnegotiations/{id}/cancel:
-    post:
-      tags:
-      - Contract Negotiation
-      operationId: cancelNegotiation
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /contractnegotiations/{id}/decline:
-    post:
-      tags:
-      - Contract Negotiation
-      operationId: declineNegotiation
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /contractnegotiations/{id}/agreement:
-    get:
-      tags:
-      - Contract Negotiation
-      operationId: getAgreementForNegotiation
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ContractAgreementDto'
-  /contractnegotiations/{id}:
-    get:
-      tags:
-      - Contract Negotiation
-      operationId: getNegotiation
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ContractNegotiationDto'
-  /contractnegotiations/{id}/state:
-    get:
-      tags:
-      - Contract Negotiation
-      operationId: getNegotiationState
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NegotiationState'
   /contractnegotiations:
     get:
       tags:
@@ -384,11 +288,51 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NegotiationId'
-  /transferprocess/{id}/cancel:
+  /contractnegotiations/{id}:
+    get:
+      tags:
+      - Contract Negotiation
+      operationId: getNegotiation
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContractNegotiationDto'
+  /contractnegotiations/{id}/agreement:
+    get:
+      tags:
+      - Contract Negotiation
+      operationId: getAgreementForNegotiation
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContractAgreementDto'
+  /contractnegotiations/{id}/cancel:
     post:
       tags:
-      - Transfer Process
-      operationId: cancelTransferProcess
+      - Contract Negotiation
+      operationId: cancelNegotiation
       parameters:
       - name: id
         in: path
@@ -402,11 +346,11 @@ paths:
           description: default response
           content:
             application/json: {}
-  /transferprocess/{id}/deprovision:
+  /contractnegotiations/{id}/decline:
     post:
       tags:
-      - Transfer Process
-      operationId: deprovisionTransferProcess
+      - Contract Negotiation
+      operationId: declineNegotiation
       parameters:
       - name: id
         in: path
@@ -420,6 +364,26 @@ paths:
           description: default response
           content:
             application/json: {}
+  /contractnegotiations/{id}/state:
+    get:
+      tags:
+      - Contract Negotiation
+      operationId: getNegotiationState
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NegotiationState'
   /transferprocess:
     get:
       tags:
@@ -511,6 +475,42 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TransferProcessDto'
+  /transferprocess/{id}/cancel:
+    post:
+      tags:
+      - Transfer Process
+      operationId: cancelTransferProcess
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /transferprocess/{id}/deprovision:
+    post:
+      tags:
+      - Transfer Process
+      operationId: deprovisionTransferProcess
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
   /transferprocess/{id}/state:
     get:
       tags:
@@ -637,40 +637,6 @@ paths:
           description: default response
           content:
             application/json: {}
-  /identity-hub/query-commits:
-    post:
-      tags:
-      - Identity Hub
-      operationId: queryCommits
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: string
-  /identity-hub/query-objects:
-    post:
-      tags:
-      - Identity Hub
-      operationId: queryObjects
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: string
   /identity-hub/collections:
     post:
       tags:
@@ -705,6 +671,40 @@ paths:
           description: default response
           content:
             application/json: {}
+  /identity-hub/query-commits:
+    post:
+      tags:
+      - Identity Hub
+      operationId: queryCommits
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
+  /identity-hub/query-objects:
+    post:
+      tags:
+      - Identity Hub
+      operationId: queryObjects
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
   /assets:
     get:
       tags:
@@ -952,113 +952,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Catalog'
-  /control/catalog:
-    get:
-      operationId: getDescription
-      parameters:
-      - name: provider
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-      deprecated: true
-  /control/transfer:
-    post:
-      operationId: addTransfer
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DataRequest'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-      deprecated: true
-  /control/agreement/{id}:
-    get:
-      operationId: getAgreementById
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-      deprecated: true
-  /control/negotiation/{id}:
-    get:
-      operationId: getNegotiationById
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-      deprecated: true
-  /control/negotiation/{id}/state:
-    get:
-      operationId: getNegotiationStateById
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-      deprecated: true
-  /control/negotiation:
-    post:
-      operationId: initiateNegotiation
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ContractOfferRequest'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-      deprecated: true
 components:
   schemas:
     Action:
       type: object
       properties:
-        type:
-          type: string
-        includedIn:
-          type: string
         constraint:
           $ref: '#/components/schemas/Constraint'
+        includedIn:
+          type: string
+        type:
+          type: string
     Asset:
       type: object
       properties:
@@ -1088,12 +992,12 @@ components:
     Catalog:
       type: object
       properties:
-        id:
-          type: string
         contractOffers:
           type: array
           items:
             $ref: '#/components/schemas/ContractOffer'
+        id:
+          type: string
     Constraint:
       required:
       - edctype
@@ -1106,24 +1010,24 @@ components:
     ContractAgreementDto:
       type: object
       properties:
-        id:
-          type: string
-        providerAgentId:
+        assetId:
           type: string
         consumerAgentId:
           type: string
+        contractEndDate:
+          type: integer
+          format: int64
         contractSigningDate:
           type: integer
           format: int64
         contractStartDate:
           type: integer
           format: int64
-        contractEndDate:
-          type: integer
-          format: int64
-        assetId:
+        id:
           type: string
         policyId:
+          type: string
+        providerAgentId:
           type: string
     ContractDefinitionDto:
       required:
@@ -1166,66 +1070,48 @@ components:
     ContractOffer:
       type: object
       properties:
-        id:
-          type: string
-        policy:
-          $ref: '#/components/schemas/Policy'
         asset:
           $ref: '#/components/schemas/Asset'
-        policyId:
-          type: string
         assetId:
           type: string
-        provider:
-          type: string
-          format: uri
         consumer:
           type: string
           format: uri
-        offerStart:
-          type: string
-          format: date-time
-        offerEnd:
+        contractEnd:
           type: string
           format: date-time
         contractStart:
           type: string
           format: date-time
-        contractEnd:
+        id:
+          type: string
+        offerEnd:
           type: string
           format: date-time
+        offerStart:
+          type: string
+          format: date-time
+        policy:
+          $ref: '#/components/schemas/Policy'
+        policyId:
+          type: string
+        provider:
+          type: string
+          format: uri
     ContractOfferDescription:
       required:
       - assetId
       - offerId
       type: object
       properties:
-        offerId:
-          type: string
         assetId:
           type: string
-        policyId:
+        offerId:
           type: string
         policy:
           $ref: '#/components/schemas/Policy'
-    ContractOfferRequest:
-      type: object
-      properties:
-        type:
+        policyId:
           type: string
-          enum:
-          - INITIAL
-          - COUNTER_OFFER
-        protocol:
-          type: string
-        connectorId:
-          type: string
-        connectorAddress:
-          type: string
-        correlationId:
-          type: string
-        contractOffer:
-          $ref: '#/components/schemas/ContractOffer'
     Criterion:
       type: object
       properties:
@@ -1259,91 +1145,62 @@ components:
     DataPlaneInstance:
       type: object
       properties:
+        id:
+          type: string
         lastActive:
           type: integer
           format: int64
+        properties:
+          type: object
+          additionalProperties:
+            type: object
         turnCount:
           type: integer
           format: int32
         url:
           type: string
           format: url
-        properties:
-          type: object
-          additionalProperties:
-            type: object
-        id:
-          type: string
-    DataRequest:
-      type: object
-      properties:
-        id:
-          type: string
-        processId:
-          type: string
-        connectorAddress:
-          type: string
-        protocol:
-          type: string
-        connectorId:
-          type: string
-        assetId:
-          type: string
-        contractId:
-          type: string
-        dataDestination:
-          $ref: '#/components/schemas/DataAddress'
-        managedResources:
-          type: boolean
-        properties:
-          type: object
-          additionalProperties:
-            type: string
-        transferType:
-          $ref: '#/components/schemas/TransferType'
-        destinationType:
-          type: string
     DataRequestDto:
       type: object
       properties:
         assetId:
           type: string
-        contractId:
-          type: string
         connectorId:
+          type: string
+        contractId:
           type: string
     DeprovisionedResource:
       type: object
       properties:
-        provisionedResourceId:
-          type: string
-        inProcess:
-          type: boolean
         error:
           type: boolean
         errorMessage:
           type: string
+        inProcess:
+          type: boolean
+        provisionedResourceId:
+          type: string
     Duty:
       type: object
       properties:
-        uid:
-          type: string
-        target:
-          type: string
         action:
           $ref: '#/components/schemas/Action'
         assignee:
           type: string
         assigner:
           type: string
+        consequence:
+          $ref: '#/components/schemas/Duty'
         constraints:
           type: array
           items:
             $ref: '#/components/schemas/Constraint'
         parentPermission:
           $ref: '#/components/schemas/Permission'
-        consequence:
-          $ref: '#/components/schemas/Duty'
+        target:
+          type: string
+        uid:
+          type: string
     FederatedCatalogCacheQuery:
       type: object
       properties:
@@ -1366,12 +1223,12 @@ components:
       properties:
         connectorAddress:
           type: string
-        protocol:
-          type: string
         connectorId:
           type: string
         offer:
           $ref: '#/components/schemas/ContractOfferDescription'
+        protocol:
+          type: string
     NegotiationState:
       type: object
       properties:
@@ -1380,10 +1237,6 @@ components:
     Permission:
       type: object
       properties:
-        uid:
-          type: string
-        target:
-          type: string
         action:
           $ref: '#/components/schemas/Action'
         assignee:
@@ -1398,11 +1251,33 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Duty'
+        target:
+          type: string
+        uid:
+          type: string
     Policy:
       type: object
       properties:
-        uid:
+        '@type':
           type: string
+          enum:
+          - SET
+          - OFFER
+          - CONTRACT
+        assignee:
+          type: string
+        assigner:
+          type: string
+        extensibleProperties:
+          type: object
+          additionalProperties:
+            type: object
+        inheritsFrom:
+          type: string
+        obligations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Duty'
         permissions:
           type: array
           items:
@@ -1411,35 +1286,13 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Prohibition'
-        obligations:
-          type: array
-          items:
-            $ref: '#/components/schemas/Duty'
-        extensibleProperties:
-          type: object
-          additionalProperties:
-            type: object
-        inheritsFrom:
-          type: string
-        assigner:
-          type: string
-        assignee:
-          type: string
         target:
           type: string
-        '@type':
+        uid:
           type: string
-          enum:
-          - SET
-          - OFFER
-          - CONTRACT
     Prohibition:
       type: object
       properties:
-        uid:
-          type: string
-        target:
-          type: string
         action:
           $ref: '#/components/schemas/Action'
         assignee:
@@ -1450,6 +1303,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Constraint'
+        target:
+          type: string
+        uid:
+          type: string
     ProvisionerWebhookRequest:
       required:
       - assetId
@@ -1458,24 +1315,24 @@ components:
       - resourceName
       type: object
       properties:
-        resourceDefinitionId:
+        apiToken:
           type: string
         assetId:
           type: string
-        resourceName:
-          type: string
         contentDataAddress:
           $ref: '#/components/schemas/DataAddress'
-        apiToken:
-          type: string
         hasToken:
           type: boolean
+        resourceDefinitionId:
+          type: string
+        resourceName:
+          type: string
     SelectionRequest:
       type: object
       properties:
-        source:
-          $ref: '#/components/schemas/DataAddress'
         destination:
+          $ref: '#/components/schemas/DataAddress'
+        source:
           $ref: '#/components/schemas/DataAddress'
         strategy:
           type: string
@@ -1487,24 +1344,24 @@ components:
     TransferProcessDto:
       type: object
       properties:
-        id:
+        createdTimestamp:
+          type: integer
+          format: int64
+        dataDestination:
+          $ref: '#/components/schemas/DataAddressInformationDto'
+        dataRequest:
+          $ref: '#/components/schemas/DataRequestDto'
+        errorDetail:
           type: string
-        type:
+        id:
           type: string
         state:
           type: string
         stateTimestamp:
           type: integer
           format: int64
-        createdTimestamp:
-          type: integer
-          format: int64
-        errorDetail:
+        type:
           type: string
-        dataRequest:
-          $ref: '#/components/schemas/DataRequestDto'
-        dataDestination:
-          $ref: '#/components/schemas/DataAddressInformationDto'
     TransferRequestDto:
       required:
       - assetId
@@ -1517,28 +1374,28 @@ components:
       - transferType
       type: object
       properties:
+        assetId:
+          type: string
         connectorAddress:
           type: string
-        id:
+        connectorId:
           type: string
         contractId:
           type: string
         dataDestination:
           $ref: '#/components/schemas/DataAddress'
+        id:
+          type: string
         managedResources:
           type: boolean
         properties:
           type: object
           additionalProperties:
             type: string
-        transferType:
-          $ref: '#/components/schemas/TransferType'
         protocol:
           type: string
-        connectorId:
-          type: string
-        assetId:
-          type: string
+        transferType:
+          $ref: '#/components/schemas/TransferType'
     TransferState:
       type: object
       properties:

--- a/resources/openapi/yaml/selector-api.yaml
+++ b/resources/openapi/yaml/selector-api.yaml
@@ -2,19 +2,21 @@ openapi: 3.0.1
 paths:
   /instances:
     get:
+      tags:
+      - Dataplane Selector
       operationId: getAll
       responses:
         default:
+          description: default response
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/DataPlaneInstance'
-          description: default response
+    post:
       tags:
       - Dataplane Selector
-    post:
       operationId: addEntry
       requestBody:
         content:
@@ -23,13 +25,13 @@ paths:
               $ref: '#/components/schemas/DataPlaneInstance'
       responses:
         default:
+          description: default response
           content:
             application/json: {}
-          description: default response
-      tags:
-      - Dataplane Selector
   /instances/select:
     post:
+      tags:
+      - Dataplane Selector
       operationId: find
       requestBody:
         content:
@@ -38,15 +40,31 @@ paths:
               $ref: '#/components/schemas/SelectionRequest'
       responses:
         default:
+          description: default response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DataPlaneInstance'
-          description: default response
-      tags:
-      - Dataplane Selector
 components:
   schemas:
+    DataPlaneInstance:
+      type: object
+      properties:
+        lastActive:
+          type: integer
+          format: int64
+        turnCount:
+          type: integer
+          format: int32
+        url:
+          type: string
+          format: url
+        properties:
+          type: object
+          additionalProperties:
+            type: object
+        id:
+          type: string
     DataAddress:
       type: object
       properties:
@@ -54,30 +72,12 @@ components:
           type: object
           additionalProperties:
             type: string
-    DataPlaneInstance:
-      type: object
-      properties:
-        id:
-          type: string
-        lastActive:
-          type: integer
-          format: int64
-        properties:
-          type: object
-          additionalProperties:
-            type: object
-        turnCount:
-          type: integer
-          format: int32
-        url:
-          type: string
-          format: url
     SelectionRequest:
       type: object
       properties:
-        destination:
-          $ref: '#/components/schemas/DataAddress'
         source:
+          $ref: '#/components/schemas/DataAddress'
+        destination:
           $ref: '#/components/schemas/DataAddress'
         strategy:
           type: string

--- a/resources/openapi/yaml/selector-api.yaml
+++ b/resources/openapi/yaml/selector-api.yaml
@@ -2,21 +2,19 @@ openapi: 3.0.1
 paths:
   /instances:
     get:
-      tags:
-      - Dataplane Selector
       operationId: getAll
       responses:
         default:
-          description: default response
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/DataPlaneInstance'
-    post:
+          description: default response
       tags:
       - Dataplane Selector
+    post:
       operationId: addEntry
       requestBody:
         content:
@@ -25,13 +23,13 @@ paths:
               $ref: '#/components/schemas/DataPlaneInstance'
       responses:
         default:
-          description: default response
           content:
             application/json: {}
-  /instances/select:
-    post:
+          description: default response
       tags:
       - Dataplane Selector
+  /instances/select:
+    post:
       operationId: find
       requestBody:
         content:
@@ -40,31 +38,15 @@ paths:
               $ref: '#/components/schemas/SelectionRequest'
       responses:
         default:
-          description: default response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DataPlaneInstance'
+          description: default response
+      tags:
+      - Dataplane Selector
 components:
   schemas:
-    DataPlaneInstance:
-      type: object
-      properties:
-        lastActive:
-          type: integer
-          format: int64
-        turnCount:
-          type: integer
-          format: int32
-        url:
-          type: string
-          format: url
-        properties:
-          type: object
-          additionalProperties:
-            type: object
-        id:
-          type: string
     DataAddress:
       type: object
       properties:
@@ -72,12 +54,30 @@ components:
           type: object
           additionalProperties:
             type: string
+    DataPlaneInstance:
+      type: object
+      properties:
+        id:
+          type: string
+        lastActive:
+          type: integer
+          format: int64
+        properties:
+          type: object
+          additionalProperties:
+            type: object
+        turnCount:
+          type: integer
+          format: int32
+        url:
+          type: string
+          format: url
     SelectionRequest:
       type: object
       properties:
-        source:
-          $ref: '#/components/schemas/DataAddress'
         destination:
+          $ref: '#/components/schemas/DataAddress'
+        source:
           $ref: '#/components/schemas/DataAddress'
         strategy:
           type: string

--- a/resources/openapi/yaml/transferprocess.yaml
+++ b/resources/openapi/yaml/transferprocess.yaml
@@ -1,46 +1,80 @@
 openapi: 3.0.1
 paths:
-  /transferprocess:
-    get:
-      operationId: getAllTransferProcesses
+  /transferprocess/{id}/cancel:
+    post:
+      tags:
+      - Transfer Process
+      operationId: cancelTransferProcess
       parameters:
-      - in: query
-        name: offset
-        schema:
-          type: integer
-          format: int32
-      - in: query
-        name: limit
-        schema:
-          type: integer
-          format: int32
-      - in: query
-        name: filter
+      - name: id
+        in: path
+        required: true
         schema:
           type: string
-      - in: query
-        name: sort
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /transferprocess/{id}/deprovision:
+    post:
+      tags:
+      - Transfer Process
+      operationId: deprovisionTransferProcess
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /transferprocess:
+    get:
+      tags:
+      - Transfer Process
+      operationId: getAllTransferProcesses
+      parameters:
+      - name: offset
+        in: query
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        schema:
+          type: string
+      - name: sort
+        in: query
         schema:
           type: string
           enum:
           - ASC
           - DESC
-      - in: query
-        name: sortField
+      - name: sortField
+        in: query
         schema:
           type: string
       responses:
         default:
+          description: default response
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/TransferProcessDto'
-          description: default response
+    post:
       tags:
       - Transfer Process
-    post:
       operationId: initiateTransfer
       requestBody:
         content:
@@ -49,90 +83,49 @@ paths:
               $ref: '#/components/schemas/TransferRequestDto'
       responses:
         default:
+          description: default response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TransferId'
-          description: default response
-      tags:
-      - Transfer Process
   /transferprocess/{id}:
     get:
+      tags:
+      - Transfer Process
       operationId: getTransferProcess
       parameters:
-      - in: path
-        name: id
+      - name: id
+        in: path
         required: true
         schema:
           type: string
       responses:
         default:
+          description: default response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TransferProcessDto'
-          description: default response
-      tags:
-      - Transfer Process
-  /transferprocess/{id}/cancel:
-    post:
-      operationId: cancelTransferProcess
-      parameters:
-      - in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      responses:
-        default:
-          content:
-            application/json: {}
-          description: default response
-      tags:
-      - Transfer Process
-  /transferprocess/{id}/deprovision:
-    post:
-      operationId: deprovisionTransferProcess
-      parameters:
-      - in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      responses:
-        default:
-          content:
-            application/json: {}
-          description: default response
-      tags:
-      - Transfer Process
   /transferprocess/{id}/state:
     get:
+      tags:
+      - Transfer Process
       operationId: getTransferProcessState
       parameters:
-      - in: path
-        name: id
+      - name: id
+        in: path
         required: true
         schema:
           type: string
       responses:
         default:
+          description: default response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TransferState'
-          description: default response
-      tags:
-      - Transfer Process
 components:
   schemas:
-    DataAddress:
-      type: object
-      properties:
-        properties:
-          type: object
-          additionalProperties:
-            type: string
     DataAddressInformationDto:
       type: object
       properties:
@@ -145,55 +138,49 @@ components:
       properties:
         assetId:
           type: string
+        contractId:
+          type: string
         connectorId:
           type: string
-        contractId:
+    TransferProcessDto:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        state:
+          type: string
+        stateTimestamp:
+          type: integer
+          format: int64
+        createdTimestamp:
+          type: integer
+          format: int64
+        errorDetail:
+          type: string
+        dataRequest:
+          $ref: '#/components/schemas/DataRequestDto'
+        dataDestination:
+          $ref: '#/components/schemas/DataAddressInformationDto'
+    TransferState:
+      type: object
+      properties:
+        state:
           type: string
     TransferId:
       type: object
       properties:
         id:
           type: string
-    TransferProcessDto:
+    DataAddress:
       type: object
       properties:
-        dataDestination:
-          $ref: '#/components/schemas/DataAddressInformationDto'
-        dataRequest:
-          $ref: '#/components/schemas/DataRequestDto'
-        errorDetail:
-          type: string
-        id:
-          type: string
-        state:
-          type: string
-        type:
-          type: string
-    TransferRequestDto:
-      type: object
-      properties:
-        assetId:
-          type: string
-        connectorAddress:
-          type: string
-        connectorId:
-          type: string
-        contractId:
-          type: string
-        dataDestination:
-          $ref: '#/components/schemas/DataAddress'
-        id:
-          type: string
-        managedResources:
-          type: boolean
         properties:
           type: object
           additionalProperties:
             type: string
-        protocol:
-          type: string
-        transferType:
-          $ref: '#/components/schemas/TransferType'
+    TransferRequestDto:
       required:
       - assetId
       - connectorAddress
@@ -203,10 +190,29 @@ components:
       - id
       - protocol
       - transferType
-    TransferState:
       type: object
       properties:
-        state:
+        connectorAddress:
+          type: string
+        id:
+          type: string
+        contractId:
+          type: string
+        dataDestination:
+          $ref: '#/components/schemas/DataAddress'
+        managedResources:
+          type: boolean
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+        transferType:
+          $ref: '#/components/schemas/TransferType'
+        protocol:
+          type: string
+        connectorId:
+          type: string
+        assetId:
           type: string
     TransferType:
       type: object

--- a/resources/openapi/yaml/transferprocess.yaml
+++ b/resources/openapi/yaml/transferprocess.yaml
@@ -1,80 +1,46 @@
 openapi: 3.0.1
 paths:
-  /transferprocess/{id}/cancel:
-    post:
-      tags:
-      - Transfer Process
-      operationId: cancelTransferProcess
-      parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /transferprocess/{id}/deprovision:
-    post:
-      tags:
-      - Transfer Process
-      operationId: deprovisionTransferProcess
-      parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
   /transferprocess:
     get:
-      tags:
-      - Transfer Process
       operationId: getAllTransferProcesses
       parameters:
-      - name: offset
-        in: query
+      - in: query
+        name: offset
         schema:
           type: integer
           format: int32
-      - name: limit
-        in: query
+      - in: query
+        name: limit
         schema:
           type: integer
           format: int32
-      - name: filter
-        in: query
+      - in: query
+        name: filter
         schema:
           type: string
-      - name: sort
-        in: query
+      - in: query
+        name: sort
         schema:
           type: string
           enum:
           - ASC
           - DESC
-      - name: sortField
-        in: query
+      - in: query
+        name: sortField
         schema:
           type: string
       responses:
         default:
-          description: default response
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/TransferProcessDto'
-    post:
+          description: default response
       tags:
       - Transfer Process
+    post:
       operationId: initiateTransfer
       requestBody:
         content:
@@ -83,49 +49,90 @@ paths:
               $ref: '#/components/schemas/TransferRequestDto'
       responses:
         default:
-          description: default response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TransferId'
-  /transferprocess/{id}:
-    get:
+          description: default response
       tags:
       - Transfer Process
+  /transferprocess/{id}:
+    get:
       operationId: getTransferProcess
       parameters:
-      - name: id
-        in: path
+      - in: path
+        name: id
         required: true
         schema:
           type: string
       responses:
         default:
-          description: default response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TransferProcessDto'
-  /transferprocess/{id}/state:
-    get:
+          description: default response
       tags:
       - Transfer Process
-      operationId: getTransferProcessState
+  /transferprocess/{id}/cancel:
+    post:
+      operationId: cancelTransferProcess
       parameters:
-      - name: id
-        in: path
+      - in: path
+        name: id
         required: true
         schema:
           type: string
       responses:
         default:
+          content:
+            application/json: {}
           description: default response
+      tags:
+      - Transfer Process
+  /transferprocess/{id}/deprovision:
+    post:
+      operationId: deprovisionTransferProcess
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Transfer Process
+  /transferprocess/{id}/state:
+    get:
+      operationId: getTransferProcessState
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TransferState'
+          description: default response
+      tags:
+      - Transfer Process
 components:
   schemas:
+    DataAddress:
+      type: object
+      properties:
+        properties:
+          type: object
+          additionalProperties:
+            type: string
     DataAddressInformationDto:
       type: object
       properties:
@@ -138,49 +145,61 @@ components:
       properties:
         assetId:
           type: string
-        contractId:
-          type: string
         connectorId:
           type: string
-    TransferProcessDto:
-      type: object
-      properties:
-        id:
-          type: string
-        type:
-          type: string
-        state:
-          type: string
-        stateTimestamp:
-          type: integer
-          format: int64
-        createdTimestamp:
-          type: integer
-          format: int64
-        errorDetail:
-          type: string
-        dataRequest:
-          $ref: '#/components/schemas/DataRequestDto'
-        dataDestination:
-          $ref: '#/components/schemas/DataAddressInformationDto'
-    TransferState:
-      type: object
-      properties:
-        state:
+        contractId:
           type: string
     TransferId:
       type: object
       properties:
         id:
           type: string
-    DataAddress:
+    TransferProcessDto:
       type: object
       properties:
+        createdTimestamp:
+          type: integer
+          format: int64
+        dataDestination:
+          $ref: '#/components/schemas/DataAddressInformationDto'
+        dataRequest:
+          $ref: '#/components/schemas/DataRequestDto'
+        errorDetail:
+          type: string
+        id:
+          type: string
+        state:
+          type: string
+        stateTimestamp:
+          type: integer
+          format: int64
+        type:
+          type: string
+    TransferRequestDto:
+      type: object
+      properties:
+        assetId:
+          type: string
+        connectorAddress:
+          type: string
+        connectorId:
+          type: string
+        contractId:
+          type: string
+        dataDestination:
+          $ref: '#/components/schemas/DataAddress'
+        id:
+          type: string
+        managedResources:
+          type: boolean
         properties:
           type: object
           additionalProperties:
             type: string
-    TransferRequestDto:
+        protocol:
+          type: string
+        transferType:
+          $ref: '#/components/schemas/TransferType'
       required:
       - assetId
       - connectorAddress
@@ -190,29 +209,10 @@ components:
       - id
       - protocol
       - transferType
+    TransferState:
       type: object
       properties:
-        connectorAddress:
-          type: string
-        id:
-          type: string
-        contractId:
-          type: string
-        dataDestination:
-          $ref: '#/components/schemas/DataAddress'
-        managedResources:
-          type: boolean
-        properties:
-          type: object
-          additionalProperties:
-            type: string
-        transferType:
-          $ref: '#/components/schemas/TransferType'
-        protocol:
-          type: string
-        connectorId:
-          type: string
-        assetId:
+        state:
           type: string
     TransferType:
       type: object

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcess.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcess.java
@@ -100,6 +100,7 @@ public class TransferProcess implements TraceCarrier {
 
     private String id;
     private Type type = Type.CONSUMER;
+    private long createdTimestamp;
     private int state;
     private int stateCount = UNSAVED.code();
     private long stateTimestamp;
@@ -116,6 +117,10 @@ public class TransferProcess implements TraceCarrier {
 
     public String getId() {
         return id;
+    }
+
+    public long getCreatedTimestamp() {
+        return createdTimestamp;
     }
 
     public Type getType() {
@@ -340,6 +345,7 @@ public class TransferProcess implements TraceCarrier {
                 .contentDataAddress(contentDataAddress)
                 .traceContext(traceContext)
                 .type(type)
+                .createdTimestamp(createdTimestamp)
                 .errorDetail(errorDetail)
                 .build();
     }
@@ -416,6 +422,11 @@ public class TransferProcess implements TraceCarrier {
 
         public Builder type(Type type) {
             process.type = type;
+            return this;
+        }
+
+        public Builder createdTimestamp(long value) {
+            process.createdTimestamp = value;
             return this;
         }
 

--- a/spi/transfer-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcessTest.java
+++ b/spi/transfer-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcessTest.java
@@ -58,6 +58,7 @@ class TransferProcessTest {
                 .newInstance()
                 .id(UUID.randomUUID().toString())
                 .type(TransferProcess.Type.PROVIDER)
+                .createdTimestamp(3)
                 .state(TransferProcessStates.COMPLETED.code())
                 .contentDataAddress(DataAddress.Builder.newInstance().type("test").build())
                 .stateCount(1)
@@ -68,6 +69,7 @@ class TransferProcessTest {
 
         assertEquals(process.getState(), copy.getState());
         assertEquals(process.getType(), copy.getType());
+        assertEquals(process.getCreatedTimestamp(), copy.getCreatedTimestamp());
         assertEquals(process.getStateCount(), copy.getStateCount());
         assertEquals(process.getStateTimestamp(), copy.getStateTimestamp());
         assertNotNull(process.getContentDataAddress());


### PR DESCRIPTION
## What this PR changes/adds

Add timestamps when querying TransferProcesses in Data management API.

## Why it does that

Useful for web front-ends, to allow to sort transfers by dates.

## Further notes

## Linked Issue(s)

Closes #1297

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
