### PR TITLE
Fix: throw auth-failed exception

### DIFF
--- a/extensions/api/auth-spi/src/main/java/org/eclipse/dataspaceconnector/api/auth/AuthenticationRequestFilter.java
+++ b/extensions/api/auth-spi/src/main/java/org/eclipse/dataspaceconnector/api/auth/AuthenticationRequestFilter.java
@@ -16,7 +16,7 @@ package org.eclipse.dataspaceconnector.api.auth;
 
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
-import org.eclipse.dataspaceconnector.spi.exception.NotAuthorizedException;
+import org.eclipse.dataspaceconnector.spi.exception.AuthenticationFailedException;
 
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -24,8 +24,8 @@ import java.util.stream.Collectors;
 import static jakarta.ws.rs.HttpMethod.OPTIONS;
 
 /**
- * Intercepts all requests sent to this resource and authenticates them using an {@link AuthenticationService}.
- * In order to be able to handle CORS requests properly, OPTIONS requests are not validated as their headers usually don't
+ * Intercepts all requests sent to this resource and authenticates them using an {@link AuthenticationService}. In order
+ * to be able to handle CORS requests properly, OPTIONS requests are not validated as their headers usually don't
  * contain credentials.
  */
 public class AuthenticationRequestFilter implements ContainerRequestFilter {
@@ -43,7 +43,7 @@ public class AuthenticationRequestFilter implements ContainerRequestFilter {
         if (!OPTIONS.equalsIgnoreCase(requestContext.getMethod())) {
             var isAuthenticated = authenticationService.isAuthenticated(headers.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
             if (!isAuthenticated) {
-                throw new NotAuthorizedException();
+                throw new AuthenticationFailedException();
             }
         }
     }

--- a/extensions/api/auth-spi/src/test/java/org/eclipse/dataspaceconnector/api/auth/AuthenticationRequestFilterTest.java
+++ b/extensions/api/auth-spi/src/test/java/org/eclipse/dataspaceconnector/api/auth/AuthenticationRequestFilterTest.java
@@ -17,7 +17,6 @@ package org.eclipse.dataspaceconnector.api.auth;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import org.eclipse.dataspaceconnector.spi.exception.AuthenticationFailedException;
-import org.eclipse.dataspaceconnector.spi.exception.NotAuthorizedException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -72,7 +71,7 @@ class AuthenticationRequestFilterTest {
 
         when(contextMock.getHeaders()).thenReturn(new MultivaluedHashMap<>(Map.of("foo", "bar")));
 
-        assertThatThrownBy(() -> filter.filter(contextMock)).isInstanceOf(NotAuthorizedException.class);
+        assertThatThrownBy(() -> filter.filter(contextMock)).isInstanceOf(AuthenticationFailedException.class);
         verify(authSrvMock).isAuthenticated(anyMap());
     }
 

--- a/spi/web-spi/src/main/java/org/eclipse/dataspaceconnector/spi/exception/AuthenticationFailedException.java
+++ b/spi/web-spi/src/main/java/org/eclipse/dataspaceconnector/spi/exception/AuthenticationFailedException.java
@@ -21,7 +21,7 @@ import org.eclipse.dataspaceconnector.spi.EdcException;
  */
 public class AuthenticationFailedException extends EdcException {
     public AuthenticationFailedException() {
-        super("Authentication not possible or failed");
+        super("Request could not be authenticated");
     }
 
     public AuthenticationFailedException(String message) {


### PR DESCRIPTION
## What this PR changes/adds

AuthenticationRequestFilter now throws an `AuthenticationFailedException` instead of a `NotAuthorizedException`, as this will trigger returning a HTTP 401 instead of a 403.

## Why it does that

To return the correct HTTP status code

## Further notes

.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
