### PR TITLE
Bugfix: `PartitionManagerImpl` should not swallow exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Remove ContractDef from Cosmos DB cache when deleting (#1330)
 * Fix misleading warning message on initialization (#1336)
 * Auto-upload of Cosmos stored procedures (#1338)
+* Resiliency against exceptions in the `PartitionManagerImpl` (#1366)
 
 ## [milestone-3] - 2022-04-08
 

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheExtension.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheExtension.java
@@ -65,7 +65,7 @@ import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 
-@Provides({Crawler.class, LoaderManager.class, QueryEngine.class, NodeQueryAdapterRegistry.class, CacheQueryAdapterRegistry.class})
+@Provides({ Crawler.class, LoaderManager.class, QueryEngine.class, NodeQueryAdapterRegistry.class, CacheQueryAdapterRegistry.class })
 public class FederatedCatalogCacheExtension implements ServiceExtension {
     public static final int DEFAULT_NUM_CRAWLERS = 1;
     private static final int DEFAULT_QUEUE_LENGTH = 50;
@@ -170,7 +170,7 @@ public class FederatedCatalogCacheExtension implements ServiceExtension {
                 .map(n -> new WorkItem(n.getTargetUrl(), selectProtocol(n.getSupportedProtocols()))).collect(Collectors.toList());
 
         return new PartitionManagerImpl(monitor,
-                new DefaultWorkItemQueue(partitionManagerConfig.getWorkItemQueueSize(10)),
+                new DefaultWorkItemQueue(partitionManagerConfig.getWorkItemQueueSize()),
                 workItems -> createCrawler(workItems, context, protocolAdapterRegistry, updateResponseQueue),
                 partitionManagerConfig.getNumCrawlers(DEFAULT_NUM_CRAWLERS),
                 nodes);

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/PartitionConfiguration.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/PartitionConfiguration.java
@@ -22,6 +22,8 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import java.time.Duration;
 import java.util.Random;
 
+import static java.lang.String.format;
+
 /**
  * Object that provides configuration for the {@link PartitionManager}.
  * All configuration values that do not allow for default values are resolved instantly, all others are resolved
@@ -29,6 +31,8 @@ import java.util.Random;
  */
 public class PartitionConfiguration {
 
+    @EdcSetting
+    static final String PART_EXECUTION_PLAN_PERIOD_SECONDS = "edc.catalog.cache.execution.period.seconds";
     @EdcSetting
     private static final String PART_WORK_ITEM_QUEUE_SIZE_SETTING = "edc.catalog.cache.partition.queue.size";
     @EdcSetting
@@ -38,18 +42,18 @@ public class PartitionConfiguration {
     @EdcSetting
     private static final String PART_LOADER_RETRY_TIMEOUT = "edc.catalog.cache.loader.timeout.millis";
     @EdcSetting
-    private static final String PART_EXECUTION_PLAN_PERIOD_SECONDS = "edc.catalog.cache.execution.period.seconds";
-    @EdcSetting
     private static final String PART_EXECUTION_PLAN_DELAY_SECONDS = "edc.catalog.cache.execution.delay.seconds";
     private static final int DEFAULT_EXECUTION_PERIOD_SECONDS = 60;
+    private static final int LOW_EXECUTION_PERIOD_SECONDS_THRESHOLD = 10;
+    private static final int DEFAULT_WORK_ITEM_QUEUE_SIZE = 10;
     private final ServiceExtensionContext context;
 
     public PartitionConfiguration(ServiceExtensionContext context) {
         this.context = context;
     }
 
-    public int getWorkItemQueueSize(int defaultValue) {
-        return context.getSetting(PART_WORK_ITEM_QUEUE_SIZE_SETTING, defaultValue);
+    public int getWorkItemQueueSize() {
+        return context.getSetting(PART_WORK_ITEM_QUEUE_SIZE_SETTING, DEFAULT_WORK_ITEM_QUEUE_SIZE);
     }
 
     public int getNumCrawlers(int defaultValue) {
@@ -76,6 +80,10 @@ public class PartitionConfiguration {
             } catch (NumberFormatException ex) {
                 initialDelaySeconds = 0;
             }
+        }
+        if (periodSeconds < LOW_EXECUTION_PERIOD_SECONDS_THRESHOLD) {
+            context.getMonitor().warning(format("An execution period of %d seconds is very low (threshold = %d). This might result in the work queue to fill up, especially on small queues (current capacity: %d)." +
+                    " A longer execution period should be considered.", periodSeconds, LOW_EXECUTION_PERIOD_SECONDS_THRESHOLD, getWorkItemQueueSize()));
         }
         return new RecurringExecutionPlan(Duration.ofSeconds(periodSeconds), Duration.ofSeconds(initialDelaySeconds));
     }

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/PartitionConfiguration.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/PartitionConfiguration.java
@@ -81,11 +81,12 @@ public class PartitionConfiguration {
                 initialDelaySeconds = 0;
             }
         }
+        var monitor = context.getMonitor();
         if (periodSeconds < LOW_EXECUTION_PERIOD_SECONDS_THRESHOLD) {
-            context.getMonitor().warning(format("An execution period of %d seconds is very low (threshold = %d). This might result in the work queue to fill up, especially on small queues (current capacity: %d)." +
+            monitor.warning(format("An execution period of %d seconds is very low (threshold = %d). This might result in the work queue to fill up, especially on small queues (current capacity: %d)." +
                     " A longer execution period should be considered.", periodSeconds, LOW_EXECUTION_PERIOD_SECONDS_THRESHOLD, getWorkItemQueueSize()));
         }
-        return new RecurringExecutionPlan(Duration.ofSeconds(periodSeconds), Duration.ofSeconds(initialDelaySeconds));
+        return new RecurringExecutionPlan(Duration.ofSeconds(periodSeconds), Duration.ofSeconds(initialDelaySeconds), monitor);
     }
 
     private int randomSeconds() {

--- a/extensions/catalog/federated-catalog-spi/src/test/java/org/eclipse/dataspaceconnector/catalog/spi/PartitionConfigurationTest.java
+++ b/extensions/catalog/federated-catalog-spi/src/test/java/org/eclipse/dataspaceconnector/catalog/spi/PartitionConfigurationTest.java
@@ -1,0 +1,36 @@
+package org.eclipse.dataspaceconnector.catalog.spi;
+
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PartitionConfigurationTest {
+
+    private PartitionConfiguration configuration;
+    private ServiceExtensionContext context;
+    private Monitor monitorMock;
+
+    @BeforeEach
+    void setup() {
+        monitorMock = mock(Monitor.class);
+        context = mock(ServiceExtensionContext.class);
+        when(context.getMonitor()).thenReturn(monitorMock);
+        configuration = new PartitionConfiguration(context);
+    }
+
+    @Test
+    void getExecutionPlan_whenLowPeriod() {
+        when(context.getSetting(eq(PartitionConfiguration.PART_EXECUTION_PLAN_PERIOD_SECONDS), anyInt())).thenReturn(9);
+
+        configuration.getExecutionPlan();
+        verify(monitorMock).warning(startsWith("An execution period of 9 seconds is very low "));
+    }
+}

--- a/extensions/catalog/federated-catalog-spi/src/test/java/org/eclipse/dataspaceconnector/catalog/spi/PartitionConfigurationTest.java
+++ b/extensions/catalog/federated-catalog-spi/src/test/java/org/eclipse/dataspaceconnector/catalog/spi/PartitionConfigurationTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi;
 
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;


### PR DESCRIPTION
## What this PR changes/adds

wraps the `workItemQueue.addAll(...)` statement in  a `try-catch` block so that an exception does not cause the `ExecutionPlan` to die a silent death anymore.

## Why it does that

When the `Runnable`, that gets passed to the `ExecutionPlan`, throws an exception, for example because the queue is full, this caused the `ExecutionPlan` to die silently.

Catching and logging any exception mitigates that.

## Further notes

- An `IllegalStateException` that is thrown by `workQueue.addAll()` is somewhat of an expected situation, therefore I opted for logging only a `WARNING`, as opposed to any other exception, that is logged as `SEVERE`.

- That situation will arise more quickly if the period of the recurring execution plan is set to a very low value.

- reading from the queue (`CrawlerImpl#L77`) already guards against any Throwable.
- Added a warning if a execution period < 10 seconds was configured.

## Linked Issue(s)

Closes #1366 

## Checklist

- [x] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
