### PR TITLE
Bugfix: replace countdown latches with awaitility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Fix usage of `NAME` property in `HttpDataSourceFactory` (#1460)
 * Fix clearing Loaders in the FCC (#1495)
 * Avoid endless loops in `ContractNegotiationManager` (#1487)
+* Fix race condition in `ContractNegotiationIntegrationTest` (#1505)
 
 ## [milestone-4] - 2022-06-07
 

--- a/core/contract/build.gradle.kts
+++ b/core/contract/build.gradle.kts
@@ -9,10 +9,12 @@
 *
 *  Contributors:
 *       Daimler TSS GmbH - Initial API and Implementation
+*       Microsoft Corporation - introduced Awaitility
 *
 */
 
 val openTelemetryVersion: String by project
+val awaitility: String by project
 
 plugins {
     `java-library`
@@ -28,6 +30,7 @@ dependencies {
     testImplementation(project(":core:defaults"))
     testImplementation(project(":extensions:junit"))
     testImplementation(testFixtures(project(":common:util")))
+    testImplementation("org.awaitility:awaitility:${awaitility}")
 }
 
 publishing {


### PR DESCRIPTION
## What this PR changes/adds

Fixes a race condition in the `ContractNegotiationIntegrationTest` by replacing the `CountdownLatch` with `awaitility`.
Awaitility allows for better control over timed assertions than a latch - here it allows us to assert multiple things, in particular:
- the listener's `pre*` method has been called
- both negotiation managers are in the desired state

The latch only waited for the _first_ condition, whereas Awaitility waits for _all of them_.

## Why it does that

To avoid race conditions, causing sporadically failing tests.

## Further notes
- countdown latches have been replaced only in the `ContractNegotiationIntegrationTest`
- replacing was also done in the `@Disabled` tests (why are they disabled?)

## Linked Issue(s)

Closes #1505 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
