### PR TITLE
core: dispatch Asset events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ in the detailed section referring to by linking pull requests or issues.
 
 #### Added
 
-*
+* Event Framework for Asset entity (#1453)
 
 #### Changed
 

--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/CoreServicesExtension.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/CoreServicesExtension.java
@@ -23,6 +23,7 @@ import org.eclipse.dataspaceconnector.core.base.agent.ParticipantAgentServiceImp
 import org.eclipse.dataspaceconnector.core.base.policy.PolicyEngineImpl;
 import org.eclipse.dataspaceconnector.core.base.policy.RuleBindingRegistryImpl;
 import org.eclipse.dataspaceconnector.core.base.policy.ScopeFilter;
+import org.eclipse.dataspaceconnector.core.event.EventRouterImpl;
 import org.eclipse.dataspaceconnector.core.health.HealthCheckServiceConfiguration;
 import org.eclipse.dataspaceconnector.core.health.HealthCheckServiceImpl;
 import org.eclipse.dataspaceconnector.core.security.DefaultPrivateKeyParseFunction;
@@ -30,6 +31,7 @@ import org.eclipse.dataspaceconnector.policy.model.PolicyRegistrationTypes;
 import org.eclipse.dataspaceconnector.spi.EdcSetting;
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgentService;
 import org.eclipse.dataspaceconnector.spi.command.CommandHandlerRegistry;
+import org.eclipse.dataspaceconnector.spi.event.EventRouter;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.policy.PolicyEngine;
@@ -204,6 +206,11 @@ public class CoreServicesExtension implements ServiceExtension {
         ofNullable(okHttpEventListener).ifPresent(builder::eventListener);
 
         return builder.build();
+    }
+
+    @Provider
+    public EventRouter eventRouter(ServiceExtensionContext context) {
+        return new EventRouterImpl(context.getMonitor());
     }
 
     @Provider(isDefault = true)

--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/event/EventRouterImpl.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/event/EventRouterImpl.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.core.event;
+
+import org.eclipse.dataspaceconnector.spi.event.Event;
+import org.eclipse.dataspaceconnector.spi.event.EventRouter;
+import org.eclipse.dataspaceconnector.spi.event.EventSubscriber;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.lang.String.format;
+import static java.util.concurrent.CompletableFuture.runAsync;
+
+public class EventRouterImpl implements EventRouter {
+
+    private final List<EventSubscriber> subscribers = new ArrayList<>();
+    private final Monitor monitor;
+
+    public EventRouterImpl(Monitor monitor) {
+        this.monitor = monitor;
+    }
+
+    @Override
+    public void register(EventSubscriber subscriber) {
+        subscribers.add(subscriber);
+    }
+
+    @Override
+    public void publish(Event event) {
+        subscribers.stream()
+                .map(subscriber -> runAsync(() -> subscriber.on(event)).thenApply(v -> subscriber))
+                .forEach(future -> future.whenComplete((subscriber, throwable) -> {
+                    if (throwable != null) {
+                        var subscriberName = subscriber.getClass().getSimpleName();
+                        var eventName = event.getClass().getSimpleName();
+                        monitor.severe(format("Subscriber %s failed to handle event %s", subscriberName, eventName), throwable);
+                    }
+                }));
+    }
+}

--- a/core/base/src/test/java/org/eclipse/dataspaceconnector/core/event/EventRouterImplTest.java
+++ b/core/base/src/test/java/org/eclipse/dataspaceconnector/core/event/EventRouterImplTest.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.core.event;
+
+import org.eclipse.dataspaceconnector.spi.event.Event;
+import org.eclipse.dataspaceconnector.spi.event.EventSubscriber;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class EventRouterImplTest {
+
+    private final Clock clock = Clock.systemUTC();
+    private final Monitor monitor = mock(Monitor.class);
+    private final EventRouterImpl eventRouter = new EventRouterImpl(monitor);
+
+    @Test
+    void shouldPublishToAllSubscribers() {
+        var subscriberA = mock(EventSubscriber.class);
+        var subscriberB = mock(EventSubscriber.class);
+        eventRouter.register(subscriberA);
+        eventRouter.register(subscriberB);
+
+        eventRouter.publish(TestEvent.Builder.newInstance().at(clock.millis()).build());
+
+        await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
+            verify(subscriberA).on(isA(TestEvent.class));
+            verify(subscriberB).on(isA(TestEvent.class));
+        });
+    }
+
+    @Test
+    void shouldNotInterruptPublishingWhenSubscriberThrowsException() {
+        var subscriberA = mock(EventSubscriber.class);
+        var subscriberB = mock(EventSubscriber.class);
+        doThrow(new RuntimeException("unexpected exception")).when(subscriberA).on(any());
+        eventRouter.register(subscriberA);
+        eventRouter.register(subscriberB);
+
+        eventRouter.publish(TestEvent.Builder.newInstance().at(clock.millis()).build());
+
+        await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
+            verify(subscriberA).on(isA(TestEvent.class));
+            verify(subscriberB).on(isA(TestEvent.class));
+        });
+    }
+
+    private static class TestEvent extends Event {
+        public static class Builder extends Event.Builder<TestEvent> {
+
+            public static Builder newInstance() {
+                return new Builder(new TestEvent());
+            }
+
+            private Builder(TestEvent event) {
+                super(event);
+            }
+        }
+    }
+}

--- a/core/defaults/src/main/java/org/eclipse/dataspaceconnector/core/defaults/assetindex/InMemoryAssetIndex.java
+++ b/core/defaults/src/main/java/org/eclipse/dataspaceconnector/core/defaults/assetindex/InMemoryAssetIndex.java
@@ -148,11 +148,6 @@ public class InMemoryAssetIndex implements AssetIndex, DataAddressResolver, Asse
     }
 
     @Override
-    public void accept(Asset asset, DataAddress dataAddress) {
-        accept(new AssetEntry(asset, dataAddress));
-    }
-
-    @Override
     public Asset deleteById(String assetId) {
         lock.writeLock().lock();
         try {

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -24,6 +24,7 @@ As a developer, I do not want to ...
 - [Customize policy engine](policy-engine.md)
 - [Dependency resolution](dependency_resolution.md)
 - [Data plane framework](data-plane-framework/README.md)
+- [Events](events.md)
 - [Logging](logging.md)
 - [Metrics](metrics.md)
 - [Releases](releases.md)

--- a/docs/developer/events.md
+++ b/docs/developer/events.md
@@ -4,13 +4,13 @@ EDC provides an eventing system that permits the developer to write extensions t
 emitted from the core of the EDC and also emit custom events.
 
 ## Subscribe to events
-The entry point for event listening is the `EventRouter` component, on which an `EventSubscribed` can be registered.
+The entry point for event listening is the `EventRouter` component, on which an `EventSubscriber` can be registered.
 
 Extension example:
 ```java
-public class ExampleEventSubscriptionExtension implements ServiceExtension{
+public class ExampleEventSubscriptionExtension implements ServiceExtension {
     @Inject
-    EventRouter eventRouter;
+    private EventRouter eventRouter;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
@@ -101,13 +101,15 @@ public class ExampleBusinessLogic {
     }    
 }
 ```
-Please note that the `at` field gives a timestamp to every event, and it's mandatory (please use the `Clock` service to get the current timestamp).
+Please note that the `at` field is a timestamp that every event has, and it's mandatory 
+(please use the `Clock` service to get the current timestamp).
 
 ## Serialization / Deserialization
 
-By default, every class that extends `Event` will be by default serialized to json (through the `TypeManager` service) 
-with an additional field called `type` that describes the name of the event class. For example, a serialized `SomethingHappened`
-instance will look like:
+By default, events must be serializable, because of this, every class that extends `Event` will be serializable to json by default 
+(through the `TypeManager` service). 
+The json will contain an additional field called `type` that describes the name of the event class. For example, a serialized `SomethingHappened`
+event will look like:
 ```json
 {
   "type": "SomethingHappened",

--- a/docs/developer/events.md
+++ b/docs/developer/events.md
@@ -1,0 +1,129 @@
+# Events
+
+EDC provides an eventing system that permits the developer to write extensions that could react to events that are 
+emitted from the core of the EDC and also emit custom events.
+
+## Subscribe to events
+The entry point for event listening is the `EventRouter` component, on which an `EventSubscribed` can be registered.
+
+Extension example:
+```java
+public class ExampleEventSubscriptionExtension implements ServiceExtension{
+    @Inject
+    EventRouter eventRouter;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        eventRouter.register(new ExampleEventSubscriber());
+    }
+}
+```
+
+Then the `EventSubscriber` subscription will receive all the events emitted from the EDC and react to them:
+```java
+public class ExampleEventSubscriber implements EventSubscriber {
+    
+    public void on(Event event) {
+        // react to event    
+    }
+    
+}
+```
+
+All the events are subclass of the `Event` abstract class so to filter events it's enough to check the type at runtime.
+```java
+public class ExampleEventSubscriber implements EventSubscriber {
+    
+    public void on(Event event) {
+        if (event instanceof AssertCreated) {
+            // react only to AssertCreated events
+        }
+    }
+    
+}
+```
+
+## Emit custom events
+It's also possible to create and publish custom events on top of the EDC eventing system.
+To define the event, extend the `Event` class adding the fields that would describe the events.
+> Rule of thumb: events should be named at past tense, as they describe something that's already happened
+```java
+public class SomethingHappened extends Event {
+    private String description;
+
+    private SomethingHappened() {
+    }
+    
+    private String getDescription() {
+        return description;
+    }
+
+    public static class Builder extends Event.Builder<SomethingHappened> {
+
+        public static Builder newInstance() {
+            return new Builder(new SomethingHappened());
+        }
+
+        private Builder(SomethingHappened event) {
+            super(event);
+        }
+
+        public Builder description(String description) {
+            event.description = description;
+            return this;
+        }
+
+        public AssetCreated build() {
+            super.build();
+            Objects.requireNonNull(event.description);
+            // this validation helps to catch up missing properties in the test phase,
+            // but isn't supposed to fail in a production environment, so it's not mandatory.
+            return event;
+        }
+    }
+}
+```
+
+As you may notice, we use the builder pattern to construct objects, as stated in the [Architecture Principles document](../architecture/architecture-principles.md).
+The extended builder will inherit all the builder method from the superclass.
+
+Once the event is created, it can be published it through the `EventRouter` component:
+```java
+public class ExampleBusinessLogic {
+    public void doSomething() {
+        // some business logic that does something
+        var event = SomethingHappened.Builder.newInstance()
+                .description("something interesting happened")
+                .at(clock.millis())
+                .build();
+        
+        eventRouter.publish(event);
+    }    
+}
+```
+Please note that the `at` field gives a timestamp to every event, and it's mandatory (please use the `Clock` service to get the current timestamp).
+
+## Serialization / Deserialization
+
+By default, every class that extends `Event` will be by default serialized to json (through the `TypeManager` service) 
+with an additional field called `type` that describes the name of the event class. For example, a serialized `SomethingHappened`
+instance will look like:
+```json
+{
+  "type": "SomethingHappened",
+  "at": 1654764642188,
+  "description": "something interesting happened"
+}
+```
+Given that, the `type` field should not be used by extending classes.
+
+To make such an event deserializable by the `TypeManager`, is necessary to register the type:
+```java
+typeManager.registerTypes(new NamedType(SomethingHappened.class, SomethingHappened.class.getSimpleName()));
+```
+
+doing so, the event can be deserialized using the `Event` superclass as type:
+```
+var deserialized = typeManager.readValue(json, Event.class);
+// deserialized will have the `SomethingHappened` type at runtime
+```

--- a/extensions/api/data-management/asset/build.gradle.kts
+++ b/extensions/api/data-management/asset/build.gradle.kts
@@ -32,10 +32,8 @@ dependencies {
 
     implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
 
-    testImplementation(project(":extensions:http"))
     testImplementation(project(":core:defaults"))
-    testImplementation(project(":extensions:transaction:transaction-local"))
-
+    testImplementation(project(":extensions:http"))
     testImplementation(project(":extensions:junit"))
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
 }

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiExtension.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiExtension.java
@@ -37,7 +37,6 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
 
 import java.time.Clock;
-import java.util.Optional;
 
 @Provides(AssetService.class)
 public class AssetApiExtension implements ServiceExtension {

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiExtension.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiExtension.java
@@ -16,7 +16,10 @@
 
 package org.eclipse.dataspaceconnector.api.datamanagement.asset;
 
+import org.eclipse.dataspaceconnector.api.datamanagement.asset.service.AssetObservableImpl;
+import org.eclipse.dataspaceconnector.api.datamanagement.asset.service.AssetService;
 import org.eclipse.dataspaceconnector.api.datamanagement.asset.service.AssetServiceImpl;
+import org.eclipse.dataspaceconnector.api.datamanagement.asset.service.EventAssetListener;
 import org.eclipse.dataspaceconnector.api.datamanagement.asset.transform.AssetDtoToAssetTransformer;
 import org.eclipse.dataspaceconnector.api.datamanagement.asset.transform.AssetToAssetDtoTransformer;
 import org.eclipse.dataspaceconnector.api.datamanagement.asset.transform.DataAddressDtoToDataAddressTransformer;
@@ -26,11 +29,17 @@ import org.eclipse.dataspaceconnector.dataloading.AssetLoader;
 import org.eclipse.dataspaceconnector.spi.WebService;
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
+import org.eclipse.dataspaceconnector.spi.event.EventRouter;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
+import org.eclipse.dataspaceconnector.spi.system.Provides;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
 
+import java.time.Clock;
+import java.util.Optional;
+
+@Provides(AssetService.class)
 public class AssetApiExtension implements ServiceExtension {
 
     @Inject
@@ -54,21 +63,32 @@ public class AssetApiExtension implements ServiceExtension {
     @Inject
     TransactionContext transactionContext;
 
+    @Inject
+    EventRouter eventRouter;
+
+    @Inject
+    Clock clock;
+
     @Override
     public String name() {
         return "Data Management API: Asset";
     }
 
     @Override
-    public void initialize(ServiceExtensionContext serviceExtensionContext) {
-        var monitor = serviceExtensionContext.getMonitor();
+    public void initialize(ServiceExtensionContext context) {
+        var monitor = context.getMonitor();
 
-        var service = new AssetServiceImpl(assetIndex, assetLoader, contractNegotiationStore, transactionContext);
+        var assetObservable = new AssetObservableImpl();
+        assetObservable.registerListener(new EventAssetListener(clock, eventRouter));
+
+        var assetService = new AssetServiceImpl(assetIndex, assetLoader, contractNegotiationStore, transactionContext, assetObservable);
+        context.registerService(AssetService.class, assetService);
 
         transformerRegistry.register(new AssetDtoToAssetTransformer());
         transformerRegistry.register(new DataAddressDtoToDataAddressTransformer());
         transformerRegistry.register(new AssetToAssetDtoTransformer());
 
-        webService.registerResource(config.getContextAlias(), new AssetApiController(monitor, service, transformerRegistry));
+        webService.registerResource(config.getContextAlias(), new AssetApiController(monitor, assetService, transformerRegistry));
     }
+
 }

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetListener.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetListener.java
@@ -24,7 +24,7 @@ import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 public interface AssetListener {
 
     /**
-     * Called afer a {@link Asset} has created.
+     * Called after a {@link Asset} was created.
      *
      * @param asset the asset that has been created.
      */
@@ -33,7 +33,7 @@ public interface AssetListener {
     }
 
     /**
-     * Called afer a {@link Asset} has deleted.
+     * Called after a {@link Asset} was deleted.
      *
      * @param asset the asset that has been deleted.
      */

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetListener.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetListener.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.datamanagement.asset.service;
+
+import org.eclipse.dataspaceconnector.spi.observe.Observable;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+
+/**
+ * Interface implemented by listeners registered to observe asset state changes via {@link Observable#registerListener}.
+ * The listener must be called after the state changes are persisted.
+ */
+public interface AssetListener {
+
+    /**
+     * Called afer a {@link Asset} has created.
+     *
+     * @param asset the asset that has been created.
+     */
+    default void created(Asset asset) {
+
+    }
+
+    /**
+     * Called afer a {@link Asset} has deleted.
+     *
+     * @param asset the asset that has been deleted.
+     */
+    default void deleted(Asset asset) {
+
+    }
+
+}

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetObservable.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetObservable.java
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.datamanagement.asset.service;
+
+import org.eclipse.dataspaceconnector.spi.observe.Observable;
+
+/**
+ * Manages and invokes {@link AssetListener}s when a state change related to an asset has happened.
+ */
+public interface AssetObservable extends Observable<AssetListener> {
+
+}

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetObservableImpl.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetObservableImpl.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.datamanagement.asset.service;
+
+import org.eclipse.dataspaceconnector.spi.observe.ObservableImpl;
+
+/**
+ * Observes Asset livecycle state changes.
+ */
+public class AssetObservableImpl extends ObservableImpl<AssetListener> implements AssetObservable {
+}

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/EventAssetListener.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/EventAssetListener.java
@@ -21,6 +21,9 @@ import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 
 import java.time.Clock;
 
+/**
+ * Listener responsible for creating and publishing events regarding Asset state changes
+ */
 public class EventAssetListener implements AssetListener {
     private final Clock clock;
     private final EventRouter eventRouter;

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/EventAssetListener.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/EventAssetListener.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.datamanagement.asset.service;
+
+import org.eclipse.dataspaceconnector.spi.event.AssetCreated;
+import org.eclipse.dataspaceconnector.spi.event.AssetDeleted;
+import org.eclipse.dataspaceconnector.spi.event.EventRouter;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+
+import java.time.Clock;
+
+public class EventAssetListener implements AssetListener {
+    private final Clock clock;
+    private final EventRouter eventRouter;
+
+    public EventAssetListener(Clock clock, EventRouter eventRouter) {
+        this.clock = clock;
+        this.eventRouter = eventRouter;
+    }
+
+    @Override
+    public void created(Asset asset) {
+        var event = AssetCreated.Builder.newInstance()
+                .id(asset.getId())
+                .at(clock.millis())
+                .build();
+
+        eventRouter.publish(event);
+    }
+
+    @Override
+    public void deleted(Asset asset) {
+        var event = AssetDeleted.Builder.newInstance()
+                .id(asset.getId())
+                .at(clock.millis())
+                .build();
+
+        eventRouter.publish(event);
+    }
+}

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetEventDispatchTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetEventDispatchTest.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.datamanagement.asset.service;
+
+import org.eclipse.dataspaceconnector.junit.extensions.EdcExtension;
+import org.eclipse.dataspaceconnector.spi.event.AssetCreated;
+import org.eclipse.dataspaceconnector.spi.event.AssetDeleted;
+import org.eclipse.dataspaceconnector.spi.event.Event;
+import org.eclipse.dataspaceconnector.spi.event.EventRouter;
+import org.eclipse.dataspaceconnector.spi.event.EventSubscriber;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.CountDownLatch;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(EdcExtension.class)
+public class AssetEventDispatchTest {
+
+    private final EventSubscriber eventSubscriber = mock(EventSubscriber.class);
+
+    @Test
+    void shouldDispatchEventsOnAssetCreationAndDeletion(AssetService service, EventRouter eventRouter) throws InterruptedException {
+        var createdLatch = onDispatchLatch(AssetCreated.class);
+        var deletedLatch = onDispatchLatch(AssetDeleted.class);
+        eventRouter.register(eventSubscriber);
+        var asset = Asset.Builder.newInstance().id("assetId").build();
+        var dataAddress = DataAddress.Builder.newInstance().type("any").build();
+
+        service.create(asset, dataAddress);
+
+        assertThat(createdLatch.await(1, SECONDS)).isTrue();
+        verify(eventSubscriber).on(isA(AssetCreated.class));
+
+        service.delete(asset.getId());
+
+        assertThat(deletedLatch.await(1, SECONDS)).isTrue();
+        verify(eventSubscriber).on(isA(AssetDeleted.class));
+    }
+
+    private CountDownLatch onDispatchLatch(Class<? extends Event> eventType) {
+        var latch = new CountDownLatch(1);
+
+        doAnswer(i -> {
+            latch.countDown();
+            return null;
+        }).when(eventSubscriber).on(isA(eventType));
+
+        return latch;
+    }
+
+}

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImplTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImplTest.java
@@ -49,8 +49,9 @@ class AssetServiceImplTest {
     private final AssetLoader loader = mock(AssetLoader.class);
     private final ContractNegotiationStore contractNegotiationStore = mock(ContractNegotiationStore.class);
     private final TransactionContext dummyTransactionContext = new NoopTransactionContext();
+    private final AssetObservable observable = mock(AssetObservable.class);
 
-    private final AssetServiceImpl service = new AssetServiceImpl(index, loader, contractNegotiationStore, dummyTransactionContext);
+    private final AssetServiceImpl service = new AssetServiceImpl(index, loader, contractNegotiationStore, dummyTransactionContext, observable);
 
     @Test
     void findById_shouldRelyOnAssetIndex() {

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImplTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImplTest.java
@@ -59,7 +59,7 @@ class AssetServiceImplTest {
 
         var asset = service.findById("assetId");
 
-        String assetId = "assetId";
+        var assetId = "assetId";
         assertThat(asset).isNotNull().matches(hasId(assetId));
     }
 
@@ -86,6 +86,7 @@ class AssetServiceImplTest {
         assertThat(inserted.succeeded()).isTrue();
         assertThat(inserted.getContent()).matches(hasId(assetId));
         verify(loader).accept(argThat(it -> assetId.equals(it.getId())), argThat(it -> addressType.equals(it.getType())));
+        verify(observable).invokeForEach(any());
     }
 
     @Test

--- a/extensions/azure/cosmos/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndex.java
+++ b/extensions/azure/cosmos/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndex.java
@@ -104,12 +104,6 @@ public class CosmosAssetIndex implements AssetIndex, DataAddressResolver, AssetL
     }
 
     @Override
-    public void accept(Asset asset, DataAddress dataAddress) {
-        var assetDocument = new AssetDocument(asset, partitionKey, dataAddress);
-        assetDb.saveItem(assetDocument);
-    }
-
-    @Override
     public Asset deleteById(String assetId) {
         try {
             var deletedItem = assetDb.deleteItem(assetId);
@@ -122,7 +116,8 @@ public class CosmosAssetIndex implements AssetIndex, DataAddressResolver, AssetL
 
     @Override
     public void accept(AssetEntry item) {
-        accept(item.getAsset(), item.getDataAddress());
+        var assetDocument = new AssetDocument(item.getAsset(), partitionKey, item.getDataAddress());
+        assetDb.saveItem(assetDocument);
     }
 
     // we need to read the AssetDocument as Object, because no custom JSON deserialization can be registered

--- a/extensions/dataloading/src/main/java/org/eclipse/dataspaceconnector/dataloading/AssetLoader.java
+++ b/extensions/dataloading/src/main/java/org/eclipse/dataspaceconnector/dataloading/AssetLoader.java
@@ -20,7 +20,9 @@ import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 
 public interface AssetLoader extends DataSink<AssetEntry> {
 
-    void accept(Asset asset, DataAddress dataAddress);
+    default void accept(Asset asset, DataAddress dataAddress) {
+        accept(new AssetEntry(asset, dataAddress));
+    }
 
     /**
      * Deletes an asset.

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/AssetCreated.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/AssetCreated.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.event;
+
+import java.util.Objects;
+
+public class AssetCreated extends Event {
+
+    private String id;
+
+    private AssetCreated() {
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public static class Builder extends Event.Builder<AssetCreated> {
+
+        public static Builder newInstance() {
+            return new Builder(new AssetCreated());
+        }
+
+        private Builder(AssetCreated event) {
+            super(event);
+        }
+
+        public Builder id(String id) {
+            event.id = id;
+            return this;
+        }
+
+        @Override
+        public AssetCreated build() {
+            super.build();
+            Objects.requireNonNull(event.id);
+            return event;
+        }
+    }
+}

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/AssetCreated.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/AssetCreated.java
@@ -16,6 +16,9 @@ package org.eclipse.dataspaceconnector.spi.event;
 
 import java.util.Objects;
 
+/**
+ * Describe a new Asset creation, after this has emitted, an Asset with a certain id will be available.
+ */
 public class AssetCreated extends Event {
 
     private String id;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/AssetDeleted.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/AssetDeleted.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.event;
+
+import java.util.Objects;
+
+public class AssetDeleted extends Event {
+
+    private String id;
+
+    private AssetDeleted() {
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public static class Builder extends Event.Builder<AssetDeleted> {
+
+        public static Builder newInstance() {
+            return new Builder(new AssetDeleted());
+        }
+
+        private Builder(AssetDeleted event) {
+            super(event);
+        }
+
+        public Builder id(String id) {
+            event.id = id;
+            return this;
+        }
+
+        @Override
+        public AssetDeleted build() {
+            super.build();
+            Objects.requireNonNull(event.id);
+            return event;
+        }
+    }
+}

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/AssetDeleted.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/AssetDeleted.java
@@ -16,6 +16,9 @@ package org.eclipse.dataspaceconnector.spi.event;
 
 import java.util.Objects;
 
+/**
+ * Describe an Asset deletion, after this has emitted, the Asset represented by the id won't be available anymore.
+ */
 public class AssetDeleted extends Event {
 
     private String id;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/Event.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/Event.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.event;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * The Event base class.
+ * It provides a default field "at" that gives the timestamp when the event was created.
+ * When serialized to JSON, will add a "type" field with the name of the runtime class name.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", include = JsonTypeInfo.As.EXTERNAL_PROPERTY)
+public abstract class Event {
+
+    protected long at;
+
+    public long getAt() {
+        return at;
+    }
+
+    public static class Builder<T extends Event> {
+
+        protected final T event;
+
+        protected Builder(T event) {
+            this.event = event;
+        }
+
+        public Builder<T> at(long at) {
+            event.at = at;
+            return this;
+        }
+
+        public T build() {
+            if (event.at == 0) {
+                throw new IllegalStateException("Event 'at' field must be set");
+            }
+            return event;
+        }
+    }
+}

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/EventRouter.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/EventRouter.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.event;
+
+/**
+ * Central component of the eventing system, the implementation keeps a list of subscribers and notifies them with
+ * every events that gets published
+ */
+public interface EventRouter {
+
+    /**
+     * Register a new subscriber to the events
+     *
+     * @param subscriber that will receive every published event
+     */
+    void register(EventSubscriber subscriber);
+
+    /**
+     * Publish an event to all the subscribers
+     *
+     * @param event the event to be published
+     */
+    void publish(Event event);
+}

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/EventSubscriber.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/EventSubscriber.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.event;
+
+/**
+ * Every implementation of this will have the possibility to react to every event published into the EDC
+ */
+public interface EventSubscriber {
+    /**
+     * Add custom logic for every event happened
+     *
+     * @param event the event happened
+     */
+    void on(Event event);
+}

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/TypeManager.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/TypeManager.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.eclipse.dataspaceconnector.spi.EdcException;
@@ -47,6 +48,9 @@ public class TypeManager {
         objectMapper.registerSubtypes(type);
     }
 
+    public void registerTypes(NamedType... type) {
+        objectMapper.registerSubtypes(type);
+    }
 
     public <T> T readValue(String info, TypeReference<T> typeReference) {
         try {

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/event/AssetCreatedTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/event/AssetCreatedTest.java
@@ -35,7 +35,6 @@ class AssetCreatedTest {
                 .build();
 
         var json = typeManager.writeValueAsString(event);
-        System.out.println(json);
         var deserialized = typeManager.readValue(json, Event.class);
 
         assertThat(deserialized)

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/event/AssetCreatedTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/event/AssetCreatedTest.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.event;
+
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AssetCreatedTest {
+
+    @Test
+    void serdes() {
+        var typeManager = new TypeManager();
+        typeManager.registerTypes(new NamedType(AssetCreated.class, AssetCreated.class.getSimpleName()));
+
+        var event = AssetCreated.Builder.newInstance()
+                .id("id")
+                .at(Clock.systemUTC().millis())
+                .build();
+
+        var json = typeManager.writeValueAsString(event);
+        System.out.println(json);
+        var deserialized = typeManager.readValue(json, Event.class);
+
+        assertThat(deserialized)
+                .isInstanceOf(AssetCreated.class)
+                .usingRecursiveComparison().isEqualTo(event);
+    }
+}

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/event/AssetDeletedTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/event/AssetDeletedTest.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.event;
+
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AssetDeletedTest {
+
+    @Test
+    void serdes() {
+        var typeManager = new TypeManager();
+        typeManager.registerTypes(new NamedType(AssetDeleted.class, AssetDeleted.class.getSimpleName()));
+
+        var event = AssetDeleted.Builder.newInstance()
+                .id("id")
+                .at(123)
+                .build();
+
+        var json = typeManager.writeValueAsString(event);
+        var deserialized = typeManager.readValue(json, Event.class);
+
+        assertThat(deserialized)
+                .isInstanceOf(AssetDeleted.class)
+                .usingRecursiveComparison().isEqualTo(event);
+    }
+}

--- a/system-tests/e2e-transfer-test/runner/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/runner/build.gradle.kts
@@ -25,17 +25,15 @@ val assertj: String by project
 dependencies {
     testImplementation(project(":extensions:sql:common-sql"))
 
+    testImplementation(project(":extensions:junit"))
+    testImplementation(testFixtures(project(":common:util")))
     testImplementation(testFixtures(project(":extensions:azure:azure-test")))
     testImplementation(testFixtures(project(":extensions:azure:cosmos:cosmos-common")))
-    testImplementation(project(":extensions:junit"))
-
     testImplementation("org.postgresql:postgresql:42.2.6")
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
     testImplementation("org.assertj:assertj-core:${assertj}")
     testImplementation("org.awaitility:awaitility:${awaitility}")
     testImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
-    testImplementation(testFixtures(project(":common:util")))
-
 
     testCompileOnly(project(":system-tests:e2e-transfer-test:backend-service"))
     testCompileOnly(project(":system-tests:e2e-transfer-test:control-plane"))


### PR DESCRIPTION
## What this PR changes/adds

Introduce events for domain class `Asset` and publish them through the `EventRouter`

## Why it does that

To permit asynchronous notifications

## Further notes

- Add a first documentation markdown about how to subscribe to and how to publish events
- Implement a default behavior for `AssetLoader.accept(Asset asset, DataAddress dataAddress)` to remove some duplication
- Add the event publishing in the `AssetService` class. Currently not every component that act on Assets pass through the service (e.g. `DataLoader`). So here I have a question: should `AssetService` moved to an upstream module (like the core module or a dedicated core-asset module?)
- Add serialization capabilities to all the events. The deserialization could be achived registering the event types on the `TypeManager`. This process is described in the doc markdown but since it's not needed (the EDC doesn't need to deserialize events for the moment) I left this out.
- The `EventRouter` publishes events in an asynchronous manner to avoid blocking the main thread and catches exceptions that could be thrown by the subscribers. It doesn't implement any retry behavior nor it uses a configurable `ExecutorService`. Those two functionalities could be addressed to further PRs.

## Linked Issue(s)

Closes #1435

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
