### PR TITLE
Feature: adds query to ContractDefinition

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -288,7 +288,7 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
-      minio:
+      postgres:
         image: postgres:14.2
         ports:
           - 5432:5432
@@ -302,7 +302,7 @@ jobs:
       - name: Postgresql Tests
         uses: ./.github/actions/run-tests
         with:
-          command: ./gradlew -p system-tests test -DincludeTags="PostgresqlIntegrationTest"
+          command: ./gradlew test -DincludeTags="PostgresqlIntegrationTest"
 
   End-To-End-Tests:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ in the detailed section referring to by linking pull requests or issues.
 #### Added
 
 * Event Framework for Asset entity (#1453)
+* SQL Translation layer (#1357, #1459)
 
 #### Changed
 

--- a/common/util/src/testFixtures/java/org/eclipse/dataspaceconnector/common/util/junit/annotations/PostgresqlDbIntegrationTest.java
+++ b/common/util/src/testFixtures/java/org/eclipse/dataspaceconnector/common/util/junit/annotations/PostgresqlDbIntegrationTest.java
@@ -9,12 +9,12 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Microsoft Corporation - moved to current location
  *
  */
 
-package org.eclipse.dataspaceconnector.test.e2e.postgresql;
+package org.eclipse.dataspaceconnector.common.util.junit.annotations;
 
-import org.eclipse.dataspaceconnector.common.util.junit.annotations.IntegrationTest;
 import org.junit.jupiter.api.Tag;
 
 import java.lang.annotation.ElementType;

--- a/core/defaults/src/main/java/org/eclipse/dataspaceconnector/core/defaults/negotiationstore/InMemoryContractNegotiationStore.java
+++ b/core/defaults/src/main/java/org/eclipse/dataspaceconnector/core/defaults/negotiationstore/InMemoryContractNegotiationStore.java
@@ -36,7 +36,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -122,14 +121,6 @@ public class InMemoryContractNegotiationStore implements ContractNegotiationStor
     @Override
     public @NotNull Stream<ContractAgreement> queryAgreements(QuerySpec querySpec) {
         return lockManager.readLock(() -> agreementQueryResolver.query(getAgreements(), querySpec));
-    }
-
-    @Override
-    public Stream<ContractNegotiation> getNegotiationsWithAgreementOnAsset(String assetId) {
-        var filter = format("contractAgreement.assetId = %s", assetId);
-        var query = QuerySpec.Builder.newInstance().filter(filter).build();
-
-        return queryNegotiations(query);
     }
 
     @Override

--- a/core/defaults/src/test/java/org/eclipse/dataspaceconnector/core/defaults/negotiationstore/InMemoryContractNegotiationStoreTest.java
+++ b/core/defaults/src/test/java/org/eclipse/dataspaceconnector/core/defaults/negotiationstore/InMemoryContractNegotiationStoreTest.java
@@ -16,6 +16,7 @@ package org.eclipse.dataspaceconnector.core.defaults.negotiationstore;
 
 
 import org.eclipse.dataspaceconnector.contract.common.ContractId;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
@@ -330,7 +331,11 @@ class InMemoryContractNegotiationStoreTest {
 
         store.save(negotiation);
 
-        var result = store.getNegotiationsWithAgreementOnAsset(assetId).collect(Collectors.toList());
+        var query = QuerySpec.Builder.newInstance()
+                .filter(List.of(new Criterion("contractAgreement.assetId", "=", assetId)))
+                .build();
+        var result = store.queryNegotiations(query).collect(Collectors.toList());
+
 
         assertThat(result).hasSize(1).usingRecursiveFieldByFieldElementComparator().containsOnly(negotiation);
     }
@@ -351,7 +356,10 @@ class InMemoryContractNegotiationStoreTest {
 
         store.save(negotiation);
 
-        var result = store.getNegotiationsWithAgreementOnAsset(assetId).collect(Collectors.toList());
+        var query = QuerySpec.Builder.newInstance()
+                .filter(List.of(new Criterion("contractAgreement.assetId", "=", assetId)))
+                .build();
+        var result = store.queryNegotiations(query).collect(Collectors.toList());
 
         assertThat(result).isEmpty();
         assertThat(store.queryAgreements(QuerySpec.none())).isEmpty();
@@ -366,7 +374,10 @@ class InMemoryContractNegotiationStoreTest {
         store.save(negotiation1);
         store.save(negotiation2);
 
-        var result = store.getNegotiationsWithAgreementOnAsset(assetId).collect(Collectors.toList());
+        var query = QuerySpec.Builder.newInstance()
+                .filter(List.of(new Criterion("contractAgreement.assetId", "=", assetId)))
+                .build();
+        var result = store.queryNegotiations(query).collect(Collectors.toList());
 
         assertThat(result).hasSize(2)
                 .extracting(ContractNegotiation::getId).containsExactlyInAnyOrder("negotiation1", "negotiation2");

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImpl.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImpl.java
@@ -31,6 +31,7 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 
 public class AssetServiceImpl implements AssetService {
+    private static final String ASSET_ID_QUERY = "contractAgreement.assetId";
     private final AssetIndex index;
     private final AssetLoader loader;
     private final ContractNegotiationStore contractNegotiationStore;
@@ -73,7 +74,7 @@ public class AssetServiceImpl implements AssetService {
         return transactionContext.execute(() -> {
 
             var query = QuerySpec.Builder.newInstance()
-                    .filter(List.of(new Criterion("contractAgreement.assetId", "=", assetId)))
+                    .filter(List.of(new Criterion(ASSET_ID_QUERY, "=", assetId)))
                     .build();
             var negotiationsOnAsset = contractNegotiationStore.queryNegotiations(query);
             if (negotiationsOnAsset.findAny().isPresent()) {

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImplTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImplTest.java
@@ -129,13 +129,13 @@ class AssetServiceImplTest {
                         .policy(Policy.Builder.newInstance().build())
                         .build())
                 .build();
-        when(contractNegotiationStore.getNegotiationsWithAgreementOnAsset(any())).thenReturn(Stream.of(contractNegotiation));
+        when(contractNegotiationStore.queryNegotiations(any())).thenReturn(Stream.of(contractNegotiation));
 
         var deleted = service.delete("assetId");
 
         assertThat(deleted.failed()).isTrue();
         assertThat(deleted.getFailure().getReason()).isEqualTo(CONFLICT);
-        verify(contractNegotiationStore).getNegotiationsWithAgreementOnAsset(any());
+        verify(contractNegotiationStore).queryNegotiations(any());
         verifyNoMoreInteractions(contractNegotiationStore);
     }
 

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImplTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetServiceImplTest.java
@@ -26,6 +26,7 @@ import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
@@ -147,6 +148,14 @@ class AssetServiceImplTest {
 
         assertThat(deleted.failed()).isTrue();
         assertThat(deleted.getFailure().getReason()).isEqualTo(NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("Verifies that the query matches the internal data model")
+    void delete_verifyCorrectQuery() {
+        var deleted = service.delete("test-asset");
+        verify(contractNegotiationStore).queryNegotiations(argThat(argument -> argument.getFilterExpression().size() == 1 &&
+                argument.getFilterExpression().get(0).getOperandLeft().equals("contractAgreement.assetId")));
     }
 
     @NotNull

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStore.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStore.java
@@ -42,7 +42,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
 import static net.jodah.failsafe.Failsafe.with;
 
@@ -161,14 +160,6 @@ public class CosmosContractNegotiationStore implements ContractNegotiationStore 
                 .map(this::toNegotiation)
                 .map(ContractNegotiation::getContractAgreement)
                 .filter(Objects::nonNull);
-    }
-
-    @Override
-    public Stream<ContractNegotiation> getNegotiationsWithAgreementOnAsset(String assetId) {
-        var filter = format("contractAgreement.assetId = %s", assetId);
-        var query = QuerySpec.Builder.newInstance().filter(filter).build();
-
-        return queryNegotiations(query);
     }
 
     @Override

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
@@ -28,6 +28,7 @@ import org.eclipse.dataspaceconnector.contract.common.ContractId;
 import org.eclipse.dataspaceconnector.contract.negotiation.store.model.ContractNegotiationDocument;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
@@ -68,9 +69,9 @@ class CosmosContractNegotiationStoreIntegrationTest {
     private static final String TEST_ID = UUID.randomUUID().toString();
     private static final String DATABASE_NAME = "connector-itest-" + TEST_ID;
     private static final String CONTAINER_PREFIX = "ContractNegotiationStore-";
-    private final Clock clock = Clock.systemUTC();
     private static CosmosContainer container;
     private static CosmosDatabase database;
+    private final Clock clock = Clock.systemUTC();
     private final String partitionKey = CONNECTOR_ID;
     private TypeManager typeManager;
     private CosmosContractNegotiationStore store;
@@ -554,7 +555,10 @@ class CosmosContractNegotiationStoreIntegrationTest {
 
         store.save(negotiation);
 
-        var result = store.getNegotiationsWithAgreementOnAsset(assetId).collect(Collectors.toList());
+        var query = QuerySpec.Builder.newInstance()
+                .filter(List.of(new Criterion("contractAgreement.assetId", "=", assetId)))
+                .build();
+        var result = store.queryNegotiations(query).collect(Collectors.toList());
 
         assertThat(result).hasSize(1).usingRecursiveFieldByFieldElementComparator().containsOnly(negotiation);
     }
@@ -575,7 +579,10 @@ class CosmosContractNegotiationStoreIntegrationTest {
 
         store.save(negotiation);
 
-        var result = store.getNegotiationsWithAgreementOnAsset(assetId).collect(Collectors.toList());
+        var query = QuerySpec.Builder.newInstance()
+                .filter(List.of(new Criterion("contractAgreement.assetId", "=", assetId)))
+                .build();
+        var result = store.queryNegotiations(query).collect(Collectors.toList());
 
         assertThat(result).isEmpty();
         assertThat(store.queryAgreements(QuerySpec.none())).isEmpty();
@@ -590,7 +597,10 @@ class CosmosContractNegotiationStoreIntegrationTest {
         store.save(negotiation1);
         store.save(negotiation2);
 
-        var result = store.getNegotiationsWithAgreementOnAsset(assetId).collect(Collectors.toList());
+        var query = QuerySpec.Builder.newInstance()
+                .filter(List.of(new Criterion("contractAgreement.assetId", "=", assetId)))
+                .build();
+        var result = store.queryNegotiations(query).collect(Collectors.toList());
 
         assertThat(result).hasSize(2)
                 .extracting(ContractNegotiation::getId).containsExactlyInAnyOrder("negotiation1", "negotiation2");

--- a/extensions/sql/asset-index-sql/src/main/java/org/eclipse/dataspaceconnector/sql/asset/index/SqlAssetIndex.java
+++ b/extensions/sql/asset-index-sql/src/main/java/org/eclipse/dataspaceconnector/sql/asset/index/SqlAssetIndex.java
@@ -30,6 +30,7 @@ import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
 import org.eclipse.dataspaceconnector.spi.transaction.datasource.DataSourceRegistry;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.eclipse.dataspaceconnector.sql.translation.SqlConditionExpression;
 import org.jetbrains.annotations.Nullable;
 
 import java.sql.Connection;
@@ -238,8 +239,8 @@ public class SqlAssetIndex implements AssetLoader, AssetIndex, DataAddressResolv
     }
 
     /**
-     * Deserializes a value into an object using the object mapper.
-     * Note: if type is {@code java.lang.String} simply {@code value.toString()} is returned.
+     * Deserializes a value into an object using the object mapper. Note: if type is {@code java.lang.String} simply
+     * {@code value.toString()} is returned.
      */
     private Object fromPropertyValue(String value, String type) throws ClassNotFoundException, JsonProcessingException {
         var clazz = Class.forName(type);

--- a/extensions/sql/asset-index-sql/src/test/java/org/eclipse/dataspaceconnector/sql/asset/index/SqlConditionExpressionTest.java
+++ b/extensions/sql/asset-index-sql/src/test/java/org/eclipse/dataspaceconnector/sql/asset/index/SqlConditionExpressionTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.sql.asset.index;
 
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.sql.translation.SqlConditionExpression;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;

--- a/extensions/sql/common-sql/src/main/java/org/eclipse/dataspaceconnector/sql/translation/SqlConditionExpression.java
+++ b/extensions/sql/common-sql/src/main/java/org/eclipse/dataspaceconnector/sql/translation/SqlConditionExpression.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *  Copyright (c) 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.sql.asset.index;
+package org.eclipse.dataspaceconnector.sql.translation;
 
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.result.Result;
@@ -27,9 +27,10 @@ import java.util.stream.StreamSupport;
 import static java.lang.String.format;
 
 /**
- * Parses a {@link Criterion} and provides methods to validate it and extract SQL prepared statement placeholders and parameters.
+ * Parses a {@link Criterion} and provides methods to validate it and extract SQL prepared statement placeholders and
+ * parameters.
  */
-class SqlConditionExpression {
+public class SqlConditionExpression {
 
     private static final String IN_OPERATOR = "in";
     private static final String LIKE_OPERATOR = "like";
@@ -38,14 +39,15 @@ class SqlConditionExpression {
     private static final String PREPARED_STATEMENT_PLACEHOLDER = "?";
     private final Criterion criterion;
 
-    SqlConditionExpression(Criterion criterion) {
+    public SqlConditionExpression(Criterion criterion) {
 
         this.criterion = criterion;
     }
 
     /**
-     * Checks whether the given {@link Criterion} is valid or not, i.e. if its {@linkplain Criterion#getOperator()} is in the list
-     * of supported operators, and whether the {@linkplain Criterion#getOperandRight()} has the correct type.
+     * Checks whether the given {@link Criterion} is valid or not, i.e. if its {@linkplain Criterion#getOperator()} is
+     * in the list of supported operators, and whether the {@linkplain Criterion#getOperandRight()} has the correct
+     * type.
      */
     public Result<Void> isValidExpression() {
         var isSupportedOperator = SUPPORTED_PREPARED_STATEMENT_OPERATORS.contains(criterion.getOperator().toLowerCase());
@@ -61,8 +63,8 @@ class SqlConditionExpression {
 
 
     /**
-     * Converts an operand into a simple SQL statement placeholder ("?"), or, if the operand is actually a list, converts
-     * it into "(?,...?)", with as many placeholders as there are list items
+     * Converts an operand into a simple SQL statement placeholder ("?"), or, if the operand is actually a list,
+     * converts it into "(?,...?)", with as many placeholders as there are list items
      */
     public String toValuePlaceholder() {
         var operandRight = criterion.getOperandRight();
@@ -74,12 +76,11 @@ class SqlConditionExpression {
     }
 
     /**
-     * Converts the {@link Criterion#getOperandRight()} to a {@link Stream} of Strings
-     * which can then be used as parameters for  prepared statements.
+     * Converts the {@link Criterion#getOperandRight()} to a {@link Stream} of Strings which can then be used as
+     * parameters for  prepared statements.
      * <p>
      * Note: {@link Stream} is used to allow a convenient use in a {@code flatMap} call
      */
-    @SuppressWarnings("unchecked")
     public Stream<String> toStatementParameter() {
         List<String> result = new ArrayList<>();
         result.add(criterion.getOperandLeft().toString());

--- a/extensions/sql/common-sql/src/main/java/org/eclipse/dataspaceconnector/sql/translation/SqlQueryStatement.java
+++ b/extensions/sql/common-sql/src/main/java/org/eclipse/dataspaceconnector/sql/translation/SqlQueryStatement.java
@@ -1,0 +1,127 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.sql.translation;
+
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+
+/**
+ * Maps a {@link QuerySpec} to a single SQL {@code SELECT ... FROM ... WHERE ...} statement. The {@code SELECT ...} part
+ * is passed in through the constructor, and the rest of the query is assembled dynamically, based on the
+ * {@link QuerySpec} and the {@link TranslationMapping}.
+ */
+public class SqlQueryStatement {
+
+    private static final String LIMIT = "LIMIT ? ";
+    private static final String OFFSET = "OFFSET ?";
+    private static final String WHERE_TOKEN = "WHERE";
+    private static final String AND_TOKEN = "AND";
+    private final String selectStatement;
+    private final List<String> whereClauses = new ArrayList<>();
+    private final List<Object> parameters = new ArrayList<>();
+
+    /**
+     * Initializes this SQL Query Statement with a SELECT clause, a {@link QuerySpec} and a translation mapping.
+     *
+     * @param selectStatement The SELECT clause, e.g. {@code SELECT * FROM your_table}
+     * @param query a {@link QuerySpec} that contains a query in the canonical format
+     * @param rootModel A {@link TranslationMapping} that enables mapping from canonical to the SQL-specific
+     *         model/format
+     */
+    public SqlQueryStatement(String selectStatement, QuerySpec query, TranslationMapping rootModel) {
+        this(selectStatement);
+        initialize(query, rootModel);
+    }
+
+    /**
+     * Initializes this SQL Query Statement with a SELECT clause
+     *
+     * @param selectStatement The SELECT clause, e.g. {@code SELECT * FROM your_table}
+     */
+    public SqlQueryStatement(String selectStatement) {
+        this.selectStatement = selectStatement;
+    }
+
+    /**
+     * Represents this query as SQL string, including parameter placeholders (?)
+     *
+     * @return the query as SQL statement
+     */
+    public String getQueryAsString() {
+        return selectStatement + " " +
+                String.join(" ", whereClauses) + " " +
+                LIMIT +
+                OFFSET +
+                ";";
+    }
+
+    /**
+     * SQL supports parameter substitution (in prepared statements), this method returns a list of those placeholders.
+     *
+     * @return an array of parameters that can be used for prepared statements
+     */
+    public Object[] getParameters() {
+        return parameters.toArray(Object[]::new);
+    }
+
+    public void addParameter(Object param) {
+        parameters.add(param);
+    }
+
+    private void initialize(QuerySpec query, TranslationMapping rootModel) {
+        whereClauses.clear();
+        parameters.clear();
+
+        var expr = query.getFilterExpression();
+        expr.forEach(e -> parseExpression(e, rootModel));
+
+        parameters.add(query.getLimit());
+        parameters.add(query.getOffset());
+    }
+
+    /**
+     * Parses a single {@link Criterion} into a {@code WHERE} or an {@code AND} clause, and puts them onto the statement
+     * stack.
+     *
+     * @param criterion One single query clause
+     * @param rootModel The root mapping model for the query
+     */
+    private void parseExpression(Criterion criterion, TranslationMapping rootModel) {
+        var columnName = rootModel.getStatement(criterion.getOperandLeft().toString());
+
+        if (columnName == null) {
+            throw new IllegalArgumentException(format("Operand \"%s\" cannot be mapped to SQL Schema", criterion.getOperandLeft()));
+        }
+        var newCriterion = new Criterion(columnName, criterion.getOperator(), criterion.getOperandRight());
+
+        var prefix = whereClauses.isEmpty() ? WHERE_TOKEN : AND_TOKEN;
+        var conditionExpr = new SqlConditionExpression(newCriterion);
+
+        if (conditionExpr.isValidExpression().failed()) {
+            throw new IllegalArgumentException("This expression is not valid!");
+        }
+
+        var clause = format("%s %s %s %s", prefix, columnName, newCriterion.getOperator(), conditionExpr.toValuePlaceholder());
+        whereClauses.add(clause);
+        var params = conditionExpr.toStatementParameter().skip(1).collect(Collectors.toList());
+        parameters.addAll(params);
+    }
+}

--- a/extensions/sql/common-sql/src/main/java/org/eclipse/dataspaceconnector/sql/translation/TranslationMapping.java
+++ b/extensions/sql/common-sql/src/main/java/org/eclipse/dataspaceconnector/sql/translation/TranslationMapping.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.sql.translation;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.lang.String.format;
+
+/**
+ * A {@linkplain TranslationMapping} maps canonical information about business objects to SQL, i.e. it contains field
+ * names of an object and maps them to their SQL schema column name.
+ * <p>
+ * Essentially, it contains a map that links field name to column name. In case the field is a complex object, it in
+ * turn must be represented by another {@link TranslationMapping} in order to recursively resolve field name.
+ */
+public abstract class TranslationMapping {
+    protected final Map<String, Object> fieldMap = new HashMap<>();
+
+    /**
+     * Converts a field/property from the canonical model into its SQL column equivalent. If the canonical property name
+     * is nested, e.g. {@code something.other.thing} then the mapper attempts to descend recursively into the tree until
+     * the correct mapping is found, or throws an exception if not found.
+     *
+     * @throws IllegalArgumentException if the canonical property name was not found.
+     */
+    public String getStatement(String canonicalPropertyName) {
+        var leftHandTokens = canonicalPropertyName.split("\\.", 2);
+
+        var key = leftHandTokens[0];
+
+        var entry = fieldMap.get(key);
+        if (entry == null) {
+            throw new IllegalArgumentException(format("Translation failed for Model '%s' at token '%s'", getClass().getName(), key));
+        }
+        if (entry instanceof TranslationMapping) {
+            //recursively descend into the metamodel tree
+            return ((TranslationMapping) entry).getStatement(leftHandTokens[1]);
+        }
+
+        return entry.toString();
+    }
+
+    protected void add(String fieldId, Object value) {
+        fieldMap.put(fieldId, value);
+    }
+}

--- a/extensions/sql/common-sql/src/test/java/org/eclipse/dataspaceconnector/sql/translation/SqlQueryStatementTest.java
+++ b/extensions/sql/common-sql/src/test/java/org/eclipse/dataspaceconnector/sql/translation/SqlQueryStatementTest.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.sql.translation;
+
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SqlQueryStatementTest {
+
+    private static final String SELECT_STATEMENT = "SELECT * FROM test-table";
+
+    @Test
+    void singleExpression_equalsOperator() {
+        var criterion = new Criterion("field1", "=", "testid1");
+        var t = new SqlQueryStatement(SELECT_STATEMENT, query(criterion), new TestMapping());
+
+        assertThat(t.getQueryAsString()).isEqualToIgnoringCase(SELECT_STATEMENT + " WHERE edc_field_1 = ? LIMIT ? OFFSET ?;");
+        assertThat(t.getParameters()).containsOnly("testid1", 50, 0);
+    }
+
+    @Test
+    void singleExpression_inOperator() {
+        var criterion = new Criterion("field1", "in", List.of("id1", "id2", "id3"));
+        var t = new SqlQueryStatement(SELECT_STATEMENT, query(criterion), new TestMapping());
+
+
+        assertThat(t.getQueryAsString()).isEqualToIgnoringCase(SELECT_STATEMENT + " WHERE edc_field_1 IN (?,?,?) LIMIT ? OFFSET ?;");
+        assertThat(t.getParameters()).containsExactlyInAnyOrder("id1", "id2", "id3", 50, 0);
+    }
+
+    @Test
+    void multipleExpressions() {
+        var criterion1 = new Criterion("field1", "in", List.of("id1", "id2", "id3"));
+        var criterion2 = new Criterion("description", "=", "something");
+        var t = new SqlQueryStatement(SELECT_STATEMENT, query(criterion1, criterion2), new TestMapping());
+
+        assertThat(t.getQueryAsString()).isEqualToIgnoringCase(SELECT_STATEMENT + " WHERE edc_field_1 IN (?,?,?) AND edc_description = ? LIMIT ? OFFSET ?;");
+        assertThat(t.getParameters()).containsExactlyInAnyOrder("id1", "id2", "id3", "something", 50, 0);
+    }
+
+    private QuerySpec query(Criterion... criterion) {
+        return QuerySpec.Builder.newInstance().filter(List.of(criterion)).build();
+    }
+}

--- a/extensions/sql/common-sql/src/test/java/org/eclipse/dataspaceconnector/sql/translation/TestMapping.java
+++ b/extensions/sql/common-sql/src/test/java/org/eclipse/dataspaceconnector/sql/translation/TestMapping.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.sql.translation;
+
+public class TestMapping extends TranslationMapping {
+    public TestMapping() {
+        add("field1", "edc_field_1");
+        add("description", "edc_description");
+        add("fooBar", "edc_foo_bar");
+    }
+}

--- a/extensions/sql/contract-negotiation-store-sql/build.gradle.kts
+++ b/extensions/sql/contract-negotiation-store-sql/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 
 val h2Version: String by project
 val assertj: String by project
+val postgresVersion: String by project
 
 dependencies {
     api(project(":spi:core-spi"))
@@ -37,6 +38,8 @@ dependencies {
     testImplementation("com.h2database:h2:${h2Version}")
     testImplementation("org.assertj:assertj-core:${assertj}")
     testImplementation(testFixtures(project(":common:util")))
+
+    testImplementation("org.postgresql:postgresql:${postgresVersion}")
 }
 
 publishing {

--- a/extensions/sql/contract-negotiation-store-sql/docs/schema.sql
+++ b/extensions/sql/contract-negotiation-store-sql/docs/schema.sql
@@ -31,37 +31,37 @@ CREATE TABLE IF NOT EXISTS edc_contract_agreement
     start_date        BIGINT,
     end_date          INTEGER,
     asset_id          VARCHAR NOT NULL,
-    policy_id         VARCHAR
+    policy            JSON
 );
 
 
 CREATE TABLE IF NOT EXISTS edc_contract_negotiation
 (
-    id                    VARCHAR                                            NOT NULL
+    id                   VARCHAR                                            NOT NULL
         CONSTRAINT contract_negotiation_pk
             PRIMARY KEY,
-    correlation_id        VARCHAR,
-    counterparty_id       VARCHAR                                            NOT NULL,
-    counterparty_address  VARCHAR                                            NOT NULL,
-    protocol              VARCHAR DEFAULT 'ids-multipart'::CHARACTER VARYING NOT NULL,
-    type                  INTEGER DEFAULT 0                                  NOT NULL,
-    state                 INTEGER DEFAULT 0                                  NOT NULL,
-    state_count           INTEGER DEFAULT 0,
-    state_timestamp       BIGINT,
-    error_detail          VARCHAR,
-    contract_agreement_id VARCHAR
+    correlation_id       VARCHAR,
+    counterparty_id      VARCHAR                                            NOT NULL,
+    counterparty_address VARCHAR                                            NOT NULL,
+    protocol             VARCHAR DEFAULT 'ids-multipart'::CHARACTER VARYING NOT NULL,
+    type                 INTEGER DEFAULT 0                                  NOT NULL,
+    state                INTEGER DEFAULT 0                                  NOT NULL,
+    state_count          INTEGER DEFAULT 0,
+    state_timestamp      BIGINT,
+    error_detail         VARCHAR,
+    agreement_id         VARCHAR
         CONSTRAINT contract_negotiation_contract_agreement_id_fk
             REFERENCES edc_contract_agreement,
-    contract_offers       VARCHAR,
-    trace_context         VARCHAR,
-    lease_id              VARCHAR
+    contract_offers      JSON,
+    trace_context        JSON,
+    lease_id             VARCHAR
         CONSTRAINT contract_negotiation_lease_lease_id_fk
             REFERENCES edc_lease
             ON DELETE SET NULL,
     CONSTRAINT provider_correlation_id CHECK (type = '0' OR correlation_id IS NOT NULL)
 );
 
-COMMENT ON COLUMN edc_contract_negotiation.contract_agreement_id IS 'ContractAgreement serialized as JSON';
+COMMENT ON COLUMN edc_contract_negotiation.agreement_id IS 'ContractAgreement serialized as JSON';
 
 COMMENT ON COLUMN edc_contract_negotiation.contract_offers IS 'List<ContractOffer> serialized as JSON';
 
@@ -77,3 +77,34 @@ CREATE UNIQUE INDEX IF NOT EXISTS contract_negotiation_id_uindex
 CREATE UNIQUE INDEX IF NOT EXISTS contract_agreement_id_uindex
     ON edc_contract_agreement (agreement_id);
 
+-- creates a view that flattens the model and that can be used for easy querying.
+-- initially, it is only used for dynamic QuerySpec support, but can be used for
+CREATE VIEW edc_contract_negotiation_view
+            (id, correlation_id, counterparty_id, counterparty_address, protocol, type, state, state_count,
+             state_timestamp, error_detail, contract_offers, lease_id, trace_context, agreement_id, provider_agent_id,
+             consumer_agent_id, signing_date, start_date, end_date, asset_id, policy)
+AS
+SELECT edc_contract_negotiation.id,
+       edc_contract_negotiation.correlation_id,
+       edc_contract_negotiation.counterparty_id,
+       edc_contract_negotiation.counterparty_address,
+       edc_contract_negotiation.protocol,
+       edc_contract_negotiation.type,
+       edc_contract_negotiation.state,
+       edc_contract_negotiation.state_count,
+       edc_contract_negotiation.state_timestamp,
+       edc_contract_negotiation.error_detail,
+       edc_contract_negotiation.contract_offers,
+       edc_contract_negotiation.lease_id,
+       edc_contract_negotiation.trace_context,
+       agr.agreement_id,
+       agr.provider_agent_id,
+       agr.consumer_agent_id,
+       agr.signing_date,
+       agr.start_date,
+       agr.end_date,
+       agr.asset_id,
+       agr.policy
+FROM edc_contract_negotiation
+         LEFT JOIN edc_contract_agreement agr
+                   ON edc_contract_negotiation.agreement_id::TEXT = agr.agreement_id::TEXT;

--- a/extensions/sql/contract-negotiation-store-sql/docs/schema.sql
+++ b/extensions/sql/contract-negotiation-store-sql/docs/schema.sql
@@ -22,7 +22,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS lease_lease_id_uindex
 
 CREATE TABLE IF NOT EXISTS edc_contract_agreement
 (
-    agreement_id      VARCHAR NOT NULL
+    agr_id            VARCHAR NOT NULL
         CONSTRAINT contract_agreement_pk
             PRIMARY KEY,
     provider_agent_id VARCHAR,
@@ -75,36 +75,4 @@ CREATE UNIQUE INDEX IF NOT EXISTS contract_negotiation_id_uindex
     ON edc_contract_negotiation (id);
 
 CREATE UNIQUE INDEX IF NOT EXISTS contract_agreement_id_uindex
-    ON edc_contract_agreement (agreement_id);
-
--- creates a view that flattens the model and that can be used for easy querying.
--- initially, it is only used for dynamic QuerySpec support, but can be used for
-CREATE VIEW edc_contract_negotiation_view
-            (id, correlation_id, counterparty_id, counterparty_address, protocol, type, state, state_count,
-             state_timestamp, error_detail, contract_offers, lease_id, trace_context, agreement_id, provider_agent_id,
-             consumer_agent_id, signing_date, start_date, end_date, asset_id, policy)
-AS
-SELECT edc_contract_negotiation.id,
-       edc_contract_negotiation.correlation_id,
-       edc_contract_negotiation.counterparty_id,
-       edc_contract_negotiation.counterparty_address,
-       edc_contract_negotiation.protocol,
-       edc_contract_negotiation.type,
-       edc_contract_negotiation.state,
-       edc_contract_negotiation.state_count,
-       edc_contract_negotiation.state_timestamp,
-       edc_contract_negotiation.error_detail,
-       edc_contract_negotiation.contract_offers,
-       edc_contract_negotiation.lease_id,
-       edc_contract_negotiation.trace_context,
-       agr.agreement_id,
-       agr.provider_agent_id,
-       agr.consumer_agent_id,
-       agr.signing_date,
-       agr.start_date,
-       agr.end_date,
-       agr.asset_id,
-       agr.policy
-FROM edc_contract_negotiation
-         LEFT JOIN edc_contract_agreement agr
-                   ON edc_contract_negotiation.agreement_id::TEXT = agr.agreement_id::TEXT;
+    ON edc_contract_agreement (agr_id);

--- a/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/SqlContractNegotiationStoreExtension.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/SqlContractNegotiationStoreExtension.java
@@ -21,9 +21,9 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
 import org.eclipse.dataspaceconnector.spi.transaction.datasource.DataSourceRegistry;
-import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.ContractNegotiationStatements;
-import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.PostgresStatements;
 import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.SqlContractNegotiationStore;
+import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.schema.ContractNegotiationStatements;
+import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.schema.postgres.PostgresDialectStatements;
 
 import java.time.Clock;
 
@@ -55,7 +55,7 @@ public class SqlContractNegotiationStoreExtension implements ServiceExtension {
      * returns an externally-provided sql statement dialect, or postgres as a default
      */
     private ContractNegotiationStatements getStatementImpl() {
-        return statements != null ? statements : new PostgresStatements();
+        return statements != null ? statements : new PostgresDialectStatements();
     }
 
     private String getDataSourceName(ServiceExtensionContext context) {

--- a/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -348,7 +348,7 @@ public class SqlContractNegotiationStore implements ContractNegotiationStore {
     }
 
     private ContractAgreement extractContractAgreement(ResultSet resultSet) throws SQLException {
-        return resultSet.getString(statements.getContractAgreementIdColumn()) == null ? null : mapContractAgreement(resultSet);
+        return resultSet.getString(statements.getContractAgreementIdFkColumn()) == null ? null : mapContractAgreement(resultSet);
     }
 
     private DataSource getDataSource() {

--- a/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -18,12 +18,14 @@ package org.eclipse.dataspaceconnector.sql.contractnegotiation.store;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
 import org.eclipse.dataspaceconnector.spi.persistence.EdcPersistenceException;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
 import org.eclipse.dataspaceconnector.spi.transaction.datasource.DataSourceRegistry;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
+import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.schema.ContractNegotiationStatements;
 import org.eclipse.dataspaceconnector.sql.lease.SqlLeaseContextBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -34,6 +36,7 @@ import java.sql.SQLException;
 import java.time.Clock;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.sql.DataSource;
 
@@ -78,14 +81,9 @@ public class SqlContractNegotiationStore implements ContractNegotiationStore {
     @Override
     public @Nullable ContractNegotiation findForCorrelationId(String correlationId) {
         return transactionContext.execute(() -> {
-            try (var connection = getConnection()) {
-                var stmt = statements.getFindByCorrelationIdTemplate();
-
-                var contractNegotiation = executeQuery(connection, this::mapContractNegotiation, stmt, correlationId);
-                return single(contractNegotiation);
-            } catch (SQLException e) {
-                throw new EdcPersistenceException(e);
-            }
+            // utilize the generic query api
+            var query = QuerySpec.Builder.newInstance().filter(List.of(new Criterion("correlationId", "=", correlationId))).build();
+            return single(queryNegotiations(query).collect(Collectors.toList()));
         });
     }
 
@@ -155,10 +153,8 @@ public class SqlContractNegotiationStore implements ContractNegotiationStore {
     public @NotNull Stream<ContractNegotiation> queryNegotiations(QuerySpec querySpec) {
         return transactionContext.execute(() -> {
             try (var connection = getConnection()) {
-                var stmt = statements.getQueryNegotiationsTemplate();
-                var offset = querySpec.getOffset();
-                var limit = querySpec.getLimit();
-                return executeQuery(connection, this::mapContractNegotiation, stmt, limit, offset).stream();
+                var statement = statements.createNegotiationsQuery(querySpec);
+                return executeQuery(connection, this::mapContractNegotiation, statement.getQueryAsString(), statement.getParameters()).stream();
             } catch (SQLException e) {
                 throw new EdcPersistenceException(e);
             }
@@ -183,23 +179,8 @@ public class SqlContractNegotiationStore implements ContractNegotiationStore {
     public @NotNull Stream<ContractAgreement> queryAgreements(QuerySpec querySpec) {
         return transactionContext.execute(() -> {
             try (var connection = getConnection()) {
-                var stmt = statements.getQueryAgreementsTemplate();
-                var offset = querySpec.getOffset();
-                var limit = querySpec.getLimit();
-                return executeQuery(connection, this::mapContractAgreement, stmt, limit, offset).stream();
-            } catch (SQLException e) {
-                throw new EdcPersistenceException(e);
-            }
-        });
-    }
-
-    @Override
-    public Stream<ContractNegotiation> getNegotiationsWithAgreementOnAsset(String assetId) {
-        var statement = statements.getNegotiationWitghAgreementOnAssetTemplate();
-
-        return transactionContext.execute(() -> {
-            try (var connection = getConnection()) {
-                return executeQuery(connection, this::mapContractNegotiation, statement, assetId).stream();
+                var statement = statements.createAgreementsQuery(querySpec);
+                return executeQuery(connection, this::mapContractAgreement, statement.getQueryAsString(), statement.getParameters()).stream();
             } catch (SQLException e) {
                 throw new EdcPersistenceException(e);
             }
@@ -326,7 +307,7 @@ public class SqlContractNegotiationStore implements ContractNegotiationStore {
                 .providerAgentId(resultSet.getString(statements.getProviderAgentColumn()))
                 .consumerAgentId(resultSet.getString(statements.getConsumerAgentColumn()))
                 .assetId(resultSet.getString(statements.getAssetIdColumn()))
-                .policy(fromJson(resultSet.getString(statements.getPolicyIdColumn()), new TypeReference<>() {
+                .policy(fromJson(resultSet.getString(statements.getPolicyColumn()), new TypeReference<>() {
                 }))
                 .contractStartDate(resultSet.getLong(statements.getStartDateColumn()))
                 .contractEndDate(resultSet.getLong(statements.getEndDateColumn()))
@@ -367,7 +348,7 @@ public class SqlContractNegotiationStore implements ContractNegotiationStore {
     }
 
     private ContractAgreement extractContractAgreement(ResultSet resultSet) throws SQLException {
-        return resultSet.getString(statements.getContractAgreementIdFkColumn()) == null ? null : mapContractAgreement(resultSet);
+        return resultSet.getString(statements.getContractAgreementIdColumn()) == null ? null : mapContractAgreement(resultSet);
     }
 
     private DataSource getDataSource() {

--- a/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/BaseSqlDialectStatements.java
@@ -97,14 +97,14 @@ public class BaseSqlDialectStatements implements ContractNegotiationStatements {
     }
 
     @Override
-    public String getSelectFromViewTemplate() {
-        return format("SELECT * FROM %s", getViewName());
+    public String getSelectNegotiationsTemplate() {
+        return format("SELECT * FROM edc_contract_negotiation LEFT JOIN edc_contract_agreement agr ON edc_contract_negotiation.agreement_id = agr.agr_id");
     }
 
     @Override
     public SqlQueryStatement createNegotiationsQuery(QuerySpec querySpec) {
         // for generic SQL, only the limit and offset fields are used!
-        var sql = "SELECT * FROM " + getViewName();
+        var sql = getSelectNegotiationsTemplate();
         var stmt = new SqlQueryStatement(sql);
         stmt.addParameter(querySpec.getLimit());
         stmt.addParameter(querySpec.getOffset());

--- a/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/BaseSqlDialectStatements.java
@@ -98,7 +98,7 @@ public class BaseSqlDialectStatements implements ContractNegotiationStatements {
 
     @Override
     public String getSelectNegotiationsTemplate() {
-        return format("SELECT * FROM edc_contract_negotiation LEFT JOIN edc_contract_agreement agr ON edc_contract_negotiation.agreement_id = agr.agr_id");
+        return format("SELECT * FROM %s LEFT JOIN %s agr ON %s.%s = agr.%s", getContractNegotiationTable(), getContractAgreementTable(), getContractNegotiationTable(), getContractAgreementIdFkColumn(), getContractAgreementIdColumn());
     }
 
     @Override

--- a/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/ContractNegotiationStatements.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/ContractNegotiationStatements.java
@@ -43,7 +43,7 @@ public interface ContractNegotiationStatements extends LeaseStatements {
 
     String getUpdateAgreementTemplate();
 
-    String getSelectFromViewTemplate();
+    String getSelectNegotiationsTemplate();
 
     @Override
     default String getLeasedByColumn() {
@@ -115,7 +115,7 @@ public interface ContractNegotiationStatements extends LeaseStatements {
     }
 
     default String getContractAgreementIdColumn() {
-        return "agreement_id";
+        return "agr_id";
     }
 
     default String getAssetIdColumn() {

--- a/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/ContractNegotiationStatements.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/ContractNegotiationStatements.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *  Copyright (c) 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,18 +12,18 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.sql.contractnegotiation.store;
+package org.eclipse.dataspaceconnector.sql.contractnegotiation.store.schema;
 
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.sql.lease.LeaseStatements;
+import org.eclipse.dataspaceconnector.sql.translation.SqlQueryStatement;
 
 /**
- * Provides names for database columns, table names and statement templates. Methods to compose statements must be
- * overridden by implementors.
+ * Provides database-related constants, such as column names, table names and statement templates. Methods to compose
+ * statements must be overridden by implementors.
  */
 public interface ContractNegotiationStatements extends LeaseStatements {
     String getFindTemplate();
-
-    String getFindByCorrelationIdTemplate();
 
     String getFindContractAgreementTemplate();
 
@@ -37,17 +37,13 @@ public interface ContractNegotiationStatements extends LeaseStatements {
 
     String getNextForStateTemplate();
 
-    String getQueryNegotiationsTemplate();
-
-    String getQueryAgreementsTemplate();
+    String getSelectFromAgreementsTemplate();
 
     String getInsertAgreementTemplate();
 
-    String getSelectByPolicyIdTemplate();
-
     String getUpdateAgreementTemplate();
 
-    String getNegotiationWitghAgreementOnAssetTemplate();
+    String getSelectFromViewTemplate();
 
     @Override
     default String getLeasedByColumn() {
@@ -69,10 +65,6 @@ public interface ContractNegotiationStatements extends LeaseStatements {
         return "lease_id";
     }
 
-
-    default String getPolicyColumnSeralized() {
-        return "serialized_policy";
-    }
 
     default String getContractNegotiationTable() {
         return "edc_contract_negotiation";
@@ -130,12 +122,12 @@ public interface ContractNegotiationStatements extends LeaseStatements {
         return "asset_id";
     }
 
-    default String getPolicyIdColumn() {
-        return "policy_id";
+    default String getPolicyColumn() {
+        return "policy";
     }
 
     default String getContractAgreementIdFkColumn() {
-        return "contract_agreement_id";
+        return "agreement_id";
     }
 
     default String getStateColumn() {
@@ -165,4 +157,12 @@ public interface ContractNegotiationStatements extends LeaseStatements {
     default String getTypeColumn() {
         return "type";
     }
+
+    default String getViewName() {
+        return "edc_contract_negotiation_view";
+    }
+
+    SqlQueryStatement createNegotiationsQuery(QuerySpec querySpec);
+
+    SqlQueryStatement createAgreementsQuery(QuerySpec querySpec);
 }

--- a/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/postgres/ContractAgreementMapping.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/postgres/ContractAgreementMapping.java
@@ -17,6 +17,10 @@ package org.eclipse.dataspaceconnector.sql.contractnegotiation.store.schema.post
 import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.schema.ContractNegotiationStatements;
 import org.eclipse.dataspaceconnector.sql.translation.TranslationMapping;
 
+/**
+ * Maps fields of a {@link org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement} onto
+ * the corresponding SQL schema (= column names)
+ */
 class ContractAgreementMapping extends TranslationMapping {
 
 

--- a/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/postgres/ContractAgreementMapping.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/postgres/ContractAgreementMapping.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.sql.contractnegotiation.store.schema.postgres;
+
+import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.schema.ContractNegotiationStatements;
+import org.eclipse.dataspaceconnector.sql.translation.TranslationMapping;
+
+class ContractAgreementMapping extends TranslationMapping {
+
+
+    private static final String FIELD_ID = "id";
+    private static final String FIELD_PROVIDER_AGENT_ID = "providerAgentId";
+    private static final String FIELD_CONSUMER_AGENT_ID = "consumerAgentId";
+    private static final String FIELD_CONTRACT_SIGNING_DATE = "contractSigningDate";
+    private static final String FIELD_CONTRACT_START_DATE = "contractStartDate";
+    private static final String FIELD_CONTRACT_END_DATE = "contractEndDate";
+    private static final String FIELD_ASSET_ID = "assetId";
+    private static final String FIELD_POLICY = "policy";
+
+    ContractAgreementMapping(ContractNegotiationStatements statements) {
+        add(FIELD_ID, statements.getContractAgreementIdColumn());
+        add(FIELD_PROVIDER_AGENT_ID, statements.getProviderAgentColumn());
+        add(FIELD_CONSUMER_AGENT_ID, statements.getConsumerAgentColumn());
+        add(FIELD_CONTRACT_SIGNING_DATE, statements.getSigningDateColumn());
+        add(FIELD_CONTRACT_START_DATE, statements.getStartDateColumn());
+        add(FIELD_CONTRACT_END_DATE, statements.getEndDateColumn());
+        add(FIELD_ASSET_ID, statements.getAssetIdColumn());
+        add(FIELD_POLICY, new PolicyMapping());
+    }
+}

--- a/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/postgres/ContractNegotiationMapping.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/postgres/ContractNegotiationMapping.java
@@ -17,6 +17,10 @@ package org.eclipse.dataspaceconnector.sql.contractnegotiation.store.schema.post
 import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.schema.ContractNegotiationStatements;
 import org.eclipse.dataspaceconnector.sql.translation.TranslationMapping;
 
+/**
+ * Maps fields of a {@link org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation}
+ * onto the corresponding SQL schema (= column names)
+ */
 class ContractNegotiationMapping extends TranslationMapping {
     private static final String FIELD_ID = "id";
     private static final String FIELD_CORRELATION_ID = "correlationId";

--- a/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/postgres/ContractNegotiationMapping.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/postgres/ContractNegotiationMapping.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.sql.contractnegotiation.store.schema.postgres;
+
+import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.schema.ContractNegotiationStatements;
+import org.eclipse.dataspaceconnector.sql.translation.TranslationMapping;
+
+class ContractNegotiationMapping extends TranslationMapping {
+    private static final String FIELD_ID = "id";
+    private static final String FIELD_CORRELATION_ID = "correlationId";
+    private static final String FIELD_COUNTER_PARTY_ID = "counterPartyId";
+    private static final String FIELD_COUNTERPARTY_ADDRESS = "counterPartyAddress";
+    private static final String FIELD_PROTOCOL = "protocol";
+    private static final String FIELD_TYPE = "type";
+    private static final String FIELD_STATE = "state";
+    private static final String FIELD_STATECOUNT = "stateCount";
+    private static final String FIELD_STATETIMESTAMP = "stateTimestamp";
+    private static final String FIELD_ERRORDETAIL = "errorDetail";
+    private static final String FIELD_CONTRACT_AGREEMENT = "contractAgreement";
+    private static final String FIELD_TRACECONTEXT = "traceContext";
+
+
+    ContractNegotiationMapping(ContractNegotiationStatements statements) {
+        // cannot use Map.of(), because that only accepts 10 pairs
+        add(FIELD_ID, statements.getIdColumn());
+        add(FIELD_CORRELATION_ID, statements.getCorrelationIdColumn());
+        add(FIELD_COUNTER_PARTY_ID, statements.getCounterPartyIdColumn());
+        add(FIELD_COUNTERPARTY_ADDRESS, statements.getCounterPartyAddressColumn());
+        add(FIELD_PROTOCOL, statements.getProtocolColumn());
+        add(FIELD_TYPE, statements.getTypeColumn());
+        add(FIELD_STATE, statements.getStateColumn());
+        add(FIELD_STATECOUNT, statements.getStateCountColumn());
+
+        add(FIELD_STATETIMESTAMP, statements.getStateTimestampColumn());
+        add(FIELD_ERRORDETAIL, statements.getErrorDetailColumn());
+
+        fieldMap.put(FIELD_CONTRACT_AGREEMENT, new ContractAgreementMapping(statements));
+        add(FIELD_TRACECONTEXT, statements.getTraceContextColumn());
+    }
+
+
+}

--- a/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/postgres/PolicyMapping.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/postgres/PolicyMapping.java
@@ -16,6 +16,10 @@ package org.eclipse.dataspaceconnector.sql.contractnegotiation.store.schema.post
 
 import org.eclipse.dataspaceconnector.sql.translation.TranslationMapping;
 
+/**
+ * Maps fields of a {@link org.eclipse.dataspaceconnector.policy.model.Policy} onto the corresponding SQL schema (=
+ * column names)
+ */
 class PolicyMapping extends TranslationMapping {
 
     private static final String FIELD_POLICY = "policy ";

--- a/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/postgres/PolicyMapping.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/postgres/PolicyMapping.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.sql.contractnegotiation.store.schema.postgres;
+
+import org.eclipse.dataspaceconnector.sql.translation.TranslationMapping;
+
+class PolicyMapping extends TranslationMapping {
+
+    private static final String FIELD_POLICY = "policy ";
+
+    @Override
+    public String getStatement(String canonicalPropertyName) {
+
+        var tokens = canonicalPropertyName.split("\\.");
+        var statementBuilder = new StringBuilder(FIELD_POLICY);
+        int length = tokens.length;
+        for (int i = 0; i < length - 1; i++) {
+            statementBuilder.append("-> ");
+            statementBuilder.append("'").append(tokens[i]).append("' ");
+        }
+
+        statementBuilder.append("->> ");
+        statementBuilder.append("'").append(tokens[length - 1]).append("'");
+        return statementBuilder.toString();
+    }
+}

--- a/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/postgres/PostgresDialectStatements.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/postgres/PostgresDialectStatements.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.sql.contractnegotiation.store.schema.postgres;
+
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.schema.BaseSqlDialectStatements;
+import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.schema.ContractNegotiationStatements;
+import org.eclipse.dataspaceconnector.sql.translation.SqlQueryStatement;
+
+/**
+ * Concrete implementation of the {@link ContractNegotiationStatements} for Postgres. Uses a mapping tree
+ * ({@link org.eclipse.dataspaceconnector.sql.translation.TranslationMapping} to generate queries.
+ *
+ * @see ContractNegotiationMapping
+ * @see ContractAgreementMapping
+ */
+public class PostgresDialectStatements extends BaseSqlDialectStatements {
+
+    @Override
+    public SqlQueryStatement createNegotiationsQuery(QuerySpec querySpec) {
+        var selectStmt = getSelectFromViewTemplate();
+        return new SqlQueryStatement(selectStmt, querySpec, new ContractNegotiationMapping(this));
+    }
+
+    @Override
+    public SqlQueryStatement createAgreementsQuery(QuerySpec querySpec) {
+        var selectStmt = getSelectFromAgreementsTemplate();
+        return new SqlQueryStatement(selectStmt, querySpec, new ContractAgreementMapping(this));
+    }
+
+    /**
+     * Overridable operator to convert strings to JSON. For postgres, this is the "::json" operator
+     */
+    @Override
+    protected String getFormatJsonOperator() {
+        return "::json";
+    }
+}

--- a/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/postgres/PostgresDialectStatements.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/postgres/PostgresDialectStatements.java
@@ -30,7 +30,7 @@ public class PostgresDialectStatements extends BaseSqlDialectStatements {
 
     @Override
     public SqlQueryStatement createNegotiationsQuery(QuerySpec querySpec) {
-        var selectStmt = getSelectFromViewTemplate();
+        var selectStmt = getSelectNegotiationsTemplate();
         return new SqlQueryStatement(selectStmt, querySpec, new ContractNegotiationMapping(this));
     }
 

--- a/extensions/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/SqlContractNegotiationStoreExtensionTest.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/SqlContractNegotiationStoreExtensionTest.java
@@ -22,9 +22,9 @@ import org.eclipse.dataspaceconnector.spi.system.injection.EdcInjectionException
 import org.eclipse.dataspaceconnector.spi.system.injection.ObjectFactory;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
 import org.eclipse.dataspaceconnector.spi.transaction.datasource.DataSourceRegistry;
-import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.ContractNegotiationStatements;
-import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.PostgresStatements;
 import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.SqlContractNegotiationStore;
+import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.schema.BaseSqlDialectStatements;
+import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.schema.ContractNegotiationStatements;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -48,7 +48,7 @@ class SqlContractNegotiationStoreExtensionTest {
 
         var service = context.getService(ContractNegotiationStore.class);
         assertThat(service).isInstanceOf(SqlContractNegotiationStore.class);
-        assertThat(service).extracting("statements").isInstanceOf(PostgresStatements.class);
+        assertThat(service).extracting("statements").isInstanceOf(BaseSqlDialectStatements.class);
     }
 
     @Test

--- a/extensions/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/PostgresContractNegotiationStoreTest.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/PostgresContractNegotiationStoreTest.java
@@ -1,0 +1,286 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.sql.contractnegotiation.store;
+
+import org.eclipse.dataspaceconnector.common.util.junit.annotations.PostgresqlDbIntegrationTest;
+import org.eclipse.dataspaceconnector.contract.common.ContractId;
+import org.eclipse.dataspaceconnector.policy.model.Action;
+import org.eclipse.dataspaceconnector.policy.model.AtomicConstraint;
+import org.eclipse.dataspaceconnector.policy.model.LiteralExpression;
+import org.eclipse.dataspaceconnector.policy.model.Operator;
+import org.eclipse.dataspaceconnector.policy.model.Permission;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyRegistrationTypes;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.spi.transaction.NoopTransactionContext;
+import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
+import org.eclipse.dataspaceconnector.spi.transaction.datasource.DataSourceRegistry;
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
+import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.schema.postgres.PostgresDialectStatements;
+import org.eclipse.dataspaceconnector.sql.lease.LeaseUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.postgresql.ds.PGSimpleDataSource;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.time.Clock;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import javax.sql.DataSource;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.dataspaceconnector.sql.SqlQueryExecutor.executeQuery;
+import static org.eclipse.dataspaceconnector.sql.contractnegotiation.TestFunctions.createContract;
+import static org.eclipse.dataspaceconnector.sql.contractnegotiation.TestFunctions.createContractBuilder;
+import static org.eclipse.dataspaceconnector.sql.contractnegotiation.TestFunctions.createNegotiation;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * This test aims to verify those parts of the contract negotiation store, that are specific to Postgres, e.g. JSON
+ * query operators.
+ */
+@PostgresqlDbIntegrationTest
+class PostgresContractNegotiationStoreTest {
+    protected static final String DATASOURCE_NAME = "contractnegotiation";
+    protected static final String CONNECTOR_NAME = "test-connector";
+    private static final String POSTGRES_USER = "postgres";
+    private static final String POSTGRES_PASSWORD = "password";
+    private static final String POSTGRES_DATABASE = "itest";
+    private static final String JDBC_URL_PREFIX = "jdbc:postgresql://localhost:5432/";
+    protected DataSourceRegistry dataSourceRegistry;
+    protected Connection connection;
+    protected SqlContractNegotiationStore store;
+    protected LeaseUtil leaseUtil;
+    private TransactionContext txManager;
+
+    @BeforeAll
+    static void prepare() {
+        // todo: reuse org.eclipse.dataspaceconnector.test.e2e.postgresql.PostgresqlLocalInstance??
+        try (var connection = DriverManager.getConnection(JDBC_URL_PREFIX + POSTGRES_USER, POSTGRES_USER, POSTGRES_PASSWORD)) {
+            connection.createStatement().execute(format("CREATE DATABASE %s;", POSTGRES_DATABASE));
+        } catch (SQLException e) {
+            // database could already exist
+        }
+    }
+
+
+    @BeforeEach
+    void setUp() throws SQLException, IOException {
+        txManager = new NoopTransactionContext();
+        dataSourceRegistry = mock(DataSourceRegistry.class);
+
+
+        var ds = new PGSimpleDataSource();
+        ds.setServerNames(new String[]{ "localhost" });
+        ds.setPortNumbers(new int[]{ 5432 });
+        ds.setUser(POSTGRES_USER);
+        ds.setPassword(POSTGRES_PASSWORD);
+        ds.setDatabaseName(POSTGRES_DATABASE);
+
+        // do not actually close
+        connection = spy(ds.getConnection());
+        doNothing().when(connection).close();
+
+        var datasourceMock = mock(DataSource.class);
+        when(datasourceMock.getConnection()).thenReturn(connection);
+        when(dataSourceRegistry.resolve(DATASOURCE_NAME)).thenReturn(datasourceMock);
+
+        var statements = new PostgresDialectStatements();
+        TypeManager manager = new TypeManager();
+
+        manager.registerTypes(PolicyRegistrationTypes.TYPES.toArray(Class<?>[]::new));
+        store = new SqlContractNegotiationStore(dataSourceRegistry, DATASOURCE_NAME, txManager, manager, statements, CONNECTOR_NAME, Clock.systemUTC());
+
+        var schema = Files.readString(Paths.get("./docs/schema.sql"));
+        try {
+            txManager.execute(() -> {
+                executeQuery(connection, schema);
+                return null;
+            });
+        } catch (Exception exc) {
+            fail(exc);
+        }
+        leaseUtil = new LeaseUtil(txManager, this::getConnection, statements, Clock.systemUTC());
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+
+        txManager.execute(() -> {
+            var dialect = new PostgresDialectStatements();
+            executeQuery(connection, "DROP TABLE " + dialect.getContractNegotiationTable() + " CASCADE");
+            executeQuery(connection, "DROP TABLE " + dialect.getContractAgreementTable() + " CASCADE");
+            executeQuery(connection, "DROP TABLE " + dialect.getLeaseTableName() + " CASCADE");
+            executeQuery(connection, "DROP VIEW IF EXISTS " + dialect.getViewName() + " CASCADE");
+        });
+        doCallRealMethod().when(connection).close();
+        connection.close();
+    }
+
+    @Test
+    void query_byAgreementId() {
+
+        var agreement1 = createContract("agr1");
+        var agreement2 = createContract("agr2");
+        var negotiation1 = createNegotiation("neg1", agreement1);
+        var negotiation2 = createNegotiation("neg2", agreement2);
+        store.save(negotiation1);
+        store.save(negotiation2);
+
+        var expression = "contractAgreement.id = agr1";
+        var query = QuerySpec.Builder.newInstance().filter(expression).build();
+        var result = store.queryNegotiations(query).collect(Collectors.toList());
+
+        assertThat(result).usingRecursiveFieldByFieldElementComparator().containsOnly(negotiation1);
+    }
+
+    @Test
+    void query_byPolicyAssignee() {
+
+        var policy = Policy.Builder.newInstance()
+                .assignee("test-assignee")
+                .assigner("test-assigner")
+                .permission(Permission.Builder.newInstance()
+                        .target("")
+                        .action(Action.Builder.newInstance()
+                                .type("USE")
+                                .build())
+                        .constraint(AtomicConstraint.Builder.newInstance()
+                                .leftExpression(new LiteralExpression("foo"))
+                                .operator(Operator.EQ)
+                                .rightExpression(new LiteralExpression("bar"))
+                                .build())
+                        .build())
+                .build();
+
+        var agreement1 = createContractBuilder("agr1").policy(policy).build();
+        var agreement2 = createContractBuilder("agr2").policy(policy).build();
+        var negotiation1 = createNegotiation("neg1", agreement1);
+        var negotiation2 = createNegotiation("neg2", agreement2);
+        store.save(negotiation1);
+        store.save(negotiation2);
+
+        var expression = "contractAgreement.policy.assignee = test-assignee";
+        var query = QuerySpec.Builder.newInstance().filter(expression).build();
+        var result = store.queryNegotiations(query).collect(Collectors.toList());
+
+        assertThat(result).usingRecursiveFieldByFieldElementComparator().containsExactlyInAnyOrder(negotiation1, negotiation2);
+    }
+
+    @Test
+    void query_invalidKey_shouldThrowException() {
+        var agreement1 = createContract("agr1");
+        var negotiation1 = createNegotiation("neg1", agreement1);
+        store.save(negotiation1);
+
+        var expression = "contractAgreement.notexist = agr1";
+        var query = QuerySpec.Builder.newInstance().filter(expression).build();
+        assertThatThrownBy(() -> store.queryNegotiations(query))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageStartingWith("Translation failed for Model");
+    }
+
+    @Test
+    void query_invalidKeyInJson() {
+        var agreement1 = createContract("agr1");
+        var negotiation1 = createNegotiation("neg1", agreement1);
+        store.save(negotiation1);
+
+        var expression = "contractAgreement.policy.permissions.notexist = foobar";
+        var query = QuerySpec.Builder.newInstance().filter(expression).build();
+        assertThat(store.queryNegotiations(query)).isEmpty();
+    }
+
+    @Test
+    void queryAgreements_withQuerySpec() {
+        IntStream.range(0, 10).forEach(i -> {
+            var contractAgreement = createContractBuilder(ContractId.createContractId(UUID.randomUUID().toString()))
+                    .assetId("asset-" + i)
+                    .build();
+            var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
+            store.save(negotiation);
+        });
+
+        var query = QuerySpec.Builder.newInstance().filter("assetId = asset-2").build();
+        var all = store.queryAgreements(query);
+
+        assertThat(all).hasSize(1);
+    }
+
+    @Test
+    void queryAgreements_withQuerySpec_invalidOperand() {
+        IntStream.range(0, 10).forEach(i -> {
+            var contractAgreement = createContractBuilder(ContractId.createContractId(UUID.randomUUID().toString()))
+                    .assetId("asset-" + i)
+                    .build();
+            var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
+            store.save(negotiation);
+        });
+
+        var query = QuerySpec.Builder.newInstance().filter("notexistprop = asset-2").build();
+        assertThatThrownBy(() -> store.queryAgreements(query));
+    }
+
+    @Test
+    void queryAgreements_withQuerySpec_noFilter() {
+        IntStream.range(0, 10).forEach(i -> {
+            var contractAgreement = createContractBuilder(ContractId.createContractId(UUID.randomUUID().toString()))
+                    .assetId("asset-" + i)
+                    .build();
+            var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
+            store.save(negotiation);
+        });
+
+        var query = QuerySpec.Builder.newInstance().offset(2).limit(2).build();
+        assertThat(store.queryAgreements(query)).hasSize(2);
+    }
+
+    @Test
+    void queryAgreements_withQuerySpec_invalidValue() {
+        IntStream.range(0, 10).forEach(i -> {
+            var contractAgreement = createContractBuilder(ContractId.createContractId(UUID.randomUUID().toString()))
+                    .assetId("asset-" + i)
+                    .build();
+            var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
+            store.save(negotiation);
+        });
+
+        var query = QuerySpec.Builder.newInstance().filter("assetId = notexist").build();
+        assertThat(store.queryAgreements(query)).isEmpty();
+    }
+
+    protected Connection getConnection() {
+        try {
+            return dataSourceRegistry.resolve(DATASOURCE_NAME).getConnection();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/extensions/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/postgres/ContractNegotiationSqlQueryStatementTest.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/postgres/ContractNegotiationSqlQueryStatementTest.java
@@ -1,0 +1,96 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.sql.contractnegotiation.store.schema.postgres;
+
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.schema.ContractNegotiationStatements;
+import org.eclipse.dataspaceconnector.sql.translation.SqlQueryStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ContractNegotiationSqlQueryStatementTest {
+
+    private static final String SELECT_STATEMENT = "SELECT * FROM test-table";
+    private final ContractNegotiationStatements postresStatements = new PostgresDialectStatements();
+
+    @Test
+    void toTargetDsl() {
+    }
+
+    @Test
+    void singleExpression_equalsOperator() {
+        var criterion = new Criterion("counterPartyId", "=", "testid1");
+        var t = new SqlQueryStatement(SELECT_STATEMENT, query(criterion), new ContractNegotiationMapping(postresStatements));
+
+
+        assertThat(t.getQueryAsString()).isEqualToIgnoringCase(SELECT_STATEMENT + " WHERE counterparty_id = ? LIMIT ? OFFSET ?;");
+        assertThat(t.getParameters()).containsOnly("testid1", 50, 0);
+    }
+
+    @Test
+    void singleExpression_inOperator() {
+        var criterion = new Criterion("counterPartyId", "in", List.of("id1", "id2", "id3"));
+        var t = new SqlQueryStatement(SELECT_STATEMENT, query(criterion), new ContractNegotiationMapping(postresStatements));
+
+
+        assertThat(t.getQueryAsString()).isEqualToIgnoringCase(SELECT_STATEMENT + " WHERE counterparty_id IN (?,?,?) LIMIT ? OFFSET ?;");
+        assertThat(t.getParameters()).containsExactlyInAnyOrder("id1", "id2", "id3", 50, 0);
+    }
+
+    @Test
+    void multipleExpressions() {
+        var criterion1 = new Criterion("counterPartyId", "in", List.of("id1", "id2", "id3"));
+        var criterion2 = new Criterion("stateCount", "=", "4");
+        var t = new SqlQueryStatement(SELECT_STATEMENT, query(criterion1, criterion2), new ContractNegotiationMapping(postresStatements));
+
+        assertThat(t.getQueryAsString()).isEqualToIgnoringCase(SELECT_STATEMENT + " WHERE counterparty_id IN (?,?,?) AND state_count = ? LIMIT ? OFFSET ?;");
+        assertThat(t.getParameters()).containsExactlyInAnyOrder("id1", "id2", "id3", "4", 50, 0);
+    }
+
+    @Test
+    void nestedFieldAccess_inOperator() {
+        var criterion = new Criterion("contractAgreement.providerAgentId", "in", List.of("id1", "id2", "id3"));
+        var t = new SqlQueryStatement(SELECT_STATEMENT, query(criterion), new ContractNegotiationMapping(postresStatements));
+
+        assertThat(t.getQueryAsString()).isEqualToIgnoringCase(SELECT_STATEMENT + " WHERE provider_agent_id IN (?,?,?) LIMIT ? OFFSET ?;");
+        assertThat(t.getParameters()).containsExactlyInAnyOrder("id1", "id2", "id3", 50, 0);
+    }
+
+    @Test
+    void multiNestedFieldAccess_inOperator() {
+        var criterion = new Criterion("contractAgreement.policy.id", "=", "testpolicyid");
+        var t = new SqlQueryStatement(SELECT_STATEMENT, query(criterion), new ContractNegotiationMapping(postresStatements));
+
+        assertThat(t.getQueryAsString()).isEqualToIgnoringCase(SELECT_STATEMENT + " WHERE policy ->> 'id' = ? LIMIT ? OFFSET ?;");
+        assertThat(t.getParameters()).containsOnly("testpolicyid", 50, 0);
+    }
+
+    @Test
+    void multiNestedFieldAccess_withXpath_inOperator() {
+        var criterion = new Criterion("contractAgreement.policy.agreements.assignee", "=", "yomama");
+        var t = new SqlQueryStatement(SELECT_STATEMENT, query(criterion), new ContractNegotiationMapping(postresStatements));
+
+        assertThat(t.getQueryAsString()).isEqualToIgnoringCase(SELECT_STATEMENT + " WHERE policy -> 'agreements' ->> 'assignee' = ? LIMIT ? OFFSET ?;");
+        assertThat(t.getParameters()).containsOnly("yomama", 50, 0);
+    }
+
+    private QuerySpec query(Criterion... criterion) {
+        return QuerySpec.Builder.newInstance().filter(List.of(criterion)).build();
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,3 +46,4 @@ azureIdentityVersion=1.4.6
 azureResourceManagerVersion=2.12.0
 azureResourceManagerDataFactory=1.0.0-beta.12
 azureKeyVaultVersion=4.2.3
+postgresVersion=42.4.0

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/store/ContractNegotiationStore.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/store/ContractNegotiationStore.java
@@ -94,12 +94,4 @@ public interface ContractNegotiationStore extends StateEntityStore<ContractNegot
      */
     @NotNull
     Stream<ContractAgreement> queryAgreements(QuerySpec querySpec);
-
-    /**
-     * Finds all negotiations, that have agreements targeting the given asset
-     *
-     * @param assetId The asset for which the negotiations + agreements are wanted.
-     * @return A stream of contract negotiations, or empty
-     */
-    Stream<ContractNegotiation> getNegotiationsWithAgreementOnAsset(String assetId);
 }

--- a/system-tests/e2e-transfer-test/control-plane-postgresql/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/control-plane-postgresql/build.gradle.kts
@@ -15,11 +15,12 @@
 plugins {
     `java-library`
 }
+val postgresVersion: String by project
 
 dependencies {
     implementation(project(":system-tests:e2e-transfer-test:control-plane"))
     implementation(project(":extensions:sql"))
     implementation(project(":extensions:sql:pool:apache-commons-pool-sql"))
     implementation(project(":extensions:transaction:transaction-local"))
-    implementation("org.postgresql:postgresql:42.2.6")
+    implementation("org.postgresql:postgresql:${postgresVersion}")
 }

--- a/system-tests/e2e-transfer-test/runner/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/runner/build.gradle.kts
@@ -21,6 +21,7 @@ val jupiterVersion: String by project
 val restAssured: String by project
 val awaitility: String by project
 val assertj: String by project
+val postgresVersion: String by project
 
 dependencies {
     testImplementation(project(":extensions:sql:common-sql"))
@@ -29,7 +30,9 @@ dependencies {
     testImplementation(testFixtures(project(":common:util")))
     testImplementation(testFixtures(project(":extensions:azure:azure-test")))
     testImplementation(testFixtures(project(":extensions:azure:cosmos:cosmos-common")))
-    testImplementation("org.postgresql:postgresql:42.2.6")
+    testImplementation(project(":extensions:junit"))
+
+    testImplementation("org.postgresql:postgresql:${postgresVersion}")
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
     testImplementation("org.assertj:assertj-core:${assertj}")
     testImplementation("org.awaitility:awaitility:${awaitility}")

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/dataspaceconnector/test/e2e/EndToEndTransferPostgresqlTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/dataspaceconnector/test/e2e/EndToEndTransferPostgresqlTest.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.dataspaceconnector.test.e2e;
 
+import org.eclipse.dataspaceconnector.common.util.junit.annotations.PostgresqlDbIntegrationTest;
 import org.eclipse.dataspaceconnector.junit.extensions.EdcRuntimeExtension;
 import org.eclipse.dataspaceconnector.spi.persistence.EdcPersistenceException;
-import org.eclipse.dataspaceconnector.test.e2e.postgresql.PostgresqlDbIntegrationTest;
 import org.eclipse.dataspaceconnector.test.e2e.postgresql.PostgresqlLocalInstance;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.RegisterExtension;


### PR DESCRIPTION
## What this PR changes/adds

This PR adds the means and utilities to translate a source data model into a (potentially arbitrary) target DSL.

Here, we're translating the canonical metamodel (= `Criterion` objects that target domain objects such as `ContractNegotiation`) into the corresponding SQL statements.

A `Criterion` such as `"contractAgreement.policy.assignee = some-assignee"` would get translated into 
```sql
SELECT * FROM contract_negotiation_view -- <--this is new!
WHERE policy ->> 'assignee' = 'some-assignee`
```

Using a view allows us to flatten the schema into a single row, and use Postgres's JSON query operators (`->` and `->>`) to query JSON-encoded fields.

The translator currently uses

## Why it does that

To enable full query support for SQL-based stores. 

## Further notes

- using the field names of business objects (e.g. `ContractNegotiation`) in combination with `Criterion` is the _canonical format_. 
- Currently only the canonical format is implemented, future implementations are possible
- Integration tests that target an actual Postgres instance were added to verify those specific queries. 
- moved the `PostgresqlDbIntegrationTest` into the `common:util` module to have access to it 
- removed the "special" query methods that were introduced recently
- similar PRs will follow for assets, contract definitions, transfer processes and policies
- documentation of all this will follow in a separate PR

## Linked Issue(s)

Closes #1457

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
