### PR TITLE
workflow: update pull-request-auto-assign-project.yaml

### DIFF
--- a/.github/workflows/pull-request-auto-assign-project.yaml
+++ b/.github/workflows/pull-request-auto-assign-project.yaml
@@ -9,11 +9,9 @@ env:
 jobs:
   assign-project:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - name: Assign to basic project
         uses: srggrs/assign-one-project-github-action@1.3.1
         with:
           project: 'https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/projects/1'
+          column_name: 'In progress'


### PR DESCRIPTION
## What this PR changes/adds

Updates the PR workflow that should assign any new PR to the project's "in progress" column. Remove permission lines and add `column_name`.

## Why it does that

Currently, the action never fails. However, no PR gets automatically assigned to a project, although this should now be the case for most, since we have more technical committers. I'm pretty sure this has worked before when I replaced the action in [5808a51](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/commits/main/.github/workflows/pull-request-auto-assign-project.yaml). 

## Further notes

Will search for another action if this still not works.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
