### PR TITLE
chore(dependabot): add dependabot.yml to activate auto dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # maintain dependencies for GitHub actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly" # default = monday
+    open-pull-requests-limit: 5
+
+  # maintain dependencies for Gradle
+  - package-ecosystem: "gradle" # checks build.gradle(.kts) and settings.gradle(.kts)
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## What this PR changes/adds

Adds `dependabot.yml`.

## Why it does that

Dependabot is activated but currently does not open up pull request to automatically update dependencies. 

## Further notes

There are a lot more properties to customize this file. These initial lines may be sufficient in the first place. Setting the limit to "5" prevents from being spammed with dependabot PRs. 

Not sure how this works with a multimodule project. If dependabot scans the `settings.gradle` and every module gets its version from there, it hopefully works.

## Linked Issue(s)

Closes #906 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
