### PR TITLE
Chore: prepare publishing Maven artifacts to OSSRH and MavenCentral

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
     id("com.rameshkp.openapi-merger-gradle-plugin") version "1.0.4"
     id("org.eclipse.dataspaceconnector.module-names")
     id("com.autonomousapps.dependency-analysis") version "1.1.0" apply (false)
+    id("org.gradle.crypto.checksum") version "1.4.0"
 }
 
 repositories {
@@ -53,6 +54,12 @@ if (project.version == "unspecified") {
     logger.warn("")
 } else {
     edcVersion = project.version as String
+}
+
+var deployUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+
+if (edcVersion.contains("SNAPSHOT")) {
+    deployUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
 }
 
 subprojects {
@@ -139,7 +146,7 @@ allprojects {
                 repositories {
                     maven {
                         name = "OSSRH"
-                        setUrl("https://oss.sonatype.org/service/local/staging/deploy/maven2")
+                        setUrl(deployUrl)
                         credentials {
                             username = System.getenv("OSSRH_USER") ?: return@credentials
                             password = System.getenv("OSSRH_PASSWORD") ?: return@credentials
@@ -156,7 +163,7 @@ allprojects {
                             name.set(project.name)
                             description.set("edc :: ${project.name}")
                             url.set(edcWebsiteUrl)
-                            
+
                             licenses {
                                 license {
                                     name.set("The Apache License, Version 2.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -180,6 +180,7 @@ allprojects {
                 }
 
                 signing {
+                    useGpgCmd()
                     sign(publishing.publications)
                 }
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,10 +56,10 @@ if (project.version == "unspecified") {
     edcVersion = project.version as String
 }
 
-var deployUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+var deployUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
 
 if (edcVersion.contains("SNAPSHOT")) {
-    deployUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+    deployUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -180,7 +180,7 @@ allprojects {
                 }
 
                 signing {
-                    useGpgCmd()
+                    //useGpgCmd()
                     sign(publishing.publications)
                 }
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,6 +73,37 @@ subprojects {
 
     tasks.register<DependencyReportTask>("allDependencies") {}
 
+    afterEvaluate {
+        publishing {
+            publications.forEach { i ->
+                println(i.name)
+                val mp = (i as MavenPublication)
+                mp.pom {
+                    name.set(project.name)
+                    description.set("edc :: ${project.name}")
+                    url.set(edcWebsiteUrl)
+
+                    licenses {
+                        license {
+                            name.set("The Apache License, Version 2.0")
+                            url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                        }
+                        developers {
+                            developer {
+                                id.set(edcDeveloperId)
+                                name.set(edcDeveloperName)
+                                email.set(edcDeveloperEmail)
+                            }
+                        }
+                        scm {
+                            connection.set(edcScmConnection)
+                            url.set(edcScmUrl)
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 buildscript {
@@ -154,40 +185,6 @@ allprojects {
                     }
                 }
 
-                publications {
-                    create<MavenPublication>("mavenJava") {
-                        java {
-                            withJavadocJar()
-                            withSourcesJar()
-                            from(components["java"])
-                        }
-                        pom {
-                            name.set(project.name)
-                            description.set("edc :: ${project.name}")
-                            url.set(edcWebsiteUrl)
-
-                            licenses {
-                                license {
-                                    name.set("The Apache License, Version 2.0")
-                                    url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                                }
-                                developers {
-                                    developer {
-                                        id.set(edcDeveloperId)
-                                        name.set(edcDeveloperName)
-                                        email.set(edcDeveloperEmail)
-                                    }
-                                }
-                                scm {
-                                    connection.set(edcScmConnection)
-                                    url.set(edcScmUrl)
-                                }
-                            }
-                        }
-                    }
-
-                }
-
                 signing {
                     useGpgCmd()
                     sign(publishing.publications)
@@ -196,6 +193,8 @@ allprojects {
         }
 
     }
+
+
 
     pluginManager.withPlugin("io.swagger.core.v3.swagger-gradle-plugin") {
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -153,11 +153,13 @@ allprojects {
                         }
                     }
                 }
+
                 publications {
                     create<MavenPublication>("mavenJava") {
                         java {
                             withJavadocJar()
                             withSourcesJar()
+                            from(components["java"])
                         }
                         pom {
                             name.set(project.name)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -180,7 +180,7 @@ allprojects {
                 }
 
                 signing {
-                    //useGpgCmd()
+                    useGpgCmd()
                     sign(publishing.publications)
                 }
             }


### PR DESCRIPTION
## What this PR changes/adds

- Switches over to using the GPG Agent for artifact signing
- Injects the required POM information into all publications
- configures the OSSRH credentials

## Why it does that

So that we can have lovely maven artifacts.

## Further notes

As soon as this PR is merged we must update the JIPP (Eclipse Jenkins) build config to use `main` instead of this feature branch

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
