### PR TITLE
core: Make ParticipantAgent claims more generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Update `slf4j-api` to `2.0.0-alpha7` (#1328)
 * Added timestamps to TransferProcess DTO (#1350)
 * Make Helm charts more generic (#1363)
+* Make `ParticipantAgent` claims more generic (#1405)
 
 #### Removed
 

--- a/extensions/data-plane-transfer/data-plane-transfer-sync/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/api/DataPlaneTransferTokenValidationApiController.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-sync/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/api/DataPlaneTransferTokenValidationApiController.java
@@ -58,7 +58,7 @@ public class DataPlaneTransferTokenValidationApiController {
         var validToken = validationResult.getContent();
 
         // decrypt data address
-        validToken.getClaims().computeIfPresent(DATA_ADDRESS, (s, s2) -> dataEncrypter.decrypt(s2));
+        validToken.getClaims().computeIfPresent(DATA_ADDRESS, (s, s2) -> dataEncrypter.decrypt((String) s2));
 
         return Response.ok(validToken).build();
     }

--- a/extensions/data-plane/data-plane-api/src/main/java/org/eclipse/dataspaceconnector/dataplane/api/controller/DataPlanePublicApiController.java
+++ b/extensions/data-plane/data-plane-api/src/main/java/org/eclipse/dataspaceconnector/dataplane/api/controller/DataPlanePublicApiController.java
@@ -165,7 +165,7 @@ public class DataPlanePublicApiController {
      * Create a {@link DataFlowRequest} based on the decoded claim token and the request content.
      */
     private DataFlowRequest createDataFlowRequest(ClaimToken claims, Map<String, String> properties) {
-        var dataAddress = typeManager.readValue(claims.getClaims().get(DataPlaneConstants.DATA_ADDRESS), DataAddress.class);
+        var dataAddress = typeManager.readValue((String) claims.getClaims().get(DataPlaneConstants.DATA_ADDRESS), DataAddress.class);
         return DataFlowRequest.Builder.newInstance()
                 .processId(UUID.randomUUID().toString())
                 .sourceDataAddress(dataAddress)

--- a/extensions/iam/decentralized-identity/dummy-credentials-verifier/src/main/java/org/eclipse/dataspaceconnector/iam/verifier/DummyCredentialsVerifier.java
+++ b/extensions/iam/decentralized-identity/dummy-credentials-verifier/src/main/java/org/eclipse/dataspaceconnector/iam/verifier/DummyCredentialsVerifier.java
@@ -13,19 +13,6 @@
  */
 
 package org.eclipse.dataspaceconnector.iam.verifier;
-/*
- *  Copyright (c) 2021 Microsoft Corporation
- *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
- *
- *  SPDX-License-Identifier: Apache-2.0
- *
- *  Contributors:
- *       Microsoft Corporation - initial API and implementation
- *
- */
 
 import org.eclipse.dataspaceconnector.iam.did.spi.credentials.CredentialsVerifier;
 import org.eclipse.dataspaceconnector.iam.did.spi.key.PublicKeyWrapper;
@@ -50,7 +37,7 @@ public class DummyCredentialsVerifier implements CredentialsVerifier {
     }
 
     @Override
-    public Result<Map<String, String>> verifyCredentials(String hubBaseUrl, PublicKeyWrapper othersPublicKey) {
+    public Result<Map<String, Object>> verifyCredentials(String hubBaseUrl, PublicKeyWrapper othersPublicKey) {
         monitor.debug("Starting (dummy) credential verification against hub URL " + hubBaseUrl);
 
         return Result.success(Map.of("region", "eu"));

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/credentials/CredentialsVerifier.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/credentials/CredentialsVerifier.java
@@ -32,6 +32,6 @@ public interface CredentialsVerifier {
      * @param hubBaseUrl the hub base url
      * @param publicKey  the hub's public key to encrypt messages with
      */
-    Result<Map<String, String>> verifyCredentials(String hubBaseUrl, PublicKeyWrapper publicKey);
+    Result<Map<String, Object>> verifyCredentials(String hubBaseUrl, PublicKeyWrapper publicKey);
 
 }

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/agent/ParticipantAgent.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/agent/ParticipantAgent.java
@@ -20,19 +20,19 @@ import java.util.Map;
 
 /**
  * Represents a system running on behalf of a dataspace participant.
- *
+ * <p>
  * A ParticipantAgent is not the same as a Participant since the former may have claims and attributes that are distinct from the latter. For example, the Acme organization may
  * have connector systems deployed in different geographical regions. While Acme may possess the claim/attribute Partner=GOLD, only the connector running in the EU will have the
  * claim Region=EU.
- *
+ * <p>
  * Claims are verifiable claims presented to the current runtime by the ParticipantAgent system, typically as part of a security token or credential store. Attributes are
  * additional values added by the current system based on
  */
 public class ParticipantAgent {
-    private final Map<String, String> claims;
+    private final Map<String, Object> claims;
     private final Map<String, String> attributes;
 
-    public ParticipantAgent(Map<String, String> claims, Map<String, String> attributes) {
+    public ParticipantAgent(Map<String, Object> claims, Map<String, String> attributes) {
         this.claims = Map.copyOf(claims);
         this.attributes = Map.copyOf(attributes);
     }
@@ -41,7 +41,7 @@ public class ParticipantAgent {
      * Returns the claims such as verifiable credentials associated with the agent.
      */
     @NotNull
-    public Map<String, String> getClaims() {
+    public Map<String, Object> getClaims() {
         return claims;
     }
 

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/iam/ClaimToken.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/iam/ClaimToken.java
@@ -22,7 +22,7 @@ import java.util.Map;
  * Currently only a String representation of claims values is supported.
  */
 public class ClaimToken {
-    private final Map<String, String> claims = new HashMap<>();
+    private final Map<String, Object> claims = new HashMap<>();
 
     private ClaimToken() {
     }
@@ -30,7 +30,7 @@ public class ClaimToken {
     /**
      * Returns the claims.
      */
-    public Map<String, String> getClaims() {
+    public Map<String, Object> getClaims() {
         return claims;
     }
 
@@ -45,12 +45,12 @@ public class ClaimToken {
             return new Builder();
         }
 
-        public Builder claim(String key, String value) {
+        public Builder claim(String key, Object value) {
             token.claims.put(key, value);
             return this;
         }
 
-        public Builder claims(Map<String, String> map) {
+        public Builder claims(Map<String, Object> map) {
             token.claims.putAll(map);
             return this;
         }


### PR DESCRIPTION
## What this PR changes/adds

This PR replaces the current `Map<String, String>` used to carry the `ParticipantAgent` claims with a `Map<String, Object>`.

## Why it does that

In order to enable carrying more complex objects into the `ParticipantAgent` claims, such as a complex json-structured file as described in the Gaia-X Trust Framework.

## Linked Issue(s)

Closes #1404.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
