### PR TITLE
Feature: add validation for contract definition id #1372

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Add signing/publishing config (#1147)
 * Verify OpenAPI definitions (#1312)
 * Documentation for CosmosDB (#1334)
+* Add validation to contract definition id (#1347)
 
 #### Changed
 

--- a/extensions/api/api-core/build.gradle.kts
+++ b/extensions/api/api-core/build.gradle.kts
@@ -28,12 +28,12 @@ dependencies {
     implementation(project(":common:util"))
     implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
     implementation("jakarta.validation:jakarta.validation-api:${jakartaValidationApi}")
+    implementation("org.glassfish.jersey.ext:jersey-bean-validation:${jerseyVersion}") //for validation
 
     testImplementation("org.glassfish.jersey.core:jersey-common:${jerseyVersion}")
     testImplementation("org.glassfish.jersey.core:jersey-server:${jerseyVersion}")
 
     testImplementation(testFixtures(project(":launchers:junit")))
-    testRuntimeOnly("org.glassfish.jersey.ext:jersey-bean-validation:${jerseyVersion}") //for validation
 }
 
 publishing {

--- a/extensions/api/data-management/asset/build.gradle.kts
+++ b/extensions/api/data-management/asset/build.gradle.kts
@@ -38,7 +38,6 @@ dependencies {
     testImplementation(testFixtures(project(":common:util")))
     testImplementation(testFixtures(project(":launchers:junit")))
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
-    testRuntimeOnly("org.glassfish.jersey.ext:jersey-bean-validation:${jerseyVersion}") //for validation
 }
 
 publishing {

--- a/extensions/api/data-management/contractagreement/build.gradle.kts
+++ b/extensions/api/data-management/contractagreement/build.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
     testImplementation(testFixtures(project(":common:util")))
     testImplementation(testFixtures(project(":launchers:junit")))
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
-    testRuntimeOnly("org.glassfish.jersey.ext:jersey-bean-validation:${jerseyVersion}") //for validation
 }
 
 publishing {

--- a/extensions/api/data-management/contractdefinition/build.gradle.kts
+++ b/extensions/api/data-management/contractdefinition/build.gradle.kts
@@ -35,7 +35,6 @@ dependencies {
     testImplementation(testFixtures(project(":common:util")))
     testImplementation(testFixtures(project(":launchers:junit")))
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
-    testRuntimeOnly("org.glassfish.jersey.ext:jersey-bean-validation:${jerseyVersion}") //for validation
 }
 
 publishing {

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/ContractDefinitionDto.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/ContractDefinitionDto.java
@@ -16,8 +16,10 @@
 package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
 
@@ -34,6 +36,12 @@ public class ContractDefinitionDto {
     private List<Criterion> criteria = new ArrayList<>();
     @NotNull
     private String id;
+
+    @AssertTrue
+    @JsonIgnore
+    public boolean isIdValid() {
+        return id != null && !id.contains(":");
+    }
 
     private ContractDefinitionDto() {
     }

--- a/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/ContractDefinitionDtoValidationTest.java
+++ b/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/ContractDefinitionDtoValidationTest.java
@@ -54,7 +54,7 @@ class ContractDefinitionDtoValidationTest {
                 .contractPolicyId(contractPolicyId)
                 .criteria(crit)
                 .build();
-        assertThat(validator.validate(dto)).hasSize(1);
+        assertThat(validator.validate(dto)).hasSizeGreaterThan(0);
     }
 
     @Test
@@ -74,7 +74,8 @@ class ContractDefinitionDtoValidationTest {
             return Stream.of(
                     Arguments.of(null, "accessPolicy", "contractPolicy"),
                     Arguments.of("id", null, "contractPolicy"),
-                    Arguments.of("id", "accessPolicy", null)
+                    Arguments.of("id", "accessPolicy", null),
+                    Arguments.of("id:123", "accessPolicy", "contractPolicy")
             );
         }
     }

--- a/extensions/api/data-management/contractnegotiation/build.gradle.kts
+++ b/extensions/api/data-management/contractnegotiation/build.gradle.kts
@@ -37,7 +37,6 @@ dependencies {
     testImplementation(project(":core:defaults"))
 
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
-    testRuntimeOnly("org.glassfish.jersey.ext:jersey-bean-validation:${jerseyVersion}") //for validation
 }
 
 publishing {

--- a/extensions/api/data-management/transferprocess/build.gradle.kts
+++ b/extensions/api/data-management/transferprocess/build.gradle.kts
@@ -40,7 +40,6 @@ dependencies {
     testImplementation(testFixtures(project(":launchers:junit")))
     testImplementation(testFixtures(project(":common:util")))
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
-    testRuntimeOnly("org.glassfish.jersey.ext:jersey-bean-validation:${jerseyVersion}") //for validation
 }
 
 publishing {

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferRequestDto.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferRequestDto.java
@@ -29,7 +29,6 @@ public class TransferRequestDto {
 
     @NotNull
     private String connectorAddress;
-    @NotNull
     private String id;
     @NotNull
     private String contractId;

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferRequestDtoValidationTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferRequestDtoValidationTest.java
@@ -69,7 +69,6 @@ class TransferRequestDtoValidationTest {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
             return Stream.of(
-                    Arguments.of(null, "connectorAddress", "contractId", destination(), transferType(), "ids-multipart", "connectorId", "assetId"),
                     Arguments.of("id", null, "contractId", destination(), transferType(), "ids-multipart", "connectorId", "assetId"),
                     Arguments.of("id", "connectorAddress", null, destination(), transferType(), "ids-multipart", "connectorId", "assetId"),
                     Arguments.of("id", "connectorAddress", "contractId", null, transferType(), "ids-multipart", "connectorId", "assetId"),

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -1377,7 +1377,6 @@ components:
       - connectorId
       - contractId
       - dataDestination
-      - id
       - protocol
       - transferType
       type: object

--- a/resources/openapi/yaml/transferprocess.yaml
+++ b/resources/openapi/yaml/transferprocess.yaml
@@ -206,7 +206,6 @@ components:
       - connectorId
       - contractId
       - dataDestination
-      - id
       - protocol
       - transferType
     TransferState:


### PR DESCRIPTION
## What this PR changes/adds

Add validation for contract definition id

## Why it does that

Validation of contract definition id by creation solves the problem in negotiation process when the id is not valid.

## Further notes

Marking jersey-bean-validation helps for the correct validation of parameters.

## Linked Issue(s)

Closes #1347 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
