### PR TITLE
Bugfix: change time when loaders are cleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ in the detailed section referring to by linking pull requests or issues.
 
 * Fixed a dead link in contributor documentation (#1477)
 * Fix usage of `NAME` property in `HttpDataSourceFactory` (#1460)
+* Fix clearing Loaders in the FCC (#1495)
 
 ## [milestone-4] - 2022-06-07
 

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/loader/LoaderManagerImpl.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/loader/LoaderManagerImpl.java
@@ -73,8 +73,8 @@ public class LoaderManagerImpl implements LoaderManager {
     }
 
     @Override
-    public void addLoader(Loader loader) {
-        loaders.add(loader);
+    public void clear() {
+        loaders.forEach(Loader::clear);
     }
 
     private void beginDequeue() {
@@ -89,7 +89,6 @@ public class LoaderManagerImpl implements LoaderManager {
                     // take the elements out of the queue and forward to loaders
                     queue.drainTo(batch, batchSize);
                     monitor.debug(format("LoaderManager: batch full, begin loading (%s items, %s workers)", batchSize, loaders.size()));
-                    loaders.forEach(Loader::clear);
                     loaders.forEach(l -> l.load(batch));
                     monitor.debug("LoaderManager: loading complete");
                 }

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/LoaderManager.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/LoaderManager.java
@@ -20,9 +20,9 @@ import org.eclipse.dataspaceconnector.catalog.spi.model.UpdateResponse;
 import java.util.concurrent.BlockingQueue;
 
 /**
- * Manages a list of {@link Loader}s.
- * If for example a Queue is used to receive {@link org.eclipse.dataspaceconnector.catalog.spi.model.UpdateResponse} objects,
- * the LoaderManager's job is to coordinate all its {@link Loader}s and forward that batch to them.
+ * Manages a list of {@link Loader}s. If for example a Queue is used to receive
+ * {@link org.eclipse.dataspaceconnector.catalog.spi.model.UpdateResponse} objects, the LoaderManager's job is to
+ * coordinate all its {@link Loader}s and forward that batch to them.
  */
 public interface LoaderManager {
 
@@ -34,5 +34,8 @@ public interface LoaderManager {
 
     void stop();
 
-    void addLoader(Loader loader);
+    /**
+     * Clears out the internal storage for all loaders. Useful when invoked before a crawl run
+     */
+    void clear();
 }


### PR DESCRIPTION
## What this PR changes/adds

To avoid inconsistent loader storages, the time, when they are cleared was changed.
Now, all loaders are cleared just before the `ExecutionPlan` is scheduled.

## Why it does that

Do avoid inconsistent loader storages.

## Further notes

- the `pre-executionHook` could be used for other tasks as well. 
- theoretically we could add a `post-executionHook` as well, but that was not needed as of now.

## Linked Issue(s)

Closes #1495 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
