### PR TITLE
Feature: add value object for `Policy` for record-keeping

### DIFF
--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/policy/ScopeFilter.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/policy/ScopeFilter.java
@@ -21,6 +21,7 @@ import org.eclipse.dataspaceconnector.policy.model.LiteralExpression;
 import org.eclipse.dataspaceconnector.policy.model.MultiplicityConstraint;
 import org.eclipse.dataspaceconnector.policy.model.Permission;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
 import org.eclipse.dataspaceconnector.policy.model.Prohibition;
 import org.eclipse.dataspaceconnector.policy.model.Rule;
 import org.eclipse.dataspaceconnector.policy.model.XoneConstraint;
@@ -58,8 +59,8 @@ public class ScopeFilter {
         var filteredObligations = policy.getObligations().stream().map(d -> applyScope(d, scope)).filter(Objects::nonNull).collect(toList());
         var filteredPermissions = policy.getPermissions().stream().map(p -> applyScope(p, scope)).filter(Objects::nonNull).collect(toList());
         var filteredProhibitions = policy.getProhibitions().stream().map(p -> applyScope(p, scope)).filter(Objects::nonNull).collect(toList());
-        var policyBuilder = Policy.Builder.newInstance();
-        policyBuilder.id(policy.getUid())
+        var policyBuilder = PolicyDefinition.Builder.newInstance();
+        policyBuilder
                 .type(policy.getType())
                 .assignee(policy.getAssignee())
                 .assigner(policy.getAssigner())

--- a/core/base/src/test/java/org/eclipse/dataspaceconnector/core/base/policy/ScopeFilterTest.java
+++ b/core/base/src/test/java/org/eclipse/dataspaceconnector/core/base/policy/ScopeFilterTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ScopeFilterTest {
+    public static final String BOUND_SCOPE = "scope1";
     private static final Action REPORT_ACTION = Action.Builder.newInstance().type("report").build();
     private static final Action SUB_ACTION = Action.Builder.newInstance().type("subaction").build();
     private static final LiteralExpression BOUND_LITERAL = new LiteralExpression("bound");
@@ -38,8 +39,6 @@ class ScopeFilterTest {
     private static final LiteralExpression EMPTY_LITERAL = new LiteralExpression("");
     public static final AtomicConstraint BOUND_CONSTRAINT = AtomicConstraint.Builder.newInstance().leftExpression(BOUND_LITERAL).rightExpression(EMPTY_LITERAL).build();
     public static final AtomicConstraint UNBOUND_CONSTRAINT = AtomicConstraint.Builder.newInstance().leftExpression(UNBOUND_LITERAL).rightExpression(EMPTY_LITERAL).build();
-    public static final String BOUND_SCOPE = "scope1";
-
     private ScopeFilter scopeFilter;
     private RuleBindingRegistry registry;
 
@@ -59,7 +58,6 @@ class ScopeFilterTest {
         var prohibition = Prohibition.Builder.newInstance().action(REPORT_ACTION).build();
 
         var policy = Policy.Builder.newInstance()
-                .id("id")
                 .assignee("assignee")
                 .assigner("assigner")
                 .target("target")
@@ -74,7 +72,6 @@ class ScopeFilterTest {
         var filteredPolicy = scopeFilter.applyScope(policy, BOUND_SCOPE);
 
         assertThat(filteredPolicy).isNotNull();
-        assertThat(filteredPolicy.getUid()).isNotNull();
         assertThat(filteredPolicy.getAssignee()).isNotNull();
         assertThat(filteredPolicy.getAssigner()).isNotNull();
         assertThat(filteredPolicy.getTarget()).isNotNull();

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
@@ -63,16 +63,13 @@ import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.comm
 public class ContractServiceExtension implements ServiceExtension {
 
     private static final long DEFAULT_ITERATION_WAIT = 5000; // millis
+    @EdcSetting
+    private static final String NEGOTIATION_CONSUMER_STATE_MACHINE_BATCH_SIZE = "edc.negotiation.consumer.state-machine.batch-size";
+    @EdcSetting
+    private static final String NEGOTIATION_PROVIDER_STATE_MACHINE_BATCH_SIZE = "edc.negotiation.provider.state-machine.batch-size";
     private Monitor monitor;
     private ConsumerContractNegotiationManagerImpl consumerNegotiationManager;
     private ProviderContractNegotiationManagerImpl providerNegotiationManager;
-
-    @EdcSetting
-    private static final String NEGOTIATION_CONSUMER_STATE_MACHINE_BATCH_SIZE = "edc.negotiation.consumer.state-machine.batch-size";
-
-    @EdcSetting
-    private static final String NEGOTIATION_PROVIDER_STATE_MACHINE_BATCH_SIZE = "edc.negotiation.provider.state-machine.batch-size";
-
     @Inject
     private AssetIndex assetIndex;
 
@@ -146,7 +143,7 @@ public class ContractServiceExtension implements ServiceExtension {
         var observable = new ContractNegotiationObservableImpl();
         context.registerService(ContractNegotiationObservable.class, observable);
 
-        context.registerService(PolicyArchive.class, new PolicyArchiveImpl(store, policyStore));
+        context.registerService(PolicyArchive.class, new PolicyArchiveImpl(store));
 
         consumerNegotiationManager = ConsumerContractNegotiationManagerImpl.Builder.newInstance()
                 .waitStrategy(waitStrategy)

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -65,7 +65,8 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
 
     private StateMachine stateMachine;
 
-    private ConsumerContractNegotiationManagerImpl() { }
+    private ConsumerContractNegotiationManagerImpl() {
+    }
 
     public void start() {
         stateMachine = StateMachine.Builder.newInstance("consumer-contract-negotiation", monitor, executorInstrumentation, waitStrategy)
@@ -84,11 +85,6 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
         if (stateMachine != null) {
             stateMachine.stop();
         }
-    }
-
-    @Override
-    public void enqueueCommand(ContractNegotiationCommand command) {
-        commandQueue.enqueue(command);
     }
 
     /**
@@ -125,12 +121,12 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
      * ContractNegotiation and transitions the ContractNegotiation to CONSUMER_APPROVING,
      * CONSUMER_OFFERING or DECLINING.
      *
-     * @param token Claim token of the consumer that send the contract request.
+     * @param token         Claim token of the consumer that send the contract request.
      * @param negotiationId Id of the ContractNegotiation.
      * @param contractOffer The contract offer.
-     * @param hash A hash of all previous contract offers.
+     * @param hash          A hash of all previous contract offers.
      * @return a {@link StatusResult}: FATAL_ERROR, if no match found for Id or no last
-     *         offer found for negotiation; OK otherwise
+     * offer found for negotiation; OK otherwise
      */
     @WithSpan
     @Override
@@ -173,12 +169,12 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
      * Validates the contract agreement sent by the provider against the last contract offer and
      * transitions the corresponding {@link ContractNegotiation} to state CONFIRMED or DECLINING.
      *
-     * @param token Claim token of the consumer that send the contract request.
+     * @param token         Claim token of the consumer that send the contract request.
      * @param negotiationId Id of the ContractNegotiation.
-     * @param agreement Agreement sent by provider.
-     * @param policy the policy
+     * @param agreement     Agreement sent by provider.
+     * @param policy        the policy
      * @return a {@link StatusResult}: FATAL_ERROR, if no match found for Id or no last
-     *         offer found for negotiation; OK otherwise
+     * offer found for negotiation; OK otherwise
      */
     @WithSpan
     @Override
@@ -215,7 +211,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
             // TODO: otherwise will fail. But should do it, since it's already confirmed? A duplicated message received shouldn't be an issue
             negotiation.transitionConfirmed();
         }
-        policyStore.save(policy);
+        //        policyStore.save(policy);
         update(negotiation, l -> l.preConfirmed(negotiation));
         monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
@@ -227,10 +223,9 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
      * Tells this manager that a {@link ContractNegotiation} has been declined by the counter-party.
      * Transitions the corresponding ContractNegotiation to state DECLINED.
      *
-     * @param token Claim token of the consumer that sent the rejection.
+     * @param token         Claim token of the consumer that sent the rejection.
      * @param negotiationId Id of the ContractNegotiation.
-     * @return a {@link StatusResult}: OK, if successfully transitioned to declined;
-     *         FATAL_ERROR, if no match found for Id.
+     * @return a {@link StatusResult}: OK, if successfully transitioned to declined; FATAL_ERROR, if no match found for Id.
      */
     @WithSpan
     @Override
@@ -248,6 +243,11 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
         return StatusResult.success(negotiation);
     }
 
+    @Override
+    public void enqueueCommand(ContractNegotiationCommand command) {
+        commandQueue.enqueue(command);
+    }
+
     private ContractNegotiation findContractNegotiationById(String negotiationId) {
         var negotiation = negotiationStore.find(negotiationId);
         if (negotiation == null) {
@@ -261,7 +261,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
      * Builds and sends a {@link ContractOfferRequest} for a given {@link ContractNegotiation} and
      * {@link ContractOffer}.
      *
-     * @param offer The contract offer.
+     * @param offer   The contract offer.
      * @param process The contract negotiation.
      * @return The response to the sent message.
      */
@@ -400,7 +400,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
                 .contractSigningDate(Instant.now().getEpochSecond())
                 .providerAgentId(String.valueOf(lastOffer.getProvider()))
                 .consumerAgentId(String.valueOf(lastOffer.getConsumer()))
-                .policyId(policy.getUid())
+                .policy(policy)
                 .assetId(lastOffer.getAsset().getId())
                 .build();
 

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -84,19 +84,14 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
         }
     }
 
-    @Override
-    public void enqueueCommand(ContractNegotiationCommand command) {
-        commandQueue.enqueue(command);
-    }
-
     /**
      * Tells this manager that a {@link ContractNegotiation} has been declined by the counter-party.
      * Transitions the corresponding ContractNegotiation to state DECLINED.
      *
-     * @param token Claim token of the consumer that sent the rejection.
+     * @param token         Claim token of the consumer that sent the rejection.
      * @param correlationId Id of the ContractNegotiation on consumer side.
      * @return a {@link StatusResult}: OK, if successfully transitioned to declined;
-     *         FATAL_ERROR, if no match found for Id.
+     * FATAL_ERROR, if no match found for Id.
      */
     @WithSpan
     @Override
@@ -120,13 +115,9 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
         return StatusResult.success(negotiation);
     }
 
-    private ContractNegotiation findContractNegotiationById(String negotiationId) {
-        var negotiation = negotiationStore.find(negotiationId);
-        if (negotiation == null) {
-            negotiation = negotiationStore.findForCorrelationId(negotiationId);
-        }
-
-        return negotiation;
+    @Override
+    public void enqueueCommand(ContractNegotiationCommand command) {
+        commandQueue.enqueue(command);
     }
 
     /**
@@ -134,7 +125,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
      * persisted, which moves it to state REQUESTED. It is then validated and transitioned to
      * CONFIRMING, PROVIDER_OFFERING or DECLINING.
      *
-     * @param token Claim token of the consumer that send the contract request.
+     * @param token   Claim token of the consumer that send the contract request.
      * @param request Container object containing all relevant request parameters.
      * @return a {@link StatusResult}: OK
      */
@@ -166,10 +157,10 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
      * {@link ContractNegotiation}. The offer is validated and the ContractNegotiation is
      * transitioned to CONFIRMING, PROVIDER_OFFERING or DECLINING.
      *
-     * @param token Claim token of the consumer that send the contract request.
+     * @param token         Claim token of the consumer that send the contract request.
      * @param correlationId Id of the ContractNegotiation on consumer side.
-     * @param offer The contract offer.
-     * @param hash A hash of all previous contract offers.
+     * @param offer         The contract offer.
+     * @param hash          A hash of all previous contract offers.
      * @return a {@link StatusResult}: FATAL_ERROR, if no match found for Id; OK otherwise
      */
     @WithSpan
@@ -184,13 +175,47 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
     }
 
     /**
+     * Tells this manager that a previously sent contract offer has been approved by the consumer.
+     * Transitions the corresponding {@link ContractNegotiation} to state CONFIRMING.
+     *
+     * @param token         Claim token of the consumer that send the contract request.
+     * @param correlationId Id of the ContractNegotiation on consumer side.
+     * @param agreement     Agreement sent by consumer.
+     * @param hash          A hash of all previous contract offers.
+     * @return a {@link StatusResult}: FATAL_ERROR, if no match found for Id; OK otherwise
+     */
+    @Override
+    public StatusResult<ContractNegotiation> consumerApproved(ClaimToken token, String correlationId, ContractAgreement agreement, String hash) {
+        var negotiation = negotiationStore.findForCorrelationId(correlationId);
+        if (negotiation == null) {
+            return StatusResult.failure(FATAL_ERROR);
+        }
+
+        monitor.debug("[Provider] Contract offer has been approved by consumer.");
+        negotiation.transitionConfirming();
+        update(negotiation, l -> l.preConfirming(negotiation));
+        monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
+                negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
+        return StatusResult.success(negotiation);
+    }
+
+    private ContractNegotiation findContractNegotiationById(String negotiationId) {
+        var negotiation = negotiationStore.find(negotiationId);
+        if (negotiation == null) {
+            negotiation = negotiationStore.findForCorrelationId(negotiationId);
+        }
+
+        return negotiation;
+    }
+
+    /**
      * Processes an incoming offer for a {@link ContractNegotiation}. The offer is validated and
      * the corresponding ContractNegotiation is transitioned to CONFIRMING, PROVIDER_OFFERING or
      * DECLINING.
      *
      * @param negotiation The ContractNegotiation.
-     * @param token Claim token of the consumer that send the contract request.
-     * @param offer The contract offer.
+     * @param token       Claim token of the consumer that send the contract request.
+     * @param offer       The contract offer.
      * @return a {@link StatusResult}: OK
      */
     private StatusResult<ContractNegotiation> processIncomingOffer(ContractNegotiation negotiation, ClaimToken token, ContractOffer offer) {
@@ -222,31 +247,6 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
         monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
 
-        return StatusResult.success(negotiation);
-    }
-
-    /**
-     * Tells this manager that a previously sent contract offer has been approved by the consumer.
-     * Transitions the corresponding {@link ContractNegotiation} to state CONFIRMING.
-     *
-     * @param token Claim token of the consumer that send the contract request.
-     * @param correlationId Id of the ContractNegotiation on consumer side.
-     * @param agreement Agreement sent by consumer.
-     * @param hash A hash of all previous contract offers.
-     * @return a {@link StatusResult}: FATAL_ERROR, if no match found for Id; OK otherwise
-     */
-    @Override
-    public StatusResult<ContractNegotiation> consumerApproved(ClaimToken token, String correlationId, ContractAgreement agreement, String hash) {
-        var negotiation = negotiationStore.findForCorrelationId(correlationId);
-        if (negotiation == null) {
-            return StatusResult.failure(FATAL_ERROR);
-        }
-
-        monitor.debug("[Provider] Contract offer has been approved by consumer.");
-        negotiation.transitionConfirming();
-        update(negotiation, l -> l.preConfirming(negotiation));
-        monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
-                negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
         return StatusResult.success(negotiation);
     }
 
@@ -391,12 +391,12 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                     .contractSigningDate(Instant.now().getEpochSecond())
                     .providerAgentId(String.valueOf(lastOffer.getProvider()))
                     .consumerAgentId(String.valueOf(lastOffer.getConsumer()))
-                    .policyId(policy.getUid())
+                    .policy(policy)
                     .assetId(lastOffer.getAsset().getId())
                     .build();
         } else {
             agreement = retrievedAgreement;
-            policy = policyStore.findById(agreement.getPolicyId());
+            policy = agreement.getPolicy();
         }
 
         var request = ContractAgreementRequest.Builder.newInstance()

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/policy/PolicyArchiveImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/policy/PolicyArchiveImpl.java
@@ -17,26 +17,22 @@ package org.eclipse.dataspaceconnector.contract.policy;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyArchive;
-import org.eclipse.dataspaceconnector.spi.policy.store.PolicyStore;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 
 import java.util.Optional;
 
 public class PolicyArchiveImpl implements PolicyArchive {
     private final ContractNegotiationStore contractNegotiationStore;
-    private final PolicyStore policyStore;
 
-    public PolicyArchiveImpl(ContractNegotiationStore contractNegotiationStore, PolicyStore policyStore) {
+    public PolicyArchiveImpl(ContractNegotiationStore contractNegotiationStore) {
         this.contractNegotiationStore = contractNegotiationStore;
-        this.policyStore = policyStore;
     }
 
     @Override
     public Policy findPolicyForContract(String contractId) {
         return Optional.ofNullable(contractId)
                 .map(contractNegotiationStore::findContractAgreement)
-                .map(ContractAgreement::getPolicyId)
-                .map(policyStore::findById)
+                .map(ContractAgreement::getPolicy)
                 .orElse(null);
     }
 

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -76,9 +76,8 @@ class ProviderContractNegotiationManagerImplTest {
     private final ContractValidationService validationService = mock(ContractValidationService.class);
     private final RemoteMessageDispatcherRegistry dispatcherRegistry = mock(RemoteMessageDispatcherRegistry.class);
     private final PolicyStore policyStore = mock(PolicyStore.class);
-    private ProviderContractNegotiationManagerImpl negotiationManager;
-
     private final String correlationId = "correlationId";
+    private ProviderContractNegotiationManagerImpl negotiationManager;
 
     @BeforeEach
     void setUp() {
@@ -118,12 +117,12 @@ class ProviderContractNegotiationManagerImplTest {
         assertThat(result.succeeded()).isTrue();
         verify(store, atLeastOnce()).save(argThat(n ->
                 n.getState() == ContractNegotiationStates.CONFIRMING.code() &&
-                n.getCounterPartyId().equals(request.getConnectorId()) &&
-                n.getCounterPartyAddress().equals(request.getConnectorAddress()) &&
-                n.getProtocol().equals(request.getProtocol()) &&
-                n.getCorrelationId().equals(request.getCorrelationId()) &&
-                n.getContractOffers().size() == 1 &&
-                n.getLastContractOffer().equals(contractOffer)
+                        n.getCounterPartyId().equals(request.getConnectorId()) &&
+                        n.getCounterPartyAddress().equals(request.getConnectorAddress()) &&
+                        n.getProtocol().equals(request.getProtocol()) &&
+                        n.getCorrelationId().equals(request.getCorrelationId()) &&
+                        n.getContractOffers().size() == 1 &&
+                        n.getLastContractOffer().equals(contractOffer)
         ));
         verify(validationService).validate(token, contractOffer);
     }
@@ -147,12 +146,12 @@ class ProviderContractNegotiationManagerImplTest {
         assertThat(result.succeeded()).isTrue();
         verify(store, atLeastOnce()).save(argThat(n ->
                 n.getState() == ContractNegotiationStates.DECLINING.code() &&
-                n.getCounterPartyId().equals(request.getConnectorId()) &&
-                n.getCounterPartyAddress().equals(request.getConnectorAddress()) &&
-                n.getProtocol().equals(request.getProtocol()) &&
-                n.getCorrelationId().equals(request.getCorrelationId()) &&
-                n.getContractOffers().size() == 1 &&
-                n.getLastContractOffer().equals(contractOffer)
+                        n.getCounterPartyId().equals(request.getConnectorId()) &&
+                        n.getCounterPartyAddress().equals(request.getConnectorAddress()) &&
+                        n.getProtocol().equals(request.getProtocol()) &&
+                        n.getCorrelationId().equals(request.getCorrelationId()) &&
+                        n.getContractOffers().size() == 1 &&
+                        n.getLastContractOffer().equals(contractOffer)
         ));
         verify(validationService).validate(token, contractOffer);
     }
@@ -178,13 +177,13 @@ class ProviderContractNegotiationManagerImplTest {
         assertThat(result.succeeded()).isTrue();
         verify(store).save(argThat(n ->
                 n.getState() == PROVIDER_OFFERING.code() &&
-                n.getCounterPartyId().equals(request.getConnectorId()) &&
-                n.getCounterPartyAddress().equals(request.getConnectorAddress()) &&
-                n.getProtocol().equals(request.getProtocol()) &&
-                n.getCorrelationId().equals(request.getCorrelationId()) &&
-                n.getContractOffers().size() == 2 &&
-                n.getContractOffers().get(0).equals(contractOffer) &&
-                n.getContractOffers().get(1).equals(counterOffer)
+                        n.getCounterPartyId().equals(request.getConnectorId()) &&
+                        n.getCounterPartyAddress().equals(request.getConnectorAddress()) &&
+                        n.getProtocol().equals(request.getProtocol()) &&
+                        n.getCorrelationId().equals(request.getCorrelationId()) &&
+                        n.getContractOffers().size() == 2 &&
+                        n.getContractOffers().get(0).equals(contractOffer) &&
+                        n.getContractOffers().get(1).equals(counterOffer)
         ));
         verify(validationService).validate(token, contractOffer);
     }
@@ -214,8 +213,8 @@ class ProviderContractNegotiationManagerImplTest {
         assertThat(result.succeeded()).isTrue();
         verify(store, atLeastOnce()).save(argThat(n ->
                 n.getState() == ContractNegotiationStates.CONFIRMING.code() &&
-                n.getContractOffers().size() == 2 &&
-                n.getContractOffers().get(1).equals(contractOffer)
+                        n.getContractOffers().size() == 2 &&
+                        n.getContractOffers().get(1).equals(contractOffer)
         ));
         verify(validationService).validate(eq(token), eq(contractOffer), any(ContractOffer.class));
     }
@@ -235,8 +234,8 @@ class ProviderContractNegotiationManagerImplTest {
         assertThat(result.succeeded()).isTrue();
         verify(store, atLeastOnce()).save(argThat(n ->
                 n.getState() == ContractNegotiationStates.DECLINING.code() &&
-                n.getContractOffers().size() == 2 &&
-                n.getContractOffers().get(1).equals(contractOffer)
+                        n.getContractOffers().size() == 2 &&
+                        n.getContractOffers().get(1).equals(contractOffer)
         ));
         verify(validationService).validate(eq(token), eq(contractOffer), any(ContractOffer.class));
     }
@@ -257,9 +256,9 @@ class ProviderContractNegotiationManagerImplTest {
         assertThat(result.succeeded()).isTrue();
         verify(store).save(argThat(n ->
                 n.getState() == PROVIDER_OFFERING.code() &&
-                n.getContractOffers().size() == 3 &&
-                n.getContractOffers().get(1).equals(contractOffer) &&
-                n.getContractOffers().get(2).equals(counterOffer)
+                        n.getContractOffers().size() == 3 &&
+                        n.getContractOffers().get(1).equals(contractOffer) &&
+                        n.getContractOffers().get(2).equals(counterOffer)
         ));
         verify(validationService).validate(eq(token), eq(contractOffer), any(ContractOffer.class));
     }
@@ -287,7 +286,7 @@ class ProviderContractNegotiationManagerImplTest {
         assertThat(result.succeeded()).isTrue();
         verify(store, atLeastOnce()).save(argThat(n ->
                 n.getState() == ContractNegotiationStates.CONFIRMING.code() &&
-                n.getContractAgreement() == null
+                        n.getContractAgreement() == null
         ));
     }
 
@@ -373,7 +372,7 @@ class ProviderContractNegotiationManagerImplTest {
         var negotiation = contractNegotiationBuilder()
                 .state(CONFIRMING.code())
                 .contractOffer(contractOffer())
-                .contractAgreement(contractAgreementBuilder().policyId("policyId").build())
+                .contractAgreement(contractAgreementBuilder().policy("policyId").build())
                 .build();
         when(store.nextForState(eq(CONFIRMING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
         when(dispatcherRegistry.send(any(), any(), any())).thenReturn(completedFuture(null));
@@ -458,7 +457,7 @@ class ProviderContractNegotiationManagerImplTest {
                 .providerAgentId("any")
                 .consumerAgentId("any")
                 .assetId("default")
-                .policyId("default");
+                .policy("default");
     }
 
     private ContractOffer contractOffer() {

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/policy/PolicyArchiveImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/policy/PolicyArchiveImplTest.java
@@ -28,7 +28,7 @@ class PolicyArchiveImplTest {
 
     private final ContractNegotiationStore contractNegotiationStore = mock(ContractNegotiationStore.class);
     private final PolicyStore policyStore = mock(PolicyStore.class);
-    private final PolicyArchiveImpl policyArchive = new PolicyArchiveImpl(contractNegotiationStore, policyStore);
+    private final PolicyArchiveImpl policyArchive = new PolicyArchiveImpl(contractNegotiationStore);
 
     @Test
     void shouldGetPolicyFromAgreement() {
@@ -68,7 +68,7 @@ class PolicyArchiveImplTest {
                 .consumerAgentId("any")
                 .providerAgentId("any")
                 .assetId("any")
-                .policyId(policyId)
+                .policy(policyId)
                 .build();
     }
 }

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImplTest.java
@@ -17,6 +17,7 @@
 package org.eclipse.dataspaceconnector.contract.validation;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgent;
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgentService;
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
@@ -65,7 +66,7 @@ class ContractValidationServiceImplTest {
     @Test
     void verifyContractOfferValidation() {
         var originalPolicy = Policy.Builder.newInstance().build();
-        var newPolicy = Policy.Builder.newInstance().build();
+        var newPolicy = PolicyDefinition.Builder.newInstance().build();
         var asset = Asset.Builder.newInstance().id("1").build();
         var contractDefinition = ContractDefinition.Builder.newInstance()
                 .id("1")
@@ -76,7 +77,7 @@ class ContractValidationServiceImplTest {
 
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
         when(definitionService.definitionFor(isA(ParticipantAgent.class), eq("1"))).thenReturn(contractDefinition);
-        when(policyStore.findById("access")).thenReturn(Policy.Builder.newInstance().build());
+        when(policyStore.findById("access")).thenReturn(PolicyDefinition.Builder.newInstance().build());
         when(policyStore.findById("contract")).thenReturn(newPolicy);
         when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(Stream.of(asset));
 
@@ -99,7 +100,7 @@ class ContractValidationServiceImplTest {
 
     @Test
     void verifyContractAgreementValidation() {
-        var newPolicy = Policy.Builder.newInstance().build();
+        var newPolicy = PolicyDefinition.Builder.newInstance().build();
 
         var contractDefinition = ContractDefinition.Builder.newInstance()
                 .id("1")
@@ -110,14 +111,14 @@ class ContractValidationServiceImplTest {
 
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
         when(definitionService.definitionFor(isA(ParticipantAgent.class), eq("1"))).thenReturn(contractDefinition);
-        when(policyStore.findById("access")).thenReturn(Policy.Builder.newInstance().build());
+        when(policyStore.findById("access")).thenReturn(PolicyDefinition.Builder.newInstance().build());
         when(policyStore.findById("contract")).thenReturn(newPolicy);
 
         var claimToken = ClaimToken.Builder.newInstance().build();
         var agreement = ContractAgreement.Builder.newInstance().id("1")
                 .providerAgentId("provider")
                 .consumerAgentId("consumer")
-                .policyId("policy")
+                .policy(Policy.Builder.newInstance().build())
                 .assetId(UUID.randomUUID().toString())
                 .contractStartDate(Instant.now().getEpochSecond())
                 .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())
@@ -180,7 +181,7 @@ class ContractValidationServiceImplTest {
         var agreement = ContractAgreement.Builder.newInstance().id("1")
                 .providerAgentId("provider")
                 .consumerAgentId("consumer")
-                .policyId("policy")
+                .policy(Policy.Builder.newInstance().build())
                 .assetId(UUID.randomUUID().toString())
                 .contractSigningDate(signingDate)
                 .contractStartDate(startDate)

--- a/core/defaults/src/main/java/org/eclipse/dataspaceconnector/core/defaults/policystore/InMemoryPolicyStore.java
+++ b/core/defaults/src/main/java/org/eclipse/dataspaceconnector/core/defaults/policystore/InMemoryPolicyStore.java
@@ -15,7 +15,7 @@
 package org.eclipse.dataspaceconnector.core.defaults.policystore;
 
 import org.eclipse.dataspaceconnector.common.concurrency.LockManager;
-import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
 import org.eclipse.dataspaceconnector.spi.persistence.EdcPersistenceException;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyStore;
 import org.eclipse.dataspaceconnector.spi.query.QueryResolver;
@@ -34,15 +34,15 @@ import java.util.stream.Stream;
 public class InMemoryPolicyStore implements PolicyStore {
 
     private final LockManager lockManager;
-    private final Map<String, Policy> policiesById = new HashMap<>();
-    private final QueryResolver<Policy> queryResolver = new ReflectionBasedQueryResolver<>(Policy.class);
+    private final Map<String, PolicyDefinition> policiesById = new HashMap<>();
+    private final QueryResolver<PolicyDefinition> queryResolver = new ReflectionBasedQueryResolver<>(PolicyDefinition.class);
 
     public InMemoryPolicyStore(LockManager lockManager) {
         this.lockManager = lockManager;
     }
 
     @Override
-    public @Nullable Policy findById(String policyId) {
+    public PolicyDefinition findById(String policyId) {
         try {
             return lockManager.readLock(() -> policiesById.get(policyId));
         } catch (Exception e) {
@@ -51,7 +51,7 @@ public class InMemoryPolicyStore implements PolicyStore {
     }
 
     @Override
-    public Stream<Policy> findAll(QuerySpec spec) {
+    public Stream<PolicyDefinition> findAll(QuerySpec spec) {
         try {
             return lockManager.readLock(() -> queryResolver.query(policiesById.values().stream(), spec));
         } catch (Exception e) {
@@ -60,7 +60,7 @@ public class InMemoryPolicyStore implements PolicyStore {
     }
 
     @Override
-    public void save(Policy policy) {
+    public void save(PolicyDefinition policy) {
         try {
             lockManager.writeLock(() -> policiesById.put(policy.getUid(), policy));
         } catch (Exception e) {
@@ -69,7 +69,7 @@ public class InMemoryPolicyStore implements PolicyStore {
     }
 
     @Override
-    public Policy deleteById(String policyId) {
+    public @Nullable PolicyDefinition deleteById(String policyId) {
         try {
             return lockManager.writeLock(() -> policiesById.remove(policyId));
         } catch (Exception e) {

--- a/core/defaults/src/test/java/org/eclipse/dataspaceconnector/core/defaults/negotiationstore/TestFunctions.java
+++ b/core/defaults/src/test/java/org/eclipse/dataspaceconnector/core/defaults/negotiationstore/TestFunctions.java
@@ -60,7 +60,7 @@ public class TestFunctions {
                 .providerAgentId("provider")
                 .consumerAgentId("consumer")
                 .assetId(UUID.randomUUID().toString())
-                .policyId(UUID.randomUUID().toString())
+                .policy(UUID.randomUUID().toString())
                 .contractStartDate(Instant.now().getEpochSecond())
                 .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())
                 .contractSigningDate(Instant.now().getEpochSecond());

--- a/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Policy.java
+++ b/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Policy.java
@@ -25,14 +25,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
  * A collection of permissions, prohibitions, and obligations associated with an asset. Subtypes are defined by {@link PolicyType}.
  */
 @JsonDeserialize(builder = Policy.Builder.class)
-public class Policy extends Identifiable {
+public class Policy {
 
     private final List<Permission> permissions = new ArrayList<>();
     private final List<Prohibition> prohibitions = new ArrayList<>();
@@ -107,10 +106,6 @@ public class Policy extends Identifiable {
                 Objects.equals(inheritsFrom, policy.inheritsFrom) && Objects.equals(assigner, policy.assigner) && Objects.equals(assignee, policy.assignee) && Objects.equals(target, policy.target) && type == policy.type;
     }
 
-    @Override
-    public String toString() {
-        return "Policy: " + uid;
-    }
 
     /**
      * Returns a copy of this policy with the specified target.
@@ -120,7 +115,6 @@ public class Policy extends Identifiable {
      */
     public Policy withTarget(String target) {
         return Builder.newInstance()
-                .id(uid)
                 .prohibitions(prohibitions.stream().map(p -> p.withTarget(target)).collect(Collectors.toList()))
                 .permissions(permissions.stream().map(p -> p.withTarget(target)).collect(Collectors.toList()))
                 .duties(obligations.stream().map(o -> o.withTarget(target)).collect(Collectors.toList()))
@@ -149,11 +143,6 @@ public class Policy extends Identifiable {
             return new Builder(new Policy());
         }
 
-        @JsonProperty("uid")
-        public B id(String id) {
-            policy.uid = id;
-            return (B) this;
-        }
 
         public B prohibition(Prohibition prohibition) {
             policy.prohibitions.add(prohibition);
@@ -228,9 +217,6 @@ public class Policy extends Identifiable {
         }
 
         public Policy build() {
-            if (policy.uid == null) {
-                policy.uid = UUID.randomUUID().toString();
-            }
             return policy;
         }
     }

--- a/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Policy.java
+++ b/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Policy.java
@@ -45,7 +45,7 @@ public class Policy extends Identifiable {
     @JsonProperty("@type")
     private PolicyType type = PolicyType.SET;
 
-    private Policy() {
+    protected Policy() {
     }
 
     public List<Permission> getPermissions() {
@@ -112,10 +112,6 @@ public class Policy extends Identifiable {
         return "Policy: " + uid;
     }
 
-    public interface Visitor<R> {
-        R visitPolicy(Policy policy);
-    }
-    
     /**
      * Returns a copy of this policy with the specified target.
      *
@@ -124,107 +120,111 @@ public class Policy extends Identifiable {
      */
     public Policy withTarget(String target) {
         return Builder.newInstance()
-                .id(this.uid)
-                .prohibitions(this.prohibitions.stream().map(p -> p.withTarget(target)).collect(Collectors.toList()))
-                .permissions(this.permissions.stream().map(p -> p.withTarget(target)).collect(Collectors.toList()))
-                .duties(this.obligations.stream().map(o -> o.withTarget(target)).collect(Collectors.toList()))
-                .assigner(this.assigner)
-                .assignee(this.assignee)
-                .inheritsFrom(this.inheritsFrom)
-                .type(this.type)
-                .extensibleProperties(this.extensibleProperties)
+                .id(uid)
+                .prohibitions(prohibitions.stream().map(p -> p.withTarget(target)).collect(Collectors.toList()))
+                .permissions(permissions.stream().map(p -> p.withTarget(target)).collect(Collectors.toList()))
+                .duties(obligations.stream().map(o -> o.withTarget(target)).collect(Collectors.toList()))
+                .assigner(assigner)
+                .assignee(assignee)
+                .inheritsFrom(inheritsFrom)
+                .type(type)
+                .extensibleProperties(extensibleProperties)
                 .target(target)
                 .build();
     }
 
-    @JsonPOJOBuilder(withPrefix = "")
-    public static class Builder {
-        private final Policy policy;
+    public interface Visitor<R> {
+        R visitPolicy(Policy policy);
+    }
 
-        private Builder() {
-            policy = new Policy();
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder<B extends Builder<B>> {
+        protected final Policy policy;
+
+        protected Builder(Policy policy) {
+            this.policy = policy;
         }
 
         public static Builder newInstance() {
-            return new Builder();
+            return new Builder(new Policy());
         }
 
         @JsonProperty("uid")
-        public Builder id(String id) {
+        public B id(String id) {
             policy.uid = id;
-            return this;
+            return (B) this;
         }
 
-        public Builder prohibition(Prohibition prohibition) {
+        public B prohibition(Prohibition prohibition) {
             policy.prohibitions.add(prohibition);
-            return this;
+            return (B) this;
         }
 
-        public Builder prohibitions(List<Prohibition> prohibitions) {
+        public B prohibitions(List<Prohibition> prohibitions) {
             policy.prohibitions.addAll(prohibitions);
-            return this;
+            return (B) this;
         }
 
-        public Builder permission(Permission permission) {
+        public B permission(Permission permission) {
             policy.permissions.add(permission);
-            return this;
+            return (B) this;
         }
 
-        public Builder permissions(List<Permission> permissions) {
+        public B permissions(List<Permission> permissions) {
             policy.permissions.addAll(permissions);
-            return this;
+            return (B) this;
         }
 
-        public Builder duty(Duty duty) {
+        public B duty(Duty duty) {
             policy.obligations.add(duty);
-            return this;
+            return (B) this;
         }
 
         @JsonProperty("obligations")
-        public Builder duties(List<Duty> duties) {
+        public B duties(List<Duty> duties) {
             policy.obligations.addAll(duties);
-            return this;
+            return (B) this;
         }
 
-        public Builder duty(String inheritsFrom) {
+        public B duty(String inheritsFrom) {
             policy.inheritsFrom = inheritsFrom;
-            return this;
+            return (B) this;
         }
 
-        public Builder assigner(String assigner) {
+        public B assigner(String assigner) {
             policy.assigner = assigner;
-            return this;
+            return (B) this;
         }
 
-        public Builder assignee(String assignee) {
+        public B assignee(String assignee) {
             policy.assignee = assignee;
-            return this;
+            return (B) this;
         }
 
-        public Builder target(String target) {
+        public B target(String target) {
             policy.target = target;
-            return this;
+            return (B) this;
         }
 
-        public Builder inheritsFrom(String inheritsFrom) {
+        public B inheritsFrom(String inheritsFrom) {
             policy.inheritsFrom = inheritsFrom;
-            return this;
+            return (B) this;
         }
 
         @JsonProperty("@type")
-        public Builder type(PolicyType type) {
+        public B type(PolicyType type) {
             policy.type = type;
-            return this;
+            return (B) this;
         }
 
-        public Builder extensibleProperty(String key, Object value) {
+        public B extensibleProperty(String key, Object value) {
             policy.extensibleProperties.put(key, value);
-            return this;
+            return (B) this;
         }
 
-        public Builder extensibleProperties(Map<String, Object> properties) {
+        public B extensibleProperties(Map<String, Object> properties) {
             policy.extensibleProperties.putAll(properties);
-            return this;
+            return (B) this;
         }
 
         public Policy build() {

--- a/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/PolicyDefinition.java
+++ b/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/PolicyDefinition.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import java.util.Objects;
+import java.util.UUID;
 
 /**
  * A collection of permissions, prohibitions, and obligations associated with an asset. Subtypes are defined by {@link PolicyType}.
@@ -67,11 +68,14 @@ public class PolicyDefinition extends Policy {
 
         @JsonProperty("uid")
         public PolicyDefinition.Builder id(String id) {
-            policy.uid = id;
+            ((PolicyDefinition) policy).uid = id;
             return this;
         }
 
         public PolicyDefinition build() {
+            if (policy == null) {
+                ((PolicyDefinition) policy).uid = UUID.randomUUID().toString();
+            }
             return (PolicyDefinition) policy;
         }
     }

--- a/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/PolicyDefinition.java
+++ b/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/PolicyDefinition.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2020, 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - added method
+ *
+ */
+
+package org.eclipse.dataspaceconnector.policy.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import java.util.Objects;
+
+/**
+ * A collection of permissions, prohibitions, and obligations associated with an asset. Subtypes are defined by {@link PolicyType}.
+ */
+@JsonDeserialize(builder = PolicyDefinition.Builder.class)
+public class PolicyDefinition extends Policy {
+
+
+    private String uid;
+
+    private PolicyDefinition() {
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), uid);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PolicyDefinition policy = (PolicyDefinition) o;
+        return super.equals(o) && Objects.equals(uid, policy.uid);
+    }
+
+    public String getUid() {
+        return uid;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends Policy.Builder<Builder> {
+
+        private Builder() {
+            super(new PolicyDefinition());
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        @JsonProperty("uid")
+        public PolicyDefinition.Builder id(String id) {
+            policy.uid = id;
+            return this;
+        }
+
+        public PolicyDefinition build() {
+            return (PolicyDefinition) policy;
+        }
+    }
+}

--- a/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/PolicyTest.java
+++ b/core/policy/policy-evaluator/src/test/java/org/eclipse/dataspaceconnector/policy/model/PolicyTest.java
@@ -35,14 +35,14 @@ class PolicyTest {
         var serialized = mapper.writeValueAsString(policy);
         assertThat(mapper.readValue(serialized, Policy.class).getPermissions()).isNotEmpty();
     }
-    
+
     @Test
     void withTarget() {
         var target = "target-id";
         var permission = Permission.Builder.newInstance().action(Action.Builder.newInstance().type("USE").build()).build();
         var prohibition = Prohibition.Builder.newInstance().action(Action.Builder.newInstance().type("MODIFY").build()).build();
         var duty = Duty.Builder.newInstance().action(Action.Builder.newInstance().type("DELETE").build()).build();
-        var policy = Policy.Builder.newInstance()
+        var policy = PolicyDefinition.Builder.newInstance()
                 .id("id")
                 .permission(permission)
                 .prohibition(prohibition)
@@ -53,10 +53,10 @@ class PolicyTest {
                 .type(PolicyType.SET)
                 .extensibleProperties(new HashMap<>())
                 .build();
-        
+
         var copy = policy.withTarget(target);
-        
-        assertThat(copy.getUid()).isEqualTo(policy.getUid());
+
+        //        assertThat(copy.getUid()).isEqualTo(policy.getUid());
         assertThat(copy.getPermissions().size()).isEqualTo(policy.getPermissions().size());
         copy.getPermissions().forEach(p -> assertThat(p.getTarget()).isEqualTo(target));
         copy.getProhibitions().forEach(p -> assertThat(p.getTarget()).isEqualTo(target));

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
@@ -99,7 +99,7 @@ class IdsApiMultipartDispatcherV1IntegrationTestServiceExtension implements Serv
                         .providerAgentId("provider")
                         .consumerAgentId("consumer")
                         .assetId(UUID.randomUUID().toString())
-                        .policyId("policyId")
+                        .policy("policyId")
                         .contractSigningDate(Instant.now().getEpochSecond())
                         .contractStartDate(Instant.now().getEpochSecond())
                         .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())
@@ -191,11 +191,6 @@ class IdsApiMultipartDispatcherV1IntegrationTestServiceExtension implements Serv
         }
 
         @Override
-        public @NotNull List<TransferProcess> nextForState(int state, int max) {
-            return Collections.EMPTY_LIST;
-        }
-
-        @Override
         public void create(TransferProcess process) {
         }
 
@@ -210,6 +205,11 @@ class IdsApiMultipartDispatcherV1IntegrationTestServiceExtension implements Serv
         @Override
         public Stream<TransferProcess> findAll(QuerySpec querySpec) {
             return null;
+        }
+
+        @Override
+        public @NotNull List<TransferProcess> nextForState(int state, int max) {
+            return Collections.EMPTY_LIST;
         }
     }
 
@@ -258,12 +258,12 @@ class IdsApiMultipartDispatcherV1IntegrationTestServiceExtension implements Serv
         public @NotNull Stream<ContractDefinition> findAll(QuerySpec spec) {
             throw new UnsupportedOperationException();
         }
-    
+
         @Override
         public ContractDefinition findById(String definitionId) {
             throw new UnsupportedOperationException();
         }
-    
+
         @Override
         public void save(Collection<ContractDefinition> definitions) {
             contractDefinitions.addAll(definitions);

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/MultipartDispatcherIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/MultipartDispatcherIntegrationTest.java
@@ -196,7 +196,7 @@ class MultipartDispatcherIntegrationTest extends AbstractMultipartDispatcherInte
     void testSendContractAgreementMessage() throws Exception {
         var contractAgreement = ContractAgreement.Builder.newInstance()
                 .id("1:23456").consumerAgentId("consumer").providerAgentId("provider")
-                .policyId("policyId")
+                .policy("policyId")
                 .assetId(UUID.randomUUID().toString())
                 .build();
 

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
@@ -107,7 +107,7 @@ class IdsApiMultipartEndpointV1IntegrationTestServiceExtension implements Servic
                         .providerAgentId("provider")
                         .consumerAgentId("consumer")
                         .assetId(UUID.randomUUID().toString())
-                        .policyId("policyId")
+                        .policy("policyId")
                         .contractStartDate(Instant.now().getEpochSecond())
                         .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())
                         .contractSigningDate(Instant.now().getEpochSecond())
@@ -226,11 +226,6 @@ class IdsApiMultipartEndpointV1IntegrationTestServiceExtension implements Servic
         }
 
         @Override
-        public @NotNull List<TransferProcess> nextForState(int state, int max) {
-            return emptyList();
-        }
-
-        @Override
         public void create(TransferProcess process) {
         }
 
@@ -245,6 +240,11 @@ class IdsApiMultipartEndpointV1IntegrationTestServiceExtension implements Servic
         @Override
         public Stream<TransferProcess> findAll(QuerySpec querySpec) {
             return null;
+        }
+
+        @Override
+        public @NotNull List<TransferProcess> nextForState(int state, int max) {
+            return emptyList();
         }
 
     }
@@ -274,12 +274,12 @@ class IdsApiMultipartEndpointV1IntegrationTestServiceExtension implements Servic
         public @NotNull Stream<ContractDefinition> findAll(QuerySpec spec) {
             throw new UnsupportedOperationException();
         }
-    
+
         @Override
         public ContractDefinition findById(String definitionId) {
             throw new UnsupportedOperationException();
         }
-    
+
         @Override
         public void save(Collection<ContractDefinition> definitions) {
             contractDefinitions.addAll(definitions);

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ArtifactRequestHandlerTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ArtifactRequestHandlerTest.java
@@ -59,6 +59,20 @@ class ArtifactRequestHandlerTest {
     private ContractValidationService contractValidationService;
     private ContractNegotiationStore contractNegotiationStore;
 
+    private static URI createUri(IdsType type, String value) {
+        return URI.create("urn:" + type.getValue() + ":" + value);
+    }
+
+    private static ContractAgreement createContractAgreement(String contractId, String assetId) {
+        return ContractAgreement.Builder.newInstance()
+                .id(contractId)
+                .providerAgentId("provider")
+                .consumerAgentId("consumer")
+                .assetId(assetId)
+                .policy("policyId")
+                .build();
+    }
+
     @BeforeEach
     public void setUp() {
         transferProcessManager = mock(TransferProcessManager.class);
@@ -100,7 +114,6 @@ class ArtifactRequestHandlerTest {
         assertThat(drCapture.getValue().getProperties()).containsExactlyEntriesOf(Map.of("foo", "bar"));
     }
 
-
     @Test
     @DisplayName("Verifies that a contract is not passed with a separate id")
     void verifyIllegalArtifactIdRequestTest() throws JsonProcessingException {
@@ -140,19 +153,5 @@ class ArtifactRequestHandlerTest {
                 .dataDestination(dataDestination)
                 .build();
         return MultipartRequest.Builder.newInstance().header(message).payload(new ObjectMapper().writeValueAsString(payload)).build();
-    }
-
-    private static URI createUri(IdsType type, String value) {
-        return URI.create("urn:" + type.getValue() + ":" + value);
-    }
-
-    private static ContractAgreement createContractAgreement(String contractId, String assetId) {
-        return ContractAgreement.Builder.newInstance()
-                .id(contractId)
-                .providerAgentId("provider")
-                .consumerAgentId("consumer")
-                .assetId(assetId)
-                .policyId("policyId")
-                .build();
     }
 }

--- a/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/dataspaceconnector/ids/transform/IdsContractAgreementToContractAgreementTransformer.java
+++ b/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/dataspaceconnector/ids/transform/IdsContractAgreementToContractAgreementTransformer.java
@@ -23,7 +23,7 @@ import org.eclipse.dataspaceconnector.ids.spi.transform.ContractTransformerInput
 import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTypeTransformer;
 import org.eclipse.dataspaceconnector.policy.model.Duty;
 import org.eclipse.dataspaceconnector.policy.model.Permission;
-import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.policy.model.Prohibition;
 import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
@@ -78,14 +78,14 @@ public class IdsContractAgreementToContractAgreementTransformer implements IdsTy
                 .map(it -> context.transform(it, Duty.class))
                 .collect(Collectors.toList());
 
-        var policy = PolicyDefinition.Builder.newInstance()
+        Policy policy = Policy.Builder.newInstance()
                 .duties(edcObligations)
                 .prohibitions(edcProhibitions)
                 .permissions(edcPermissions)
                 .build();
 
         var builder = ContractAgreement.Builder.newInstance()
-                .policyId(policy.getUid())
+                .policy(policy)
                 .consumerAgentId(String.valueOf(contractAgreement.getConsumer()))
                 .providerAgentId(String.valueOf(contractAgreement.getProvider()))
                 .assetId(asset.getId());

--- a/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/dataspaceconnector/ids/transform/IdsContractAgreementToContractAgreementTransformer.java
+++ b/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/dataspaceconnector/ids/transform/IdsContractAgreementToContractAgreementTransformer.java
@@ -23,7 +23,7 @@ import org.eclipse.dataspaceconnector.ids.spi.transform.ContractTransformerInput
 import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTypeTransformer;
 import org.eclipse.dataspaceconnector.policy.model.Duty;
 import org.eclipse.dataspaceconnector.policy.model.Permission;
-import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
 import org.eclipse.dataspaceconnector.policy.model.Prohibition;
 import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
@@ -78,7 +78,7 @@ public class IdsContractAgreementToContractAgreementTransformer implements IdsTy
                 .map(it -> context.transform(it, Duty.class))
                 .collect(Collectors.toList());
 
-        var policy = Policy.Builder.newInstance()
+        var policy = PolicyDefinition.Builder.newInstance()
                 .duties(edcObligations)
                 .prohibitions(edcProhibitions)
                 .permissions(edcPermissions)

--- a/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/dataspaceconnector/ids/transform/ContractAgreementRequestToIdsContractAgreementTransformerTest.java
+++ b/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/dataspaceconnector/ids/transform/ContractAgreementRequestToIdsContractAgreementTransformerTest.java
@@ -98,7 +98,7 @@ class ContractAgreementRequestToIdsContractAgreementTransformerTest {
                 .contractStartDate(Instant.now().getEpochSecond())
                 .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())
                 .contractSigningDate(Instant.now().getEpochSecond())
-                .policyId(policy.getUid())
+                .policy(policy)
                 .build();
 
         return ContractAgreementRequest.Builder.newInstance()

--- a/docs/developer/modules.md
+++ b/docs/developer/modules.md
@@ -79,7 +79,6 @@ org.eclipse.dataspaceconnector:jetty-micrometer:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:iam-daps:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:decentralized-identity:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:iam-mock:0.0.1-SNAPSHOT
-org.eclipse.dataspaceconnector:ids-policy:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:asset-index-sql:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:common-sql:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:contractdefinition-store-sql:0.0.1-SNAPSHOT

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiControllerIntegrationTest.java
@@ -20,6 +20,7 @@ import org.eclipse.dataspaceconnector.api.datamanagement.asset.model.AssetDto;
 import org.eclipse.dataspaceconnector.api.datamanagement.asset.model.AssetEntryDto;
 import org.eclipse.dataspaceconnector.dataloading.AssetLoader;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
@@ -222,7 +223,7 @@ public class AssetApiControllerIntegrationTest {
                 .providerAgentId(UUID.randomUUID().toString())
                 .consumerAgentId(UUID.randomUUID().toString())
                 .assetId(asset.getId())
-                .policyId("policyId")
+                .policy(Policy.Builder.newInstance().build())
                 .build();
     }
 

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImplTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImplTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.api.datamanagement.asset.service;
 
 import org.eclipse.dataspaceconnector.dataloading.AssetLoader;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
@@ -120,7 +121,7 @@ class AssetServiceImplTest {
                         .providerAgentId(UUID.randomUUID().toString())
                         .consumerAgentId(UUID.randomUUID().toString())
                         .assetId("assetId")
-                        .policyId("policyId")
+                        .policy(Policy.Builder.newInstance().build())
                         .build())
                 .build();
         when(contractNegotiationStore.queryNegotiations(any())).thenReturn(Stream.of(contractNegotiation));

--- a/extensions/api/data-management/contractagreement/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/model/ContractAgreementDto.java
+++ b/extensions/api/data-management/contractagreement/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/model/ContractAgreementDto.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 
 public class ContractAgreementDto {
     @NotNull
@@ -34,8 +35,7 @@ public class ContractAgreementDto {
     private long contractEndDate;
     @NotNull
     private String assetId;
-    @NotNull
-    private String policyId;
+    private Policy policy;
 
     @AssertTrue
     @JsonIgnore
@@ -73,8 +73,8 @@ public class ContractAgreementDto {
         return assetId;
     }
 
-    public String getPolicyId() {
-        return policyId;
+    public Policy getPolicy() {
+        return policy;
     }
 
     public static final class Builder {
@@ -123,8 +123,8 @@ public class ContractAgreementDto {
             return this;
         }
 
-        public Builder policyId(String policyId) {
-            agreement.policyId = policyId;
+        public Builder policy(Policy policyId) {
+            agreement.policy = policyId;
             return this;
         }
 

--- a/extensions/api/data-management/contractagreement/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/transform/ContractAgreementToContractAgreementDtoTransformer.java
+++ b/extensions/api/data-management/contractagreement/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/transform/ContractAgreementToContractAgreementDtoTransformer.java
@@ -38,7 +38,7 @@ public class ContractAgreementToContractAgreementDtoTransformer implements DtoTr
         return ContractAgreementDto.Builder.newInstance()
                 .id(object.getId())
                 .assetId(object.getAssetId())
-                .policyId(object.getPolicyId())
+                .policy(object.getPolicy())
                 .consumerAgentId(object.getConsumerAgentId())
                 .providerAgentId(object.getProviderAgentId())
                 .contractStartDate(object.getContractStartDate())

--- a/extensions/api/data-management/contractagreement/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/contractagreement/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApiControllerIntegrationTest.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.api.datamanagement.contractagreement;
 
 import io.restassured.specification.RequestSpecification;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
@@ -125,7 +126,7 @@ public class ContractAgreementApiControllerIntegrationTest {
                 .providerAgentId(UUID.randomUUID().toString())
                 .consumerAgentId(UUID.randomUUID().toString())
                 .assetId(UUID.randomUUID().toString())
-                .policyId("policyId")
+                .policy(Policy.Builder.newInstance().build())
                 .build();
     }
 

--- a/extensions/api/data-management/contractagreement/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApiControllerTest.java
+++ b/extensions/api/data-management/contractagreement/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApiControllerTest.java
@@ -20,6 +20,7 @@ import org.eclipse.dataspaceconnector.api.datamanagement.contractagreement.servi
 import org.eclipse.dataspaceconnector.api.exception.ObjectNotFoundException;
 import org.eclipse.dataspaceconnector.api.query.QuerySpecDto;
 import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.result.Result;
@@ -129,7 +130,7 @@ class ContractAgreementApiControllerTest {
                 .consumerAgentId(UUID.randomUUID().toString())
                 .providerAgentId(UUID.randomUUID().toString())
                 .assetId(UUID.randomUUID().toString())
-                .policyId("policyId")
+                .policy(Policy.Builder.newInstance().build())
                 .build();
     }
 

--- a/extensions/api/data-management/contractagreement/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/model/ContractAgreementDtoTest.java
+++ b/extensions/api/data-management/contractagreement/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/model/ContractAgreementDtoTest.java
@@ -16,6 +16,7 @@ package org.eclipse.dataspaceconnector.api.datamanagement.contractagreement.mode
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,7 +34,7 @@ class ContractAgreementDtoTest {
                 .contractSigningDate(5432L)
                 .providerAgentId("provider")
                 .consumerAgentId("consumer")
-                .policyId("policy-id")
+                .policy(Policy.Builder.newInstance().build())
                 .build();
 
         var json = om.writeValueAsString(dto);

--- a/extensions/api/data-management/contractagreement/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/model/ContractAgreementDtoValidationTest.java
+++ b/extensions/api/data-management/contractagreement/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/model/ContractAgreementDtoValidationTest.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.api.datamanagement.contractagreement.mode
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -54,7 +55,7 @@ class ContractAgreementDtoValidationTest {
     void validation_invalidProperty(String id, String assetId, String policyId, String consumerAgentId, String providerAgentId, long startDate, long endDate, long signingDate) {
         var agreement = ContractAgreementDto.Builder.newInstance()
                 .assetId(assetId)
-                .policyId(policyId)
+                .policy(Policy.Builder.newInstance().build())
                 .consumerAgentId(consumerAgentId)
                 .providerAgentId(providerAgentId)
                 .id(id)
@@ -70,7 +71,7 @@ class ContractAgreementDtoValidationTest {
     void validation_validDto() {
         var agreement = ContractAgreementDto.Builder.newInstance()
                 .assetId("Asset")
-                .policyId("policy")
+                .policy(Policy.Builder.newInstance().build())
                 .consumerAgentId("cons")
                 .providerAgentId("prov")
                 .id("someId")

--- a/extensions/api/data-management/contractagreement/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/service/ContractAgreementServiceImplTest.java
+++ b/extensions/api/data-management/contractagreement/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/service/ContractAgreementServiceImplTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.api.datamanagement.contractagreement.service;
 
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.transaction.NoopTransactionContext;
@@ -70,7 +71,7 @@ class ContractAgreementServiceImplTest {
                 .providerAgentId(UUID.randomUUID().toString())
                 .consumerAgentId(UUID.randomUUID().toString())
                 .assetId(UUID.randomUUID().toString())
-                .policyId("policyId")
+                .policy(Policy.Builder.newInstance().build())
                 .build();
     }
 }

--- a/extensions/api/data-management/contractagreement/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/transform/ContractAgreementToContractAgreementDtoTransformerTest.java
+++ b/extensions/api/data-management/contractagreement/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/transform/ContractAgreementToContractAgreementDtoTransformerTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.api.datamanagement.contractagreement.transform;
 
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 import org.junit.jupiter.api.Test;
@@ -39,7 +40,7 @@ class ContractAgreementToContractAgreementDtoTransformerTest {
                 .consumerAgentId("consumerAgentId")
                 .providerAgentId("providerAgentId")
                 .assetId("assetId")
-                .policyId("policyId")
+                .policy(Policy.Builder.newInstance().build())
                 .contractStartDate(1)
                 .contractSigningDate(2)
                 .contractEndDate(3)
@@ -49,7 +50,7 @@ class ContractAgreementToContractAgreementDtoTransformerTest {
 
         assertThat(dto.getId()).isEqualTo("agreementId");
         assertThat(dto.getAssetId()).isEqualTo("assetId");
-        assertThat(dto.getPolicyId()).isEqualTo("policyId");
+        assertThat(dto.getPolicy()).isEqualTo("policyId");
         assertThat(dto.getContractStartDate()).isEqualTo(1);
         assertThat(dto.getContractSigningDate()).isEqualTo(2);
         assertThat(dto.getContractEndDate()).isEqualTo(3);

--- a/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/model/ContractAgreementDto.java
+++ b/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/model/ContractAgreementDto.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.model;
 
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+
 public class ContractAgreementDto {
     private String id;
     private String providerAgentId;
@@ -22,7 +24,7 @@ public class ContractAgreementDto {
     private long contractStartDate;
     private long contractEndDate;
     private String assetId;
-    private String policyId;
+    private Policy policy;
 
     public String getId() {
         return id;
@@ -52,8 +54,8 @@ public class ContractAgreementDto {
         return assetId;
     }
 
-    public String getPolicyId() {
-        return policyId;
+    public Policy getPolicy() {
+        return policy;
     }
 
     public static final class Builder {
@@ -102,8 +104,8 @@ public class ContractAgreementDto {
             return this;
         }
 
-        public Builder policyId(String policyId) {
-            agreement.policyId = policyId;
+        public Builder policyId(Policy policy) {
+            agreement.policy = policy;
             return this;
         }
 

--- a/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/ContractAgreementToContractAgreementDtoTransformer.java
+++ b/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/ContractAgreementToContractAgreementDtoTransformer.java
@@ -38,7 +38,7 @@ public class ContractAgreementToContractAgreementDtoTransformer implements DtoTr
         return ContractAgreementDto.Builder.newInstance()
                 .id(object.getId())
                 .assetId(object.getAssetId())
-                .policyId(object.getPolicyId())
+                .policyId(object.getPolicy())
                 .consumerAgentId(object.getConsumerAgentId())
                 .providerAgentId(object.getProviderAgentId())
                 .contractStartDate(object.getContractStartDate())

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
@@ -228,7 +228,7 @@ class ContractNegotiationApiControllerIntegrationTest {
                 .providerAgentId(UUID.randomUUID().toString())
                 .consumerAgentId(UUID.randomUUID().toString())
                 .assetId(UUID.randomUUID().toString())
-                .policyId(UUID.randomUUID().toString())
+                .policy(UUID.randomUUID().toString())
                 .build();
     }
 

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerTest.java
@@ -278,7 +278,7 @@ class ContractNegotiationApiControllerTest {
                 .providerAgentId(UUID.randomUUID().toString())
                 .consumerAgentId(UUID.randomUUID().toString())
                 .assetId(UUID.randomUUID().toString())
-                .policyId(UUID.randomUUID().toString())
+                .policy(UUID.randomUUID().toString())
                 .build();
     }
 

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/service/ContractNegotiationServiceImplTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/service/ContractNegotiationServiceImplTest.java
@@ -243,7 +243,7 @@ class ContractNegotiationServiceImplTest {
                 .providerAgentId(UUID.randomUUID().toString())
                 .consumerAgentId(UUID.randomUUID().toString())
                 .assetId(UUID.randomUUID().toString())
-                .policyId(UUID.randomUUID().toString())
+                .policy(UUID.randomUUID().toString())
                 .build();
     }
 

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/ContractAgreementToContractAgreementDtoTransformerTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/ContractAgreementToContractAgreementDtoTransformerTest.java
@@ -39,7 +39,7 @@ class ContractAgreementToContractAgreementDtoTransformerTest {
                 .consumerAgentId("consumerAgentId")
                 .providerAgentId("providerAgentId")
                 .assetId("assetId")
-                .policyId("policyId")
+                .policy("policyId")
                 .contractStartDate(1)
                 .contractSigningDate(2)
                 .contractEndDate(3)
@@ -49,7 +49,7 @@ class ContractAgreementToContractAgreementDtoTransformerTest {
 
         assertThat(dto.getId()).isEqualTo("agreementId");
         assertThat(dto.getAssetId()).isEqualTo("assetId");
-        assertThat(dto.getPolicyId()).isEqualTo("policyId");
+        assertThat(dto.getPolicy()).isEqualTo("policyId");
         assertThat(dto.getContractStartDate()).isEqualTo(1);
         assertThat(dto.getContractSigningDate()).isEqualTo(2);
         assertThat(dto.getContractEndDate()).isEqualTo(3);

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/ContractNegotiationToContractNegotiationDtoTransformerTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/ContractNegotiationToContractNegotiationDtoTransformerTest.java
@@ -68,7 +68,7 @@ class ContractNegotiationToContractNegotiationDtoTransformerTest {
                 .consumerAgentId("any")
                 .providerAgentId("any")
                 .assetId(UUID.randomUUID().toString())
-                .policyId(UUID.randomUUID().toString())
+                .policy(UUID.randomUUID().toString())
                 .build();
     }
 

--- a/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyApi.java
+++ b/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyApi.java
@@ -18,7 +18,7 @@ import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.eclipse.dataspaceconnector.api.query.QuerySpecDto;
-import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
 
 import java.util.List;
 
@@ -26,11 +26,11 @@ import java.util.List;
 @Tag(name = "Policy")
 public interface PolicyApi {
 
-    List<Policy> getAllPolicies(@Valid QuerySpecDto querySpecDto);
+    List<PolicyDefinition> getAllPolicies(@Valid QuerySpecDto querySpecDto);
 
-    Policy getPolicy(String id);
+    PolicyDefinition getPolicy(String id);
 
-    void createPolicy(Policy policy);
+    void createPolicy(PolicyDefinition policy);
 
     void deletePolicy(String id);
 

--- a/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyApiController.java
+++ b/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyApiController.java
@@ -32,6 +32,7 @@ import org.eclipse.dataspaceconnector.api.query.QuerySpecDto;
 import org.eclipse.dataspaceconnector.api.result.ServiceResult;
 import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
@@ -59,7 +60,7 @@ public class PolicyApiController implements PolicyApi {
 
     @GET
     @Override
-    public List<Policy> getAllPolicies(@Valid @BeanParam QuerySpecDto querySpecDto) {
+    public List<PolicyDefinition> getAllPolicies(@Valid @BeanParam QuerySpecDto querySpecDto) {
         var result = transformerRegistry.transform(querySpecDto, QuerySpec.class);
         if (result.failed()) {
             monitor.warning("Error transforming QuerySpec: " + String.join(", ", result.getFailureMessages()));
@@ -77,7 +78,7 @@ public class PolicyApiController implements PolicyApi {
     @GET
     @Path("{id}")
     @Override
-    public Policy getPolicy(@PathParam("id") String id) {
+    public PolicyDefinition getPolicy(@PathParam("id") String id) {
         monitor.debug(format("Attempting to return policy with ID %s", id));
         return Optional.of(id)
                 .map(it -> policyService.findById(id))
@@ -86,7 +87,7 @@ public class PolicyApiController implements PolicyApi {
 
     @POST
     @Override
-    public void createPolicy(Policy policy) {
+    public void createPolicy(PolicyDefinition policy) {
 
         var result = policyService.create(policy);
 
@@ -110,7 +111,7 @@ public class PolicyApiController implements PolicyApi {
         }
     }
 
-    private void handleFailedResult(ServiceResult<Policy> result, String id) {
+    private void handleFailedResult(ServiceResult<PolicyDefinition> result, String id) {
         switch (result.reason()) {
             case NOT_FOUND:
                 throw new ObjectNotFoundException(Policy.class, id);

--- a/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/service/PolicyService.java
+++ b/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/service/PolicyService.java
@@ -15,10 +15,9 @@
 package org.eclipse.dataspaceconnector.api.datamanagement.policy.service;
 
 import org.eclipse.dataspaceconnector.api.result.ServiceResult;
-import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 
@@ -35,8 +34,7 @@ public interface PolicyService {
      * @return the policy, null if it's not found
      */
 
-    @Nullable
-    Policy findById(String policyId);
+    PolicyDefinition findById(String policyId);
 
     /**
      * Query policies
@@ -46,7 +44,7 @@ public interface PolicyService {
      */
 
     @NotNull
-    Collection<Policy> query(QuerySpec query);
+    Collection<PolicyDefinition> query(QuerySpec query);
 
     /**
      * Delete a policy
@@ -56,7 +54,7 @@ public interface PolicyService {
      */
 
     @NotNull
-    ServiceResult<Policy> deleteById(String policyId);
+    ServiceResult<PolicyDefinition> deleteById(String policyId);
 
     /**
      * Create an policy
@@ -65,5 +63,5 @@ public interface PolicyService {
      */
 
     @NotNull
-    ServiceResult<Policy> create(Policy policy);
+    ServiceResult<PolicyDefinition> create(PolicyDefinition policy);
 }

--- a/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/service/PolicyServiceImpl.java
+++ b/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/service/PolicyServiceImpl.java
@@ -15,7 +15,7 @@
 package org.eclipse.dataspaceconnector.api.datamanagement.policy.service;
 
 import org.eclipse.dataspaceconnector.api.result.ServiceResult;
-import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyStore;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
@@ -40,19 +40,19 @@ public class PolicyServiceImpl implements PolicyService {
     }
 
     @Override
-    public Policy findById(String policyId) {
+    public PolicyDefinition findById(String policyId) {
         return transactionContext.execute(() ->
                 policyStore.findById(policyId));
     }
 
     @Override
-    public @NotNull Collection<Policy> query(QuerySpec query) {
+    public @NotNull Collection<PolicyDefinition> query(QuerySpec query) {
         return transactionContext.execute(() ->
                 policyStore.findAll(query).collect(toList()));
     }
 
     @Override
-    public @NotNull ServiceResult<Policy> deleteById(String policyId) {
+    public @NotNull ServiceResult<PolicyDefinition> deleteById(String policyId) {
 
         var contractFilter = format("contractPolicyId = %s ", policyId);
         var accessFilter = format("accessPolicyId = %s ", policyId);
@@ -85,7 +85,7 @@ public class PolicyServiceImpl implements PolicyService {
     }
 
     @Override
-    public @NotNull ServiceResult<Policy> create(Policy policy) {
+    public @NotNull ServiceResult<PolicyDefinition> create(PolicyDefinition policy) {
 
         return transactionContext.execute(() -> {
             if (policyStore.findById(policy.getUid()) == null) {

--- a/extensions/api/data-management/policydefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyApiControllerTest.java
+++ b/extensions/api/data-management/policydefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyApiControllerTest.java
@@ -21,6 +21,7 @@ import org.eclipse.dataspaceconnector.api.query.QuerySpecDto;
 import org.eclipse.dataspaceconnector.api.result.ServiceResult;
 import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.result.Result;
@@ -54,7 +55,7 @@ class PolicyApiControllerTest {
 
     @Test
     void getPolicyById() {
-        when(service.findById("id")).thenReturn(Policy.Builder.newInstance().build());
+        when(service.findById("id")).thenReturn(PolicyDefinition.Builder.newInstance().build());
 
         var policyDto = controller.getPolicy("id");
 
@@ -70,7 +71,7 @@ class PolicyApiControllerTest {
 
     @Test
     void getAllPolicies() {
-        when(service.query(any())).thenReturn(List.of(Policy.Builder.newInstance().build()));
+        when(service.query(any())).thenReturn(List.of(PolicyDefinition.Builder.newInstance().build()));
         when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
                 .thenReturn(Result.success(QuerySpec.Builder.newInstance().offset(10).build()));
         var querySpec = QuerySpecDto.Builder.newInstance().build();
@@ -92,7 +93,7 @@ class PolicyApiControllerTest {
 
     @Test
     void createPolicy() {
-        var policyDefinition = Policy.Builder.newInstance()
+        var policyDefinition = PolicyDefinition.Builder.newInstance()
                 .inheritsFrom("inheritant")
                 .assigner("the tester")
                 .assignee("the tested")
@@ -101,21 +102,20 @@ class PolicyApiControllerTest {
                 .permissions(List.of())
                 .prohibitions(List.of())
                 .duties(List.of())
-                .id("an Id")
                 .build();
 
-        var policy = Policy.Builder.newInstance().build();
+        var policy = PolicyDefinition.Builder.newInstance().build();
 
         when(service.create(any())).thenReturn(ServiceResult.success(policy));
 
         controller.createPolicy(policyDefinition);
 
-        verify(service).create(isA(Policy.class));
+        verify(service).create(isA(PolicyDefinition.class));
     }
 
     @Test
     void createPolicy_alreadyExists() {
-        var policyDefinition = Policy.Builder.newInstance()
+        var policyDefinition = PolicyDefinition.Builder.newInstance()
                 .inheritsFrom("inheritant")
                 .assigner("the tester")
                 .assignee("the tested")
@@ -124,7 +124,6 @@ class PolicyApiControllerTest {
                 .permissions(List.of())
                 .prohibitions(List.of())
                 .duties(List.of())
-                .id("an Id")
                 .build();
 
         var policy = Policy.Builder.newInstance().build();
@@ -136,7 +135,7 @@ class PolicyApiControllerTest {
 
     @Test
     void deletePolicy() {
-        when(service.deleteById("id")).thenReturn(ServiceResult.success(Policy.Builder.newInstance().build()));
+        when(service.deleteById("id")).thenReturn(ServiceResult.success(PolicyDefinition.Builder.newInstance().build()));
         controller.deletePolicy("id");
         verify(service).deleteById("id");
     }

--- a/extensions/api/data-management/policydefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/TestFunctions.java
+++ b/extensions/api/data-management/policydefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/TestFunctions.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.dataspaceconnector.api.datamanagement.policy;
 
-import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 
 import java.util.List;
@@ -22,8 +22,8 @@ import java.util.Map;
 
 public class TestFunctions {
 
-    static Policy createPolicy(String id) {
-        return Policy.Builder.newInstance()
+    static PolicyDefinition createPolicy(String id) {
+        return PolicyDefinition.Builder.newInstance()
                 .inheritsFrom("inheritant")
                 .assigner("the tester")
                 .assignee("the tested")

--- a/extensions/api/data-management/policydefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/service/PolicyServiceImplTest.java
+++ b/extensions/api/data-management/policydefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/service/PolicyServiceImplTest.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.dataspaceconnector.api.datamanagement.policy.service;
 
-import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyStore;
@@ -64,7 +64,7 @@ public class PolicyServiceImplTest {
 
     @Test
     void createPolicy_shouldCreatePolicyIfItDoesNotAlreadyExist() {
-        Policy policy = createPolicy("policyId");
+        var policy = createPolicy("policyId");
         when(policyStore.findById("policyId")).thenReturn(null);
 
         var inserted = policyServiceImpl.create(policy);
@@ -149,11 +149,11 @@ public class PolicyServiceImplTest {
 
 
     @NotNull
-    private Predicate<Policy> hasId(String policyId) {
+    private Predicate<PolicyDefinition> hasId(String policyId) {
         return it -> policyId.equals(it.getUid());
     }
 
-    private Policy createPolicy(String policyId) {
-        return Policy.Builder.newInstance().id(policyId).build();
+    private PolicyDefinition createPolicy(String policyId) {
+        return PolicyDefinition.Builder.newInstance().id(policyId).build();
     }
 }

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/TestFunctions.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/TestFunctions.java
@@ -17,6 +17,7 @@
 package org.eclipse.dataspaceconnector.contract.negotiation.store;
 
 import org.eclipse.dataspaceconnector.contract.negotiation.store.model.ContractNegotiationDocument;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates;
@@ -57,7 +58,7 @@ public class TestFunctions {
                 .providerAgentId("provider")
                 .consumerAgentId("consumer")
                 .assetId(UUID.randomUUID().toString())
-                .policyId(UUID.randomUUID().toString())
+                .policy(Policy.Builder.newInstance().build())
                 .contractStartDate(Instant.now().getEpochSecond())
                 .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())
                 .contractSigningDate(Instant.now().getEpochSecond())

--- a/extensions/azure/cosmos/policy-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/cosmos/policy/store/PolicyDocument.java
+++ b/extensions/azure/cosmos/policy-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/cosmos/policy/store/PolicyDocument.java
@@ -18,13 +18,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.eclipse.dataspaceconnector.azure.cosmos.CosmosDocument;
-import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
 
 @JsonTypeName("dataspaceconnector:policydocument")
-public class PolicyDocument extends CosmosDocument<Policy> {
+public class PolicyDocument extends CosmosDocument<PolicyDefinition> {
 
     @JsonCreator
-    public PolicyDocument(@JsonProperty("wrappedInstance") Policy policy,
+    public PolicyDocument(@JsonProperty("wrappedInstance") PolicyDefinition policy,
                           @JsonProperty("partitionKey") String partitionKey) {
         super(policy, partitionKey);
     }

--- a/extensions/azure/cosmos/policy-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/cosmos/policy/store/CosmosPolicyStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/policy-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/cosmos/policy/store/CosmosPolicyStoreIntegrationTest.java
@@ -28,6 +28,7 @@ import org.eclipse.dataspaceconnector.policy.model.Action;
 import org.eclipse.dataspaceconnector.policy.model.Duty;
 import org.eclipse.dataspaceconnector.policy.model.Permission;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
@@ -194,7 +195,7 @@ public class CosmosPolicyStoreIntegrationTest {
         container.createItem(doc1);
         container.createItem(doc2);
 
-        assertThat(store.findAll(QuerySpec.none())).hasSize(2).extracting(Policy::getUid).containsExactlyInAnyOrder(doc1.getId(), doc2.getId());
+        assertThat(store.findAll(QuerySpec.none())).hasSize(2).extracting(PolicyDefinition::getUid).containsExactlyInAnyOrder(doc1.getId(), doc2.getId());
     }
 
     @Test
@@ -203,7 +204,7 @@ public class CosmosPolicyStoreIntegrationTest {
         var all = IntStream.range(0, 10).mapToObj(i -> generateDocument(TEST_PARTITION_KEY)).peek(d -> container.createItem(d)).map(PolicyDocument::getId).collect(Collectors.toList());
 
         // page size fits
-        assertThat(store.findAll(QuerySpec.Builder.newInstance().offset(3).limit(4).build())).hasSize(4).extracting(Policy::getUid).isSubsetOf(all);
+        assertThat(store.findAll(QuerySpec.Builder.newInstance().offset(3).limit(4).build())).hasSize(4).extracting(PolicyDefinition::getUid).isSubsetOf(all);
 
     }
 
@@ -213,7 +214,7 @@ public class CosmosPolicyStoreIntegrationTest {
         var all = IntStream.range(0, 10).mapToObj(i -> generateDocument(TEST_PARTITION_KEY)).peek(d -> container.createItem(d)).map(PolicyDocument::getId).collect(Collectors.toList());
 
         // page size fits
-        assertThat(store.findAll(QuerySpec.Builder.newInstance().offset(3).limit(40).build())).hasSize(7).extracting(Policy::getUid).isSubsetOf(all);
+        assertThat(store.findAll(QuerySpec.Builder.newInstance().offset(3).limit(40).build())).hasSize(7).extracting(PolicyDefinition::getUid).isSubsetOf(all);
     }
 
     @Test
@@ -223,7 +224,7 @@ public class CosmosPolicyStoreIntegrationTest {
         var expectedId = documents.get(3).getId();
 
         var query = QuerySpec.Builder.newInstance().filter("uid=" + expectedId).build();
-        assertThat(store.findAll(query)).extracting(Policy::getUid).containsOnly(expectedId);
+        assertThat(store.findAll(query)).extracting(PolicyDefinition::getUid).containsOnly(expectedId);
     }
 
     @Test
@@ -251,7 +252,7 @@ public class CosmosPolicyStoreIntegrationTest {
         IntStream.range(0, 10).mapToObj(i -> generateDocument(TEST_PARTITION_KEY)).forEach(d -> container.createItem(d));
 
         var ascendingQuery = QuerySpec.Builder.newInstance().sortField("uid").sortOrder(SortOrder.ASC).build();
-        assertThat(store.findAll(ascendingQuery)).hasSize(10).isSortedAccordingTo(Comparator.comparing(Policy::getUid));
+        assertThat(store.findAll(ascendingQuery)).hasSize(10).isSortedAccordingTo(Comparator.comparing(PolicyDefinition::getUid));
         var descendingQuery = QuerySpec.Builder.newInstance().sortField("uid").sortOrder(SortOrder.DESC).build();
         assertThat(store.findAll(descendingQuery)).hasSize(10).isSortedAccordingTo((c1, c2) -> c2.getUid().compareTo(c1.getUid()));
     }
@@ -276,7 +277,7 @@ public class CosmosPolicyStoreIntegrationTest {
         assertThat(store.findAll(QuerySpec.none())).containsExactly(policy);
 
         // modify the object
-        var modifiedPolicy = Policy.Builder.newInstance()
+        var modifiedPolicy = PolicyDefinition.Builder.newInstance()
                 .id(policy.getUid())
                 .permission(Permission.Builder.newInstance()
                         .target("test-asset-id")

--- a/extensions/azure/cosmos/policy-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/cosmos/policy/store/CosmosPolicyStoreTest.java
+++ b/extensions/azure/cosmos/policy-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/cosmos/policy/store/CosmosPolicyStoreTest.java
@@ -18,7 +18,7 @@ import com.azure.cosmos.models.SqlQuerySpec;
 import net.jodah.failsafe.RetryPolicy;
 import org.eclipse.dataspaceconnector.azure.cosmos.CosmosDbApi;
 import org.eclipse.dataspaceconnector.azure.cosmos.CosmosDocument;
-import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
 import org.eclipse.dataspaceconnector.spi.persistence.EdcPersistenceException;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
@@ -106,7 +106,7 @@ class CosmosPolicyStoreTest {
 
         var all = store.findAll(QuerySpec.none());
 
-        assertThat(all).isNotEmpty().containsExactlyInAnyOrder((Policy) captor.getValue().getWrappedInstance());
+        assertThat(all).isNotEmpty().containsExactlyInAnyOrder((PolicyDefinition) captor.getValue().getWrappedInstance());
         verify(cosmosDbApiMock).queryAllItems();
         verify(cosmosDbApiMock).saveItem(captor.capture());
     }
@@ -188,7 +188,7 @@ class CosmosPolicyStoreTest {
         store.reload();
 
         var all = store.findAll(QuerySpec.Builder.newInstance().filter("uid=" + doc.getId()).build());
-        assertThat(all).hasSize(1).extracting(Policy::getUid).containsOnly(doc.getId());
+        assertThat(all).hasSize(1).extracting(PolicyDefinition::getUid).containsOnly(doc.getId());
         verify(cosmosDbApiMock).queryAllItems();
         verifyNoMoreInteractions(cosmosDbApiMock);
     }
@@ -216,7 +216,7 @@ class CosmosPolicyStoreTest {
         store.reload();
 
         var all = store.findAll(QuerySpec.Builder.newInstance().sortField("uid").sortOrder(SortOrder.ASC).build()).collect(Collectors.toList());
-        assertThat(all).hasSize(10).isSortedAccordingTo(Comparator.comparing(Policy::getUid));
+        assertThat(all).hasSize(10).isSortedAccordingTo(Comparator.comparing(PolicyDefinition::getUid));
 
         verify(cosmosDbApiMock).queryAllItems();
         verifyNoMoreInteractions(cosmosDbApiMock);

--- a/extensions/azure/cosmos/policy-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/cosmos/policy/store/TestFunctions.java
+++ b/extensions/azure/cosmos/policy-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/cosmos/policy/store/TestFunctions.java
@@ -14,18 +14,18 @@
 
 package org.eclipse.dataspaceconnector.cosmos.policy.store;
 
-import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
 
 import java.util.UUID;
 
 public class TestFunctions {
 
-    public static Policy generatePolicy() {
+    public static PolicyDefinition generatePolicy() {
         return generatePolicy(UUID.randomUUID().toString());
     }
 
-    public static Policy generatePolicy(String id) {
-        return Policy.Builder.newInstance()
+    public static PolicyDefinition generatePolicy(String id) {
+        return PolicyDefinition.Builder.newInstance()
                 .id(id)
                 .build();
     }

--- a/extensions/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/validation/ContractValidationRuleTest.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/validation/ContractValidationRuleTest.java
@@ -101,7 +101,7 @@ class ContractValidationRuleTest {
         return ContractAgreement.Builder.newInstance()
                 .id(contractId)
                 .assetId(UUID.randomUUID().toString())
-                .policyId(UUID.randomUUID().toString())
+                .policy(UUID.randomUUID().toString())
                 .contractEndDate(endDate.getEpochSecond())
                 .consumerAgentId("any")
                 .providerAgentId("any")

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
@@ -120,7 +120,7 @@ public class HttpProvisionerExtensionEndToEndTest {
         var contractAgreement = ContractAgreement.Builder.newInstance()
                 .assetId(ASSET_ID)
                 .id(CONTRACT_ID)
-                .policyId(POLICY_ID)
+                .policy(POLICY_ID)
                 .consumerAgentId("consumer")
                 .providerAgentId("provider")
                 .build();

--- a/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/ContractNegotiationStatements.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/ContractNegotiationStatements.java
@@ -128,8 +128,8 @@ public interface ContractNegotiationStatements extends LeaseStatements {
         return "asset_id";
     }
 
-    default String getPolicyIdColumn() {
-        return "policy_id";
+    default String getPolicyColumn() {
+        return "contract_policy";
     }
 
     default String getContractAgreementIdFkColumn() {

--- a/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/PostgresStatements.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/PostgresStatements.java
@@ -95,19 +95,19 @@ public final class PostgresStatements implements ContractNegotiationStatements {
     public String getInsertAgreementTemplate() {
         return format("INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s, %s) VALUES (?, ?, ?, ?, ?, ?, ?, ?);",
                 getContractAgreementTable(), getContractAgreementIdColumn(), getProviderAgentColumn(), getConsumerAgentColumn(),
-                getSigningDateColumn(), getStartDateColumn(), getEndDateColumn(), getAssetIdColumn(), getPolicyIdColumn());
+                getSigningDateColumn(), getStartDateColumn(), getEndDateColumn(), getAssetIdColumn(), getPolicyColumn());
     }
 
     @Override
     public String getSelectByPolicyIdTemplate() {
-        return format("SELECT DISTINCT %s FROM %s WHERE %s = ?", getPolicyColumnSeralized(), getContractAgreementTable(), getPolicyIdColumn());
+        return format("SELECT DISTINCT %s FROM %s WHERE %s = ?", getPolicyColumnSeralized(), getContractAgreementTable(), getPolicyColumn());
     }
 
     @Override
     public String getUpdateAgreementTemplate() {
         return format("UPDATE %s SET %s=?, %s=?, %s=?, %s=?, %s=?, %s=?, %s=? WHERE %s =?",
                 getContractAgreementTable(), getProviderAgentColumn(), getConsumerAgentColumn(), getSigningDateColumn(),
-                getStartDateColumn(), getEndDateColumn(), getAssetIdColumn(), getPolicyIdColumn(), getContractAgreementIdColumn());
+                getStartDateColumn(), getEndDateColumn(), getAssetIdColumn(), getPolicyColumn(), getContractAgreementIdColumn());
     }
 
     @Override

--- a/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -274,7 +274,7 @@ public class SqlContractNegotiationStore implements ContractNegotiationStore {
                             contractAgreement.getContractStartDate(),
                             contractAgreement.getContractEndDate(),
                             contractAgreement.getAssetId(),
-                            contractAgreement.getPolicyId()
+                            toJson(contractAgreement.getPolicy())
                     );
                 } else {
                     // update agreement
@@ -285,7 +285,7 @@ public class SqlContractNegotiationStore implements ContractNegotiationStore {
                             contractAgreement.getContractStartDate(),
                             contractAgreement.getContractEndDate(),
                             contractAgreement.getAssetId(),
-                            contractAgreement.getPolicyId(),
+                            toJson(contractAgreement.getPolicy()),
                             agrId);
                 }
 
@@ -311,7 +311,8 @@ public class SqlContractNegotiationStore implements ContractNegotiationStore {
                 .providerAgentId(resultSet.getString(statements.getProviderAgentColumn()))
                 .consumerAgentId(resultSet.getString(statements.getConsumerAgentColumn()))
                 .assetId(resultSet.getString(statements.getAssetIdColumn()))
-                .policyId(resultSet.getString(statements.getPolicyIdColumn()))
+                .policy(fromJson(resultSet.getString(statements.getPolicyColumn()), new TypeReference<>() {
+                }))
                 .contractStartDate(resultSet.getLong(statements.getStartDateColumn()))
                 .contractEndDate(resultSet.getLong(statements.getEndDateColumn()))
                 .contractSigningDate(resultSet.getLong(statements.getSigningDateColumn()))

--- a/extensions/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/TestFunctions.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/TestFunctions.java
@@ -67,15 +67,14 @@ public class TestFunctions {
                 .providerAgentId("provider")
                 .consumerAgentId("consumer")
                 .assetId(UUID.randomUUID().toString())
-                .policyId(UUID.randomUUID().toString())
+                .policy(createPolicy())
                 .contractStartDate(Instant.now().getEpochSecond())
                 .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())
                 .contractSigningDate(Instant.now().getEpochSecond());
     }
 
-    public static Policy createPolicy(String uid) {
+    public static Policy createPolicy() {
         return Policy.Builder.newInstance()
-                .id(uid)
                 .permission(Permission.Builder.newInstance()
                         .target("")
                         .action(Action.Builder.newInstance()

--- a/extensions/sql/policy-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/policy/store/SqlPolicyStore.java
+++ b/extensions/sql/policy-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/policy/store/SqlPolicyStore.java
@@ -17,7 +17,7 @@ package org.eclipse.dataspaceconnector.sql.policy.store;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.eclipse.dataspaceconnector.policy.model.Duty;
 import org.eclipse.dataspaceconnector.policy.model.Permission;
-import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
 import org.eclipse.dataspaceconnector.policy.model.PolicyType;
 import org.eclipse.dataspaceconnector.policy.model.Prohibition;
 import org.eclipse.dataspaceconnector.spi.persistence.EdcPersistenceException;
@@ -56,7 +56,7 @@ public class SqlPolicyStore implements PolicyStore {
     }
 
     @Override
-    public @Nullable Policy findById(String id) {
+    public PolicyDefinition findById(String id) {
         try {
             return single(executeQuery(getConnection(), this::mapResultSet, sqlPolicyStoreStatements.getSqlFindByClauseTemplate(), id));
         } catch (SQLException exception) {
@@ -65,7 +65,7 @@ public class SqlPolicyStore implements PolicyStore {
     }
 
     @Override
-    public Stream<Policy> findAll(QuerySpec querySpec) {
+    public Stream<PolicyDefinition> findAll(QuerySpec querySpec) {
         Objects.requireNonNull(querySpec);
         var query = sqlPolicyStoreStatements.getSqlFindClauseTemplate();
 
@@ -77,7 +77,7 @@ public class SqlPolicyStore implements PolicyStore {
     }
 
     @Override
-    public void save(Policy policy) {
+    public void save(PolicyDefinition policy) {
         Objects.requireNonNull(policy);
         transactionContext.execute(() -> {
             if (findById(policy.getUid()) != null) {
@@ -89,7 +89,7 @@ public class SqlPolicyStore implements PolicyStore {
     }
 
     @Override
-    public Policy deleteById(String policyId) {
+    public @Nullable PolicyDefinition deleteById(String policyId) {
         Objects.requireNonNull(policyId);
         return transactionContext.execute(() -> {
             try (var connection = getConnection()) {
@@ -104,39 +104,47 @@ public class SqlPolicyStore implements PolicyStore {
         });
     }
 
-    private void insert(Policy policy) {
+    private void insert(PolicyDefinition policy) {
         transactionContext.execute(() -> {
             try (var connection = getConnection()) {
                 executeQuery(connection, sqlPolicyStoreStatements.getSqlInsertClauseTemplate(),
                         policy.getUid(),
-                        toJson(policy.getPermissions(), new TypeReference<List<Permission>>() {}),
-                        toJson(policy.getProhibitions(), new TypeReference<List<Prohibition>>() {}),
-                        toJson(policy.getObligations(), new TypeReference<List<Duty>>() {}),
+                        toJson(policy.getPermissions(), new TypeReference<List<Permission>>() {
+                        }),
+                        toJson(policy.getProhibitions(), new TypeReference<List<Prohibition>>() {
+                        }),
+                        toJson(policy.getObligations(), new TypeReference<List<Duty>>() {
+                        }),
                         toJson(policy.getExtensibleProperties()),
                         policy.getInheritsFrom(),
                         policy.getAssigner(),
                         policy.getAssignee(),
                         policy.getTarget(),
-                        toJson(policy.getType(), new TypeReference<PolicyType>() {}));
+                        toJson(policy.getType(), new TypeReference<PolicyType>() {
+                        }));
             } catch (Exception e) {
                 throw new EdcPersistenceException(e.getMessage(), e);
             }
         });
     }
 
-    private void update(Policy policy) {
+    private void update(PolicyDefinition policy) {
         transactionContext.execute(() -> {
             try (var connection = getConnection()) {
                 executeQuery(connection, sqlPolicyStoreStatements.getSqlUpdateClauseTemplate(),
-                        toJson(policy.getPermissions(), new TypeReference<List<Permission>>() {}),
-                        toJson(policy.getProhibitions(), new TypeReference<List<Prohibition>>() {}),
-                        toJson(policy.getObligations(), new TypeReference<List<Duty>>() {}),
+                        toJson(policy.getPermissions(), new TypeReference<List<Permission>>() {
+                        }),
+                        toJson(policy.getProhibitions(), new TypeReference<List<Prohibition>>() {
+                        }),
+                        toJson(policy.getObligations(), new TypeReference<List<Duty>>() {
+                        }),
                         toJson(policy.getExtensibleProperties()),
                         policy.getInheritsFrom(),
                         policy.getAssigner(),
                         policy.getAssignee(),
                         policy.getTarget(),
-                        toJson(policy.getType(), new TypeReference<PolicyType>() {}),
+                        toJson(policy.getType(), new TypeReference<PolicyType>() {
+                        }),
                         policy.getUid());
             } catch (Exception e) {
                 throw new EdcPersistenceException(e.getMessage(), e);
@@ -144,18 +152,23 @@ public class SqlPolicyStore implements PolicyStore {
         });
     }
 
-    private Policy mapResultSet(ResultSet resultSet) throws SQLException {
-        return Policy.Builder.newInstance()
+    private PolicyDefinition mapResultSet(ResultSet resultSet) throws SQLException {
+        return PolicyDefinition.Builder.newInstance()
                 .id(resultSet.getString(sqlPolicyStoreStatements.getPolicyColumnId()))
-                .permissions(fromJson(resultSet.getString(sqlPolicyStoreStatements.getPolicyColumnPermissions()), new TypeReference<>() {}))
-                .prohibitions(fromJson(resultSet.getString(sqlPolicyStoreStatements.getPolicyColumnProhibitions()), new TypeReference<>() {}))
-                .duties(fromJson(resultSet.getString(sqlPolicyStoreStatements.getPolicyColumnDuties()), new TypeReference<>() {}))
-                .extensibleProperties(fromJson(resultSet.getString(sqlPolicyStoreStatements.getPolicyColumnExtensibleProperties()), new TypeReference<>() {}))
+                .permissions(fromJson(resultSet.getString(sqlPolicyStoreStatements.getPolicyColumnPermissions()), new TypeReference<>() {
+                }))
+                .prohibitions(fromJson(resultSet.getString(sqlPolicyStoreStatements.getPolicyColumnProhibitions()), new TypeReference<>() {
+                }))
+                .duties(fromJson(resultSet.getString(sqlPolicyStoreStatements.getPolicyColumnDuties()), new TypeReference<>() {
+                }))
+                .extensibleProperties(fromJson(resultSet.getString(sqlPolicyStoreStatements.getPolicyColumnExtensibleProperties()), new TypeReference<>() {
+                }))
                 .inheritsFrom(resultSet.getString(sqlPolicyStoreStatements.getPolicyColumnInheritsFrom()))
                 .assigner(resultSet.getString(sqlPolicyStoreStatements.getPolicyColumnAssigner()))
                 .assignee(resultSet.getString(sqlPolicyStoreStatements.getPolicyColumnAssignee()))
                 .target(resultSet.getString(sqlPolicyStoreStatements.getPolicyColumnTarget()))
-                .type(fromJson(resultSet.getString(sqlPolicyStoreStatements.getPolicyColumnPolicyType()), new TypeReference<>() {}))
+                .type(fromJson(resultSet.getString(sqlPolicyStoreStatements.getPolicyColumnPolicyType()), new TypeReference<>() {
+                }))
                 .build();
     }
 

--- a/extensions/sql/policy-store-sql/src/test/java/org/eclipse/dataspaceconnector/slq/policy/store/SqlPolicyStoreTest.java
+++ b/extensions/sql/policy-store-sql/src/test/java/org/eclipse/dataspaceconnector/slq/policy/store/SqlPolicyStoreTest.java
@@ -17,7 +17,7 @@ package org.eclipse.dataspaceconnector.slq.policy.store;
 import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.policy.model.Duty;
 import org.eclipse.dataspaceconnector.policy.model.Permission;
-import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
 import org.eclipse.dataspaceconnector.policy.model.PolicyType;
 import org.eclipse.dataspaceconnector.policy.model.Prohibition;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
@@ -101,11 +101,11 @@ class SqlPolicyStoreTest {
     @DisplayName("Save (update) a single policy that already exists")
     void save_alreadyExists() {
         var id = getRandomId();
-        Policy policy1 = Policy.Builder.newInstance()
+        var policy1 = PolicyDefinition.Builder.newInstance()
                 .id(id)
                 .target("Target1")
                 .build();
-        Policy policy2 = Policy.Builder.newInstance()
+        var policy2 = PolicyDefinition.Builder.newInstance()
                 .id(id)
                 .target("Target2")
                 .build();
@@ -122,7 +122,7 @@ class SqlPolicyStoreTest {
     @Test
     @DisplayName("Find policy by ID that exists")
     void findById_whenPresent() {
-        Policy policy = getDummyPolicy(getRandomId());
+        var policy = getDummyPolicy(getRandomId());
         sqlPolicyStore.save(policy);
 
         var policyFromDb = sqlPolicyStore.findById(policy.getUid());
@@ -210,7 +210,7 @@ class SqlPolicyStoreTest {
         return UUID.randomUUID().toString();
     }
 
-    private Policy getDummyPolicy(String id) {
+    private PolicyDefinition getDummyPolicy(String id) {
         var permission = Permission.Builder.newInstance()
                 .uid(id)
                 .build();
@@ -223,7 +223,7 @@ class SqlPolicyStoreTest {
                 .uid(id)
                 .build();
 
-        return Policy.Builder.newInstance()
+        return PolicyDefinition.Builder.newInstance()
                 .id(id)
                 .permission(permission)
                 .prohibition(prohibition)
@@ -236,7 +236,7 @@ class SqlPolicyStoreTest {
                 .build();
     }
 
-    private List<Policy> getDummyPolicies(int count) {
+    private List<PolicyDefinition> getDummyPolicies(int count) {
         return IntStream.range(0, count).mapToObj(i -> getDummyPolicy(getRandomId())).collect(Collectors.toList());
     }
 

--- a/samples/04.0-file-transfer/transfer-file/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferExtension.java
+++ b/samples/04.0-file-transfer/transfer-file/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferExtension.java
@@ -19,7 +19,7 @@ import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataTransferExecuto
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.PipelineService;
 import org.eclipse.dataspaceconnector.policy.model.Action;
 import org.eclipse.dataspaceconnector.policy.model.Permission;
-import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyStore;
@@ -66,12 +66,12 @@ public class FileTransferExtension implements ServiceExtension {
         context.getMonitor().info("File Transfer Extension initialized!");
     }
 
-    private Policy createPolicy() {
+    private PolicyDefinition createPolicy() {
         var usePermission = Permission.Builder.newInstance()
                 .action(Action.Builder.newInstance().type("USE").build())
                 .build();
 
-        return Policy.Builder.newInstance()
+        return PolicyDefinition.Builder.newInstance()
                 .id(USE_POLICY)
                 .permission(usePermission)
                 .build();

--- a/samples/05-file-transfer-cloud/data-seeder/src/main/java/org/eclipse/dataspaceconnector/sample5/data/seeder/FakeSetup.java
+++ b/samples/05-file-transfer-cloud/data-seeder/src/main/java/org/eclipse/dataspaceconnector/sample5/data/seeder/FakeSetup.java
@@ -17,7 +17,7 @@ package org.eclipse.dataspaceconnector.sample5.data.seeder;
 import org.eclipse.dataspaceconnector.dataloading.AssetLoader;
 import org.eclipse.dataspaceconnector.policy.model.Action;
 import org.eclipse.dataspaceconnector.policy.model.Permission;
-import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
@@ -68,7 +68,7 @@ public class FakeSetup {
     }
 
     public void setupContractOffers() {
-        Policy publicPolicy = Policy.Builder.newInstance()
+        var publicPolicy = PolicyDefinition.Builder.newInstance()
                 .permission(Permission.Builder.newInstance()
                         .action(Action.Builder.newInstance()
                                 .type("USE")

--- a/samples/other/run-from-junit/src/test/java/org/eclipse/dataspaceconnector/junit/EndToEndTest.java
+++ b/samples/other/run-from-junit/src/test/java/org/eclipse/dataspaceconnector/junit/EndToEndTest.java
@@ -19,6 +19,7 @@ import org.eclipse.dataspaceconnector.dataloading.AssetLoader;
 import org.eclipse.dataspaceconnector.ids.spi.Protocols;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
@@ -144,7 +145,7 @@ public class EndToEndTest {
         var contractAgreement = ContractAgreement.Builder.newInstance()
                 .assetId(ASSET_ID)
                 .id(CONTRACT_ID)
-                .policyId(POLICY_ID)
+                .policy(POLICY_ID)
                 .consumerAgentId("consumer")
                 .providerAgentId("provider")
                 .build();
@@ -158,14 +159,14 @@ public class EndToEndTest {
                 .build();
         negotiationStore.save(contractNegotiation);
 
-        policyStore.save(Policy.Builder.newInstance().id(POLICY_ID).build());
+        policyStore.save(PolicyDefinition.Builder.newInstance().id(POLICY_ID).build());
     }
 
     @Provides(IdentityService.class)
     private static class TestServiceExtension implements ServiceExtension {
         @Inject
         private AssetLoader loader;
-        
+
         @Override
         public void initialize(ServiceExtensionContext context) {
             context.registerService(IdentityService.class, new IdentityService() {

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/agreement/ContractAgreement.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/agreement/ContractAgreement.java
@@ -37,7 +37,7 @@ public class ContractAgreement {
     private final long contractStartDate;
     private final long contractEndDate;
     private final String assetId;
-    private final String policyId;
+    private final Policy policy;
 
     private ContractAgreement(@NotNull String id,
                               @NotNull String providerAgentId,
@@ -45,7 +45,7 @@ public class ContractAgreement {
                               long contractSigningDate,
                               long contractStartDate,
                               long contractEndDate,
-                              @NotNull String policyId,
+                              @NotNull Policy policy,
                               @NotNull String assetId) {
         this.id = Objects.requireNonNull(id);
         this.providerAgentId = Objects.requireNonNull(providerAgentId);
@@ -54,7 +54,7 @@ public class ContractAgreement {
         this.contractStartDate = contractStartDate;
         this.contractEndDate = contractEndDate;
         this.assetId = Objects.requireNonNull(assetId);
-        this.policyId = Objects.requireNonNull(policyId);
+        this.policy = Objects.requireNonNull(policy);
     }
 
     /**
@@ -141,13 +141,13 @@ public class ContractAgreement {
      *
      * @return policy
      */
-    public String getPolicyId() {
-        return policyId;
+    public Policy getPolicy() {
+        return policy;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, providerAgentId, consumerAgentId, contractSigningDate, contractStartDate, contractEndDate, assetId, policyId);
+        return Objects.hash(id, providerAgentId, consumerAgentId, contractSigningDate, contractStartDate, contractEndDate, assetId, policy);
     }
 
     @Override
@@ -161,7 +161,7 @@ public class ContractAgreement {
         ContractAgreement that = (ContractAgreement) o;
         return contractSigningDate == that.contractSigningDate && contractStartDate == that.contractStartDate && contractEndDate == that.contractEndDate &&
                 Objects.equals(id, that.id) && Objects.equals(providerAgentId, that.providerAgentId) && Objects.equals(consumerAgentId, that.consumerAgentId) &&
-                Objects.equals(assetId, that.assetId) && Objects.equals(policyId, that.policyId);
+                Objects.equals(assetId, that.assetId) && Objects.equals(policy, that.policy);
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -175,7 +175,6 @@ public class ContractAgreement {
         private long contractEndDate;
         private String assetId;
         private Policy policy;
-        private String policyId;
 
         private Builder() {
         }
@@ -220,13 +219,13 @@ public class ContractAgreement {
             return this;
         }
 
-        public Builder policyId(String policyId) {
-            this.policyId = policyId;
+        public Builder policy(Policy policy) {
+            this.policy = policy;
             return this;
         }
 
         public ContractAgreement build() {
-            return new ContractAgreement(id, providerAgentId, consumerAgentId, contractSigningDate, contractStartDate, contractEndDate, policyId, assetId);
+            return new ContractAgreement(id, providerAgentId, consumerAgentId, contractSigningDate, contractStartDate, contractEndDate, policy, assetId);
         }
     }
 }

--- a/spi/policy-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/store/PolicyStore.java
+++ b/spi/policy-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/store/PolicyStore.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.spi.policy.store;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
 import org.eclipse.dataspaceconnector.spi.persistence.EdcPersistenceException;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.jetbrains.annotations.Nullable;
@@ -33,8 +34,7 @@ public interface PolicyStore {
      * @return {@link Policy} or null if not found.
      * @throws EdcPersistenceException if something goes wrong.
      */
-    @Nullable
-    Policy findById(String policyId);
+    PolicyDefinition findById(String policyId);
 
     /**
      * Find stream of policies in the store based on query spec.
@@ -43,7 +43,7 @@ public interface PolicyStore {
      * @return A {@link Stream} of {@link Policy}. Might be empty, never null.
      * @throws EdcPersistenceException if something goes wrong.
      */
-    Stream<Policy> findAll(QuerySpec spec);
+    Stream<PolicyDefinition> findAll(QuerySpec spec);
 
     /**
      * Persists the policy.
@@ -51,7 +51,7 @@ public interface PolicyStore {
      * @param policy to be saved.
      * @throws EdcPersistenceException if something goes wrong.
      */
-    void save(Policy policy);
+    void save(PolicyDefinition policy);
 
     /**
      * Deletes a policy for the given id.
@@ -61,7 +61,7 @@ public interface PolicyStore {
      * @throws EdcPersistenceException if something goes wrong.
      */
     @Nullable
-    Policy deleteById(String policyId);
+    PolicyDefinition deleteById(String policyId);
 
     /**
      * If the store implementation supports caching, this method triggers a cache-reload.

--- a/system-tests/azure-tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/local/BlobTransferUtils.java
+++ b/system-tests/azure-tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/local/BlobTransferUtils.java
@@ -79,8 +79,7 @@ public class BlobTransferUtils {
         seedProviderData(ASSETS_PATH, asset);
     }
 
-    @NotNull
-    public static String createPolicy() {
+    public static Policy createPolicy() {
         var policy = Policy.Builder.newInstance()
                 .permission(Permission.Builder.newInstance()
                         .target(PROVIDER_ASSET_ID)
@@ -91,7 +90,7 @@ public class BlobTransferUtils {
 
         seedProviderData(POLICIES_PATH, policy);
 
-        return policy.getUid();
+        return policy;
     }
 
     public static void createContractDefinition(String policyId) {

--- a/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferExtension.java
+++ b/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferExtension.java
@@ -19,7 +19,7 @@ import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataTransferExecuto
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.PipelineService;
 import org.eclipse.dataspaceconnector.policy.model.Action;
 import org.eclipse.dataspaceconnector.policy.model.Permission;
-import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyStore;
@@ -67,13 +67,13 @@ public class FileTransferExtension implements ServiceExtension {
         context.getMonitor().info("File Transfer Extension initialized!");
     }
 
-    private Policy createPolicy() {
+    private PolicyDefinition createPolicy() {
 
         var usePermission = Permission.Builder.newInstance()
                 .action(Action.Builder.newInstance().type("idsc:USE").build())
                 .build();
 
-        return Policy.Builder.newInstance()
+        return PolicyDefinition.Builder.newInstance()
                 .id(USE_POLICY)
                 .permission(usePermission)
                 .target("test-document")

--- a/system-tests/tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/utils/TransferSimulationUtils.java
+++ b/system-tests/tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/utils/TransferSimulationUtils.java
@@ -28,7 +28,6 @@ import org.jetbrains.annotations.NotNull;
 
 import java.time.Duration;
 import java.util.Map;
-import java.util.UUID;
 
 import static io.gatling.javaapi.core.CoreDsl.StringBody;
 import static io.gatling.javaapi.core.CoreDsl.doWhileDuring;
@@ -207,7 +206,6 @@ public abstract class TransferSimulationUtils {
 
     private static String loadContractAgreement(String providerUrl) {
         var policy = Policy.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
                 .permission(Permission.Builder.newInstance()
                         .target("test-document")
                         .action(Action.Builder.newInstance().type("USE").build())


### PR DESCRIPTION
## What this PR changes/adds

Policies should be stored alongside `ContractNegotiation`s and `ContractAgreements`, and for that we need another policy object _without_ an ID.

This PR renames `Policy` -> `PolicyDefinition` and introduces a `Policy` object, that comes without an ID.

## Why it does that

To fix a bug during data transfers, where the `PolicyArchive` could not resolve a policy because the ID was not serialized over IDS.

## Further notes

WIP.

## Linked Issue(s)

Closes #1340 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
