### PR TITLE
helm: Make Helm charts more generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Update the CodeQL version from v1 to v2
 * Update `slf4j-api` to `2.0.0-alpha7` (#1328)
 * Added timestamps to TransferProcess DTO (#1350)
+* Make Helm charts more generic (#1363)
 
 #### Removed
 

--- a/docs/developer/modules.md
+++ b/docs/developer/modules.md
@@ -79,7 +79,6 @@ org.eclipse.dataspaceconnector:jetty-micrometer:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:iam-daps:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:decentralized-identity:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:iam-mock:0.0.1-SNAPSHOT
-org.eclipse.dataspaceconnector:ids-policy:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:asset-index-sql:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:common-sql:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:contractdefinition-store-sql:0.0.1-SNAPSHOT

--- a/resources/charts/dataspace-connector/templates/configmap.yaml
+++ b/resources/charts/dataspace-connector/templates/configmap.yaml
@@ -8,11 +8,3 @@ data:
   {{- range $envName, $value := .Values.edc.env }}
   {{ $envName | quote }}: {{ $value | quote }}
   {{- end }}
-  WEB_HTTP_PORT: {{ .Values.edc.port | quote }}
-  WEB_HTTP_PATH: {{ .Values.edc.path | quote }}
-  WEB_HTTP_IDS_PORT: {{ .Values.edc.idsApi.port | quote }}
-  WEB_HTTP_IDS_PATH: {{ .Values.edc.idsApi.path | quote }}
-  {{ if eq .Values.edc.managementApi.enabled true }}
-  WEB_HTTP_DATA_PORT: {{ .Values.edc.managementApi.port | quote }}
-  WEB_HTTP_DATA_PATH: {{ .Values.edc.managementApi.path | quote }}
-  {{ end }}

--- a/resources/charts/dataspace-connector/templates/deployment.yaml
+++ b/resources/charts/dataspace-connector/templates/deployment.yaml
@@ -20,6 +20,10 @@ spec:
       labels:
         {{- include "dataspace-connector.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -33,17 +37,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - name: http
-              containerPort: {{ .Values.edc.port }}
-              protocol: TCP
-            - name: http-ids
-              containerPort: {{ .Values.edc.idsApi.port }}
-              protocol: TCP
-            {{ if .Values.edc.managementApi.enabled }}
-            - name: http-mgmt
-              containerPort: {{ .Values.edc.managementApi.port }}
-              protocol: TCP
-            {{ end }}
+            {{- range $k, $v := .Values.ports }}
+            - containerPort: {{ $v.containerPort }}
+              name: {{ $k }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "dataspace-connector.fullname" . }}-envvars
@@ -67,6 +64,8 @@ spec:
             initialDelaySeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            {{- toYaml .Values.edc.volumeMounts | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/resources/charts/dataspace-connector/templates/ingress.yaml
+++ b/resources/charts/dataspace-connector/templates/ingress.yaml
@@ -27,6 +27,7 @@ spec:
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
+    {{ if .paths }}
     - host: {{ .host | quote }}
       http:
         paths:
@@ -34,10 +35,16 @@ spec:
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
-                  number: {{ $svcPort }}
+                  number: {{ .port }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ .port }}
+              {{- end }}
           {{- end }}
+    {{ end }}
     {{- end }}
   {{- end }}

--- a/resources/charts/dataspace-connector/templates/service.yaml
+++ b/resources/charts/dataspace-connector/templates/service.yaml
@@ -7,19 +7,11 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.edc.port }}
-      protocol: TCP
-      name: http
-    {{ if .Values.edc.managementApi.enabled }}
-    - port: {{ .Values.service.managementApi.port }}
-      targetPort: {{ .Values.edc.managementApi.port }}
-      protocol: TCP
-      name: http-mgmt
-    {{ end }}
-    - port: {{ .Values.service.idsApi.port }}
-      targetPort: {{ .Values.edc.idsApi.port }}
-      protocol: TCP
-      name: http-ids
+  {{- range $k, $v := .Values.ports }}
+  - port: {{ default $v.containerPort $v.servicePort }}
+    targetPort: {{ $v.containerPort }}
+    name: {{ $k }}
+    protocol: TCP
+  {{- end }}
   selector:
     {{- include "dataspace-connector.selectorLabels" . | nindent 4 }}

--- a/resources/charts/dataspace-connector/values.yaml
+++ b/resources/charts/dataspace-connector/values.yaml
@@ -27,25 +27,36 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+ports: {}
+  # Example:
+  #  http:
+  #    containerPort: 8181
+  #    servicePort: 80 (Optional: if not provided, the value of containerPort will be used)
+  #    path: /api
+
+volumes: []
+  # Define a volume that can then be mounted into a container. Please refer to https://kubernetes.io/docs/concepts/storage/volumes/
+  # for more details. Below example will create a volume from the content of the `log-config` ConfigMap keyed with `log_level`:
+  # - name: config-vol
+  #   configMap:
+  #     name: log-config
+  #     items:
+  #     - key: log_level
+  #       path: log_level
+
 edc:
-  port: 8181
-  path: /api
-  managementApi:
-    enabled: true
-    port: 9191
-    path: /api/v1/data
-  idsApi:
-    port: 8282
-    path: /api/v1/ids
   env: {}
   envSecrets: {}
+  volumeMounts: []
+  # Mount the provided volume in the POD filesystem at the specific path. Please refer to
+  # https://kubernetes.io/fr/docs/concepts/storage/volumes/ for more details.
+  # Example:
+  # - name: config-vol
+  #   mountPath: /etc/config
+  # will mount the `config-vol` volume at /etc/config
+
 service:
   type: ClusterIP
-  port: 80
-  managementApi:
-    port: 91
-  idsApi:
-    port: 8282
 
 ingress:
   enabled: false
@@ -56,6 +67,7 @@ ingress:
   hosts:
     - host: dataspace-connector.local
       paths: []
+
   tls: []
   #  - secretName: dataspace-connector-tls
   #    hosts:

--- a/system-tests/minikube/minikube-test.sh
+++ b/system-tests/minikube/minikube-test.sh
@@ -12,7 +12,7 @@ dir=$(dirname $0)
 
 for target in consumer provider; do
   docker build -t $target --build-arg JAR=system-tests/runtimes/file-transfer-$target/build/libs/$target.jar -f launchers/generic/Dockerfile .
-  helm upgrade --install -f $dir/values-$target.yaml $target resources/charts/dataspace-connector
+  helm upgrade --install -f $dir/values-controlplane.yaml -f $dir/values-$target.yaml $target resources/charts/dataspace-connector
 done
 
 # Wait for pods to be live

--- a/system-tests/minikube/values-consumer.yaml
+++ b/system-tests/minikube/values-consumer.yaml
@@ -1,9 +1,10 @@
 image:
   repository: consumer
   tag: latest
+
 service:
   type: NodePort
-  port: 8181
+
 edc:
   env:
     IDS_WEBHOOK_ADDRESS: http://consumer-dataspace-connector:8282

--- a/system-tests/minikube/values-controlplane.yaml
+++ b/system-tests/minikube/values-controlplane.yaml
@@ -1,0 +1,22 @@
+edc:
+  env:
+    WEB_HTTP_PORT: 8181
+    WEB_HTTP_PATH: /api
+    WEB_HTTP_IDS_PORT: 8282
+    WEB_HTTP_IDS_PATH: /api/v1/ids
+    WEB_HTTP_DATA_PORT: 9191
+    WEB_HTTP_DATA_PATH: /api/v1/data
+
+ports:
+  http:
+    containerPort: 8181
+    servicePort: 80
+    path: /api
+  ids:
+    containerPort: 8282
+    servicePort: 8282
+    path: /api/v1/ids
+  http-mgmt:
+    containerPort: 9191
+    servicePort: 91
+    path: /api/v1/data

--- a/system-tests/minikube/values-provider.yaml
+++ b/system-tests/minikube/values-provider.yaml
@@ -1,6 +1,7 @@
 image:
   repository: provider
   tag: latest
+
 edc:
   env:
     IDS_WEBHOOK_ADDRESS: http://provider-dataspace-connector:8282


### PR DESCRIPTION
## What this PR changes/adds

This PR brings some improvement to the existing Helm charts, which was tainted for only being used to deploy the Control Plane of the EDC. 

In order to avoid code duplication for deploying other components of the EDC (data plane, data plane selector, federated catalog...), we make the existing Helm charts more generic. Especially,:

- We remove the hardcoded environment variables within the Deployment objects, as this is specific to the EDC component which is being deployed (for example, Data Plane does not have an IDS port, so existing charts could not be used to deploy the DPF). 
- Ports numbering is now up to the client which is using the helm charts, and is no longer hardcoded in the helm chart (as this is something that is defined at image build-time).
- Unlimited number of ports can now be registered (http, http-ids, http-mgnt was hardcoded before).
- We offer the possibility to mount file in volume within the POD (this unlock usage of some filesystem extensions.
- Ingress can now expose more than one port, which was not possible with the current implementation. 

## Why it does that

Avoid duplication of Helm charts for the other EDC components.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
