### PR TITLE
Bugfix: right-hand operand may contain equals signs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Fix misleading warning message on initialization (#1336)
 * Auto-upload of Cosmos stored procedures (#1338)
 * Resiliency against exceptions in the `PartitionManagerImpl` (#1366)
+* QuerySpec when right-op contains "=" or " " (#1380)
 
 ## [milestone-3] - 2022-04-08
 

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/QuerySpec.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/QuerySpec.java
@@ -67,7 +67,7 @@ public class QuerySpec {
     }
 
     public static final class Builder {
-        private static final String EQUALS_EXPRESSION_PATTERN = "[^\\s\\\\]*(\\s*)=(\\s*)[^\\s\\\\]*";
+        private static final String EQUALS_EXPRESSION_PATTERN = "[^\\s\\\\]*(\\s*)=(\\s*)[^\\\\]*";
         private final QuerySpec querySpec;
         private boolean equalsAsContains = false;
 
@@ -129,13 +129,14 @@ public class QuerySpec {
 
             if (filterExpression != null) {
                 if (Pattern.matches(EQUALS_EXPRESSION_PATTERN, filterExpression)) { // something like X = Y
-                    // remove whitespaces
-                    filterExpression = filterExpression.replace(" ", "");
-                    // we'll interpret the "=" as "contains"
-                    var tokens = filterExpression.split("=");
-                    querySpec.filterExpression = List.of(new Criterion(tokens[0], equalsAsContains ? "contains" : "=", tokens[1]));
+                    // we'll interpret the "=" as "contains" if desired
+                    var tokens = filterExpression.split("=", 2);
+                    var left = tokens[0].trim();
+                    var right = tokens[1].trim();
+                    var op = equalsAsContains ? "contains" : "=";
+                    querySpec.filterExpression = List.of(new Criterion(left, op, right));
                 } else {
-                    var s = filterExpression.split(" +");
+                    var s = filterExpression.split(" +", 3);
 
                     //generic LEFT OPERAND RIGHT expression
                     if (s.length >= 3) {

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/query/QuerySpecTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/query/QuerySpecTest.java
@@ -84,4 +84,28 @@ class QuerySpecTest {
         assertThat(qs.getFilterExpression()).isNotNull().isEmpty();
     }
 
+    @Test
+    void verify_filterEqualsWithValueContainsEqualsSign() {
+        var spec = QuerySpec.Builder.newInstance().equalsAsContains(true).filter("additionalProp1=a/b=c/d").build();
+        assertThat(spec.getFilterExpression()).hasSize(1).containsOnly(new Criterion("additionalProp1", "contains", "a/b=c/d"));
+
+        var spec2 = QuerySpec.Builder.newInstance().equalsAsContains(false).filter("additionalProp1=a/b=c/d").build();
+        assertThat(spec2.getFilterExpression()).hasSize(1).containsOnly(new Criterion("additionalProp1", "=", "a/b=c/d"));
+    }
+
+    @Test
+    void verify_filterEqualsWithValueContainsSpaces() {
+        var spec = QuerySpec.Builder.newInstance().equalsAsContains(true).filter("additionalProp1=a/b c/d").build();
+        assertThat(spec.getFilterExpression()).hasSize(1).containsOnly(new Criterion("additionalProp1", "contains", "a/b c/d"));
+
+        var spec2 = QuerySpec.Builder.newInstance().equalsAsContains(false).filter("additionalProp1=a/b c/d").build();
+        assertThat(spec2.getFilterExpression()).hasSize(1).containsOnly(new Criterion("additionalProp1", "=", "a/b c/d"));
+    }
+
+    @Test
+    void verify_filterWithValueContainsSpaces() {
+        var spec = QuerySpec.Builder.newInstance().filter("key instanceof some value").build();
+        assertThat(spec.getFilterExpression()).hasSize(1).containsOnly(new Criterion("key", "instanceof", "some value"));
+    }
+
 }


### PR DESCRIPTION
## What this PR changes/adds

This PR adds the `limit` parameter to the `String#split` method, causing the right-hand operand to be used "as-is", and not chop off parts after the "=" sign.

## Why it does that

When building `QuerySpec`s out of a filter string, there was a bug when the right-hand operand contained a `"="` sign: the portion right of it would get chopped off because `String#split` would tokenize into too many elements.

## Further notes

The Regex to detect EQUALS expressions and the generic parse step (the `else` path) was adapted, so that the right-hand operand may also contain spaces.

**Please comment in case this is not the desired behaviour**

## Linked Issue(s)

Closes #1380 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
