### PR TITLE
Bugfix: check to determine if asset can be deleted

### DIFF
--- a/common/util/build.gradle.kts
+++ b/common/util/build.gradle.kts
@@ -35,6 +35,7 @@ publishing {
         create<MavenPublication>("common-util") {
             artifactId = "common-util"
             from(components["java"])
+            artifacts.forEach { a -> println(a.file) }
         }
     }
 }

--- a/common/util/src/main/java/org/eclipse/dataspaceconnector/common/reflection/ReflectionUtil.java
+++ b/common/util/src/main/java/org/eclipse/dataspaceconnector/common/reflection/ReflectionUtil.java
@@ -33,13 +33,14 @@ public class ReflectionUtil {
     private static final String CLOSING_BRACKET = "]";
 
     /**
-     * Utility function to get value of a field from an object. For field names currently the dot notation and array indexers are supported:
+     * Utility function to get value of a field from an object. For field names currently the dot notation and array
+     * indexers are supported:
      * <pre>
      *     someObject.someValue
      *     someObject[2].someValue //someObject must impement the List interface
      * </pre>
      *
-     * @param object       The object
+     * @param object The object
      * @param propertyName The name of the field
      * @return The field's value.
      * @throws ReflectionException if the field does not exist or is not accessible
@@ -53,6 +54,9 @@ public class ReflectionUtil {
             var field = propertyName.substring(0, dotIx);
             var rest = propertyName.substring(dotIx + 1);
             object = getFieldValue(field, object);
+            if (object == null) {
+                return null;
+            }
             return getFieldValue(rest, object);
         } else if (propertyName.matches(ARRAY_INDEXER_REGEX)) { //array indexer
             var openingBracketIx = propertyName.indexOf(OPENING_BRACKET);
@@ -82,10 +86,10 @@ public class ReflectionUtil {
 
 
     /**
-     * Utility function to get value of a field from an object. Essentially the same as {@link ReflectionUtil#getFieldValue(String, Object)}
-     * but it does not throw an exception
+     * Utility function to get value of a field from an object. Essentially the same as
+     * {@link ReflectionUtil#getFieldValue(String, Object)} but it does not throw an exception
      *
-     * @param object       The object
+     * @param object The object
      * @param propertyName The name of the field
      * @return The field's value. Returns null if the field does not exist or is inaccessible.
      */
@@ -118,9 +122,10 @@ public class ReflectionUtil {
 
 
     /**
-     * Gets a field with a given name from all declared fields of a class including supertypes. Will include protected and private fields.
+     * Gets a field with a given name from all declared fields of a class including supertypes. Will include protected
+     * and private fields.
      *
-     * @param clazz     The class of the object
+     * @param clazz The class of the object
      * @param fieldName The fieldname
      * @return A field with the given name, null if the field does not exist
      */

--- a/common/util/src/test/java/org/eclipse/dataspaceconnector/common/reflection/AnotherObject.java
+++ b/common/util/src/test/java/org/eclipse/dataspaceconnector/common/reflection/AnotherObject.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.common.reflection;
+
+public class AnotherObject {
+    private final String anotherDescription;
+
+    public AnotherObject(String desc) {
+        anotherDescription = desc;
+    }
+}

--- a/common/util/src/test/java/org/eclipse/dataspaceconnector/common/reflection/ReflectionUtilTest.java
+++ b/common/util/src/test/java/org/eclipse/dataspaceconnector/common/reflection/ReflectionUtilTest.java
@@ -159,6 +159,24 @@ class ReflectionUtilTest {
     }
 
     @Test
+    void getFieldValue_whenParentExist() {
+        var to = new TestObjectSubSubclass("test-desc", 1, "foobar");
+        to.setAnotherObject(new AnotherObject("another-desc"));
+
+        String fieldValue = ReflectionUtil.getFieldValue("anotherObject.anotherDescription", to);
+        assertThat(fieldValue).isEqualTo("another-desc");
+    }
+
+    @Test
+    void getFieldValue_whenParentNotExist() {
+        var to = new TestObjectSubSubclass("test-desc", 1, "foobar");
+        to.setAnotherObject(null);
+
+        String fieldValue = ReflectionUtil.getFieldValue("anotherObject.anotherDescription", to);
+        assertThat(fieldValue).isNull();
+    }
+
+    @Test
     void getFieldValue_withArrayIndex() {
         var to1 = new TestObject("to1", 420);
         var o = new TestObjectWithList("test-desc", 0, List.of(to1, new TestObject("to2", 69)));

--- a/common/util/src/test/java/org/eclipse/dataspaceconnector/common/reflection/TestObjectSubSubclass.java
+++ b/common/util/src/test/java/org/eclipse/dataspaceconnector/common/reflection/TestObjectSubSubclass.java
@@ -16,6 +16,7 @@ package org.eclipse.dataspaceconnector.common.reflection;
 
 public class TestObjectSubSubclass extends TestObjectSubclass {
     private final String description;
+    private AnotherObject anotherObject;
 
     public TestObjectSubSubclass(String description, int priority, String testProperty) {
         super(description, priority, testProperty);
@@ -25,5 +26,13 @@ public class TestObjectSubSubclass extends TestObjectSubclass {
     @Override
     public String getDescription() {
         return description;
+    }
+
+    public AnotherObject getAnotherObject() {
+        return anotherObject;
+    }
+
+    public void setAnotherObject(AnotherObject anotherObject) {
+        this.anotherObject = anotherObject;
     }
 }

--- a/core/defaults/src/main/java/org/eclipse/dataspaceconnector/core/defaults/negotiationstore/InMemoryContractNegotiationStore.java
+++ b/core/defaults/src/main/java/org/eclipse/dataspaceconnector/core/defaults/negotiationstore/InMemoryContractNegotiationStore.java
@@ -36,11 +36,11 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 
 /**
- * An in-memory, threadsafe process store.
- * This implementation is intended for testing purposes only.
+ * An in-memory, threadsafe process store. This implementation is intended for testing purposes only.
  */
 public class InMemoryContractNegotiationStore implements ContractNegotiationStore {
 
@@ -122,6 +122,14 @@ public class InMemoryContractNegotiationStore implements ContractNegotiationStor
     @Override
     public @NotNull Stream<ContractAgreement> queryAgreements(QuerySpec querySpec) {
         return lockManager.readLock(() -> agreementQueryResolver.query(getAgreements(), querySpec));
+    }
+
+    @Override
+    public Stream<ContractNegotiation> getNegotiationsWithAgreementOnAsset(String assetId) {
+        var filter = format("contractAgreement.assetId = %s", assetId);
+        var query = QuerySpec.Builder.newInstance().filter(filter).build();
+
+        return queryNegotiations(query);
     }
 
     @Override

--- a/core/defaults/src/test/java/org/eclipse/dataspaceconnector/core/defaults/negotiationstore/InMemoryContractNegotiationStoreTest.java
+++ b/core/defaults/src/test/java/org/eclipse/dataspaceconnector/core/defaults/negotiationstore/InMemoryContractNegotiationStoreTest.java
@@ -357,6 +357,22 @@ class InMemoryContractNegotiationStoreTest {
         assertThat(store.queryAgreements(QuerySpec.none())).isEmpty();
     }
 
+    @Test
+    void getNegotiationsWithAgreementOnAsset_multipleNegotiationsSameAsset() {
+        var assetId = UUID.randomUUID().toString();
+        var negotiation1 = createNegotiationBuilder("negotiation1").contractAgreement(createAgreementBuilder().id("contract1").assetId(assetId).build()).build();
+        var negotiation2 = createNegotiationBuilder("negotiation2").contractAgreement(createAgreementBuilder().id("contract2").assetId(assetId).build()).build();
+
+        store.save(negotiation1);
+        store.save(negotiation2);
+
+        var result = store.getNegotiationsWithAgreementOnAsset(assetId).collect(Collectors.toList());
+
+        assertThat(result).hasSize(2)
+                .extracting(ContractNegotiation::getId).containsExactlyInAnyOrder("negotiation1", "negotiation2");
+
+    }
+
     @NotNull
     private ContractNegotiation requestingNegotiation() {
         var negotiation = createNegotiation(UUID.randomUUID().toString());

--- a/core/defaults/src/test/java/org/eclipse/dataspaceconnector/core/defaults/negotiationstore/InMemoryContractNegotiationStoreTest.java
+++ b/core/defaults/src/test/java/org/eclipse/dataspaceconnector/core/defaults/negotiationstore/InMemoryContractNegotiationStoreTest.java
@@ -20,6 +20,7 @@ import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -318,6 +320,41 @@ class InMemoryContractNegotiationStoreTest {
         var query = QuerySpec.Builder.newInstance().sortField("notexist").sortOrder(SortOrder.DESC).build();
 
         assertThat(store.queryAgreements(query)).isEmpty();
+    }
+
+    @Test
+    void getNegotiationsWithAgreementOnAsset_negotiationWithAgreement() {
+        var agreement = createAgreementBuilder().id("contract1").build();
+        var negotiation = createNegotiationBuilder("negotiation1").contractAgreement(agreement).build();
+        var assetId = agreement.getAssetId();
+
+        store.save(negotiation);
+
+        var result = store.getNegotiationsWithAgreementOnAsset(assetId).collect(Collectors.toList());
+
+        assertThat(result).hasSize(1).usingRecursiveFieldByFieldElementComparator().containsOnly(negotiation);
+    }
+
+    @Test
+    void getNegotiationsWithAgreementOnAsset_negotiationWithoutAgreement() {
+        var assetId = UUID.randomUUID().toString();
+        var negotiation = ContractNegotiation.Builder.newInstance()
+                .type(ContractNegotiation.Type.CONSUMER)
+                .id("negotiation1")
+                .contractAgreement(null)
+                .correlationId("corr-negotiation1")
+                .state(ContractNegotiationStates.REQUESTED.code())
+                .counterPartyAddress("consumer")
+                .counterPartyId("consumerId")
+                .protocol("ids-multipart")
+                .build();
+
+        store.save(negotiation);
+
+        var result = store.getNegotiationsWithAgreementOnAsset(assetId).collect(Collectors.toList());
+
+        assertThat(result).isEmpty();
+        assertThat(store.queryAgreements(QuerySpec.none())).isEmpty();
     }
 
     @NotNull

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImplTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImplTest.java
@@ -40,6 +40,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 class AssetServiceImplTest {
@@ -73,15 +74,17 @@ class AssetServiceImplTest {
 
     @Test
     void createAsset_shouldCreateAssetIfItDoesNotAlreadyExist() {
-        var asset = createAsset("assetId");
-        when(index.findById("assetId")).thenReturn(null);
-        var dataAddress = DataAddress.Builder.newInstance().type("addressType").build();
+        var assetId = "assetId";
+        var asset = createAsset(assetId);
+        when(index.findById(assetId)).thenReturn(null);
+        var addressType = "addressType";
+        var dataAddress = DataAddress.Builder.newInstance().type(addressType).build();
 
         var inserted = service.create(asset, dataAddress);
 
         assertThat(inserted.succeeded()).isTrue();
-        assertThat(inserted.getContent()).matches(hasId("assetId"));
-        verify(loader).accept(argThat(it -> "assetId".equals(it.getId())), argThat(it -> "addressType".equals(it.getType())));
+        assertThat(inserted.getContent()).matches(hasId(assetId));
+        verify(loader).accept(argThat(it -> assetId.equals(it.getId())), argThat(it -> addressType.equals(it.getType())));
     }
 
     @Test
@@ -120,16 +123,17 @@ class AssetServiceImplTest {
                         .id(UUID.randomUUID().toString())
                         .providerAgentId(UUID.randomUUID().toString())
                         .consumerAgentId(UUID.randomUUID().toString())
-                        .assetId("assetId")
-                        .policy(Policy.Builder.newInstance().build())
-                        .build())
+                        .assetId(asset.getId())
+                        .policy(Policy.Builder.newInstance().build())                        .build())
                 .build();
-        when(contractNegotiationStore.queryNegotiations(any())).thenReturn(Stream.of(contractNegotiation));
+        when(contractNegotiationStore.getNegotiationsWithAgreementOnAsset(any())).thenReturn(Stream.of(contractNegotiation));
 
         var deleted = service.delete("assetId");
 
         assertThat(deleted.failed()).isTrue();
         assertThat(deleted.getFailure().getReason()).isEqualTo(CONFLICT);
+        verify(contractNegotiationStore).getNegotiationsWithAgreementOnAsset(any());
+        verifyNoMoreInteractions(contractNegotiationStore);
     }
 
     @Test

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImplTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImplTest.java
@@ -124,7 +124,8 @@ class AssetServiceImplTest {
                         .providerAgentId(UUID.randomUUID().toString())
                         .consumerAgentId(UUID.randomUUID().toString())
                         .assetId(asset.getId())
-                        .policy(Policy.Builder.newInstance().build())                        .build())
+                        .policy(Policy.Builder.newInstance().build())
+                        .build())
                 .build();
         when(contractNegotiationStore.getNegotiationsWithAgreementOnAsset(any())).thenReturn(Stream.of(contractNegotiation));
 

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStore.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStore.java
@@ -42,6 +42,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
 import static net.jodah.failsafe.Failsafe.with;
 
@@ -160,6 +161,14 @@ public class CosmosContractNegotiationStore implements ContractNegotiationStore 
                 .map(this::toNegotiation)
                 .map(ContractNegotiation::getContractAgreement)
                 .filter(Objects::nonNull);
+    }
+
+    @Override
+    public Stream<ContractNegotiation> getNegotiationsWithAgreementOnAsset(String assetId) {
+        var filter = format("contractAgreement.assetId = %s", assetId);
+        var query = QuerySpec.Builder.newInstance().filter(filter).build();
+
+        return queryNegotiations(query);
     }
 
     @Override

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
@@ -56,10 +56,10 @@ import java.util.stream.IntStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
-import static org.eclipse.dataspaceconnector.contract.negotiation.store.TestFunctions.generateAgreementBuilder;
+import static org.eclipse.dataspaceconnector.contract.negotiation.store.TestFunctions.createContractBuilder;
+import static org.eclipse.dataspaceconnector.contract.negotiation.store.TestFunctions.createNegotiation;
+import static org.eclipse.dataspaceconnector.contract.negotiation.store.TestFunctions.createNegotiationBuilder;
 import static org.eclipse.dataspaceconnector.contract.negotiation.store.TestFunctions.generateDocument;
-import static org.eclipse.dataspaceconnector.contract.negotiation.store.TestFunctions.generateNegotiation;
-import static org.eclipse.dataspaceconnector.contract.negotiation.store.TestFunctions.generateNegotiationBuilder;
 
 @AzureCosmosDbIntegrationTest
 class CosmosContractNegotiationStoreIntegrationTest {
@@ -178,7 +178,7 @@ class CosmosContractNegotiationStoreIntegrationTest {
 
     @Test
     void save_notExists_shouldCreate() {
-        var negotiation = generateNegotiation();
+        var negotiation = TestFunctions.createNegotiation();
         store.save(negotiation);
 
         var allObjs = container.readAllItems(new PartitionKey(partitionKey), Object.class);
@@ -188,7 +188,7 @@ class CosmosContractNegotiationStoreIntegrationTest {
 
     @Test
     void save_exists_shouldUpdate() {
-        var negotiation = generateNegotiation();
+        var negotiation = TestFunctions.createNegotiation();
         container.createItem(new ContractNegotiationDocument(negotiation, partitionKey));
 
         assertThat(container.readAllItems(new PartitionKey(partitionKey), Object.class)).hasSize(1);
@@ -208,7 +208,7 @@ class CosmosContractNegotiationStoreIntegrationTest {
 
     @Test
     void save_leasedByOther_shouldRaiseException() {
-        var negotiation = generateNegotiation("test-id", ContractNegotiationStates.CONFIRMED);
+        var negotiation = createNegotiation("test-id", ContractNegotiationStates.CONFIRMED);
         var item = new ContractNegotiationDocument(negotiation, partitionKey);
         item.acquireLease("someone-else");
         container.createItem(item);
@@ -220,7 +220,7 @@ class CosmosContractNegotiationStoreIntegrationTest {
 
     @Test
     void delete_leasedByOther_shouldRaiseException() {
-        var negotiation = generateNegotiation("test-id", ContractNegotiationStates.CONFIRMED);
+        var negotiation = createNegotiation("test-id", ContractNegotiationStates.CONFIRMED);
         var item = new ContractNegotiationDocument(negotiation, partitionKey);
         item.acquireLease("someone-else");
         container.createItem(item);
@@ -231,7 +231,7 @@ class CosmosContractNegotiationStoreIntegrationTest {
     @Test
     void nextForState() {
         var state = ContractNegotiationStates.CONFIRMED;
-        var n = generateNegotiation(state);
+        var n = TestFunctions.createNegotiation(state);
         container.createItem(new ContractNegotiationDocument(n, partitionKey));
 
         var result = store.nextForState(state.code(), 10);
@@ -244,7 +244,7 @@ class CosmosContractNegotiationStoreIntegrationTest {
         var numElements = 10;
 
         var preparedNegotiations = IntStream.range(0, numElements)
-                .mapToObj(i -> generateNegotiation(state))
+                .mapToObj(i -> TestFunctions.createNegotiation(state))
                 .peek(n -> container.createItem(new ContractNegotiationDocument(n, partitionKey)))
                 .collect(Collectors.toList());
 
@@ -255,7 +255,7 @@ class CosmosContractNegotiationStoreIntegrationTest {
     @Test
     void nextForState_noResult() {
         var state = ContractNegotiationStates.CONFIRMED;
-        var n = generateNegotiation(state);
+        var n = TestFunctions.createNegotiation(state);
         container.createItem(new ContractNegotiationDocument(n, partitionKey));
 
         var result = store.nextForState(ContractNegotiationStates.PROVIDER_OFFERING.code(), 10);
@@ -265,15 +265,15 @@ class CosmosContractNegotiationStoreIntegrationTest {
     @Test
     void nextForState_onlyReturnsFreeItems() {
         var state = ContractNegotiationStates.CONFIRMED;
-        var n1 = generateNegotiation(state);
+        var n1 = TestFunctions.createNegotiation(state);
         var doc1 = new ContractNegotiationDocument(n1, partitionKey);
         container.createItem(doc1);
 
-        var n2 = generateNegotiation(state);
+        var n2 = TestFunctions.createNegotiation(state);
         var doc2 = new ContractNegotiationDocument(n2, partitionKey);
         container.createItem(doc2);
 
-        var n3 = generateNegotiation(state);
+        var n3 = TestFunctions.createNegotiation(state);
         var doc3 = new ContractNegotiationDocument(n3, partitionKey);
         doc3.acquireLease("another-connector");
         container.createItem(doc3);
@@ -285,7 +285,7 @@ class CosmosContractNegotiationStoreIntegrationTest {
     @Test
     void nextForState_leasedBySelf() {
         var state = ContractNegotiationStates.CONFIRMED;
-        var n = generateNegotiation(state);
+        var n = TestFunctions.createNegotiation(state);
         var doc = new ContractNegotiationDocument(n, partitionKey);
         container.createItem(doc);
 
@@ -303,7 +303,7 @@ class CosmosContractNegotiationStoreIntegrationTest {
     @Test
     void nextForState_leasedByAnotherExpired() {
         var state = ContractNegotiationStates.CONFIRMED;
-        var n = generateNegotiation(state);
+        var n = TestFunctions.createNegotiation(state);
         var doc = new ContractNegotiationDocument(n, partitionKey);
         Duration leaseDuration = Duration.ofSeconds(10); // give it some time to compensate for TOF delays
         doc.acquireLease("another-connector", leaseDuration);
@@ -325,7 +325,7 @@ class CosmosContractNegotiationStoreIntegrationTest {
 
     @Test
     void nextForState_verifySaveClearsLease() {
-        var n = generateNegotiation("test-id", ContractNegotiationStates.CONSUMER_OFFERED);
+        var n = createNegotiation("test-id", ContractNegotiationStates.CONSUMER_OFFERED);
         var doc = new ContractNegotiationDocument(n, partitionKey);
         container.createItem(doc);
 
@@ -351,7 +351,7 @@ class CosmosContractNegotiationStoreIntegrationTest {
     @Test
     @DisplayName("Verify that a leased entity can still be deleted")
     void nextForState_verifyDelete() {
-        var n = generateNegotiation("test-id", ContractNegotiationStates.CONSUMER_OFFERED);
+        var n = createNegotiation("test-id", ContractNegotiationStates.CONSUMER_OFFERED);
         var doc = new ContractNegotiationDocument(n, partitionKey);
         container.createItem(doc);
 
@@ -454,8 +454,8 @@ class CosmosContractNegotiationStoreIntegrationTest {
 
     @Test
     void getAgreementsForDefinitionId() {
-        var contractAgreement = generateAgreementBuilder().id(ContractId.createContractId("definitionId")).build();
-        var negotiation = generateNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
+        var contractAgreement = createContractBuilder().id(ContractId.createContractId("definitionId")).build();
+        var negotiation = createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
         store.save(negotiation);
 
         var result = store.getAgreementsForDefinitionId("definitionId");
@@ -465,8 +465,8 @@ class CosmosContractNegotiationStoreIntegrationTest {
 
     @Test
     void getAgreementsForDefinitionId_notFound() {
-        var contractAgreement = generateAgreementBuilder().id(ContractId.createContractId("otherDefinitionId")).build();
-        var negotiation = generateNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
+        var contractAgreement = createContractBuilder().id(ContractId.createContractId("otherDefinitionId")).build();
+        var negotiation = createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
         store.save(negotiation);
 
         var result = store.getAgreementsForDefinitionId("definitionId");
@@ -477,8 +477,8 @@ class CosmosContractNegotiationStoreIntegrationTest {
     @Test
     void queryAgreements_noQuerySpec() {
         IntStream.range(0, 10).forEach(i -> {
-            var contractAgreement = generateAgreementBuilder().id(ContractId.createContractId(UUID.randomUUID().toString())).build();
-            var negotiation = generateNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
+            var contractAgreement = createContractBuilder().id(ContractId.createContractId(UUID.randomUUID().toString())).build();
+            var negotiation = createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
             store.save(negotiation);
         });
 
@@ -490,8 +490,8 @@ class CosmosContractNegotiationStoreIntegrationTest {
     @Test
     void queryAgreements_verifyPaging() {
         IntStream.range(0, 10).forEach(i -> {
-            var contractAgreement = generateAgreementBuilder().id(ContractId.createContractId(UUID.randomUUID().toString())).build();
-            var negotiation = generateNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
+            var contractAgreement = createContractBuilder().id(ContractId.createContractId(UUID.randomUUID().toString())).build();
+            var negotiation = createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
             store.save(negotiation);
         });
 
@@ -505,8 +505,8 @@ class CosmosContractNegotiationStoreIntegrationTest {
     @Test
     void queryAgreements_verifyFiltering() {
         IntStream.range(0, 10).forEach(i -> {
-            var contractAgreement = generateAgreementBuilder().id(i + ":" + i).build();
-            var negotiation = generateNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
+            var contractAgreement = createContractBuilder().id(i + ":" + i).build();
+            var negotiation = createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
             store.save(negotiation);
         });
         var query = QuerySpec.Builder.newInstance().equalsAsContains(false).filter("id=3:3").build();
@@ -519,8 +519,8 @@ class CosmosContractNegotiationStoreIntegrationTest {
     @Test
     void queryAgreements_verifySorting() {
         IntStream.range(0, 9).forEach(i -> {
-            var contractAgreement = generateAgreementBuilder().id(i + ":" + i).build();
-            var negotiation = generateNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
+            var contractAgreement = createContractBuilder().id(i + ":" + i).build();
+            var negotiation = createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
             store.save(negotiation);
         });
 
@@ -533,8 +533,8 @@ class CosmosContractNegotiationStoreIntegrationTest {
     @Test
     void queryAgreements_verifySorting_invalidProperty() {
         IntStream.range(0, 10).forEach(i -> {
-            var contractAgreement = generateAgreementBuilder().id(i + ":" + i).build();
-            var negotiation = generateNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
+            var contractAgreement = createContractBuilder().id(i + ":" + i).build();
+            var negotiation = createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
             store.save(negotiation);
         });
 
@@ -546,8 +546,8 @@ class CosmosContractNegotiationStoreIntegrationTest {
 
     @Test
     void getNegotiationsWithAgreementOnAsset_negotiationWithAgreement() {
-        var agreement = generateAgreementBuilder().id("contract1").build();
-        var negotiation = generateNegotiationBuilder("negotiation1").contractAgreement(agreement).build();
+        var agreement = createContractBuilder().id("contract1").build();
+        var negotiation = createNegotiationBuilder("negotiation1").contractAgreement(agreement).build();
         var assetId = agreement.getAssetId();
 
         store.save(negotiation);
@@ -577,6 +577,22 @@ class CosmosContractNegotiationStoreIntegrationTest {
 
         assertThat(result).isEmpty();
         assertThat(store.queryAgreements(QuerySpec.none())).isEmpty();
+    }
+
+    @Test
+    void getNegotiationsWithAgreementOnAsset_multipleNegotiationsSameAsset() {
+        var assetId = UUID.randomUUID().toString();
+        var negotiation1 = createNegotiation("negotiation1", createContractBuilder("contract1").assetId(assetId).build());
+        var negotiation2 = createNegotiation("negotiation2", createContractBuilder("contract2").assetId(assetId).build());
+
+        store.save(negotiation1);
+        store.save(negotiation2);
+
+        var result = store.getNegotiationsWithAgreementOnAsset(assetId).collect(Collectors.toList());
+
+        assertThat(result).hasSize(2)
+                .extracting(ContractNegotiation::getId).containsExactlyInAnyOrder("negotiation1", "negotiation2");
+
     }
 
     private ContractNegotiationDocument toDocument(Object object) {

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreTest.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreTest.java
@@ -36,7 +36,6 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.dataspaceconnector.contract.negotiation.store.TestFunctions.generateDocument;
-import static org.eclipse.dataspaceconnector.contract.negotiation.store.TestFunctions.generateNegotiation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -103,7 +102,7 @@ class CosmosContractNegotiationStoreTest {
 
     @Test
     void save() {
-        var negotiation = generateNegotiation();
+        var negotiation = TestFunctions.createNegotiation();
 
         store.save(negotiation);
 

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/TestFunctions.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/TestFunctions.java
@@ -28,22 +28,26 @@ import java.util.UUID;
 
 public class TestFunctions {
 
-    public static ContractNegotiation generateNegotiation() {
-        return generateNegotiation(ContractNegotiationStates.UNSAVED);
+    public static ContractNegotiation createNegotiation() {
+        return createNegotiation(ContractNegotiationStates.UNSAVED);
     }
 
-    public static ContractNegotiation generateNegotiation(ContractNegotiationStates state) {
-        return generateNegotiation(UUID.randomUUID().toString(), state);
+    public static ContractNegotiation createNegotiation(ContractNegotiationStates state) {
+        return createNegotiation(UUID.randomUUID().toString(), state);
     }
 
-    public static ContractNegotiation generateNegotiation(String id, ContractNegotiationStates state) {
-        return generateNegotiationBuilder(id)
+    public static ContractNegotiation createNegotiation(String id, ContractNegotiationStates state) {
+        return createNegotiationBuilder(id)
                 .state(state.code())
-                .contractAgreement(generateAgreementBuilder().build())
+                .contractAgreement(createContractBuilder().build())
                 .build();
     }
 
-    public static ContractNegotiation.Builder generateNegotiationBuilder(String id) {
+    public static ContractNegotiation createNegotiation(String id, ContractAgreement agreement) {
+        return createNegotiationBuilder(id).contractAgreement(agreement).build();
+    }
+
+    public static ContractNegotiation.Builder createNegotiationBuilder(String id) {
         return ContractNegotiation.Builder.newInstance()
                 .id(id)
                 .correlationId(UUID.randomUUID().toString())
@@ -53,7 +57,11 @@ public class TestFunctions {
                 .stateCount(1);
     }
 
-    public static ContractAgreement.Builder generateAgreementBuilder() {
+    public static ContractAgreement.Builder createContractBuilder() {
+        return createContractBuilder("1:2");
+    }
+
+    public static ContractAgreement.Builder createContractBuilder(String id) {
         return ContractAgreement.Builder.newInstance()
                 .providerAgentId("provider")
                 .consumerAgentId("consumer")
@@ -62,11 +70,11 @@ public class TestFunctions {
                 .contractStartDate(Instant.now().getEpochSecond())
                 .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())
                 .contractSigningDate(Instant.now().getEpochSecond())
-                .id("1:2");
+                .id(id);
     }
 
     public static ContractNegotiationDocument generateDocument() {
-        return generateDocument(generateNegotiation());
+        return generateDocument(createNegotiation());
     }
 
     public static ContractNegotiationDocument generateDocument(ContractNegotiation negotiation) {

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/model/ContractNegotiationDocumentSerializationTest.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/model/ContractNegotiationDocumentSerializationTest.java
@@ -14,12 +14,12 @@
 
 package org.eclipse.dataspaceconnector.contract.negotiation.store.model;
 
+import org.eclipse.dataspaceconnector.contract.negotiation.store.TestFunctions;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.dataspaceconnector.contract.negotiation.store.TestFunctions.generateNegotiation;
 
 class ContractNegotiationDocumentSerializationTest {
 
@@ -34,7 +34,7 @@ class ContractNegotiationDocumentSerializationTest {
 
     @Test
     void testSerialization() {
-        var def = generateNegotiation();
+        var def = TestFunctions.createNegotiation();
         var pk = def.getState();
 
         var document = new ContractNegotiationDocument(def, partitionKey);
@@ -49,7 +49,7 @@ class ContractNegotiationDocumentSerializationTest {
 
     @Test
     void testDeserialization() {
-        var def = generateNegotiation();
+        var def = TestFunctions.createNegotiation();
 
         var document = new ContractNegotiationDocument(def, partitionKey);
         String json = typeManager.writeValueAsString(document);

--- a/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/ContractNegotiationStatements.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/ContractNegotiationStatements.java
@@ -17,8 +17,8 @@ package org.eclipse.dataspaceconnector.sql.contractnegotiation.store;
 import org.eclipse.dataspaceconnector.sql.lease.LeaseStatements;
 
 /**
- * Provides names for database columns, table names and statement templates.
- * Methods to compose statements must be overridden by implementors.
+ * Provides names for database columns, table names and statement templates. Methods to compose statements must be
+ * overridden by implementors.
  */
 public interface ContractNegotiationStatements extends LeaseStatements {
     String getFindTemplate();
@@ -46,6 +46,8 @@ public interface ContractNegotiationStatements extends LeaseStatements {
     String getSelectByPolicyIdTemplate();
 
     String getUpdateAgreementTemplate();
+
+    String getNegotiationWitghAgreementOnAssetTemplate();
 
     @Override
     default String getLeasedByColumn() {

--- a/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/PostgresStatements.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/PostgresStatements.java
@@ -111,6 +111,19 @@ public final class PostgresStatements implements ContractNegotiationStatements {
     }
 
     @Override
+    public String getNegotiationWitghAgreementOnAssetTemplate() {
+        return format("SELECT * FROM %s\n" +
+                        "INNER JOIN %s eca on %s.%s = eca.%s\n" +
+                        "WHERE %s.%s in (SELECT %s\n" +
+                        "FROM %s\n" +
+                        "WHERE %s = ?);\n",
+                getContractNegotiationTable(), getContractAgreementTable(), getContractNegotiationTable(), getContractAgreementIdFkColumn(),
+                getContractAgreementIdColumn(),
+                getContractNegotiationTable(), getContractAgreementIdFkColumn(), getContractAgreementIdColumn(), getContractAgreementTable(),
+                getAssetIdColumn());
+    }
+
+    @Override
     public String getDeleteLeaseTemplate() {
         return format("DELETE FROM %s WHERE %s=?", getLeaseTableName(), getLeaseIdColumn());
     }

--- a/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -193,13 +193,7 @@ public class SqlContractNegotiationStore implements ContractNegotiationStore {
 
     @Override
     public Stream<ContractNegotiation> getNegotiationsWithAgreementOnAsset(String assetId) {
-        var statement = "\n" +
-                "SELECT *\n" +
-                "FROM edc_contract_negotiation\n" +
-                "INNER JOIN edc_contract_agreement eca on edc_contract_negotiation.contract_agreement_id = eca.agreement_id\n" +
-                "WHERE edc_contract_negotiation.contract_agreement_id in (SELECT agreement_id\n" +
-                "                                                         FROM edc_contract_agreement\n" +
-                "                                                         WHERE asset_id = ?);\n";
+        var statement = statements.getNegotiationWitghAgreementOnAssetTemplate();
 
         return transactionContext.execute(() -> {
             try (var connection = getConnection()) {

--- a/extensions/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/TestFunctions.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/TestFunctions.java
@@ -27,27 +27,13 @@ import java.util.UUID;
 public class TestFunctions {
 
     public static ContractNegotiation createNegotiation(String id) {
-        return ContractNegotiation.Builder.newInstance()
-                .type(ContractNegotiation.Type.CONSUMER)
-                .id(id)
-                .contractAgreement(null)
-                .correlationId("corr-" + id)
-                .state(ContractNegotiationStates.REQUESTED.code())
-                .counterPartyAddress("consumer")
-                .counterPartyId("consumerId")
-                .protocol("ids-multipart")
+        return createNegotiationBuilder(id)
                 .build();
     }
 
     public static ContractNegotiation createNegotiation(String id, ContractAgreement agreement) {
-        return ContractNegotiation.Builder.newInstance()
-                .type(ContractNegotiation.Type.CONSUMER)
-                .id(id)
+        return createNegotiationBuilder(id)
                 .contractAgreement(agreement)
-                .correlationId("corr-" + id)
-                .counterPartyAddress("consumer")
-                .counterPartyId("consumerId")
-                .protocol("ids-multipart")
                 .build();
     }
 
@@ -62,10 +48,38 @@ public class TestFunctions {
                 .providerAgentId("provider")
                 .consumerAgentId("consumer")
                 .assetId(UUID.randomUUID().toString())
-                .policy(Policy.Builder.newInstance().build())
+                .policy(Policy.Builder.newInstance().build()))
                 .contractStartDate(Instant.now().getEpochSecond())
                 .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())
                 .contractSigningDate(Instant.now().getEpochSecond());
     }
 
+    public static ContractNegotiation.Builder createNegotiationBuilder(String id) {
+        return ContractNegotiation.Builder.newInstance()
+                .type(ContractNegotiation.Type.CONSUMER)
+                .id(id)
+                .contractAgreement(null)
+                .correlationId("corr-" + id)
+                .state(ContractNegotiationStates.REQUESTED.code())
+                .counterPartyAddress("consumer")
+                .counterPartyId("consumerId")
+                .protocol("ids-multipart");
+    }
+
+    public static Policy createPolicy(String uid) {
+        return Policy.Builder.newInstance()
+                .id(uid)
+                .permission(Permission.Builder.newInstance()
+                        .target("")
+                        .action(Action.Builder.newInstance()
+                                .type("USE")
+                                .build())
+                        .constraint(AtomicConstraint.Builder.newInstance()
+                                .leftExpression(new LiteralExpression("foo"))
+                                .operator(Operator.EQ)
+                                .rightExpression(new LiteralExpression("bar"))
+                                .build())
+                        .build())
+                .build();
+    }
 }

--- a/extensions/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/TestFunctions.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/TestFunctions.java
@@ -15,6 +15,11 @@
 
 package org.eclipse.dataspaceconnector.sql.contractnegotiation;
 
+import org.eclipse.dataspaceconnector.policy.model.Action;
+import org.eclipse.dataspaceconnector.policy.model.AtomicConstraint;
+import org.eclipse.dataspaceconnector.policy.model.LiteralExpression;
+import org.eclipse.dataspaceconnector.policy.model.Operator;
+import org.eclipse.dataspaceconnector.policy.model.Permission;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
@@ -48,7 +53,7 @@ public class TestFunctions {
                 .providerAgentId("provider")
                 .consumerAgentId("consumer")
                 .assetId(UUID.randomUUID().toString())
-                .policy(Policy.Builder.newInstance().build()))
+                .policy(createPolicy())
                 .contractStartDate(Instant.now().getEpochSecond())
                 .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())
                 .contractSigningDate(Instant.now().getEpochSecond());
@@ -66,9 +71,8 @@ public class TestFunctions {
                 .protocol("ids-multipart");
     }
 
-    public static Policy createPolicy(String uid) {
+    public static Policy createPolicy() {
         return Policy.Builder.newInstance()
-                .id(uid)
                 .permission(Permission.Builder.newInstance()
                         .target("")
                         .action(Action.Builder.newInstance()

--- a/extensions/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStoreTest.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStoreTest.java
@@ -402,6 +402,43 @@ class SqlContractNegotiationStoreTest {
     }
 
     @Test
+    void getNegotiationsWithAgreementOnAsset_negotiationWithAgreement() {
+        var agreement = createContract("contract1");
+        var negotiation = createNegotiation("negotiation1", agreement);
+        var assetId = agreement.getAssetId();
+
+        store.save(negotiation);
+
+        var result = store.getNegotiationsWithAgreementOnAsset(assetId).collect(Collectors.toList());
+
+        assertThat(result).hasSize(1).usingRecursiveFieldByFieldElementComparator().containsOnly(negotiation);
+
+    }
+
+    @Test
+    void getNegotiationsWithAgreementOnAsset_negotiationWithoutAgreement() {
+        var assetId = UUID.randomUUID().toString();
+        var negotiation = ContractNegotiation.Builder.newInstance()
+                .type(ContractNegotiation.Type.CONSUMER)
+                .id("negotiation1")
+                .contractAgreement(null)
+                .correlationId("corr-negotiation1")
+                .state(ContractNegotiationStates.REQUESTED.code())
+                .counterPartyAddress("consumer")
+                .counterPartyId("consumerId")
+                .protocol("ids-multipart")
+                .build();
+
+        store.save(negotiation);
+
+        var result = store.getNegotiationsWithAgreementOnAsset(assetId).collect(Collectors.toList());
+
+        assertThat(result).isEmpty();
+        assertThat(store.queryAgreements(QuerySpec.none())).isEmpty();
+
+    }
+
+    @Test
     @DisplayName("Verify that paging is used")
     void queryNegotiations_withAgreement() {
         var querySpec = QuerySpec.Builder.newInstance().limit(10).offset(5).build();

--- a/extensions/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStoreTest.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStoreTest.java
@@ -298,7 +298,7 @@ class SqlContractNegotiationStoreTest {
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactly(agreement);
 
-        assertThat(Objects.requireNonNull(store.find(negotiationId)).getContractAgreement()).isEqualTo(agreement);
+        assertThat(Objects.requireNonNull(store.find(negotiationId)).getContractAgreement()).usingRecursiveComparison().isEqualTo(agreement);
     }
 
     @Test

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/store/ContractNegotiationStore.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/store/ContractNegotiationStore.java
@@ -49,7 +49,8 @@ public interface ContractNegotiationStore extends StateEntityStore<ContractNegot
     ContractAgreement findContractAgreement(String contractId);
 
     /**
-     * Persists a contract negotiation. This follows UPSERT semantics, so if the object didn't exit before, it's created.
+     * Persists a contract negotiation. This follows UPSERT semantics, so if the object didn't exit before, it's
+     * created.
      */
     void save(ContractNegotiation negotiation);
 
@@ -59,8 +60,8 @@ public interface ContractNegotiationStore extends StateEntityStore<ContractNegot
     void delete(String negotiationId);
 
     /**
-     * Finds all contract negotiations that are covered by a specific {@link QuerySpec}. If no {@link QuerySpec#getSortField()}
-     * is specified, results are not explicitly sorted.
+     * Finds all contract negotiations that are covered by a specific {@link QuerySpec}. If no
+     * {@link QuerySpec#getSortField()} is specified, results are not explicitly sorted.
      * <p>
      * The general order of precedence of the query parameters is:
      * <pre>
@@ -85,12 +86,20 @@ public interface ContractNegotiationStore extends StateEntityStore<ContractNegot
 
 
     /**
-     * Finds all contract agreement that are covered by a specific {@link QuerySpec}.
-     * If no {@link QuerySpec#getSortField()} is specified, results are not explicitly sorted.
+     * Finds all contract agreement that are covered by a specific {@link QuerySpec}. If no
+     * {@link QuerySpec#getSortField()} is specified, results are not explicitly sorted.
      *
      * @param querySpec The query spec, e.g. paging, filtering, etc.
      * @return a stream of ContractAgreement, cannot be null.
      */
     @NotNull
     Stream<ContractAgreement> queryAgreements(QuerySpec querySpec);
+
+    /**
+     * Finds all negotiations, that have agreements targeting the given asset
+     *
+     * @param assetId The asset for which the negotiations + agreements are wanted.
+     * @return A stream of contract negotiations, or empty
+     */
+    Stream<ContractNegotiation> getNegotiationsWithAgreementOnAsset(String assetId);
 }


### PR DESCRIPTION
## What this PR changes/adds

This PR adds a method to the `ContractNegotiationStore` that returns all `ContractNegotiation`s that have a `ContractAgreement` which references a particular asset in order to check, whether the asset can be deleted or not.

## Why it does that
Deleting Assets should be forbidden once it is referenced by a `ContractAgreement`. Previously the check used a filter expression, which is not (yet) implemented for SQL.

## Further notes

- The implementations for CosmosDB and InMem did not change functionally - the same query as was there before can be used. Only SQL - due to its relational nature - needed some love. 
- the `ReflectionUtil` threw a NPE when recursively resolving a field, who's parent is null, e.g. `ContractNegotiation -> contractAgreement -> assetId` when `contractAgreement` is null.

## Linked Issue(s)

Closes #1403 

## Checklist

- [x] added appropriate tests? (some)
- [ ] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
