### PR TITLE
Decentralized identity: fix private key class

### DIFF
--- a/extensions/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityServiceExtension.java
+++ b/extensions/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityServiceExtension.java
@@ -15,8 +15,8 @@
 
 package org.eclipse.dataspaceconnector.identity;
 
-import org.eclipse.dataspaceconnector.iam.did.crypto.key.EcPrivateKeyWrapper;
 import org.eclipse.dataspaceconnector.iam.did.spi.credentials.CredentialsVerifier;
+import org.eclipse.dataspaceconnector.iam.did.spi.key.PrivateKeyWrapper;
 import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidResolverRegistry;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
@@ -58,7 +58,7 @@ public class DecentralizedIdentityServiceExtension implements ServiceExtension {
 
         // we'll use the connector name to restore the Private Key
         var connectorName = context.getConnectorId();
-        var privateKey = privateKeyResolver.resolvePrivateKey(connectorName, EcPrivateKeyWrapper.class); //to get the private key
+        var privateKey = privateKeyResolver.resolvePrivateKey(connectorName, PrivateKeyWrapper.class); //to get the private key
         Objects.requireNonNull(privateKey, "Couldn't resolve private key for " + connectorName);
 
         return new DecentralizedIdentityService(resolverRegistry, credentialsVerifier, context.getMonitor(), privateKey, didUrl, context.getClock());

--- a/extensions/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityServiceExtension.java
+++ b/extensions/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityServiceExtension.java
@@ -58,7 +58,7 @@ public class DecentralizedIdentityServiceExtension implements ServiceExtension {
 
         // we'll use the connector name to restore the Private Key
         var connectorName = context.getConnectorId();
-        var privateKey = privateKeyResolver.resolvePrivateKey(connectorName, PrivateKeyWrapper.class); //to get the private key
+        var privateKey = privateKeyResolver.resolvePrivateKey(connectorName, PrivateKeyWrapper.class);
         Objects.requireNonNull(privateKey, "Couldn't resolve private key for " + connectorName);
 
         return new DecentralizedIdentityService(resolverRegistry, credentialsVerifier, context.getMonitor(), privateKey, didUrl, context.getClock());


### PR DESCRIPTION
## What this PR changes/adds

Fix to use the correct class, as supported to be supplied by `IdentityDidCoreExtension`.

## Why it does that

Runtime does not work when integrated in MVD, an exception is thrown that a resolver is missing for the given class. Use of the superclass is also the semantically correct code.

## Further notes

## Linked Issue(s)

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
