### PR TITLE
Add validation for contract definition id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Postgresql end to end test (#1278)
 * Add signing/publishing config (#1147)
 * Verify OpenAPI definitions (#1312)
+* Add validation to contract definition id (#1347)
 
 #### Changed
 

--- a/common/util/build.gradle.kts
+++ b/common/util/build.gradle.kts
@@ -21,8 +21,11 @@ plugins {
 val jupiterVersion: String by project
 val mockitoVersion: String by project
 val okHttpVersion: String by project
+val jakartaValidationApi: String by project
 
 dependencies {
+    implementation("jakarta.validation:jakarta.validation-api:${jakartaValidationApi}")
+
     testFixturesImplementation("org.mockito:mockito-core:${mockitoVersion}")
     testFixturesImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
     testFixturesRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")

--- a/common/util/src/main/java/org/eclipse/dataspaceconnector/common/annotations/Uuid.java
+++ b/common/util/src/main/java/org/eclipse/dataspaceconnector/common/annotations/Uuid.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2022 ZF Friedrichshafen AG
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial Implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.common.annotations;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import org.eclipse.dataspaceconnector.common.validator.UuidValidator;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = UuidValidator.class)
+@Target({ ElementType.METHOD, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Uuid {
+    String message() default "Invalid UUID";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/common/util/src/main/java/org/eclipse/dataspaceconnector/common/validator/UuidValidator.java
+++ b/common/util/src/main/java/org/eclipse/dataspaceconnector/common/validator/UuidValidator.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2022 ZF Friedrichshafen AG
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial Implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.common.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.eclipse.dataspaceconnector.common.annotations.Uuid;
+
+import java.util.UUID;
+
+public class UuidValidator implements ConstraintValidator<Uuid, String> {
+
+    @Override
+    public void initialize(Uuid contactNumber) {
+    }
+
+    @Override
+    public boolean isValid(String uuid, ConstraintValidatorContext cxt) {
+        if (uuid == null) {
+            return false;
+        }
+
+        try {
+            UUID.fromString(uuid);
+        } catch (IllegalArgumentException exception) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/common/util/src/test/java/org/eclipse/dataspaceconnector/common/validator/UuidValidatorTest.java
+++ b/common/util/src/test/java/org/eclipse/dataspaceconnector/common/validator/UuidValidatorTest.java
@@ -1,0 +1,24 @@
+package org.eclipse.dataspaceconnector.common.validator;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UuidValidatorTest {
+
+    UuidValidator uuidValidator = new UuidValidator();
+
+    @Test
+    void isValid_valid_UUID() {
+        String uuid = UUID.randomUUID().toString();
+        assertThat(uuidValidator.isValid(uuid, null)).isTrue();
+    }
+
+    @Test
+    void isValid_invalid_UUID() {
+        String uuid = "invalid-uuid-string";
+        assertThat(uuidValidator.isValid(uuid, null)).isFalse();
+    }
+}

--- a/extensions/api/api-core/build.gradle.kts
+++ b/extensions/api/api-core/build.gradle.kts
@@ -28,12 +28,12 @@ dependencies {
     implementation(project(":common:util"))
     implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
     implementation("jakarta.validation:jakarta.validation-api:${jakartaValidationApi}")
+    implementation("org.glassfish.jersey.ext:jersey-bean-validation:${jerseyVersion}") //for validation
 
     testImplementation("org.glassfish.jersey.core:jersey-common:${jerseyVersion}")
     testImplementation("org.glassfish.jersey.core:jersey-server:${jerseyVersion}")
 
     testImplementation(testFixtures(project(":launchers:junit")))
-    testRuntimeOnly("org.glassfish.jersey.ext:jersey-bean-validation:${jerseyVersion}") //for validation
 }
 
 publishing {

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/ContractDefinitionDto.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/ContractDefinitionDto.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import jakarta.validation.constraints.NotNull;
+import org.eclipse.dataspaceconnector.common.annotations.Uuid;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
 
 import java.util.ArrayList;
@@ -32,7 +33,7 @@ public class ContractDefinitionDto {
     private String contractPolicyId;
     @NotNull
     private List<Criterion> criteria = new ArrayList<>();
-    @NotNull
+    @Uuid
     private String id;
 
     private ContractDefinitionDto() {

--- a/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiControllerIntegrationTest.java
@@ -104,7 +104,7 @@ public class ContractDefinitionApiControllerIntegrationTest {
 
     @Test
     void postContractDefinition(ContractDefinitionStore store) {
-        var dto = createDto("definitionId");
+        var dto = createDto(UUID.randomUUID().toString());
 
         baseRequest()
                 .body(dto)
@@ -118,7 +118,7 @@ public class ContractDefinitionApiControllerIntegrationTest {
     @Test
     void postContractDefinition_invalidBody(ContractDefinitionStore store) {
         var dto = ContractDefinitionDto.Builder.newInstance()
-                .id("test-id")
+                .id(UUID.randomUUID().toString())
                 .contractPolicyId(null)
                 .accessPolicyId(UUID.randomUUID().toString())
                 .build();
@@ -133,9 +133,27 @@ public class ContractDefinitionApiControllerIntegrationTest {
     }
 
     @Test
+    void postContractDefinition_invalidContractDefinitionId(ContractDefinitionStore store) {
+        var dto = ContractDefinitionDto.Builder.newInstance()
+                .id("invalid-id")
+                .contractPolicyId(UUID.randomUUID().toString())
+                .accessPolicyId(UUID.randomUUID().toString())
+                .build();
+
+        baseRequest()
+                .body(dto)
+                .contentType(JSON)
+                .post("/contractdefinitions")
+                .then()
+                .statusCode(400);
+        assertThat(store.findAll()).isEmpty();
+    }
+
+    @Test
     void postContractDefinition_alreadyExists(ContractDefinitionLoader loader, ContractDefinitionStore store) {
-        loader.accept(createContractDefinition("definitionId"));
-        var dto = createDto("definitionId");
+        String id = UUID.randomUUID().toString();
+        loader.accept(createContractDefinition(id));
+        var dto = createDto(id);
 
         baseRequest()
                 .body(dto)


### PR DESCRIPTION
## What this PR changes/adds

Add validation for contract definition id

## Why it does that

Validation of contract definition id by creation solves the problem in negotiation process when the id is not valid.

## Further notes

Marking jersey-bean-validation helps for the correct validation of parameters.


## Linked Issue(s)

Closes #1347

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
