### PR TITLE
Doc: adds info about stale issues/PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,24 @@ we would appreciate if your pull request applies to the following points:
       has been signed as well as commits have been signed-off and
     * _Continuous Integration_ performing various test conventions.
 
+### Stale issues and PRs
+
+In order to keep our backlog clean we are using a bot that helps us label and eventually close old issues and PRs. The
+following table shows the particular timings.
+
+|                        | `stale` after | closed after days `stale` |
+|------------------------|---------------|---------------------------|
+| Issue without assignee | 14            | 7                         |
+| Issue with assignee    | 28            | 7                         |
+| PR                     | 7             | 7                         |
+
+Note that updating an issue, e.g. by commenting, will remove the `stale` label again and reset the counters. However,
+we ask the community **not to abuse** this feature (e.g. commenting "what's the status?" every X days would certainly 
+be seen as abuse). If an issue receives no attention, there usually
+are reasons for it. It is therefore advisable to clarify in advance whether any particular feature fits into EDC's
+planning schedule and roadmap. For that, we recommend opening a discussion. They serve us as a system of record, that 
+means we monitor them more closely, and do not close them automatically.
+
 ### Add Documentation
 
 Every decision record, launcher, extension, or any type of module has to provide documentation that covers at least

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,9 +157,9 @@ following table shows the particular timings.
 
 Note that updating an issue, e.g. by commenting, will remove the `stale` label again and reset the counters. However,
 we ask the community **not to abuse** this feature (e.g. commenting "what's the status?" every X days would certainly 
-be seen as abuse). If an issue receives no attention, there usually
+be qualified as abuse). If an issue receives no attention, there usually
 are reasons for it. It is therefore advisable to clarify in advance whether any particular feature fits into EDC's
-planning schedule and roadmap. For that, we recommend opening a discussion. They serve us as a system of record, that 
+planning schedule and roadmap. For that, we recommend opening a discussion. Discussions serve us as a system of record, that 
 means we monitor them more closely, and do not close them automatically.
 
 ### Add Documentation


### PR DESCRIPTION
## What this PR changes/adds

Adds a section to `CONTRIBUTING.md` about labeling issues and PRs `stale` and then auto-closing them.

## Why it does that

Full transparency and disclosure



## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
