### PR TITLE
Fix: remove `token-validation` dependency from BOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Deprecated Control API (#1310)
 * Remove sample module `:extensions:policy:ids-policy` (#1348)
 * Unused `:launchers:basic` (#1360)
+* Dependency onto `token-validation` from IDS BOM (#1387)
 
 #### Fixed
 

--- a/data-protocols/ids/build.gradle.kts
+++ b/data-protocols/ids/build.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
     api(project(":data-protocols:ids:ids-transform-v1"))
     api(project(":data-protocols:ids:ids-api-multipart-endpoint-v1"))
     api(project(":data-protocols:ids:ids-api-multipart-dispatcher-v1"))
-    api(project(":data-protocols:ids:ids-token-validation"))
     api(project(":data-protocols:ids:ids-api-configuration"))
 }
 


### PR DESCRIPTION
## What this PR changes/adds

Removes the `ids:token-validation` dependency from the IDS BOM.

## Why it does that

To avoid transitive dependency onto `Oauth2ValidationRulesRegistry`

## Further notes

n/a

## Linked Issue(s)

Closes #1387 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
