### PR TITLE
Feature: create CosmosDB with terraform for integration testing

### DIFF
--- a/extensions/azure/azure-test/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/testfixtures/CosmosTestClient.java
+++ b/extensions/azure/azure-test/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/testfixtures/CosmosTestClient.java
@@ -43,7 +43,7 @@ public interface CosmosTestClient {
     static CosmosClient createClient() {
         var cosmosKey = propOrEnv("COSMOS_KEY", null);
         if (!StringUtils.isNullOrBlank(cosmosKey)) {
-            String endpoint = propOrEnv("COSMOS_URL", "https://cosmos-itest.documents.azure.com:443/");
+            String endpoint = propOrEnv("COSMOS_URL", "https://cosmos-edc-itest.documents.azure.com:443/");
             return azureClient(cosmosKey, endpoint);
         } else {
             return localClient();

--- a/extensions/azure/azure-test/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/testfixtures/CosmosTestClient.java
+++ b/extensions/azure/azure-test/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/testfixtures/CosmosTestClient.java
@@ -43,7 +43,7 @@ public interface CosmosTestClient {
     static CosmosClient createClient() {
         var cosmosKey = propOrEnv("COSMOS_KEY", null);
         if (!StringUtils.isNullOrBlank(cosmosKey)) {
-            String endpoint = propOrEnv("COSMOS_URL", "https://cosmos-edc-itest.documents.azure.com:443/");
+            String endpoint = propOrEnv("COSMOS_URL", "https://edcintdev-cosmosdb.documents.azure.com:443/");
             return azureClient(cosmosKey, endpoint);
         } else {
             return localClient();

--- a/resources/azure/testing/terraform-apply.sh
+++ b/resources/azure/testing/terraform-apply.sh
@@ -29,6 +29,7 @@ terraform output -raw ci_client_id | $gh secret set AZURE_CLIENT_ID
 terraform output -raw EDC_AZURE_SUBSCRIPTION_ID | $gh secret set AZURE_SUBSCRIPTION_ID
 terraform output -raw EDC_AZURE_TENANT_ID | $gh secret set AZURE_TENANT_ID
 terraform output -raw EDC_COSMOS_ITEST_KEY | $gh secret set COSMOS_KEY
+terraform output -raw EDC_COSMOS_ITEST_URL | $gh secret set COSMOS_URL
 
 cd ..
 

--- a/resources/azure/testing/terraform-apply.sh
+++ b/resources/azure/testing/terraform-apply.sh
@@ -28,6 +28,7 @@ echo "== Collecting terraform outputs =="
 terraform output -raw ci_client_id | $gh secret set AZURE_CLIENT_ID
 terraform output -raw EDC_AZURE_SUBSCRIPTION_ID | $gh secret set AZURE_SUBSCRIPTION_ID
 terraform output -raw EDC_AZURE_TENANT_ID | $gh secret set AZURE_TENANT_ID
+terraform output -raw EDC_COSMOS_ITEST_KEY | $gh secret set COSMOS_KEY
 
 cd ..
 

--- a/resources/azure/testing/terraform/main.tf
+++ b/resources/azure/testing/terraform/main.tf
@@ -128,7 +128,6 @@ resource "azurerm_cosmosdb_account" "cosmosdb_integrationtest" {
   location            = "westeurope"
   resource_group_name = azurerm_resource_group.main.name
   offer_type          = "Standard"
-  kind                = "GlobalDocumentDB"
 
   enable_automatic_failover = false
   enable_free_tier          = true

--- a/resources/azure/testing/terraform/main.tf
+++ b/resources/azure/testing/terraform/main.tf
@@ -124,7 +124,7 @@ resource "azurerm_key_vault_secret" "consumer_storage_key" {
 ## CosmosDB account for integration testing. No need to create databases or containers,
 ## they are created by the tests
 resource "azurerm_cosmosdb_account" "cosmosdb_integrationtest" {
-  name                = "cosmos-edc-itest"
+    name                     = "${var.prefix}-cosmosdb"
   location            = "westeurope"
   resource_group_name = azurerm_resource_group.main.name
   offer_type          = "Standard"

--- a/resources/azure/testing/terraform/main.tf
+++ b/resources/azure/testing/terraform/main.tf
@@ -124,7 +124,7 @@ resource "azurerm_key_vault_secret" "consumer_storage_key" {
 ## CosmosDB account for integration testing. No need to create databases or containers,
 ## they are created by the tests
 resource "azurerm_cosmosdb_account" "cosmosdb_integrationtest" {
-    name                     = "${var.prefix}-cosmosdb"
+  name                = "${var.prefix}-cosmosdb"
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
   offer_type          = "Standard"
@@ -141,7 +141,7 @@ resource "azurerm_cosmosdb_account" "cosmosdb_integrationtest" {
   }
 
   geo_location {
-    location          = "westeurope"
+    location          = azurerm_resource_group.main.location
     failover_priority = 0
   }
 }

--- a/resources/azure/testing/terraform/main.tf
+++ b/resources/azure/testing/terraform/main.tf
@@ -106,7 +106,7 @@ resource "azurerm_key_vault_secret" "provider_storage_key" {
   name         = "${azurerm_storage_account.provider.name}-key1"
   value        = azurerm_storage_account.provider.primary_access_key
   key_vault_id = azurerm_key_vault.main.id
-  depends_on = [
+  depends_on   = [
     azurerm_role_assignment.ci_key_vault
   ]
 }
@@ -116,7 +116,33 @@ resource "azurerm_key_vault_secret" "consumer_storage_key" {
   name         = "${azurerm_storage_account.consumer.name}-key1"
   value        = azurerm_storage_account.consumer.primary_access_key
   key_vault_id = azurerm_key_vault.main.id
-  depends_on = [
+  depends_on   = [
     azurerm_role_assignment.ci_key_vault
   ]
+}
+
+## CosmosDB account for integration testing. No need to create databases or containers,
+## they are created by the tests
+resource "azurerm_cosmosdb_account" "cosmosdb_integrationtest" {
+  name                = "cosmos-edc-itest"
+  location            = "westeurope"
+  resource_group_name = azurerm_resource_group.main.name
+  offer_type          = "Standard"
+  kind                = "GlobalDocumentDB"
+
+  enable_automatic_failover = false
+  enable_free_tier          = true
+
+  capabilities {
+    name = "EnableAggregationPipeline"
+  }
+
+  consistency_policy {
+    consistency_level = "Strong"
+  }
+
+  geo_location {
+    location          = "westeurope"
+    failover_priority = 0
+  }
 }

--- a/resources/azure/testing/terraform/main.tf
+++ b/resources/azure/testing/terraform/main.tf
@@ -125,7 +125,7 @@ resource "azurerm_key_vault_secret" "consumer_storage_key" {
 ## they are created by the tests
 resource "azurerm_cosmosdb_account" "cosmosdb_integrationtest" {
     name                     = "${var.prefix}-cosmosdb"
-  location            = "westeurope"
+  location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
   offer_type          = "Standard"
 

--- a/resources/azure/testing/terraform/outputs.tf
+++ b/resources/azure/testing/terraform/outputs.tf
@@ -65,3 +65,7 @@ output "EDC_COSMOS_ITEST_KEY" {
   sensitive   = true
 }
 
+output "EDC_COSMOS_ITEST_URL" {
+  value       = azurerm_cosmosdb_account.cosmosdb_integrationtest.endpoint
+  description = "Public endpoint for the CosmosDB Account used in testing"
+}

--- a/resources/azure/testing/terraform/outputs.tf
+++ b/resources/azure/testing/terraform/outputs.tf
@@ -58,3 +58,10 @@ output "test_key_vault_name" {
   value       = azurerm_key_vault.main.name
   description = "Name of the Azure Key Vault connected to the Data Factory."
 }
+
+output "EDC_COSMOS_ITEST_KEY" {
+  value       = azurerm_cosmosdb_account.cosmosdb_integrationtest.primary_key
+  description = "Primary access key for the CosmosDB Account used in testing"
+  sensitive   = true
+}
+


### PR DESCRIPTION
## What this PR changes/adds

Adds scripting scaffold to provision a CosmosDB instance with terraform when setting up forks.

## Why it does that

To maintain consistency with the other Azure resources.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #1377 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
