### PR TITLE
fix(sql): fixed JSON deserialization issue in transfer-process-store-sql extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Fix race condition in `ContractNegotiationIntegrationTest` (#1505)
 * Fix for change in Cosmos DB behavior on missing sort fields (#1514)
 * Effectively removed default LIMIT in SQL Contract Def Store (#1515)
+* Fix for JSON Deserialization of `ResourceDefinition` and `ProvisionedResource` (#1572)
 
 ## [milestone-4] - 2022-06-07
 

--- a/extensions/sql/transfer-process-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/postgres/PostgresTransferProcessStoreTest.java
+++ b/extensions/sql/transfer-process-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/postgres/PostgresTransferProcessStoreTest.java
@@ -632,7 +632,6 @@ class PostgresTransferProcessStoreTest {
     @JsonDeserialize(builder = TestResourceDef.Builder.class)
     static class TestResourceDef extends ResourceDefinition {
 
-        @JsonPOJOBuilder(withPrefix = "")
         public static class Builder extends ResourceDefinition.Builder<TestResourceDef, Builder> {
             private Builder() {
                 super(new TestResourceDef());
@@ -649,7 +648,6 @@ class PostgresTransferProcessStoreTest {
     @JsonTypeName("dataspaceconnector:testprovisionedresource")
     static class TestProvisionedResource extends ProvisionedResource {
 
-        @JsonPOJOBuilder(withPrefix = "")
         public static class Builder extends ProvisionedResource.Builder<TestProvisionedResource, Builder> {
             private Builder() {
                 super(new TestProvisionedResource());

--- a/extensions/sql/transfer-process-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/postgres/PostgresTransferProcessStoreTest.java
+++ b/extensions/sql/transfer-process-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/postgres/PostgresTransferProcessStoreTest.java
@@ -17,7 +17,6 @@ package org.eclipse.dataspaceconnector.sql.transferprocess.store.postgres;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.dataspaceconnector.common.util.junit.annotations.PostgresqlDbIntegrationTest;
 import org.eclipse.dataspaceconnector.common.util.postgres.PostgresqlLocalInstance;
 import org.eclipse.dataspaceconnector.policy.model.PolicyRegistrationTypes;

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionedResource.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ProvisionedResource.java
@@ -55,7 +55,7 @@ public abstract class ProvisionedResource implements Polymorphic {
         return hasToken;
     }
 
-    @JsonPOJOBuilder
+    @JsonPOJOBuilder(withPrefix = "")
     public static class Builder<PR extends ProvisionedResource, B extends Builder<PR, B>> {
         protected PR provisionedResource;
 

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ResourceDefinition.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ResourceDefinition.java
@@ -42,7 +42,7 @@ public abstract class ResourceDefinition implements Polymorphic {
         this.transferProcessId = transferProcessId;
     }
 
-    @JsonPOJOBuilder
+    @JsonPOJOBuilder(withPrefix = "")
     public static class Builder<RD extends ResourceDefinition, B extends Builder<RD, B>> {
         protected final RD resourceDefinition;
 


### PR DESCRIPTION
## What this PR changes/adds

We discovered an issue during the query of the transfer-process-store-sql, which prevented the extension to successfully query transfer-processes. This PR fixes that issue.

## Why it does that

The `@JsonPOJOBuilder` annotation requires by default builder methods in the style `withId`. This behaviour can be overridden with `@JsonPOJOBuilder(withPrefix = "")`.

## Further notes

## Linked Issue(s)

## Checklist

- [x] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
