### PR TITLE
chore: refine close-inactive-issue workflow

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -9,15 +9,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: write
     steps:
       - uses: actions/stale@v5
         with:
+          operations-per-run: 200
           days-before-issue-stale: 14
           days-before-issue-close: 7
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 14 days with no activity."
           close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
           remove-issue-stale-when-updated: true
           exempt-all-issue-milestones: true # issues with assigned milestones will be ignored
           exempt-all-issue-assignees: true # issues with assignees will be ignored
@@ -28,15 +30,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: write
     steps:
       - uses: actions/stale@v5
         with:
+          operations-per-run: 200
           days-before-issue-stale: 28
           days-before-issue-close: 7
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 28 days with no activity."
           close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
           remove-issue-stale-when-updated: true
           exempt-all-issue-milestones: true # issues with assigned milestones will be ignored
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -45,11 +49,13 @@ jobs:
   close-inactive-pull-requests:
     runs-on: ubuntu-latest
     permissions:
-      issues: write
       pull-requests: write
     steps:
       - uses: actions/stale@v5
         with:
+          operations-per-run: 200
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
           stale-pr-label: "stale"
           stale-pr-message: "This pull request is stale because it has been open for 7 days with no activity."
           close-pr-message: "This pull request was closed because it has been inactive for 7 days since being marked as stale."


### PR DESCRIPTION
## What this PR changes/adds

Extend `operations-per-run` from 30 to 200. Add `-1` to either issue- or pr-specific param, as the top level parameter sets a default value we need to overwrite. Remove write permissions for issues or PRs as a step should only run on either issues or PRs. 

## Why it does that

see above

## Further notes

--

## Linked Issue(s)

Relates #1392 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
