### PR TITLE
Fix: do not use `QuerySpec` when SqlContractDefinitionStore#findAll()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Avoid endless loops in `ContractNegotiationManager` (#1487)
 * Fix race condition in `ContractNegotiationIntegrationTest` (#1505)
 * Fix for change in Cosmos DB behavior on missing sort fields (#1514)
+* Effectively removed default LIMIT in SQL Contract Def Store (#1515) 
 
 ## [milestone-4] - 2022-06-07
 

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractDefinitionServiceImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractDefinitionServiceImpl.java
@@ -24,6 +24,7 @@ import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitio
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.policy.PolicyEngine;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyDefinitionStore;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
 import org.jetbrains.annotations.NotNull;
@@ -55,7 +56,8 @@ public class ContractDefinitionServiceImpl implements ContractDefinitionService 
     @NotNull
     @Override
     public Stream<ContractDefinition> definitionsFor(ParticipantAgent agent) {
-        return definitionStore.findAll().stream()
+        //todo: once IDS supports pagination, replace this with the actual paging parameters
+        return definitionStore.findAll(QuerySpec.max())
                 .filter(definition -> evaluatePolicies(definition, agent));
     }
 

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -177,6 +177,7 @@ class ContractNegotiationIntegrationTest extends AbstractContractNegotiationInte
         await().atMost(DEFAULT_TEST_TIMEOUT)
                 .pollInterval(DEFAULT_POLL_INTERVAL)
                 .untilAsserted(() -> {
+                    assertThat(consumerNegotiationId).isNotNull();
                     var consumerNegotiation = consumerStore.find(consumerNegotiationId);
                     var providerNegotiation = providerStore.findForCorrelationId(consumerNegotiationId);
 

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -74,6 +74,7 @@ class ContractNegotiationIntegrationTest extends AbstractContractNegotiationInte
         await().atMost(DEFAULT_TEST_TIMEOUT)
                 .pollInterval(DEFAULT_POLL_INTERVAL)
                 .untilAsserted(() -> {
+                    assertThat(consumerNegotiationId).isNotNull();
                     var consumerNegotiation = consumerStore.find(consumerNegotiationId);
                     var providerNegotiation = providerStore.findForCorrelationId(consumerNegotiationId);
 

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractDefinitionServiceImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractDefinitionServiceImplTest.java
@@ -22,13 +22,14 @@ import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitio
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.policy.PolicyEngine;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyDefinitionStore;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression.SELECT_ALL;
@@ -61,13 +62,13 @@ class ContractDefinitionServiceImplTest {
         var def = PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build();
         when(policyStore.findById(any())).thenReturn(def);
         when(policyEngine.evaluate(NEGOTIATION_SCOPE, def.getPolicy(), agent)).thenReturn(Result.success(def.getPolicy()));
-        when(definitionStore.findAll()).thenReturn(List.of(ContractDefinition.Builder.newInstance().id("1").accessPolicyId("access").contractPolicyId("contract").selectorExpression(SELECT_ALL).build()));
+        when(definitionStore.findAll(eq(QuerySpec.max()))).thenReturn(Stream.of(ContractDefinition.Builder.newInstance().id("1").accessPolicyId("access").contractPolicyId("contract").selectorExpression(SELECT_ALL).build()));
 
         var definitions = definitionService.definitionsFor(agent);
 
         assertThat(definitions).hasSize(1);
         verify(policyEngine, atLeastOnce()).evaluate(NEGOTIATION_SCOPE, def.getPolicy(), agent);
-        verify(definitionStore).findAll();
+        verify(definitionStore).findAll(eq(QuerySpec.max()));
     }
 
     @Test
@@ -77,13 +78,13 @@ class ContractDefinitionServiceImplTest {
         when(policyStore.findById(any())).thenReturn(definition);
         var contractDefinition = ContractDefinition.Builder.newInstance().id("1").accessPolicyId("access").contractPolicyId("contract").selectorExpression(SELECT_ALL).build();
         when(policyEngine.evaluate(any(), any(), any())).thenReturn(Result.failure("invalid"));
-        when(definitionStore.findAll()).thenReturn(List.of(contractDefinition));
+        when(definitionStore.findAll(eq(QuerySpec.max()))).thenReturn(Stream.of(contractDefinition));
 
         var result = definitionService.definitionsFor(agent);
 
         assertThat(result).isEmpty();
         verify(policyEngine, atLeastOnce()).evaluate(NEGOTIATION_SCOPE, definition.getPolicy(), agent);
-        verify(definitionStore).findAll();
+        verify(definitionStore).findAll(eq(QuerySpec.max()));
     }
 
     @Test
@@ -96,13 +97,13 @@ class ContractDefinitionServiceImplTest {
         when(policyEngine.evaluate(eq(NEGOTIATION_SCOPE), any(), any()))
                 .thenReturn(Result.success(definition.getPolicy()))
                 .thenReturn(Result.failure("invalid"));
-        when(definitionStore.findAll()).thenReturn(List.of(contractDefinition));
+        when(definitionStore.findAll(eq(QuerySpec.max()))).thenReturn(Stream.of(contractDefinition));
 
         var result = definitionService.definitionsFor(agent);
 
         assertThat(result).isEmpty();
         verify(policyEngine, atLeastOnce()).evaluate(NEGOTIATION_SCOPE, definition.getPolicy(), agent);
-        verify(definitionStore).findAll();
+        verify(definitionStore).findAll(QuerySpec.max());
     }
 
     @Test
@@ -111,7 +112,7 @@ class ContractDefinitionServiceImplTest {
         var policy = Policy.Builder.newInstance().build();
         when(policyStore.findById(any())).thenReturn(null);
         when(policyEngine.evaluate(NEGOTIATION_SCOPE, policy, agent)).thenReturn(Result.success(policy));
-        when(definitionStore.findAll()).thenReturn(List.of(ContractDefinition.Builder.newInstance().id("1").accessPolicyId("access").contractPolicyId("contract").selectorExpression(SELECT_ALL).build()));
+        when(definitionStore.findAll(QuerySpec.max())).thenReturn(Stream.of(ContractDefinition.Builder.newInstance().id("1").accessPolicyId("access").contractPolicyId("contract").selectorExpression(SELECT_ALL).build()));
 
         var definitions = definitionService.definitionsFor(agent);
 

--- a/core/defaults/src/main/java/org/eclipse/dataspaceconnector/core/defaults/contractdefinition/InMemoryContractDefinitionStore.java
+++ b/core/defaults/src/main/java/org/eclipse/dataspaceconnector/core/defaults/contractdefinition/InMemoryContractDefinitionStore.java
@@ -23,7 +23,6 @@ import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDe
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
@@ -35,11 +34,6 @@ import java.util.stream.Stream;
 public class InMemoryContractDefinitionStore implements ContractDefinitionStore {
     private final Map<String, ContractDefinition> cache = new ConcurrentHashMap<>();
     private final QueryResolver<ContractDefinition> queryResolver = new ReflectionBasedQueryResolver<>(ContractDefinition.class);
-
-    @Override
-    public @NotNull Collection<ContractDefinition> findAll() {
-        return Collections.unmodifiableCollection(cache.values());
-    }
 
     @Override
     public @NotNull Stream<ContractDefinition> findAll(QuerySpec spec) {

--- a/core/defaults/src/test/java/org/eclipse/dataspaceconnector/core/defaults/contractdefinition/InMemoryContractDefinitionStoreTest.java
+++ b/core/defaults/src/test/java/org/eclipse/dataspaceconnector/core/defaults/contractdefinition/InMemoryContractDefinitionStoreTest.java
@@ -37,14 +37,14 @@ class InMemoryContractDefinitionStoreTest {
         var definition2 = ContractDefinition.Builder.newInstance().id("2").accessPolicyId("access").contractPolicyId("contract").selectorExpression(SELECT_ALL).build();
 
         store.save(definition1);
-        assertThat(store.findAll()).contains(definition1);
+        assertThat(store.findAll(QuerySpec.max())).contains(definition1);
 
         store.save(List.of(definition2));
-        assertThat(store.findAll()).contains(definition1);
+        assertThat(store.findAll(QuerySpec.max())).contains(definition1);
 
         var deletedDefinition = store.deleteById(definition1.getId());
         assertThat(deletedDefinition).isEqualTo(definition1);
-        assertThat(store.findAll()).doesNotContain(definition1);
+        assertThat(store.findAll(QuerySpec.max())).doesNotContain(definition1);
     }
 
     @Test

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
@@ -253,11 +253,6 @@ class IdsApiMultipartDispatcherV1IntegrationTestServiceExtension implements Serv
         }
 
         @Override
-        public @NotNull Collection<ContractDefinition> findAll() {
-            return contractDefinitions;
-        }
-
-        @Override
         public @NotNull Stream<ContractDefinition> findAll(QuerySpec spec) {
             throw new UnsupportedOperationException();
         }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
@@ -266,11 +266,6 @@ class IdsApiMultipartEndpointV1IntegrationTestServiceExtension implements Servic
         private final List<ContractDefinition> contractDefinitions = new ArrayList<>();
 
         @Override
-        public @NotNull Collection<ContractDefinition> findAll() {
-            return contractDefinitions;
-        }
-
-        @Override
         public @NotNull Stream<ContractDefinition> findAll(QuerySpec spec) {
             throw new UnsupportedOperationException();
         }

--- a/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiControllerIntegrationTest.java
@@ -21,6 +21,7 @@ import org.eclipse.dataspaceconnector.dataloading.ContractDefinitionLoader;
 import org.eclipse.dataspaceconnector.junit.extensions.EdcExtension;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -112,7 +113,7 @@ public class ContractDefinitionApiControllerIntegrationTest {
                 .post("/contractdefinitions")
                 .then()
                 .statusCode(204);
-        assertThat(store.findAll()).isNotEmpty();
+        assertThat(store.findAll(QuerySpec.max())).isNotEmpty();
     }
 
     @Test
@@ -129,7 +130,7 @@ public class ContractDefinitionApiControllerIntegrationTest {
                 .post("/contractdefinitions")
                 .then()
                 .statusCode(400);
-        assertThat(store.findAll()).isEmpty();
+        assertThat(store.findAll(QuerySpec.max())).isEmpty();
     }
 
     @Test
@@ -143,7 +144,7 @@ public class ContractDefinitionApiControllerIntegrationTest {
                 .post("/contractdefinitions")
                 .then()
                 .statusCode(409);
-        assertThat(store.findAll()).hasSize(1);
+        assertThat(store.findAll(QuerySpec.max())).hasSize(1);
     }
 
     @Test
@@ -155,7 +156,7 @@ public class ContractDefinitionApiControllerIntegrationTest {
                 .delete("/contractdefinitions/definitionId")
                 .then()
                 .statusCode(204);
-        assertThat(store.findAll()).isEmpty();
+        assertThat(store.findAll(QuerySpec.max())).isEmpty();
     }
 
     @Test

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStore.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStore.java
@@ -63,11 +63,6 @@ public class CosmosContractDefinitionStore implements ContractDefinitionStore {
     }
 
     @Override
-    public @NotNull Collection<ContractDefinition> findAll() {
-        return getCache().values();
-    }
-
-    @Override
     public @NotNull Stream<ContractDefinition> findAll(QuerySpec spec) {
         return lockManager.readLock(() -> queryResolver.query(getCache().values().stream(), spec));
     }

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreIntegrationTest.java
@@ -104,7 +104,7 @@ public class CosmosContractDefinitionStoreIntegrationTest {
         container.createItem(doc2);
 
         store.reload();
-        assertThat(store.findAll()).hasSize(2).containsExactlyInAnyOrder(doc1.getWrappedInstance(), doc2.getWrappedInstance());
+        assertThat(store.findAll(QuerySpec.max())).hasSize(2).containsExactlyInAnyOrder(doc1.getWrappedInstance(), doc2.getWrappedInstance());
     }
 
     @Test
@@ -114,12 +114,12 @@ public class CosmosContractDefinitionStoreIntegrationTest {
         container.createItem(doc1);
         container.createItem(doc2);
 
-        assertThat(store.findAll()).hasSize(2);
+        assertThat(store.findAll(QuerySpec.max())).hasSize(2);
     }
 
     @Test
     void findAll_emptyResult() {
-        assertThat(store.findAll()).isNotNull().isEmpty();
+        assertThat(store.findAll(QuerySpec.max())).isNotNull().isEmpty();
     }
 
     @Test
@@ -187,11 +187,11 @@ public class CosmosContractDefinitionStoreIntegrationTest {
     void save_delete_find_shouldNotExist() {
         var def1 = generateDefinition();
         store.save(def1);
-        assertThat(store.findAll()).containsOnly(def1);
+        assertThat(store.findAll(QuerySpec.max())).containsOnly(def1);
 
         store.deleteById(def1.getId());
 
-        assertThat(store.findAll()).doesNotContain(def1);
+        assertThat(store.findAll(QuerySpec.max())).doesNotContain(def1);
     }
 
     @Test
@@ -332,7 +332,7 @@ public class CosmosContractDefinitionStoreIntegrationTest {
         // add an object
         var def = generateDefinition();
         store.save(def);
-        assertThat(store.findAll()).containsExactly(def);
+        assertThat(store.findAll(QuerySpec.max())).containsExactly(def);
 
         // modify the object
         var modifiedDef = ContractDefinition.Builder.newInstance().id(def.getId())

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreTest.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreTest.java
@@ -68,7 +68,7 @@ class CosmosContractDefinitionStoreTest {
         when(cosmosDbApiMock.queryAllItems()).thenReturn(List.of(doc1, doc2));
 
         store.reload();
-        var all = store.findAll();
+        var all = store.findAll(QuerySpec.max());
 
         assertThat(all).hasSize(2).containsExactlyInAnyOrder(doc1.getWrappedInstance(), doc2.getWrappedInstance());
         verify(cosmosDbApiMock).queryAllItems();
@@ -78,28 +78,28 @@ class CosmosContractDefinitionStoreTest {
     void findAll_noReload() {
         when(cosmosDbApiMock.queryAllItems()).thenReturn(Collections.emptyList());
 
-        var all = store.findAll();
+        var all = store.findAll(QuerySpec.max());
         assertThat(all).isEmpty();
         verify(cosmosDbApiMock).queryAllItems();
     }
-    
+
     @Test
     void findById() {
         var doc = generateDocument(TEST_PART_KEY);
         when(cosmosDbApiMock.queryAllItems()).thenReturn(List.of(doc));
-        
+
         var result = store.findById(doc.getId());
-        
+
         assertThat(result).isNotNull().isEqualTo(doc.getWrappedInstance());
         verify(cosmosDbApiMock).queryAllItems();
     }
-    
+
     @Test
     void findById_invalidId() {
         when(cosmosDbApiMock.queryAllItems()).thenReturn(Collections.emptyList());
-        
+
         var result = store.findById("invalid-id");
-        
+
         assertThat(result).isNull();
         verify(cosmosDbApiMock).queryAllItems();
     }
@@ -128,7 +128,7 @@ class CosmosContractDefinitionStoreTest {
 
         store.save(definition); //should write through the cache
 
-        var all = store.findAll();
+        var all = store.findAll(QuerySpec.max());
 
         assertThat(all).isNotEmpty().containsExactlyInAnyOrder((ContractDefinition) captor.getValue().getWrappedInstance());
         verify(cosmosDbApiMock).queryAllItems();

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FccTestExtension.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FccTestExtension.java
@@ -179,11 +179,6 @@ public class FccTestExtension implements ServiceExtension {
         private final List<ContractDefinition> contractDefinitions = new ArrayList<>();
 
         @Override
-        public @NotNull Collection<ContractDefinition> findAll() {
-            return contractDefinitions;
-        }
-
-        @Override
         public @NotNull Stream<ContractDefinition> findAll(QuerySpec spec) {
             throw new UnsupportedOperationException();
         }

--- a/extensions/sql/contract-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionStore.java
+++ b/extensions/sql/contract-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionStore.java
@@ -36,10 +36,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.sql.DataSource;
 
+import static java.lang.String.format;
 import static org.eclipse.dataspaceconnector.sql.SqlQueryExecutor.executeQuery;
 
 public class SqlContractDefinitionStore implements ContractDefinitionStore {
@@ -69,7 +69,15 @@ public class SqlContractDefinitionStore implements ContractDefinitionStore {
 
     @Override
     public @NotNull Collection<ContractDefinition> findAll() {
-        return findAll(QuerySpec.none()).collect(Collectors.toList());
+        return transactionContext.execute(() -> {
+
+            try (var connection = getConnection()) {
+                var queryStmt = format("SELECT * FROM %s", statements.getContractDefinitionTable());
+                return executeQuery(connection, this::mapResultSet, queryStmt);
+            } catch (SQLException exception) {
+                throw new EdcPersistenceException(exception);
+            }
+        });
     }
 
     @Override
@@ -160,7 +168,7 @@ public class SqlContractDefinitionStore implements ContractDefinitionStore {
         Objects.requireNonNull(definition);
         transactionContext.execute(() -> {
             if (!existsById(connection, definition.getId())) {
-                throw new EdcPersistenceException(String.format("Cannot update. Contract Definition with ID '%s' does not exist.", definition.getId()));
+                throw new EdcPersistenceException(format("Cannot update. Contract Definition with ID '%s' does not exist.", definition.getId()));
             }
 
             executeQuery(connection, statements.getUpdateTemplate(),
@@ -197,7 +205,7 @@ public class SqlContractDefinitionStore implements ContractDefinitionStore {
     }
 
     private DataSource getDataSource() {
-        return Objects.requireNonNull(dataSourceRegistry.resolve(dataSourceName), String.format("DataSource %s could not be resolved", dataSourceName));
+        return Objects.requireNonNull(dataSourceRegistry.resolve(dataSourceName), format("DataSource %s could not be resolved", dataSourceName));
     }
 
     private Connection getConnection() throws SQLException {

--- a/extensions/sql/contract-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionStore.java
+++ b/extensions/sql/contract-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionStore.java
@@ -68,19 +68,6 @@ public class SqlContractDefinitionStore implements ContractDefinitionStore {
     }
 
     @Override
-    public @NotNull Collection<ContractDefinition> findAll() {
-        return transactionContext.execute(() -> {
-
-            try (var connection = getConnection()) {
-                var queryStmt = format("SELECT * FROM %s", statements.getContractDefinitionTable());
-                return executeQuery(connection, this::mapResultSet, queryStmt);
-            } catch (SQLException exception) {
-                throw new EdcPersistenceException(exception);
-            }
-        });
-    }
-
-    @Override
     public @NotNull Stream<ContractDefinition> findAll(QuerySpec spec) {
         return transactionContext.execute(() -> {
             Objects.requireNonNull(spec);

--- a/extensions/sql/contract-definition-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionStoreTest.java
+++ b/extensions/sql/contract-definition-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionStoreTest.java
@@ -32,6 +32,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -223,13 +225,14 @@ public class SqlContractDefinitionStoreTest {
         assertThat(definitionsRetrieved.size()).isEqualTo(definitionsExpected.size());
     }
 
-    @Test
-    void findAll_verifyQueryDefaults() {
-        var all = IntStream.range(0, 100).mapToObj(i -> getContractDefinition("id" + i, "policyId" + i, "contractId" + i))
+    @ParameterizedTest
+    @ValueSource(ints = { 49, 50, 51, 100 })
+    void findAll_verifyQueryDefaults(int size) {
+        var all = IntStream.range(0, size).mapToObj(i -> getContractDefinition("id" + i, "policyId" + i, "contractId" + i))
                 .peek(cd -> sqlContractDefinitionStore.save(cd))
                 .collect(Collectors.toList());
 
-        assertThat(sqlContractDefinitionStore.findAll()).hasSize(50)
+        assertThat(sqlContractDefinitionStore.findAll()).hasSize(size)
                 .usingRecursiveFieldByFieldElementComparator()
                 .isSubsetOf(all);
     }

--- a/extensions/sql/contract-definition-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionStoreTest.java
+++ b/extensions/sql/contract-definition-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionStoreTest.java
@@ -110,10 +110,10 @@ public class SqlContractDefinitionStoreTest {
         var definition = getContractDefinition("id", "policy", "contract");
         sqlContractDefinitionStore.save(definition);
 
-        var definitions = sqlContractDefinitionStore.findAll();
+        var definitions = sqlContractDefinitionStore.findAll(QuerySpec.max());
 
         assertThat(definitions).isNotNull();
-        assertThat(definitions.size()).isEqualTo(1);
+        assertThat(definitions).hasSize(1);
     }
 
     @Test
@@ -122,7 +122,7 @@ public class SqlContractDefinitionStoreTest {
         sqlContractDefinitionStore.save(getContractDefinition("id", "policy", "contract"));
         sqlContractDefinitionStore.save(getContractDefinition("id", "updatedAccess", "updatedContract"));
 
-        var result = sqlContractDefinitionStore.findAll();
+        var result = sqlContractDefinitionStore.findAll(QuerySpec.max());
 
         assertThat(result).hasSize(1).containsExactly(getContractDefinition("id", "updatedAccess", "updatedContract"));
     }
@@ -135,10 +135,10 @@ public class SqlContractDefinitionStoreTest {
         sqlContractDefinitionStore.save(definition1);
         sqlContractDefinitionStore.save(definition2);
 
-        var definitions = sqlContractDefinitionStore.findAll();
+        var definitions = sqlContractDefinitionStore.findAll(QuerySpec.max());
 
         assertThat(definitions).isNotNull();
-        assertThat(definitions.size()).isEqualTo(2);
+        assertThat(definitions).hasSize(2);
     }
 
     @Test
@@ -147,10 +147,9 @@ public class SqlContractDefinitionStoreTest {
         var definitionsCreated = getContractDefinitions(10);
         sqlContractDefinitionStore.save(definitionsCreated);
 
-        var definitionsRetrieved = sqlContractDefinitionStore.findAll();
+        var definitionsRetrieved = sqlContractDefinitionStore.findAll(QuerySpec.max());
 
-        assertThat(definitionsRetrieved).hasSize(10);
-        assertThat(definitionsRetrieved.size()).isEqualTo(definitionsCreated.size());
+        assertThat(definitionsRetrieved).hasSize(definitionsCreated.size());
     }
 
     @Test
@@ -159,7 +158,7 @@ public class SqlContractDefinitionStoreTest {
         sqlContractDefinitionStore.save(getContractDefinitions(3));
         sqlContractDefinitionStore.save(getContractDefinitions(10));
 
-        var definitionsRetrieved = sqlContractDefinitionStore.findAll();
+        var definitionsRetrieved = sqlContractDefinitionStore.findAll(QuerySpec.max());
 
         assertThat(definitionsRetrieved).hasSize(10);
     }
@@ -173,10 +172,10 @@ public class SqlContractDefinitionStoreTest {
         //
         sqlContractDefinitionStore.save(definitionsCreated);
 
-        var definitionsRetrieved = sqlContractDefinitionStore.findAll();
+        var definitionsRetrieved = sqlContractDefinitionStore.findAll(QuerySpec.max());
 
         assertThat(definitionsRetrieved).isNotNull();
-        assertThat(definitionsRetrieved.size()).isEqualTo(definitionsCreated.size());
+        assertThat(definitionsRetrieved).hasSize(definitionsCreated.size());
     }
 
     @Test
@@ -185,7 +184,7 @@ public class SqlContractDefinitionStoreTest {
         var definition = getContractDefinition("id", "policy1", "contract1");
 
         sqlContractDefinitionStore.update(definition);
-        var existing = sqlContractDefinitionStore.findAll();
+        var existing = sqlContractDefinitionStore.findAll(QuerySpec.max());
         assertThat(existing).hasSize(1).containsExactly(definition);
     }
 
@@ -219,10 +218,10 @@ public class SqlContractDefinitionStoreTest {
         var definitionsExpected = getContractDefinitions(10);
         sqlContractDefinitionStore.save(definitionsExpected);
 
-        var definitionsRetrieved = sqlContractDefinitionStore.findAll();
+        var definitionsRetrieved = sqlContractDefinitionStore.findAll(QuerySpec.max());
 
         assertThat(definitionsRetrieved).isNotNull();
-        assertThat(definitionsRetrieved.size()).isEqualTo(definitionsExpected.size());
+        assertThat(definitionsRetrieved).hasSize(definitionsExpected.size());
     }
 
     @ParameterizedTest
@@ -232,7 +231,7 @@ public class SqlContractDefinitionStoreTest {
                 .peek(cd -> sqlContractDefinitionStore.save(cd))
                 .collect(Collectors.toList());
 
-        assertThat(sqlContractDefinitionStore.findAll()).hasSize(size)
+        assertThat(sqlContractDefinitionStore.findAll(QuerySpec.max())).hasSize(size)
                 .usingRecursiveFieldByFieldElementComparator()
                 .isSubsetOf(all);
     }
@@ -356,11 +355,11 @@ public class SqlContractDefinitionStoreTest {
     void delete() {
         var definitionExpected = getContractDefinition("test-id1", "policy1", "contract1");
         sqlContractDefinitionStore.save(definitionExpected);
-        assertThat(sqlContractDefinitionStore.findAll()).hasSize(1);
+        assertThat(sqlContractDefinitionStore.findAll(QuerySpec.max())).hasSize(1);
 
         var deleted = sqlContractDefinitionStore.deleteById("test-id1");
         assertThat(deleted).isNotNull().usingRecursiveComparison().isEqualTo(definitionExpected);
-        assertThat(sqlContractDefinitionStore.findAll()).isEmpty();
+        assertThat(sqlContractDefinitionStore.findAll(QuerySpec.max())).isEmpty();
     }
 
     @Test

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/store/ContractDefinitionStore.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/store/ContractDefinitionStore.java
@@ -29,12 +29,6 @@ public interface ContractDefinitionStore {
 
 
     /**
-     * Returns all the definitions in the store.
-     */
-    @NotNull
-    Collection<ContractDefinition> findAll();
-
-    /**
      * Returns all the definitions in the store that are covered by a given {@link QuerySpec}.
      * <p>
      * Note: supplying a sort field that does not exist on the {@link ContractDefinition} may cause some implementations

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/QuerySpec.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/QuerySpec.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.spi.query;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -35,8 +36,32 @@ public class QuerySpec {
         return new QuerySpec();
     }
 
+    /**
+     * Generates a {@link QuerySpec} with limit = {@link Integer#MAX_VALUE} and offset = 0
+     */
+    public static QuerySpec max() {
+        return QuerySpec.Builder.newInstance().limit(Integer.MAX_VALUE).build();
+    }
+
     public String getSortField() {
         return sortField;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(offset, limit, filterExpression, sortOrder, sortField);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        QuerySpec querySpec = (QuerySpec) o;
+        return offset == querySpec.offset && limit == querySpec.limit && Objects.equals(filterExpression, querySpec.filterExpression) && sortOrder == querySpec.sortOrder && Objects.equals(sortField, querySpec.sortField);
     }
 
     @Override


### PR DESCRIPTION
## What this PR changes/adds

Does not use a `QuerySpec` when executing `SqlContractDefinitionStore#findAll`, instead execute a plain `SELECT * FROM...`.

## Why it does that

all = no limits!


## Linked Issue(s)

Closes #1515 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
