### PR TITLE
Feature: add full query support for SQL ContractDefinition store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ in the detailed section referring to by linking pull requests or issues.
 #### Changed
 
 * Provided default no-op `TransactionContext` (#1461)
-* Refactored query capabilites for `Asset` (#1459)
+* Refactored query capabilities for `Asset` (#1459)
+* Refactored query capabilities for `ContractDefinition` (#1458)
 
 #### Removed
 

--- a/core/defaults/src/main/java/org/eclipse/dataspaceconnector/core/defaults/contractdefinition/InMemoryContractDefinitionStore.java
+++ b/core/defaults/src/main/java/org/eclipse/dataspaceconnector/core/defaults/contractdefinition/InMemoryContractDefinitionStore.java
@@ -28,8 +28,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
-import static java.lang.String.format;
-
 /**
  * The default store implementation used when no extension is configured in a runtime. {@link ContractDefinition}s are
  * stored ephemerally in memory.
@@ -79,14 +77,4 @@ public class InMemoryContractDefinitionStore implements ContractDefinitionStore 
     public void reload() {
         // no-op
     }
-
-    @Override
-    public Stream<ContractDefinition> isReferenced(String policyId) {
-
-        var queryAccessPolicyFilter = QuerySpec.Builder.newInstance().filter(format("accessPolicyId = %s ", policyId)).build();
-        var queryContractPolicyFilter = QuerySpec.Builder.newInstance().filter(format("contractPolicyId = %s ", policyId)).build();
-
-        return Stream.concat(findAll(queryAccessPolicyFilter), findAll(queryContractPolicyFilter));
-    }
-
 }

--- a/core/defaults/src/test/java/org/eclipse/dataspaceconnector/core/defaults/contractdefinition/InMemoryContractDefinitionStoreTest.java
+++ b/core/defaults/src/test/java/org/eclipse/dataspaceconnector/core/defaults/contractdefinition/InMemoryContractDefinitionStoreTest.java
@@ -115,51 +115,6 @@ class InMemoryContractDefinitionStoreTest {
         assertThat(store.findById("invalid-id")).isNull();
     }
 
-    @Test
-    void isReferenced_notReferenced() {
-        var definitionsExpected = getContractDefinition("def1", "apol1", "cpol1");
-        store.save(definitionsExpected);
-
-        assertThat(store.isReferenced("testpol1")).isEmpty();
-    }
-
-    @Test
-    void isReferenced_asAccessPolicy() {
-        var definitionExpected = getContractDefinition("def1", "apol1", "cpol1");
-        store.save(definitionExpected);
-
-        assertThat(store.isReferenced("apol1")).usingRecursiveFieldByFieldElementComparator().containsOnly(definitionExpected);
-    }
-
-    @Test
-    void isReferenced_asContractPolicy() {
-        var definitionExpected = getContractDefinition("def1", "apol1", "cpol1");
-        store.save(definitionExpected);
-
-        assertThat(store.isReferenced("cpol1")).usingRecursiveFieldByFieldElementComparator().containsOnly(definitionExpected);
-    }
-
-    @Test
-    void isReferenced_byMultipleDefinitions() {
-        var def1 = getContractDefinition("def1", "apol1", "cpol1");
-        var def2 = getContractDefinition("def2", "apol1", "cpol2");
-        var def3 = getContractDefinition("def3", "apol1", "cpol3");
-        var def4 = getContractDefinition("def4", "apol2", "cpol4");
-        var def5 = getContractDefinition("def5", "apol2", "cpol1");
-
-        store.save(List.of(def1, def2, def3, def4, def5));
-
-        assertThat(store.isReferenced("apol1")).usingRecursiveFieldByFieldElementComparator().containsExactlyInAnyOrder(def1, def2, def3);
-        assertThat(store.isReferenced("cpol1")).usingRecursiveFieldByFieldElementComparator().containsExactlyInAnyOrder(def1, def5);
-
-    }
-
-    private ContractDefinition getContractDefinition(String definitionId, String accessPolicyId, String contractPolicyId) {
-        return ContractDefinition.Builder.newInstance().id(definitionId).accessPolicyId(accessPolicyId).contractPolicyId(contractPolicyId).selectorExpression(SELECT_ALL).build();
-
-    }
-
-
     private ContractDefinition createContractDefinition(String id) {
         return ContractDefinition.Builder.newInstance().id(id).accessPolicyId("access").contractPolicyId("contract").selectorExpression(SELECT_ALL).build();
     }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
@@ -291,11 +291,6 @@ class IdsApiMultipartDispatcherV1IntegrationTestServiceExtension implements Serv
         public void reload() {
             throw new NotImplementedError();
         }
-
-        @Override
-        public Stream<ContractDefinition> isReferenced(String policyId) {
-            throw new UnsupportedOperationException();
-        }
     }
 
     private static class FakeContractValidationService implements ContractValidationService {

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
@@ -304,11 +304,6 @@ class IdsApiMultipartEndpointV1IntegrationTestServiceExtension implements Servic
         public void reload() {
             throw new NotImplementedError();
         }
-
-        @Override
-        public Stream<ContractDefinition> isReferenced(String policyId) {
-            throw new UnsupportedOperationException();
-        }
     }
 
     private static class FakeContractValidationService implements ContractValidationService {

--- a/extensions/api/data-management/policydefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/service/PolicyDefinitionServiceImplTest.java
+++ b/extensions/api/data-management/policydefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/service/PolicyDefinitionServiceImplTest.java
@@ -32,7 +32,9 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.api.result.ServiceFailure.Reason.NOT_FOUND;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class PolicyDefinitionServiceImplTest {
@@ -146,6 +148,18 @@ public class PolicyDefinitionServiceImplTest {
 
         assertThat(deleted.failed()).isTrue();
         assertThat(deleted.getFailure().getReason()).isEqualTo(NOT_FOUND);
+    }
+
+    @Test
+    void delete_verifyCorrectQueries() {
+        var policyId = "test-policy";
+        when(policyStore.findById(policyId)).thenReturn(createPolicy(policyId));
+        policyServiceImpl.deleteById(policyId);
+
+        verify(contractDefinitionStore).findAll(argThat(qs -> qs.getFilterExpression().size() == 1 &&
+                qs.getFilterExpression().get(0).getOperandLeft().equals("accessPolicyId")));
+        verify(contractDefinitionStore).findAll(argThat(qs -> qs.getFilterExpression().size() == 1 &&
+                qs.getFilterExpression().get(0).getOperandLeft().equals("contractPolicyId")));
     }
 
 

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStore.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStore.java
@@ -37,7 +37,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.lang.String.format;
 import static net.jodah.failsafe.Failsafe.with;
 
 /**
@@ -131,14 +130,6 @@ public class CosmosContractDefinitionStore implements ContractDefinitionStore {
             objectCache.set(databaseObjects);
             return null;
         });
-    }
-
-    @Override
-    public Stream<ContractDefinition> isReferenced(String policyId) {
-        var queryAccessPolicyFilter = QuerySpec.Builder.newInstance().filter(format("accessPolicyId = %s ", policyId)).build();
-        var queryContractPolicyFilter = QuerySpec.Builder.newInstance().filter(format("contractPolicyId = %s ", policyId)).build();
-
-        return Stream.concat(findAll(queryAccessPolicyFilter), findAll(queryContractPolicyFilter));
     }
 
     private void storeInCache(ContractDefinition definition) {

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreIntegrationTest.java
@@ -350,45 +350,6 @@ public class CosmosContractDefinitionStoreIntegrationTest {
 
     }
 
-    @Test
-    void isReferenced_notReferenced() {
-        var definitionsExpected = getContractDefinition("def1", "apol1", "cpol1");
-        store.save(definitionsExpected);
-
-        assertThat(store.isReferenced("testpol1")).isEmpty();
-    }
-
-    @Test
-    void isReferenced_asAccessPolicy() {
-        var definitionExpected = getContractDefinition("def1", "apol1", "cpol1");
-        store.save(definitionExpected);
-
-        assertThat(store.isReferenced("apol1")).usingRecursiveFieldByFieldElementComparator().containsOnly(definitionExpected);
-    }
-
-    @Test
-    void isReferenced_asContractPolicy() {
-        var definitionExpected = getContractDefinition("def1", "apol1", "cpol1");
-        store.save(definitionExpected);
-
-        assertThat(store.isReferenced("cpol1")).usingRecursiveFieldByFieldElementComparator().containsOnly(definitionExpected);
-    }
-
-    @Test
-    void isReferenced_byMultipleDefinitions() {
-        var def1 = getContractDefinition("def1", "apol1", "cpol1");
-        var def2 = getContractDefinition("def2", "apol1", "cpol2");
-        var def3 = getContractDefinition("def3", "apol1", "cpol3");
-        var def4 = getContractDefinition("def4", "apol2", "cpol4");
-        var def5 = getContractDefinition("def5", "apol2", "cpol1");
-
-        store.save(List.of(def1, def2, def3, def4, def5));
-
-        assertThat(store.isReferenced("apol1")).usingRecursiveFieldByFieldElementComparator().containsExactlyInAnyOrder(def1, def2, def3);
-        assertThat(store.isReferenced("cpol1")).usingRecursiveFieldByFieldElementComparator().containsExactlyInAnyOrder(def1, def5);
-
-    }
-
     private ContractDefinition getContractDefinition(String definitionId, String accessPolicyId, String contractPolicyId) {
         return ContractDefinition.Builder.newInstance().id(definitionId).accessPolicyId(accessPolicyId).contractPolicyId(contractPolicyId).selectorExpression(SELECT_ALL).build();
 

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FccTestExtension.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FccTestExtension.java
@@ -217,11 +217,6 @@ public class FccTestExtension implements ServiceExtension {
         public void reload() {
             throw new NotImplementedError();
         }
-
-        @Override
-        public Stream<ContractDefinition> isReferenced(String policyId) {
-            throw new UnsupportedOperationException();
-        }
     }
 
 

--- a/extensions/sql/asset-index-sql/src/test/java/org/eclipse/dataspaceconnector/sql/assetindex/schema/postgres/PostgresAssetIndexTest.java
+++ b/extensions/sql/asset-index-sql/src/test/java/org/eclipse/dataspaceconnector/sql/assetindex/schema/postgres/PostgresAssetIndexTest.java
@@ -58,13 +58,11 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @PostgresqlDbIntegrationTest
-//todo: remove the extends!!
 class PostgresAssetIndexTest {
     protected static final String DATASOURCE_NAME = "asset";
     private static final String POSTGRES_USER = "postgres";
     private static final String POSTGRES_PASSWORD = "password";
     private static final String POSTGRES_DATABASE = "itest";
-    private static final String JDBC_URL_PREFIX = "jdbc:postgresql://localhost:5432/";
     private SqlAssetIndex sqlAssetIndex;
     private BaseSqlDialectStatements sqlStatements;
     private TransactionContext transactionContext;

--- a/extensions/sql/common-sql/src/main/java/org/eclipse/dataspaceconnector/sql/translation/SqlQueryStatement.java
+++ b/extensions/sql/common-sql/src/main/java/org/eclipse/dataspaceconnector/sql/translation/SqlQueryStatement.java
@@ -115,8 +115,9 @@ public class SqlQueryStatement {
         var prefix = whereClauses.isEmpty() ? WHERE_TOKEN : AND_TOKEN;
         var conditionExpr = new SqlConditionExpression(newCriterion);
 
-        if (conditionExpr.isValidExpression().failed()) {
-            throw new IllegalArgumentException("This expression is not valid!");
+        var validExpression = conditionExpr.isValidExpression();
+        if (validExpression.failed()) {
+            throw new IllegalArgumentException("This expression is not valid: " + String.join(", ", validExpression.getFailureMessages()));
         }
 
         var clause = format("%s %s %s %s", prefix, columnName, newCriterion.getOperator(), conditionExpr.toValuePlaceholder());

--- a/extensions/sql/common-sql/src/main/java/org/eclipse/dataspaceconnector/sql/translation/TranslationMapping.java
+++ b/extensions/sql/common-sql/src/main/java/org/eclipse/dataspaceconnector/sql/translation/TranslationMapping.java
@@ -38,7 +38,6 @@ public abstract class TranslationMapping {
      */
     public String getStatement(String canonicalPropertyName) {
         var leftHandTokens = canonicalPropertyName.split("\\.", 2);
-
         var key = leftHandTokens[0];
 
         var entry = fieldMap.get(key);
@@ -46,8 +45,10 @@ public abstract class TranslationMapping {
             throw new IllegalArgumentException(format("Translation failed for Model '%s' at token '%s'", getClass().getName(), key));
         }
         if (entry instanceof TranslationMapping) {
+            var mappingEntry = (TranslationMapping) entry;
+            var nextToken = leftHandTokens.length < 2 ? null : leftHandTokens[1];
             //recursively descend into the metamodel tree
-            return ((TranslationMapping) entry).getStatement(leftHandTokens[1]);
+            return mappingEntry.getStatement(nextToken);
         }
 
         return entry.toString();

--- a/extensions/sql/contract-definition-store-sql/build.gradle.kts
+++ b/extensions/sql/contract-definition-store-sql/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 
 val h2Version: String by project
 val assertj: String by project
+val postgresVersion: String by project
 
 dependencies {
     api(project(":spi:core-spi"))
@@ -34,6 +35,8 @@ dependencies {
     testImplementation("com.h2database:h2:${h2Version}")
     testImplementation("org.assertj:assertj-core:${assertj}")
     testImplementation(testFixtures(project(":common:util")))
+    testImplementation("org.postgresql:postgresql:${postgresVersion}")
+
 }
 
 publishing {

--- a/extensions/sql/contract-definition-store-sql/docs/schema.sql
+++ b/extensions/sql/contract-definition-store-sql/docs/schema.sql
@@ -19,6 +19,6 @@ CREATE TABLE IF NOT EXISTS edc_contract_definitions
     contract_definition_id VARCHAR NOT NULL,
     access_policy_id       VARCHAR NOT NULL,
     contract_policy_id     VARCHAR NOT NULL,
-    selector_expression    VARCHAR NOT NULL,
+    selector_expression    JSON NOT NULL,
     PRIMARY KEY (contract_definition_id)
 );

--- a/extensions/sql/contract-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionStoreExtension.java
+++ b/extensions/sql/contract-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionStoreExtension.java
@@ -25,6 +25,8 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
 import org.eclipse.dataspaceconnector.spi.transaction.datasource.DataSourceRegistry;
+import org.eclipse.dataspaceconnector.sql.contractdefinition.store.schema.ContractDefinitionStatements;
+import org.eclipse.dataspaceconnector.sql.contractdefinition.store.schema.postgres.PostgresDialectStatements;
 
 @Provides({ ContractDefinitionStore.class, ContractDefinitionLoader.class })
 public class SqlContractDefinitionStoreExtension implements ServiceExtension {
@@ -55,7 +57,7 @@ public class SqlContractDefinitionStoreExtension implements ServiceExtension {
     }
 
     private ContractDefinitionStatements getStatementImpl() {
-        return statements == null ? new PostgresStatements() : statements;
+        return statements == null ? new PostgresDialectStatements() : statements;
     }
 
 }

--- a/extensions/sql/contract-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/sql/contract-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/schema/BaseSqlDialectStatements.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *  Copyright (c) 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,22 +12,20 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.sql.contractdefinition.store;
+package org.eclipse.dataspaceconnector.sql.contractdefinition.store.schema;
+
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.sql.contractdefinition.store.schema.postgres.ContractDefinitionMapping;
+import org.eclipse.dataspaceconnector.sql.translation.SqlQueryStatement;
 
 import static java.lang.String.format;
 
-class PostgresStatements implements ContractDefinitionStatements {
+public class BaseSqlDialectStatements implements ContractDefinitionStatements {
     @Override
     public String getDeleteByIdTemplate() {
         return format("DELETE FROM %s WHERE %s = ?",
                 getContractDefinitionTable(),
                 getIdColumn());
-    }
-
-    @Override
-    public String getSelectAllTemplate() {
-        return format("SELECT * from %s LIMIT ? OFFSET ?",
-                getContractDefinitionTable());
     }
 
     @Override
@@ -37,12 +35,13 @@ class PostgresStatements implements ContractDefinitionStatements {
 
     @Override
     public String getInsertTemplate() {
-        return format("INSERT INTO %s (%s, %s, %s, %s) VALUES (?, ?, ?, ?)",
+        return format("INSERT INTO %s (%s, %s, %s, %s) VALUES (?, ?, ?, ?%s)",
                 getContractDefinitionTable(),
                 getIdColumn(),
                 getAccessPolicyIdColumn(),
                 getContractPolicyIdColumn(),
-                getSelectorExpressionColumn());
+                getSelectorExpressionColumn(),
+                getFormatAsJsonOperator());
     }
 
     @Override
@@ -56,17 +55,19 @@ class PostgresStatements implements ContractDefinitionStatements {
 
     @Override
     public String getUpdateTemplate() {
-        return format("UPDATE %s SET %s = ?, %s = ?, %s = ?, %s = ? WHERE %s = ?",
+        return format("UPDATE %s SET %s = ?, %s = ?, %s = ?, %s = ?%s WHERE %s = ?",
                 getContractDefinitionTable(),
                 getIdColumn(),
                 getAccessPolicyIdColumn(),
                 getContractPolicyIdColumn(),
                 getSelectorExpressionColumn(),
+                getFormatAsJsonOperator(),
                 getIdColumn());
     }
 
     @Override
-    public String getIsPolicyReferencedTemplate() {
-        return format("SELECT * FROM %s WHERE (%s=? OR %s=?);", getContractDefinitionTable(), getAccessPolicyIdColumn(), getContractPolicyIdColumn());
+    public SqlQueryStatement createQuery(QuerySpec querySpec) {
+        var select = format("SELECT * FROM %s", getContractDefinitionTable());
+        return new SqlQueryStatement(select, querySpec, new ContractDefinitionMapping(this));
     }
 }

--- a/extensions/sql/contract-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/schema/ContractDefinitionStatements.java
+++ b/extensions/sql/contract-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/schema/ContractDefinitionStatements.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Daimler TSS GmbH
+ *  Copyright (c) 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,12 +8,14 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Daimler TSS GmbH - Initial implementation
- *       Microsoft Corporation - refactoring
+ *       Microsoft Corporation - initial API and implementation
  *
  */
 
-package org.eclipse.dataspaceconnector.sql.contractdefinition.store;
+package org.eclipse.dataspaceconnector.sql.contractdefinition.store.schema;
+
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.sql.translation.SqlQueryStatement;
 
 /**
  * Defines all statements that are needed for the ContractDefinition store
@@ -41,8 +43,6 @@ public interface ContractDefinitionStatements {
 
     String getDeleteByIdTemplate();
 
-    String getSelectAllTemplate();
-
     String getFindByTemplate();
 
     String getInsertTemplate();
@@ -51,5 +51,9 @@ public interface ContractDefinitionStatements {
 
     String getUpdateTemplate();
 
-    String getIsPolicyReferencedTemplate();
+    SqlQueryStatement createQuery(QuerySpec querySpec);
+
+    default String getFormatAsJsonOperator() {
+        return " FORMAT JSON";
+    }
 }

--- a/extensions/sql/contract-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/schema/postgres/ContractDefinitionMapping.java
+++ b/extensions/sql/contract-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/schema/postgres/ContractDefinitionMapping.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.sql.contractdefinition.store.schema.postgres;
+
+import org.eclipse.dataspaceconnector.sql.contractdefinition.store.schema.ContractDefinitionStatements;
+import org.eclipse.dataspaceconnector.sql.translation.TranslationMapping;
+
+/**
+ * Maps fields of a {@link org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition} onto the
+ * corresponding SQL schema (= column names)
+ */
+public class ContractDefinitionMapping extends TranslationMapping {
+    public ContractDefinitionMapping(ContractDefinitionStatements statements) {
+        add("id", statements.getIdColumn());
+        add("accessPolicyId", statements.getAccessPolicyIdColumn());
+        add("accessPolicy", statements.getAccessPolicyIdColumn());
+        add("contractPolicyId", statements.getContractPolicyIdColumn());
+        add("contractPolicy", statements.getContractPolicyIdColumn());
+        add("selectorExpression", new SelectorExpressionMapping());
+    }
+}

--- a/extensions/sql/contract-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/schema/postgres/CriterionMapping.java
+++ b/extensions/sql/contract-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/schema/postgres/CriterionMapping.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.sql.contractdefinition.store.schema.postgres;
+
+import org.eclipse.dataspaceconnector.sql.translation.TranslationMapping;
+
+/**
+ * Maps fields of a {@link org.eclipse.dataspaceconnector.spi.query.Criterion} onto the corresponding SQL schema (=
+ * column names)
+ */
+class CriterionMapping extends TranslationMapping {
+
+    CriterionMapping() {
+    }
+
+    @Override
+    public String getStatement(String canonicalPropertyName) {
+        var statementBuilder = new StringBuilder("criteria");
+        if (canonicalPropertyName == null) {
+            statementBuilder.append("::text");
+            return statementBuilder.toString();
+        }
+        var tokens = canonicalPropertyName.split("\\.");
+
+        int length = tokens.length;
+        for (int i = 0; i < length - 1; i++) {
+            statementBuilder.append("-> ");
+            statementBuilder.append("'").append(tokens[i]).append("' ");
+        }
+
+        statementBuilder.append(" ->> ");
+        statementBuilder.append("'").append(tokens[length - 1]).append("'");
+        return statementBuilder.toString();
+    }
+}

--- a/extensions/sql/contract-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/schema/postgres/PostgresDialectStatements.java
+++ b/extensions/sql/contract-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/schema/postgres/PostgresDialectStatements.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.sql.contractdefinition.store.schema.postgres;
+
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.sql.contractdefinition.store.schema.BaseSqlDialectStatements;
+import org.eclipse.dataspaceconnector.sql.translation.SqlQueryStatement;
+
+import static java.lang.String.format;
+
+/**
+ * Contains Postgres-specific SQL statements
+ */
+public class PostgresDialectStatements extends BaseSqlDialectStatements {
+    @Override
+    public String getFormatAsJsonOperator() {
+        return "::json";
+    }
+
+    @Override
+    public SqlQueryStatement createQuery(QuerySpec querySpec) {
+        // if any criterion targets a JSON array field, we need to slightly adapt the FROM clause
+        if (querySpec.getFilterExpression().stream().anyMatch(c -> c.getOperandLeft().toString().startsWith("selectorExpression.criteria"))) {
+            var select = getSelectFromJsonArrayTemplate(format("%s -> '%s'", getSelectorExpressionColumn(), "criteria"), "criteria");
+            return new SqlQueryStatement(select, querySpec, new ContractDefinitionMapping(this));
+        }
+        return super.createQuery(querySpec);
+    }
+
+    /**
+     * Creates a SELECT statement that targets a Postgres JSON array
+     *
+     * @param jsonPath The path to the array object, which is passed as parameter to the
+     *         {@code json_array_elements()} function
+     * @param aliasName the alias under which the JSON array is available, e.g. for WHERE clauses
+     */
+    private String getSelectFromJsonArrayTemplate(String jsonPath, String aliasName) {
+        return format("SELECT * FROM %s, json_array_elements(%s) as %s", getContractDefinitionTable(), jsonPath, aliasName);
+    }
+}

--- a/extensions/sql/contract-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/schema/postgres/SelectorExpressionMapping.java
+++ b/extensions/sql/contract-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/schema/postgres/SelectorExpressionMapping.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.sql.contractdefinition.store.schema.postgres;
+
+import org.eclipse.dataspaceconnector.sql.translation.TranslationMapping;
+
+/**
+ * Maps fields of a {@link org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression} onto the corresponding SQL
+ * schema (= column names)
+ */
+class SelectorExpressionMapping extends TranslationMapping {
+
+    SelectorExpressionMapping() {
+        add("criteria", new CriterionMapping());
+    }
+
+
+}

--- a/extensions/sql/contract-definition-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/TestFunctions.java
+++ b/extensions/sql/contract-definition-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/TestFunctions.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.sql.contractdefinition.store;
+
+import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class TestFunctions {
+
+    public static ContractDefinition getContractDefinition(String id, String accessPolicyId, String contractPolicyId) {
+        return ContractDefinition.Builder.newInstance()
+                .id(id)
+                .accessPolicyId(accessPolicyId)
+                .contractPolicyId(contractPolicyId)
+                .selectorExpression(AssetSelectorExpression.Builder.newInstance().build())
+                .build();
+    }
+
+    public static List<ContractDefinition> getContractDefinitions(int count) {
+        return IntStream.range(0, count)
+                .mapToObj(i -> getContractDefinition("id" + i, "policy" + i, "contract" + i))
+                .collect(Collectors.toList());
+    }
+}

--- a/extensions/sql/contract-definition-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/postgres/PostgresContractDefinitionStoreTest.java
+++ b/extensions/sql/contract-definition-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/postgres/PostgresContractDefinitionStoreTest.java
@@ -1,0 +1,197 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.sql.contractdefinition.store.postgres;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.dataspaceconnector.common.util.junit.annotations.PostgresqlDbIntegrationTest;
+import org.eclipse.dataspaceconnector.common.util.postgres.PostgresqlLocalInstance;
+import org.eclipse.dataspaceconnector.policy.model.PolicyRegistrationTypes;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.spi.transaction.NoopTransactionContext;
+import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
+import org.eclipse.dataspaceconnector.spi.transaction.datasource.DataSourceRegistry;
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.eclipse.dataspaceconnector.sql.contractdefinition.store.SqlContractDefinitionStore;
+import org.eclipse.dataspaceconnector.sql.contractdefinition.store.schema.BaseSqlDialectStatements;
+import org.eclipse.dataspaceconnector.sql.contractdefinition.store.schema.postgres.PostgresDialectStatements;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.postgresql.ds.PGSimpleDataSource;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.sql.DataSource;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.sql.SqlQueryExecutor.executeQuery;
+import static org.eclipse.dataspaceconnector.sql.contractdefinition.store.TestFunctions.getContractDefinitions;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@PostgresqlDbIntegrationTest
+public class PostgresContractDefinitionStoreTest {
+    protected static final String DATASOURCE_NAME = "contractdefinition";
+    private static final String POSTGRES_USER = "postgres";
+    private static final String POSTGRES_PASSWORD = "password";
+    private static final String POSTGRES_DATABASE = "itest";
+    private SqlContractDefinitionStore store;
+    private BaseSqlDialectStatements sqlStatements;
+    private TransactionContext transactionContext;
+    private Connection connection;
+
+    @BeforeAll
+    static void prepare() {
+        PostgresqlLocalInstance.createDatabase(POSTGRES_DATABASE);
+    }
+
+    @BeforeEach
+    void setUp() throws SQLException, IOException {
+        transactionContext = new NoopTransactionContext();
+        DataSourceRegistry dataSourceRegistry = mock(DataSourceRegistry.class);
+
+
+        var ds = new PGSimpleDataSource();
+        ds.setServerNames(new String[]{ "localhost" });
+        ds.setPortNumbers(new int[]{ 5432 });
+        ds.setUser(POSTGRES_USER);
+        ds.setPassword(POSTGRES_PASSWORD);
+        ds.setDatabaseName(POSTGRES_DATABASE);
+
+        // do not actually close
+        connection = spy(ds.getConnection());
+        doNothing().when(connection).close();
+
+        var datasourceMock = mock(DataSource.class);
+        when(datasourceMock.getConnection()).thenReturn(connection);
+        when(dataSourceRegistry.resolve(DATASOURCE_NAME)).thenReturn(datasourceMock);
+
+        sqlStatements = new PostgresDialectStatements();
+        TypeManager manager = new TypeManager();
+
+        manager.registerTypes(PolicyRegistrationTypes.TYPES.toArray(Class<?>[]::new));
+        store = new SqlContractDefinitionStore(dataSourceRegistry, DATASOURCE_NAME, transactionContext, sqlStatements, manager);
+        var schema = Files.readString(Paths.get("./docs/schema.sql"));
+        try {
+            transactionContext.execute(() -> {
+                executeQuery(connection, schema);
+                return null;
+            });
+        } catch (Exception exc) {
+            fail(exc);
+        }
+    }
+
+    @Test
+    void find_queryBySelectorExpression_left() {
+        var definitionsExpected = getContractDefinitions(20);
+        // add a selector expression to the last 5 elements
+        definitionsExpected.get(0).getSelectorExpression().getCriteria().add(new Criterion(Asset.PROPERTY_ID, "=", "test-asset"));
+        definitionsExpected.get(5).getSelectorExpression().getCriteria().add(new Criterion(Asset.PROPERTY_ID, "=", "foobar-asset"));
+        store.save(definitionsExpected);
+
+        var spec = QuerySpec.Builder.newInstance()
+                .filter(format("selectorExpression.criteria.left = %s", Asset.PROPERTY_ID))
+                .build();
+
+        var definitionsRetrieved = store.findAll(spec).collect(Collectors.toList());
+
+        assertThat(definitionsRetrieved).hasSize(2)
+                .usingRecursiveFieldByFieldElementComparator()
+                .allSatisfy(cd -> assertThat(cd.getId()).matches("id[0,5]"));
+    }
+
+    @Test
+    void find_queryBySelectorExpression_right() {
+        var definitionsExpected = getContractDefinitions(20);
+        definitionsExpected.get(0).getSelectorExpression().getCriteria().add(new Criterion(Asset.PROPERTY_ID, "=", "test-asset"));
+        definitionsExpected.get(5).getSelectorExpression().getCriteria().add(new Criterion(Asset.PROPERTY_ID, "=", "foobar-asset"));
+        store.save(definitionsExpected);
+
+        var spec = QuerySpec.Builder.newInstance()
+                .filter("selectorExpression.criteria.right = foobar-asset")
+                .build();
+
+        var definitionsRetrieved = store.findAll(spec).collect(Collectors.toList());
+
+        assertThat(definitionsRetrieved).hasSize(1)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsOnly(definitionsExpected.get(5));
+    }
+
+    @Test
+    void find_queryMultiple() {
+        var definitionsExpected = getContractDefinitions(20);
+        definitionsExpected.forEach(d -> d.getSelectorExpression().getCriteria().add(new Criterion(Asset.PROPERTY_ID, "=", "test-asset")));
+        store.save(definitionsExpected);
+
+        var spec = QuerySpec.Builder.newInstance()
+                .filter(List.of(new Criterion("selectorExpression.criteria.right", "=", "test-asset"),
+                        new Criterion("contractPolicyId", "=", "contract4")))
+                .build();
+
+        var definitionsRetrieved = store.findAll(spec).collect(Collectors.toList());
+
+        assertThat(definitionsRetrieved).hasSize(1)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsOnly(definitionsExpected.get(4));
+    }
+
+    @Test
+    void find_queryMultiple_noMatch() {
+        var definitionsExpected = getContractDefinitions(20);
+        store.save(definitionsExpected);
+
+        var spec = QuerySpec.Builder.newInstance()
+                .filter(List.of(new Criterion("selectorExpression.criteria.right", "=", "test-asset"),
+                        new Criterion("contractPolicyId", "=", "contract4")))
+                .build();
+
+        assertThat(store.findAll(spec).collect(Collectors.toList())).isEmpty();
+    }
+
+    @Test
+    void find_queryBySelectorExpression_entireCriterion() throws JsonProcessingException {
+        var definitionsExpected = getContractDefinitions(20);
+        definitionsExpected.get(0).getSelectorExpression().getCriteria().add(new Criterion(Asset.PROPERTY_ID, "=", "test-asset"));
+        var def5 = definitionsExpected.get(5);
+        def5.getSelectorExpression().getCriteria().add(new Criterion(Asset.PROPERTY_ID, "=", "foobar-asset"));
+        store.save(definitionsExpected);
+
+        var json = new ObjectMapper().writeValueAsString(new Criterion(Asset.PROPERTY_ID, "=", "foobar-asset"));
+
+        var spec = QuerySpec.Builder.newInstance()
+                .filter("selectorExpression.criteria = " + json)
+                .build();
+
+        assertThat(store.findAll(spec)).hasSize(1)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsOnly(def5);
+    }
+
+
+}

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/store/ContractDefinitionStore.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/store/ContractDefinitionStore.java
@@ -78,13 +78,4 @@ public interface ContractDefinitionStore {
      */
     default void reload() {
     }
-
-    /**
-     * Checks whether the given policy is referenced by any {@link ContractDefinition}, either via
-     * {@link ContractDefinition#getAccessPolicyId()} or via {@link ContractDefinition#getContractPolicyId()}.
-     *
-     * @param policyId The ID of the policy
-     * @return a {@link Stream} of contract definitions, that reference the given policy.
-     */
-    Stream<ContractDefinition> isReferenced(String policyId);
 }


### PR DESCRIPTION
## What this PR changes/adds

Adds full query support to the `SqlContractDefinitionStore`.

## Why it does that

Makes the flexible query feature reach "into" the database.

## Further notes

- removed the "special" method(s) from the `SqlContractDefinitionStore`.

## Linked Issue(s)

Closes #1458 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
