### PR TITLE
System tests: extend Gatling scope

### DIFF
--- a/.github/workflows/performancetests.yaml
+++ b/.github/workflows/performancetests.yaml
@@ -15,7 +15,7 @@ jobs:
     env:
       REPEAT: 5
       AT_ONCE_USERS: 10
-      MAX_RESPONSE_TIME: 5000
+      MAX_RESPONSE_TIME: 10000
       SUCCESS_PERCENTAGE: 100.0
 
     steps:

--- a/extensions/azure/azure-test/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/testfixtures/AbstractAzureBlobTest.java
+++ b/extensions/azure/azure-test/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/testfixtures/AbstractAzureBlobTest.java
@@ -16,9 +16,6 @@ package org.eclipse.dataspaceconnector.azure.testfixtures;
 
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
-import com.azure.storage.blob.BlobServiceClientBuilder;
-import com.azure.storage.common.StorageSharedKeyCredential;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -47,31 +44,10 @@ public abstract class AbstractAzureBlobTest {
     public void setupClient() {
         account1ContainerName = "storage-container-" + testRunId;
 
-        blobServiceClient1 = getBlobServiceClient(account1Name, account1Key);
-        blobServiceClient2 = getBlobServiceClient(account2Name, account2Key);
+        blobServiceClient1 = TestFunctions.getBlobServiceClient(account1Name, account1Key);
+        blobServiceClient2 = TestFunctions.getBlobServiceClient(account2Name, account2Key);
 
         createContainer(blobServiceClient1, account1ContainerName);
-    }
-
-    @NotNull
-    private static BlobServiceClient getBlobServiceClient(String accountName, String key) {
-        return getBlobServiceClient(accountName, key, getEndpoint(accountName));
-    }
-
-    @NotNull
-    public static BlobServiceClient getBlobServiceClient(String accountName, String key, String endpoint) {
-        var client = new BlobServiceClientBuilder()
-                .credential(new StorageSharedKeyCredential(accountName, key))
-                .endpoint(endpoint)
-                .buildClient();
-
-        client.getAccountInfo();
-        return client;
-    }
-
-    @NotNull
-    protected static String getEndpoint(String accountName) {
-        return "http://127.0.0.1:10000/" + accountName;
     }
 
     protected void createContainer(BlobServiceClient client, String containerName) {

--- a/extensions/azure/azure-test/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/testfixtures/AbstractAzureBlobTest.java
+++ b/extensions/azure/azure-test/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/testfixtures/AbstractAzureBlobTest.java
@@ -54,7 +54,7 @@ public abstract class AbstractAzureBlobTest {
     }
 
     @NotNull
-    public static BlobServiceClient getBlobServiceClient(String accountName, String key) {
+    private static BlobServiceClient getBlobServiceClient(String accountName, String key) {
         return getBlobServiceClient(accountName, key, getEndpoint(accountName));
     }
 

--- a/extensions/azure/azure-test/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/testfixtures/AbstractAzureBlobTest.java
+++ b/extensions/azure/azure-test/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/testfixtures/AbstractAzureBlobTest.java
@@ -54,10 +54,15 @@ public abstract class AbstractAzureBlobTest {
     }
 
     @NotNull
-    private BlobServiceClient getBlobServiceClient(String accountName, String key) {
+    public static BlobServiceClient getBlobServiceClient(String accountName, String key) {
+        return getBlobServiceClient(accountName, key, getEndpoint(accountName));
+    }
+
+    @NotNull
+    public static BlobServiceClient getBlobServiceClient(String accountName, String key, String endpoint) {
         var client = new BlobServiceClientBuilder()
                 .credential(new StorageSharedKeyCredential(accountName, key))
-                .endpoint(getEndpoint(accountName))
+                .endpoint(endpoint)
                 .buildClient();
 
         client.getAccountInfo();
@@ -65,7 +70,7 @@ public abstract class AbstractAzureBlobTest {
     }
 
     @NotNull
-    protected String getEndpoint(String accountName) {
+    protected static String getEndpoint(String accountName) {
         return "http://127.0.0.1:10000/" + accountName;
     }
 

--- a/extensions/azure/azure-test/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/testfixtures/TestFunctions.java
+++ b/extensions/azure/azure-test/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/testfixtures/TestFunctions.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.azure.testfixtures;
+
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.common.StorageSharedKeyCredential;
+import org.jetbrains.annotations.NotNull;
+
+public final class TestFunctions {
+    private TestFunctions() {
+    }
+
+    @NotNull
+    public static BlobServiceClient getBlobServiceClient(String accountName, String key) {
+        return getBlobServiceClient(accountName, key, getBlobServiceTestEndpoint(accountName));
+    }
+
+    @NotNull
+    public static BlobServiceClient getBlobServiceClient(String accountName, String key, String endpoint) {
+        var client = new BlobServiceClientBuilder()
+                .credential(new StorageSharedKeyCredential(accountName, key))
+                .endpoint(endpoint)
+                .buildClient();
+
+        client.getAccountInfo();
+        return client;
+    }
+
+    @NotNull
+    public static String getBlobServiceTestEndpoint(String accountName) {
+        return "http://127.0.0.1:10000/" + accountName;
+    }
+}

--- a/extensions/azure/blobstorage/blob-provision/src/test/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectContainerStatusCheckerIntegrationTest.java
+++ b/extensions/azure/blobstorage/blob-provision/src/test/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectContainerStatusCheckerIntegrationTest.java
@@ -18,6 +18,7 @@ import net.jodah.failsafe.RetryPolicy;
 import org.eclipse.dataspaceconnector.azure.blob.core.AzureBlobStoreSchema;
 import org.eclipse.dataspaceconnector.azure.blob.core.api.BlobStoreApiImpl;
 import org.eclipse.dataspaceconnector.azure.testfixtures.AbstractAzureBlobTest;
+import org.eclipse.dataspaceconnector.azure.testfixtures.TestFunctions;
 import org.eclipse.dataspaceconnector.azure.testfixtures.annotations.AzureStorageIntegrationTest;
 import org.eclipse.dataspaceconnector.common.testfixtures.TestUtils;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
@@ -49,7 +50,7 @@ class ObjectContainerStatusCheckerIntegrationTest extends AbstractAzureBlobTest 
         Vault vault = mock(Vault.class);
 
         when(vault.resolveSecret(account1Name + "-key1")).thenReturn(account1Key);
-        var blobStoreApi = new BlobStoreApiImpl(vault, getEndpoint(account1Name));
+        var blobStoreApi = new BlobStoreApiImpl(vault, TestFunctions.getBlobServiceTestEndpoint(account1Name));
         checker = new ObjectContainerStatusChecker(blobStoreApi, policy);
     }
 

--- a/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/AzureDataPlaneCopyIntegrationTest.java
+++ b/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/AzureDataPlaneCopyIntegrationTest.java
@@ -23,6 +23,7 @@ import org.eclipse.dataspaceconnector.azure.blob.core.api.BlobStoreApiImpl;
 import org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline.AzureStorageDataSinkFactory;
 import org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline.AzureStorageDataSourceFactory;
 import org.eclipse.dataspaceconnector.azure.testfixtures.AbstractAzureBlobTest;
+import org.eclipse.dataspaceconnector.azure.testfixtures.TestFunctions;
 import org.eclipse.dataspaceconnector.azure.testfixtures.annotations.AzureStorageIntegrationTest;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
@@ -64,8 +65,8 @@ class AzureDataPlaneCopyIntegrationTest extends AbstractAzureBlobTest {
     Monitor monitor = mock(Monitor.class);
     Vault vault = mock(Vault.class);
 
-    BlobStoreApi account1Api = new BlobStoreApiImpl(vault, getEndpoint(account1Name));
-    BlobStoreApi account2Api = new BlobStoreApiImpl(vault, getEndpoint(account2Name));
+    BlobStoreApi account1Api = new BlobStoreApiImpl(vault, TestFunctions.getBlobServiceTestEndpoint(account1Name));
+    BlobStoreApi account2Api = new BlobStoreApiImpl(vault, TestFunctions.getBlobServiceTestEndpoint(account2Name));
 
     @BeforeEach
     void setUp() {

--- a/system-tests/azure-data-factory-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/local/AzureDataFactoryTransferIntegrationTest.java
+++ b/system-tests/azure-data-factory-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/local/AzureDataFactoryTransferIntegrationTest.java
@@ -35,13 +35,15 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.UUID;
 
+import static java.lang.String.format;
 import static java.lang.String.valueOf;
 import static java.lang.System.getenv;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.system.tests.local.BlobTransferSimulationConfiguration.BLOB_CONTENT;
 import static org.eclipse.dataspaceconnector.system.tests.local.BlobTransferUtils.createAsset;
 import static org.eclipse.dataspaceconnector.system.tests.local.BlobTransferUtils.createContractDefinition;
 import static org.eclipse.dataspaceconnector.system.tests.local.BlobTransferUtils.createPolicy;
@@ -135,13 +137,12 @@ public class AzureDataFactoryTransferIntegrationTest {
     public void transferBlob_success() {
         // Arrange
         var vault = AzureVault.authenticateWithSecret(new ConsoleMonitor(), AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET, KEY_VAULT_NAME);
+        var account2Key = Objects.requireNonNull(vault.resolveSecret(format("%s-key1", CONSUMER_STORAGE_ACCOUNT_NAME)));
         var blobStoreApi = new BlobStoreApiImpl(vault, BLOB_STORE_ENDPOINT_TEMPLATE);
 
         // Upload a blob with test data on provider blob container
-        var blobContent = "AzureDataFactoryTransferIntegrationTest-" + UUID.randomUUID();
-
         blobStoreApi.createContainer(PROVIDER_STORAGE_ACCOUNT_NAME, PROVIDER_CONTAINER_NAME);
-        blobStoreApi.putBlob(PROVIDER_STORAGE_ACCOUNT_NAME, PROVIDER_CONTAINER_NAME, PROVIDER_ASSET_FILE, blobContent.getBytes(UTF_8));
+        blobStoreApi.putBlob(PROVIDER_STORAGE_ACCOUNT_NAME, PROVIDER_CONTAINER_NAME, PROVIDER_ASSET_FILE, BLOB_CONTENT.getBytes(UTF_8));
         // Add for cleanup
         CONTAINER_CLEANUP.add(() -> blobStoreApi.deleteContainer(PROVIDER_STORAGE_ACCOUNT_NAME, PROVIDER_CONTAINER_NAME));
 
@@ -152,22 +153,10 @@ public class AzureDataFactoryTransferIntegrationTest {
 
         // Act
         System.setProperty(BlobTransferLocalSimulation.ACCOUNT_NAME_PROPERTY, CONSUMER_STORAGE_ACCOUNT_NAME);
+        System.setProperty(BlobTransferLocalSimulation.ACCOUNT_KEY_PROPERTY, account2Key);
+        System.setProperty(BlobTransferLocalSimulation.ACCOUNT_ENDPOINT_PROPERTY, format("https://%s.blob.core.windows.net", CONSUMER_STORAGE_ACCOUNT_NAME));
         System.setProperty(BlobTransferLocalSimulation.MAX_DURATION_SECONDS_PROPERTY, "360"); // ADF SLA is to initiate copy within 4 minutes
         runGatling(BlobTransferLocalSimulation.class, TransferSimulationUtils.DESCRIPTION);
-
-        // Assert
-        var provisionedContainerName = BlobTransferUtils.getProvisionedContainerName();
-        // Add for cleanup
-        CONTAINER_CLEANUP.add(() -> blobStoreApi.deleteContainer(CONSUMER_STORAGE_ACCOUNT_NAME, provisionedContainerName));
-
-        var actualBlobContent = blobStoreApi.getBlob(CONSUMER_STORAGE_ACCOUNT_NAME, provisionedContainerName, PROVIDER_ASSET_FILE);
-        assertThat(actualBlobContent.length)
-                .withFailMessage("Destination blob %s not created", PROVIDER_ASSET_FILE)
-                .isGreaterThan(0);
-        assertThat(new String(actualBlobContent))
-                .withFailMessage("Transferred file contents are not same as the source file")
-                .isEqualTo(blobContent);
-
     }
 
     @NotNull

--- a/system-tests/azure-tests/build.gradle.kts
+++ b/system-tests/azure-tests/build.gradle.kts
@@ -22,6 +22,8 @@ plugins {
 val gatlingVersion: String by project
 val storageBlobVersion: String by project
 val restAssured: String by project
+val assertj: String by project
+val faker: String by project
 
 dependencies {
     testImplementation("io.gatling.highcharts:gatling-charts-highcharts:${gatlingVersion}") {
@@ -41,8 +43,11 @@ dependencies {
     testImplementation(testFixtures(project(":common:util")))
     testImplementation(testFixtures(project(":launchers:junit")))
     testImplementation(testFixtures(project(":system-tests:tests")))
-    testFixturesImplementation(testFixtures(project(":system-tests:tests")))
     testImplementation(testFixtures(project(":extensions:azure:azure-test")))
+    testFixturesImplementation(testFixtures(project(":system-tests:tests")))
+    testFixturesImplementation(testFixtures(project(":extensions:azure:azure-test")))
+    testFixturesImplementation("org.assertj:assertj-core:${assertj}")
+    testFixturesImplementation("com.github.javafaker:javafaker:${faker}")
     testImplementation("com.azure:azure-storage-blob:${storageBlobVersion}")
     testFixturesImplementation("io.rest-assured:rest-assured:${restAssured}")
 

--- a/system-tests/azure-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/local/BlobTransferIntegrationTest.java
+++ b/system-tests/azure-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/local/BlobTransferIntegrationTest.java
@@ -18,6 +18,7 @@ package org.eclipse.dataspaceconnector.system.tests.local;
 
 import com.azure.core.util.BinaryData;
 import org.eclipse.dataspaceconnector.azure.testfixtures.AbstractAzureBlobTest;
+import org.eclipse.dataspaceconnector.azure.testfixtures.TestFunctions;
 import org.eclipse.dataspaceconnector.azure.testfixtures.annotations.AzureStorageIntegrationTest;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcRuntimeExtension;
 import org.eclipse.dataspaceconnector.junit.launcher.MockVault;
@@ -127,7 +128,7 @@ public class BlobTransferIntegrationTest extends AbstractAzureBlobTest {
         // Act
         System.setProperty(ACCOUNT_NAME_PROPERTY, account2Name);
         System.setProperty(ACCOUNT_KEY_PROPERTY, account2Key);
-        System.setProperty(ACCOUNT_ENDPOINT_PROPERTY, getEndpoint(account2Name));
+        System.setProperty(ACCOUNT_ENDPOINT_PROPERTY, TestFunctions.getBlobServiceTestEndpoint(account2Name));
         runGatling(BlobTransferLocalSimulation.class, TransferSimulationUtils.DESCRIPTION);
     }
 

--- a/system-tests/azure-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/local/BlobTransferIntegrationTest.java
+++ b/system-tests/azure-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/local/BlobTransferIntegrationTest.java
@@ -35,12 +35,12 @@ import java.util.Map;
 import java.util.UUID;
 
 import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.system.tests.local.BlobTransferLocalSimulation.ACCOUNT_ENDPOINT_PROPERTY;
+import static org.eclipse.dataspaceconnector.system.tests.local.BlobTransferLocalSimulation.ACCOUNT_KEY_PROPERTY;
 import static org.eclipse.dataspaceconnector.system.tests.local.BlobTransferLocalSimulation.ACCOUNT_NAME_PROPERTY;
 import static org.eclipse.dataspaceconnector.system.tests.local.BlobTransferUtils.createAsset;
 import static org.eclipse.dataspaceconnector.system.tests.local.BlobTransferUtils.createContractDefinition;
 import static org.eclipse.dataspaceconnector.system.tests.local.BlobTransferUtils.createPolicy;
-import static org.eclipse.dataspaceconnector.system.tests.local.BlobTransferUtils.getProvisionedContainerName;
 import static org.eclipse.dataspaceconnector.system.tests.local.TransferLocalSimulation.CONSUMER_CONNECTOR_PATH;
 import static org.eclipse.dataspaceconnector.system.tests.local.TransferLocalSimulation.CONSUMER_CONNECTOR_PORT;
 import static org.eclipse.dataspaceconnector.system.tests.local.TransferLocalSimulation.CONSUMER_IDS_API;
@@ -109,7 +109,7 @@ public class BlobTransferIntegrationTest extends AbstractAzureBlobTest {
     public void transferBlob_success() {
         // Arrange
         // Upload a blob with test data on provider blob container (in account1).
-        var blobContent = "BlobTransferIntegrationTest-" + UUID.randomUUID();
+        var blobContent = BlobTransferSimulationConfiguration.BLOB_CONTENT;
         createContainer(blobServiceClient1, PROVIDER_CONTAINER_NAME);
         blobServiceClient1.getBlobContainerClient(PROVIDER_CONTAINER_NAME)
                 .getBlobClient(PROVIDER_ASSET_FILE)
@@ -126,19 +126,9 @@ public class BlobTransferIntegrationTest extends AbstractAzureBlobTest {
 
         // Act
         System.setProperty(ACCOUNT_NAME_PROPERTY, account2Name);
+        System.setProperty(ACCOUNT_KEY_PROPERTY, account2Key);
+        System.setProperty(ACCOUNT_ENDPOINT_PROPERTY, getEndpoint(account2Name));
         runGatling(BlobTransferLocalSimulation.class, TransferSimulationUtils.DESCRIPTION);
-
-        // Assert
-        var container = getProvisionedContainerName();
-        var destinationBlob = blobServiceClient2.getBlobContainerClient(container)
-                .getBlobClient(PROVIDER_ASSET_FILE);
-        assertThat(destinationBlob.exists())
-                .withFailMessage("Destination blob %s not created", destinationBlob.getBlobUrl())
-                .isTrue();
-        var actualBlobContent = destinationBlob.downloadContent().toString();
-        assertThat(actualBlobContent)
-                .withFailMessage("Transferred file contents are not same as the source file")
-                .isEqualTo(blobContent);
     }
 
 }

--- a/system-tests/azure-tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/local/BlobTransferLocalSimulation.java
+++ b/system-tests/azure-tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/local/BlobTransferLocalSimulation.java
@@ -16,10 +16,15 @@ package org.eclipse.dataspaceconnector.system.tests.local;
 
 public class BlobTransferLocalSimulation extends TransferLocalSimulation {
     static final String ACCOUNT_NAME_PROPERTY = "BlobTransferLocalSimulation-account-name";
+    static final String ACCOUNT_KEY_PROPERTY = "BlobTransferLocalSimulation-account-key";
+    static final String ACCOUNT_ENDPOINT_PROPERTY = "BlobTransferLocalSimulation-account-endpoint";
     static final String MAX_DURATION_SECONDS_PROPERTY = "BlobTransferLocalSimulation-copy-max-duration-seconds";
 
     public BlobTransferLocalSimulation() {
-        super(new BlobTransferSimulationConfiguration(System.getProperty(ACCOUNT_NAME_PROPERTY),
+        super(new BlobTransferSimulationConfiguration(
+                System.getProperty(ACCOUNT_NAME_PROPERTY),
+                System.getProperty(ACCOUNT_KEY_PROPERTY),
+                System.getProperty(ACCOUNT_ENDPOINT_PROPERTY),
                 Integer.parseInt(System.getProperty(MAX_DURATION_SECONDS_PROPERTY, "30"))));
     }
 }

--- a/system-tests/azure-tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/local/BlobTransferSimulationConfiguration.java
+++ b/system-tests/azure-tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/local/BlobTransferSimulationConfiguration.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.dataspaceconnector.system.tests.local;
 
+import com.azure.storage.blob.BlobServiceClient;
+import com.github.javafaker.Faker;
 import org.eclipse.dataspaceconnector.azure.blob.core.AzureBlobStoreSchema;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
@@ -24,6 +26,9 @@ import org.eclipse.dataspaceconnector.system.tests.utils.TransferSimulationConfi
 import java.time.Duration;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.azure.testfixtures.AbstractAzureBlobTest.getBlobServiceClient;
+import static org.eclipse.dataspaceconnector.system.tests.utils.TransferSimulationUtils.PROVIDER_ASSET_FILE;
 import static org.eclipse.dataspaceconnector.system.tests.utils.TransferSimulationUtils.PROVIDER_ASSET_ID;
 
 /**
@@ -32,11 +37,12 @@ import static org.eclipse.dataspaceconnector.system.tests.utils.TransferSimulati
  */
 public class BlobTransferSimulationConfiguration implements TransferSimulationConfiguration {
 
-    private final String accountName;
-    private final Integer maxSeconds;
+    private final BlobServiceClient blobServiceClient;
+    private final int maxSeconds;
+    static final String BLOB_CONTENT = Faker.instance().lorem().sentence();
 
-    public BlobTransferSimulationConfiguration(String accountName, Integer maxSeconds) {
-        this.accountName = accountName;
+    public BlobTransferSimulationConfiguration(String accountName, String accountKey, String accountEndpoint, int maxSeconds) {
+        this.blobServiceClient = getBlobServiceClient(accountName, accountKey, accountEndpoint);
         this.maxSeconds = maxSeconds;
     }
 
@@ -50,7 +56,7 @@ public class BlobTransferSimulationConfiguration implements TransferSimulationCo
                 "protocol", "ids-multipart",
                 "dataDestination", DataAddress.Builder.newInstance()
                         .type(AzureBlobStoreSchema.TYPE)
-                        .property(AzureBlobStoreSchema.ACCOUNT_NAME, accountName)
+                        .property(AzureBlobStoreSchema.ACCOUNT_NAME, blobServiceClient.getAccountName())
                         .build(),
                 "managedResources", true,
                 "transferType", TransferType.Builder.transferType()
@@ -62,8 +68,23 @@ public class BlobTransferSimulationConfiguration implements TransferSimulationCo
         return new TypeManager().writeValueAsString(request);
     }
 
-    @Override
     public Duration copyMaxDuration() {
         return Duration.ofSeconds(maxSeconds);
+    }
+
+    @Override
+    public boolean verifyTransferResult(Map<String, String> dataDestinationProperties) {
+        // Assert
+        var container = dataDestinationProperties.get("container");
+        var destinationBlob = blobServiceClient.getBlobContainerClient(container)
+                .getBlobClient(PROVIDER_ASSET_FILE);
+        assertThat(destinationBlob.exists())
+                .withFailMessage("Destination blob %s not created", destinationBlob.getBlobUrl())
+                .isTrue();
+        var actualBlobContent = destinationBlob.downloadContent().toString();
+        assertThat(actualBlobContent)
+                .withFailMessage("Transferred file contents are not same as the source file")
+                .isEqualTo(BLOB_CONTENT);
+        return true;
     }
 }

--- a/system-tests/azure-tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/local/BlobTransferSimulationConfiguration.java
+++ b/system-tests/azure-tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/local/BlobTransferSimulationConfiguration.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.system.tests.local;
 import com.azure.storage.blob.BlobServiceClient;
 import com.github.javafaker.Faker;
 import org.eclipse.dataspaceconnector.azure.blob.core.AzureBlobStoreSchema;
+import org.eclipse.dataspaceconnector.azure.testfixtures.TestFunctions;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferType;
@@ -27,7 +28,6 @@ import java.time.Duration;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.dataspaceconnector.azure.testfixtures.AbstractAzureBlobTest.getBlobServiceClient;
 import static org.eclipse.dataspaceconnector.system.tests.utils.TransferSimulationUtils.PROVIDER_ASSET_FILE;
 import static org.eclipse.dataspaceconnector.system.tests.utils.TransferSimulationUtils.PROVIDER_ASSET_ID;
 
@@ -42,7 +42,7 @@ public class BlobTransferSimulationConfiguration implements TransferSimulationCo
     static final String BLOB_CONTENT = Faker.instance().lorem().sentence();
 
     public BlobTransferSimulationConfiguration(String accountName, String accountKey, String accountEndpoint, int maxSeconds) {
-        this.blobServiceClient = getBlobServiceClient(accountName, accountKey, accountEndpoint);
+        this.blobServiceClient = TestFunctions.getBlobServiceClient(accountName, accountKey, accountEndpoint);
         this.maxSeconds = maxSeconds;
     }
 

--- a/system-tests/azure-tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/local/BlobTransferSimulationConfiguration.java
+++ b/system-tests/azure-tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/local/BlobTransferSimulationConfiguration.java
@@ -73,7 +73,7 @@ public class BlobTransferSimulationConfiguration implements TransferSimulationCo
     }
 
     @Override
-    public boolean verifyTransferResult(Map<String, String> dataDestinationProperties) {
+    public boolean isTransferResultValid(Map<String, String> dataDestinationProperties) {
         // Assert
         var container = dataDestinationProperties.get("container");
         var destinationBlob = blobServiceClient.getBlobContainerClient(container)

--- a/system-tests/azure-tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/local/BlobTransferUtils.java
+++ b/system-tests/azure-tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/local/BlobTransferUtils.java
@@ -42,18 +42,6 @@ public class BlobTransferUtils {
     private static final String POLICIES_PATH = "/policies";
     private static final String CONTRACT_DEFINITIONS_PATH = "/contractdefinitions";
 
-    @NotNull
-    public static String getProvisionedContainerName() {
-        return given()
-                .baseUri(CONSUMER_CONNECTOR_MANAGEMENT_URL + CONSUMER_MANAGEMENT_PATH)
-                .when()
-                .get(TRANSFER_PROCESSES_PATH)
-                .then()
-                .statusCode(200)
-                .extract().body()
-                .jsonPath().getString("[0].dataDestination.properties.container");
-    }
-
     public static void createAsset(String accountName, String containerName) {
         var asset = Map.of(
                 "asset", Map.of(

--- a/system-tests/azure-tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/local/BlobTransferUtils.java
+++ b/system-tests/azure-tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/local/BlobTransferUtils.java
@@ -28,13 +28,10 @@ import java.util.Map;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
-import static org.eclipse.dataspaceconnector.system.tests.local.TransferLocalSimulation.CONSUMER_CONNECTOR_MANAGEMENT_URL;
-import static org.eclipse.dataspaceconnector.system.tests.local.TransferLocalSimulation.CONSUMER_MANAGEMENT_PATH;
 import static org.eclipse.dataspaceconnector.system.tests.local.TransferLocalSimulation.PROVIDER_CONNECTOR_MANAGEMENT_URL;
 import static org.eclipse.dataspaceconnector.system.tests.local.TransferLocalSimulation.PROVIDER_MANAGEMENT_PATH;
 import static org.eclipse.dataspaceconnector.system.tests.utils.TransferSimulationUtils.PROVIDER_ASSET_FILE;
 import static org.eclipse.dataspaceconnector.system.tests.utils.TransferSimulationUtils.PROVIDER_ASSET_ID;
-import static org.eclipse.dataspaceconnector.system.tests.utils.TransferSimulationUtils.TRANSFER_PROCESSES_PATH;
 
 public class BlobTransferUtils {
 

--- a/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferExtension.java
+++ b/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferExtension.java
@@ -70,7 +70,7 @@ public class FileTransferExtension implements ServiceExtension {
     private Policy createPolicy() {
 
         var usePermission = Permission.Builder.newInstance()
-                .action(Action.Builder.newInstance().type("idsc:USE").build())
+                .action(Action.Builder.newInstance().type("USE").build())
                 .build();
 
         return Policy.Builder.newInstance()

--- a/system-tests/tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/FileTransferSimulationConfiguration.java
+++ b/system-tests/tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/FileTransferSimulationConfiguration.java
@@ -57,4 +57,11 @@ public class FileTransferSimulationConfiguration implements TransferSimulationCo
 
         return new TypeManager().writeValueAsString(request);
     }
+
+    @Override
+    public boolean verifyTransferResult(Map<String, String> dataDestinationProperties) {
+        // Do not effectively verify file content here, as it would not work when running in minikube.
+        // File content is verified in local integration test.
+        return true;
+    }
 }

--- a/system-tests/tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/FileTransferSimulationConfiguration.java
+++ b/system-tests/tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/FileTransferSimulationConfiguration.java
@@ -27,6 +27,9 @@ import static org.eclipse.dataspaceconnector.system.tests.utils.TransferSimulati
 /**
  * Configuration for File transfer used in
  * {@link org.eclipse.dataspaceconnector.system.tests.local.FileTransferLocalSimulation}.
+ * <p>
+ * The result file content is not verified, as it would not work when running in minikube.
+ * File content is verified in local integration test.
  */
 public class FileTransferSimulationConfiguration implements TransferSimulationConfiguration {
 
@@ -56,12 +59,5 @@ public class FileTransferSimulationConfiguration implements TransferSimulationCo
         );
 
         return new TypeManager().writeValueAsString(request);
-    }
-
-    @Override
-    public boolean verifyTransferResult(Map<String, String> dataDestinationProperties) {
-        // Do not effectively verify file content here, as it would not work when running in minikube.
-        // File content is verified in local integration test.
-        return true;
     }
 }

--- a/system-tests/tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/local/TransferLocalSimulation.java
+++ b/system-tests/tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/local/TransferLocalSimulation.java
@@ -51,7 +51,7 @@ public abstract class TransferLocalSimulation extends Simulation {
     public static final String IDS_PATH = "/api/v1/ids";
     private static final int REPEAT = Integer.parseInt(propOrEnv("repeat", "1"));
     private static final int AT_ONCE_USERS = Integer.parseInt(propOrEnv("at.once.users", "1"));
-    private static final int MAX_RESPONSE_TIME = Integer.parseInt(propOrEnv("max.response.time", "5000"));
+    private static final int MAX_RESPONSE_TIME = Integer.parseInt(propOrEnv("max.response.time", "10000"));
     private static final double SUCCESS_PERCENTAGE = Double.parseDouble(propOrEnv("success.percentage", "100.0"));
 
     public TransferLocalSimulation(TransferSimulationConfiguration simulationConfiguration) {

--- a/system-tests/tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/utils/TransferSimulationConfiguration.java
+++ b/system-tests/tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/utils/TransferSimulationConfiguration.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.system.tests.utils;
 
 import java.time.Duration;
+import java.util.Map;
 
 /**
  * Pluggable definition for {@link org.eclipse.dataspaceconnector.system.tests.local.TransferLocalSimulation}
@@ -25,5 +26,9 @@ public interface TransferSimulationConfiguration {
 
     default Duration copyMaxDuration() {
         return Duration.ofSeconds(30);
+    }
+
+    default boolean verifyTransferResult(Map<String, String> dataDestinationProperties) {
+        return true;
     }
 }

--- a/system-tests/tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/utils/TransferSimulationConfiguration.java
+++ b/system-tests/tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/utils/TransferSimulationConfiguration.java
@@ -28,7 +28,7 @@ public interface TransferSimulationConfiguration {
         return Duration.ofSeconds(30);
     }
 
-    default boolean verifyTransferResult(Map<String, String> dataDestinationProperties) {
+    default boolean isTransferResultValid(Map<String, String> dataDestinationProperties) {
         return true;
     }
 }

--- a/system-tests/tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/utils/TransferSimulationUtils.java
+++ b/system-tests/tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/utils/TransferSimulationUtils.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.system.tests.utils;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.gatling.javaapi.core.ChainBuilder;
 import io.gatling.javaapi.core.Session;
 import io.gatling.javaapi.http.HttpRequestActionBuilder;
@@ -45,6 +46,7 @@ import static java.lang.String.format;
  */
 public abstract class TransferSimulationUtils {
 
+    public static final String CONTRACT_OFFER_ID = "contractOfferId";
     public static final String CONTRACT_AGREEMENT_ID = "contractAgreementId";
     public static final String CONTRACT_NEGOTIATION_REQUEST_ID = "contractNegotiationRequestId";
     public static final String TRANSFER_PROCESS_ID = "transferProcessId";
@@ -59,6 +61,8 @@ public abstract class TransferSimulationUtils {
     public static final String TRANSFER_PROCESSES_PATH = "/transferprocess";
     public static final String IDS_PATH = "/api/v1/ids";
 
+    private static final TypeManager TYPE_MANAGER = new TypeManager();
+
     private TransferSimulationUtils() {
     }
 
@@ -69,10 +73,49 @@ public abstract class TransferSimulationUtils {
      * @param simulationConfiguration Configuration for transfers.
      */
     public static ChainBuilder contractNegotiationAndTransfer(String providerUrl, TransferSimulationConfiguration simulationConfiguration) {
-        return startContractAgreement(providerUrl)
+        return getOffer(providerUrl)
+                .exec(negotiateContract(providerUrl))
                 .exec(waitForContractAgreement())
                 .exec(startTransfer(providerUrl, simulationConfiguration))
-                .exec(waitForTransferCompletion(simulationConfiguration));
+                .exec(waitForTransferState(TransferProcessStates.COMPLETED, simulationConfiguration.copyMaxDuration()))
+                .doIf(s -> verifyTransferResult(simulationConfiguration, s))
+                .then(
+                        exec(deprovision())
+                                .exec(waitForTransferState(TransferProcessStates.ENDED, Duration.ofSeconds(60)))
+
+                                // Perform one additional request if the transfer successful.
+                                // This allows running Gatling assertions to validate that the transfer actually succeeded
+                                // (and timeout was not reached).
+                                .group(TRANSFER_SUCCESSFUL)
+                                .on(exec(getTransferStatus())));
+    }
+
+    private static boolean verifyTransferResult(TransferSimulationConfiguration simulationConfiguration, Session s) {
+        try {
+            return simulationConfiguration.verifyTransferResult(TYPE_MANAGER.readValue(s.get("dataDestinationProperties"), new TypeReference<>() {
+            }));
+        } catch (Throwable t) {
+            t.printStackTrace(); // print e.g. assertion error for debugging
+            return false;
+        }
+    }
+
+    private static ChainBuilder getOffer(String providerUrl) {
+        var connectorAddress = getConnectorAddress(providerUrl);
+        return group("Get contract offer")
+                .on(exec(getContractOffer(connectorAddress)));
+    }
+
+    @NotNull
+    private static HttpRequestActionBuilder getContractOffer(String providerUrl) {
+        return http("Get contract offer")
+                .get("/catalog")
+                .queryParam("providerUrl", providerUrl)
+                .header(CONTENT_TYPE, "application/json")
+                .check(status().is(200))
+                .check(jmesPath("contractOffers[0].id")
+                        .notNull()
+                        .saveAs(CONTRACT_OFFER_ID));
     }
 
     /**
@@ -82,7 +125,7 @@ public abstract class TransferSimulationUtils {
      *
      * @param providerUrl URL for the Provider API, as accessed from the Consumer runtime.
      */
-    private static ChainBuilder startContractAgreement(String providerUrl) {
+    private static ChainBuilder negotiateContract(String providerUrl) {
         var connectorAddress = getConnectorAddress(providerUrl);
         return group("Contract negotiation")
                 .on(exec(initiateContractNegotiation(connectorAddress)));
@@ -92,7 +135,8 @@ public abstract class TransferSimulationUtils {
     private static HttpRequestActionBuilder initiateContractNegotiation(String connectorAddress) {
         return http("Initiate contract negotiation")
                 .post("/contractnegotiations")
-                .body(StringBody(loadContractAgreement(connectorAddress)))
+                .body(StringBody(session -> loadContractAgreement(
+                        connectorAddress, session.getString(CONTRACT_OFFER_ID))))
                 .header(CONTENT_TYPE, "application/json")
                 .check(status().is(200))
                 .check(jmesPath("id")
@@ -111,10 +155,10 @@ public abstract class TransferSimulationUtils {
     private static ChainBuilder waitForContractAgreement() {
         return exec(session -> session.set("status", -1))
                 .group("Wait for agreement")
-                .on(doWhileDuring(session -> contractAgreementNotCompleted(session), Duration.ofSeconds(30))
+                .on(doWhileDuring(TransferSimulationUtils::contractAgreementNotCompleted, Duration.ofSeconds(30))
                         .on(exec(getContractStatus()).pace(Duration.ofSeconds(1)))
                 )
-                .exitHereIf(session -> contractAgreementNotCompleted(session));
+                .exitHereIf(TransferSimulationUtils::contractAgreementNotCompleted);
     }
 
     private static boolean contractAgreementNotCompleted(Session session) {
@@ -166,32 +210,34 @@ public abstract class TransferSimulationUtils {
     }
 
     /**
-     * Gatling chain for calling the transfer status endpoint repeatedly until a COMPLETED state is
+     * Gatling chain for calling the transfer status endpoint repeatedly until a given state is
      * attained, or a timeout is reached.
      * <p>
      * Expects the Transfer Process ID to be provided in the {@see TRANSFER_PROCESS_ID} session key.
      *
-     * @param simulationConfiguration See {@link TransferSimulationConfiguration}
+     * @param state state to wait for.
+     * @param maxDuration maximum duration to wait for.
      */
-    private static ChainBuilder waitForTransferCompletion(TransferSimulationConfiguration simulationConfiguration) {
-        return group("Wait for transfer")
+    private static ChainBuilder waitForTransferState(TransferProcessStates state, Duration maxDuration) {
+        return group("Wait for transfer " + state)
                 .on(exec(session -> session.set("status", "INITIAL"))
-                        .doWhileDuring(session -> transferNotCompleted(session),
-                                simulationConfiguration.copyMaxDuration())
+                        .doWhileDuring(session -> transferNotInState(session, state),
+                                maxDuration)
                         .on(exec(getTransferStatus()).pace(Duration.ofSeconds(1))))
 
-                .exitHereIf(session -> transferNotCompleted(session))
-
-                // Perform one additional request if the transfer successful.
-                // This allows running Gatling assertions to validate that the transfer actually succeeded
-                // (and timeout was not reached).
-                .group(TRANSFER_SUCCESSFUL)
-                .on(exec(getTransferStatus()));
+                .exitHereIf(session -> transferNotInState(session, state));
     }
 
     @NotNull
-    private static Boolean transferNotCompleted(Session session) {
-        return !session.getString("status").equals(TransferProcessStates.COMPLETED.name());
+    private static HttpRequestActionBuilder deprovision() {
+        return http("Deprovision")
+                .post(session -> format("%s/%s/deprovision", TRANSFER_PROCESSES_PATH, session.getString(TRANSFER_PROCESS_ID)))
+                .check(status().is(204));
+    }
+
+    @NotNull
+    private static Boolean transferNotInState(Session session, TransferProcessStates state) {
+        return !session.getString("status").equals(state.name());
     }
 
     @NotNull
@@ -201,11 +247,12 @@ public abstract class TransferSimulationUtils {
                 .check(status().is(200))
                 .check(
                         jmesPath("id").is(session -> session.getString(TRANSFER_PROCESS_ID)),
-                        jmesPath("state").saveAs("status")
+                        jmesPath("state").saveAs("status"),
+                        jmesPath("dataDestination.properties").saveAs("dataDestinationProperties")
                 );
     }
 
-    private static String loadContractAgreement(String providerUrl) {
+    private static String loadContractAgreement(String providerUrl, String offerId) {
         var policy = Policy.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .permission(Permission.Builder.newInstance()
@@ -219,7 +266,7 @@ public abstract class TransferSimulationUtils {
                 "connectorAddress", providerUrl,
                 "protocol", "ids-multipart",
                 "offer", Map.of(
-                        "offerId", "1:1",
+                        "offerId", offerId,
                         "assetId", PROVIDER_ASSET_ID,
                         "policy", policy
                 )

--- a/system-tests/tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/utils/TransferSimulationUtils.java
+++ b/system-tests/tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/utils/TransferSimulationUtils.java
@@ -92,7 +92,7 @@ public abstract class TransferSimulationUtils {
 
     private static boolean verifyTransferResult(TransferSimulationConfiguration simulationConfiguration, Session s) {
         try {
-            return simulationConfiguration.verifyTransferResult(TYPE_MANAGER.readValue(s.get("dataDestinationProperties"), new TypeReference<>() {
+            return simulationConfiguration.isTransferResultValid(TYPE_MANAGER.readValue(s.get("dataDestinationProperties"), new TypeReference<>() {
             }));
         } catch (Throwable t) {
             t.printStackTrace(); // print e.g. assertion error for debugging


### PR DESCRIPTION
## What this PR changes/adds

Gatling System/Performance test scope is extended to include catalog query (contract offers) as well as deprovisioning after data transfer is performed.

## Why it does that

This allows catching more potential errors, and provides additional performance data.

## Further notes

Catalog query takes slightly over 5 seconds locally, so extended the global timeout from 5 to 10 seconds.

## Linked Issue(s)

Closes #1296 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
