### PR TITLE
Docs: fix dead link to architecture principles page. (fixes #1477)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ in the detailed section referring to by linking pull requests or issues.
 
 #### Fixed
 
-*
+* Fixed a dead link in contributor documentation (#1477)
 
 ## [milestone-4] - 2022-06-07
 

--- a/pr_etiquette.md
+++ b/pr_etiquette.md
@@ -4,7 +4,7 @@
 
 Submitting pull requests in EDC should be done while adhering to a couple of simple rules.
 
-- Familiarize yourself with [coding style](styleguide.md), [architectural patterns](docs/architecture-principles.md) and
+- Familiarize yourself with [coding style](styleguide.md), [architectural patterns](docs/architecture/architecture-principles.md) and
   other contribution guidelines.
 - No surprise PRs please. Before you submit a PR, open a discussion or an issue outlining your planned work and give
   people time to comment. It may even be advisable to contact committers using the `@mention` feature. Unsolicited PRs


### PR DESCRIPTION
## What this PR changes/adds

fixes dead link in "Etiquette for pull requests" documentation.

## Why it does that

as a follow-up of 05af5e45745fe897d2d0c20095fe2e30d8d00c2c.

## Linked Issue(s)

Closes #1477.

## Checklist

- [-] added appropriate tests?
- [-] performed checkstyle check locally?
- [-] added/updated copyright headers?
- [-] documented public classes/methods?
- [-] added/updated relevant documentation?
- [-] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
