### PR TITLE
Bugfix: brings back the edcVersion variable in the build file

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,23 +46,15 @@ val edcDeveloperEmail: String by project
 val edcScmConnection: String by project
 val edcWebsiteUrl: String by project
 val edcScmUrl: String by project
-val groupId: String = "org.eclipse.dataspaceconnector"
-var edcVersion: String = "0.0.1-SNAPSHOT"
-
-if (project.version == "unspecified") {
-    logger.warn("No version was specified, setting default 0.0.1-SNAPSHOT")
-    logger.warn("If you want to set a version, use the -Pversion=X.Y.Z parameter")
-    logger.warn("")
-    project.version = "0.0.1-SNAPSHOT"
-} else {
-    edcVersion = project.version as String
-}
+val groupId: String by project
+val defaultVersion: String by project
 
 // required by the nexus publishing plugin
+val projectVersion: String = (project.findProperty("version") ?: defaultVersion) as String
 
 var deployUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
 
-if (edcVersion.contains("SNAPSHOT")) {
+if (projectVersion.contains("SNAPSHOT")) {
     deployUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
 }
 
@@ -161,7 +153,9 @@ allprojects {
 
     pluginManager.withPlugin("java-library") {
         group = groupId
-        version = edcVersion
+        version = projectVersion
+
+        println("selecting version $projectVersion for module $name")
 
         dependencies {
             api("org.jetbrains:annotations:${jetBrainsAnnotationsVersion}")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,19 +47,22 @@ val edcScmConnection: String by project
 val edcWebsiteUrl: String by project
 val edcScmUrl: String by project
 val groupId: String = "org.eclipse.dataspaceconnector"
+var edcVersion: String = "0.0.1-SNAPSHOT"
 
 if (project.version == "unspecified") {
     logger.warn("No version was specified, setting default 0.0.1-SNAPSHOT")
     logger.warn("If you want to set a version, use the -Pversion=X.Y.Z parameter")
     logger.warn("")
     project.version = "0.0.1-SNAPSHOT"
+} else {
+    edcVersion = project.version as String
 }
 
 // required by the nexus publishing plugin
 
 var deployUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
 
-if (project.version.toString().contains("SNAPSHOT")) {
+if (edcVersion.contains("SNAPSHOT")) {
     deployUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
 }
 
@@ -158,7 +161,7 @@ allprojects {
 
     pluginManager.withPlugin("java-library") {
         group = groupId
-        version = project.version
+        version = edcVersion
 
         dependencies {
             api("org.jetbrains:annotations:${jetBrainsAnnotationsVersion}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
+groupId=org.eclipse.dataspaceconnector
+defaultVersion=0.0.1-SNAPSHOT
 javaVersion=11
 infoModelVersion=4.2.7
 jetBrainsAnnotationsVersion=15.0


### PR DESCRIPTION
## What this PR changes/adds

This PR reinstates the previously discarded `edcVersion` variable to hold the default value for the version.

## Why it does that

Due to some gradle weirdness it was possible that the version string was `"unspecified"` in subprojects.

**We won't be able to produce SNAPSHOT versions until this is merged**

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
