### PR TITLE
chore: activate close-inactive-issue workflow

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -12,19 +12,18 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
-          operations-per-run: 200
+          operations-per-run: 1000
           days-before-issue-stale: 14
           days-before-issue-close: 7
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 14 days with no activity."
           close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
-          days-before-pr-stale: -1
-          days-before-pr-close: -1
+          days-before-pr-stale: -1 # ignore PRs (overwrite default days-before-stale)
+          days-before-pr-close: -1 # ignore PRs (overwrite default days-before-close)
           remove-issue-stale-when-updated: true
           exempt-all-issue-milestones: true # issues with assigned milestones will be ignored
           exempt-all-issue-assignees: true # issues with assignees will be ignored
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          debug-only: true
 
   close-issues-with-assignee:
     runs-on: ubuntu-latest
@@ -33,18 +32,17 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
-          operations-per-run: 200
+          operations-per-run: 1000
           days-before-issue-stale: 28
           days-before-issue-close: 7
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 28 days with no activity."
           close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
-          days-before-pr-stale: -1
-          days-before-pr-close: -1
+          days-before-pr-stale: -1 # ignore PRs (overwrite default days-before-stale)
+          days-before-pr-close: -1 # ignore PRs (overwrite default days-before-close)
           remove-issue-stale-when-updated: true
           exempt-all-issue-milestones: true # issues with assigned milestones will be ignored
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          debug-only: true
 
   close-inactive-pull-requests:
     runs-on: ubuntu-latest
@@ -53,9 +51,9 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
-          operations-per-run: 200
-          days-before-issue-stale: -1
-          days-before-issue-close: -1
+          operations-per-run: 1000
+          days-before-issue-stale: -1 # ignore issues (overwrite default days-before-stale)
+          days-before-issue-close: -1 # ignore issues (overwrite default days-before-close)
           stale-pr-label: "stale"
           stale-pr-message: "This pull request is stale because it has been open for 7 days with no activity."
           close-pr-message: "This pull request was closed because it has been inactive for 7 days since being marked as stale."
@@ -63,4 +61,3 @@ jobs:
           days-before-pr-close: 7
           remove-pr-stale-when-updated: true
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          debug-only: true


### PR DESCRIPTION
## What this PR changes/adds

Increase operations as the dry run showed that 200 is still not enough. Enable workflow.

## Why it does that

To actually run the action.

## Further notes

--

## Linked Issue(s)

Closes #1392 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
