### PR TITLE
feat(ids): add paging to IDS description requests

### DIFF
--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractDefinitionServiceImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractDefinitionServiceImpl.java
@@ -21,6 +21,7 @@ import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgent;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractDefinitionService;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
+import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.policy.PolicyEngine;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyDefinitionStore;
@@ -55,9 +56,10 @@ public class ContractDefinitionServiceImpl implements ContractDefinitionService 
 
     @NotNull
     @Override
-    public Stream<ContractDefinition> definitionsFor(ParticipantAgent agent) {
-        //todo: once IDS supports pagination, replace this with the actual paging parameters
-        return definitionStore.findAll(QuerySpec.max())
+    public Stream<ContractDefinition> definitionsFor(ParticipantAgent agent, Range range) {
+        return definitionStore.findAll(QuerySpec.Builder.newInstance()
+                        .range(range)
+                        .build())
                 .filter(definition -> evaluatePolicies(definition, agent));
     }
 

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImpl.java
@@ -24,6 +24,7 @@ import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractDefinitionService;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferQuery;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
+import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyDefinitionStore;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
@@ -52,10 +53,10 @@ public class ContractOfferServiceImpl implements ContractOfferService {
 
     @Override
     @NotNull
-    public Stream<ContractOffer> queryContractOffers(ContractOfferQuery query) {
+    public Stream<ContractOffer> queryContractOffers(ContractOfferQuery query, Range range) {
         var agent = agentService.createFor(query.getClaimToken());
 
-        return definitionService.definitionsFor(agent)
+        return definitionService.definitionsFor(agent, range)
                 .flatMap(definition -> {
                     var assets = assetIndex.queryAssets(definition.getSelectorExpression());
                     return Optional.of(definition.getContractPolicyId())

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractDefinitionServiceImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractDefinitionServiceImplTest.java
@@ -19,6 +19,7 @@ import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgent;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
+import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.policy.PolicyEngine;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyDefinitionStore;
@@ -45,6 +46,7 @@ import static org.mockito.Mockito.when;
 
 class ContractDefinitionServiceImplTest {
 
+    private static final Range DEFAULT_RANGE = new Range(0, 10);
     private final PolicyEngine policyEngine = mock(PolicyEngine.class);
     private final PolicyDefinitionStore policyStore = mock(PolicyDefinitionStore.class);
     private final ContractDefinitionStore definitionStore = mock(ContractDefinitionStore.class);
@@ -62,13 +64,13 @@ class ContractDefinitionServiceImplTest {
         var def = PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build();
         when(policyStore.findById(any())).thenReturn(def);
         when(policyEngine.evaluate(NEGOTIATION_SCOPE, def.getPolicy(), agent)).thenReturn(Result.success(def.getPolicy()));
-        when(definitionStore.findAll(eq(QuerySpec.max()))).thenReturn(Stream.of(ContractDefinition.Builder.newInstance().id("1").accessPolicyId("access").contractPolicyId("contract").selectorExpression(SELECT_ALL).build()));
+        when(definitionStore.findAll(any())).thenReturn(Stream.of(ContractDefinition.Builder.newInstance().id("1").accessPolicyId("access").contractPolicyId("contract").selectorExpression(SELECT_ALL).build()));
 
-        var definitions = definitionService.definitionsFor(agent);
+        var definitions = definitionService.definitionsFor(agent, DEFAULT_RANGE);
 
         assertThat(definitions).hasSize(1);
         verify(policyEngine, atLeastOnce()).evaluate(NEGOTIATION_SCOPE, def.getPolicy(), agent);
-        verify(definitionStore).findAll(eq(QuerySpec.max()));
+        verify(definitionStore).findAll(any());
     }
 
     @Test
@@ -78,13 +80,13 @@ class ContractDefinitionServiceImplTest {
         when(policyStore.findById(any())).thenReturn(definition);
         var contractDefinition = ContractDefinition.Builder.newInstance().id("1").accessPolicyId("access").contractPolicyId("contract").selectorExpression(SELECT_ALL).build();
         when(policyEngine.evaluate(any(), any(), any())).thenReturn(Result.failure("invalid"));
-        when(definitionStore.findAll(eq(QuerySpec.max()))).thenReturn(Stream.of(contractDefinition));
+        when(definitionStore.findAll(any())).thenReturn(Stream.of(contractDefinition));
 
-        var result = definitionService.definitionsFor(agent);
+        var result = definitionService.definitionsFor(agent, DEFAULT_RANGE);
 
         assertThat(result).isEmpty();
         verify(policyEngine, atLeastOnce()).evaluate(NEGOTIATION_SCOPE, definition.getPolicy(), agent);
-        verify(definitionStore).findAll(eq(QuerySpec.max()));
+        verify(definitionStore).findAll(any());
     }
 
     @Test
@@ -97,13 +99,13 @@ class ContractDefinitionServiceImplTest {
         when(policyEngine.evaluate(eq(NEGOTIATION_SCOPE), any(), any()))
                 .thenReturn(Result.success(definition.getPolicy()))
                 .thenReturn(Result.failure("invalid"));
-        when(definitionStore.findAll(eq(QuerySpec.max()))).thenReturn(Stream.of(contractDefinition));
+        when(definitionStore.findAll(any())).thenReturn(Stream.of(contractDefinition));
 
-        var result = definitionService.definitionsFor(agent);
+        var result = definitionService.definitionsFor(agent, DEFAULT_RANGE);
 
         assertThat(result).isEmpty();
         verify(policyEngine, atLeastOnce()).evaluate(NEGOTIATION_SCOPE, definition.getPolicy(), agent);
-        verify(definitionStore).findAll(QuerySpec.max());
+        verify(definitionStore).findAll(any());
     }
 
     @Test
@@ -114,7 +116,7 @@ class ContractDefinitionServiceImplTest {
         when(policyEngine.evaluate(NEGOTIATION_SCOPE, policy, agent)).thenReturn(Result.success(policy));
         when(definitionStore.findAll(QuerySpec.max())).thenReturn(Stream.of(ContractDefinition.Builder.newInstance().id("1").accessPolicyId("access").contractPolicyId("contract").selectorExpression(SELECT_ALL).build()));
 
-        var definitions = definitionService.definitionsFor(agent);
+        var definitions = definitionService.definitionsFor(agent, DEFAULT_RANGE);
 
         assertThat(definitions).hasSize(0);
         verify(policyEngine, never()).evaluate(any(), any(), any());

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartCatalogDescriptionRequestSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartCatalogDescriptionRequestSender.java
@@ -28,6 +28,7 @@ import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTransformerRegistry;
 import org.eclipse.dataspaceconnector.ids.transform.IdsProtocol;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
+import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.CatalogRequest;
@@ -44,8 +45,8 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * IdsMultipartSender implementation for connector catalog requests. Sends IDS DescriptionRequestMessages and
- * expects an IDS DescriptionResponseMessage as the response.
+ * IdsMultipartSender implementation for connector catalog requests. Sends IDS DescriptionRequestMessages and expects an
+ * IDS DescriptionResponseMessage as the response.
  */
 public class MultipartCatalogDescriptionRequestSender extends IdsMultipartSender<CatalogRequest, Catalog> {
 
@@ -70,7 +71,7 @@ public class MultipartCatalogDescriptionRequestSender extends IdsMultipartSender
 
     @Override
     protected Message buildMessageHeader(CatalogRequest request, DynamicAttributeToken token) {
-        return new DescriptionRequestMessageBuilder()
+        var message = new DescriptionRequestMessageBuilder()
                 ._modelVersion_(IdsProtocol.INFORMATION_MODEL_VERSION)
                 //._issued_(gregorianNow()) TODO once https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/236 is done
                 ._securityToken_(token)
@@ -78,6 +79,10 @@ public class MultipartCatalogDescriptionRequestSender extends IdsMultipartSender
                 ._senderAgent_(getConnectorId())
                 ._recipientConnector_(Collections.singletonList(URI.create(request.getConnectorId())))
                 .build();
+        //TODO: IDS REFACTORING: incorporate this into the protocol itself
+        message.setProperty(Range.FROM, request.getRange().getFrom());
+        message.setProperty(Range.TO, request.getRange().getTo());
+        return message;
     }
 
     @Override

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/IdsApiMultipartDispatcherV1IntegrationTestServiceExtension.java
@@ -35,6 +35,7 @@ import org.eclipse.dataspaceconnector.spi.contract.validation.ContractValidation
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
 import org.eclipse.dataspaceconnector.spi.message.MessageContext;
+import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcher;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyArchive;
@@ -157,7 +158,7 @@ class IdsApiMultipartDispatcherV1IntegrationTestServiceExtension implements Serv
 
         @Override
         @NotNull
-        public Stream<ContractOffer> queryContractOffers(ContractOfferQuery query) {
+        public Stream<ContractOffer> queryContractOffers(ContractOfferQuery query, Range range) {
             return assets.stream().map(asset ->
                     ContractOffer.Builder.newInstance()
                             .policy(createEverythingAllowedPolicy())

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/ArtifactDescriptionRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/ArtifactDescriptionRequestHandler.java
@@ -20,13 +20,14 @@ import org.eclipse.dataspaceconnector.ids.spi.IdsType;
 import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTransformerRegistry;
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
+import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-public class ArtifactDescriptionRequestHandler extends AbstractDescriptionRequestHandler<Asset, Artifact> {
+public class ArtifactDescriptionRequestHandler extends PageableDescriptionRequestHandler<Asset, Artifact> {
     private final AssetIndex assetIndex;
 
     public ArtifactDescriptionRequestHandler(
@@ -45,7 +46,7 @@ public class ArtifactDescriptionRequestHandler extends AbstractDescriptionReques
     }
 
     @Override
-    protected Asset retrieveObject(@NotNull IdsId idsId, @NotNull ClaimToken claimToken) {
+    protected Asset retrieveObject(@NotNull IdsId idsId, @NotNull ClaimToken claimToken, Range range) {
         return assetIndex.findById(idsId.getValue());
     }
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/DataCatalogDescriptionRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/DataCatalogDescriptionRequestHandler.java
@@ -21,11 +21,12 @@ import org.eclipse.dataspaceconnector.ids.spi.IdsType;
 import org.eclipse.dataspaceconnector.ids.spi.service.CatalogService;
 import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTransformerRegistry;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
+import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.jetbrains.annotations.NotNull;
 
-public class DataCatalogDescriptionRequestHandler extends AbstractDescriptionRequestHandler<Catalog, ResourceCatalog> {
+public class DataCatalogDescriptionRequestHandler extends PageableDescriptionRequestHandler<Catalog, ResourceCatalog> {
     private final CatalogService dataCatalogService;
 
     public DataCatalogDescriptionRequestHandler(
@@ -44,7 +45,7 @@ public class DataCatalogDescriptionRequestHandler extends AbstractDescriptionReq
     }
 
     @Override
-    protected Catalog retrieveObject(@NotNull IdsId idsId, @NotNull ClaimToken claimToken) {
-        return dataCatalogService.getDataCatalog(claimToken);
+    protected Catalog retrieveObject(@NotNull IdsId idsId, @NotNull ClaimToken claimToken, Range range) {
+        return dataCatalogService.getDataCatalog(claimToken, range);
     }
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/MultipartRequestUtil.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/MultipartRequestUtil.java
@@ -21,8 +21,16 @@ import static java.util.Optional.ofNullable;
 
 public class MultipartRequestUtil {
 
-    public static int getInt(@NotNull DescriptionRequestMessage descriptionRequestMessage, String propertyName, int defaultValue) {
-        return ofNullable(descriptionRequestMessage.getProperties())
+    /**
+     * Extracts an arbitrary property from a {@link DescriptionRequestMessage}
+     *
+     * @param message The message
+     * @param propertyName the name of the property
+     * @param defaultValue If the message does not contain that property the default value is returned.
+     * @return either the property parsed into an Integer, or the default value
+     */
+    public static int getInt(@NotNull DescriptionRequestMessage message, String propertyName, int defaultValue) {
+        return ofNullable(message.getProperties())
                 .map(map -> map.get(propertyName))
                 .map(v -> Integer.parseInt(v.toString()))
                 .orElse(defaultValue);

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/MultipartRequestUtil.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/MultipartRequestUtil.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.ids.api.multipart.handler.description;
+
+import de.fraunhofer.iais.eis.DescriptionRequestMessage;
+import org.jetbrains.annotations.NotNull;
+
+import static java.util.Optional.ofNullable;
+
+public class MultipartRequestUtil {
+
+    public static int getInt(@NotNull DescriptionRequestMessage descriptionRequestMessage, String propertyName, int defaultValue) {
+        return ofNullable(descriptionRequestMessage.getProperties())
+                .map(map -> map.get(propertyName))
+                .map(v -> Integer.parseInt(v.toString()))
+                .orElse(defaultValue);
+    }
+}

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/RepresentationDescriptionRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/RepresentationDescriptionRequestHandler.java
@@ -20,13 +20,14 @@ import org.eclipse.dataspaceconnector.ids.spi.IdsType;
 import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTransformerRegistry;
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
+import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-public class RepresentationDescriptionRequestHandler extends AbstractDescriptionRequestHandler<Asset, Representation> {
+public class RepresentationDescriptionRequestHandler extends PageableDescriptionRequestHandler<Asset, Representation> {
     private final AssetIndex assetIndex;
 
     public RepresentationDescriptionRequestHandler(
@@ -45,7 +46,7 @@ public class RepresentationDescriptionRequestHandler extends AbstractDescription
     }
 
     @Override
-    protected Asset retrieveObject(@NotNull IdsId idsId, @NotNull ClaimToken claimToken) {
+    protected Asset retrieveObject(@NotNull IdsId idsId, @NotNull ClaimToken claimToken, Range range) {
         return assetIndex.findById(idsId.getValue());
     }
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/ResourceDescriptionRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/ResourceDescriptionRequestHandler.java
@@ -23,6 +23,7 @@ import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferQuery;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
+import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
@@ -34,7 +35,7 @@ import java.util.Objects;
 
 import static java.util.stream.Collectors.toList;
 
-public class ResourceDescriptionRequestHandler extends AbstractDescriptionRequestHandler<OfferedAsset, Resource> {
+public class ResourceDescriptionRequestHandler extends PageableDescriptionRequestHandler<OfferedAsset, Resource> {
     private final AssetIndex assetIndex;
     private final ContractOfferService contractOfferService;
 
@@ -56,7 +57,7 @@ public class ResourceDescriptionRequestHandler extends AbstractDescriptionReques
     }
 
     @Override
-    protected OfferedAsset retrieveObject(@NotNull IdsId idsId, @NotNull ClaimToken claimToken) {
+    protected OfferedAsset retrieveObject(@NotNull IdsId idsId, @NotNull ClaimToken claimToken, Range range) {
         String assetId = idsId.getValue();
         Asset asset = assetIndex.findById(assetId);
         if (asset == null) {
@@ -67,8 +68,7 @@ public class ResourceDescriptionRequestHandler extends AbstractDescriptionReques
                 .claimToken(claimToken)
                 .criterion(new Criterion(Asset.PROPERTY_ID, "=", assetId))
                 .build();
-
-        List<ContractOffer> targetingContractOffers = contractOfferService.queryContractOffers(contractOfferQuery).collect(toList());
+        List<ContractOffer> targetingContractOffers = contractOfferService.queryContractOffers(contractOfferQuery, range).collect(toList());
 
         return new OfferedAsset(asset, targetingContractOffers);
     }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsApiMultipartEndpointV1IntegrationTestServiceExtension.java
@@ -39,6 +39,7 @@ import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
 import org.eclipse.dataspaceconnector.spi.iam.TokenParameters;
 import org.eclipse.dataspaceconnector.spi.iam.TokenRepresentation;
 import org.eclipse.dataspaceconnector.spi.message.MessageContext;
+import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcher;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyArchive;
@@ -189,7 +190,7 @@ class IdsApiMultipartEndpointV1IntegrationTestServiceExtension implements Servic
 
         @Override
         @NotNull
-        public Stream<ContractOffer> queryContractOffers(ContractOfferQuery query) {
+        public Stream<ContractOffer> queryContractOffers(ContractOfferQuery query, Range range) {
             return assets.stream().map(asset ->
                     ContractOffer.Builder.newInstance()
                             .id("1")

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/ResourceDescriptionRequestHandlerTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/ResourceDescriptionRequestHandlerTest.java
@@ -39,6 +39,7 @@ import static org.eclipse.dataspaceconnector.ids.api.multipart.handler.descripti
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -74,7 +75,6 @@ public class ResourceDescriptionRequestHandlerTest {
     }
 
     @Test
-    @SuppressWarnings("ConstantConditions")
     public void testConstructorArgumentsNotNullable() {
         assertThrows(NullPointerException.class,
                 () -> new ResourceDescriptionRequestHandler(null, CONNECTOR_ID, assetIndex, contractOfferService, transformerRegistry));
@@ -94,7 +94,7 @@ public class ResourceDescriptionRequestHandlerTest {
         when(assetIndex.findById(anyString())).thenReturn(Asset.Builder.newInstance().build());
         var resourceResult = Result.success(resource);
         when(transformerRegistry.transform(isA(OfferedAsset.class), eq(Resource.class))).thenReturn(resourceResult);
-        when(contractOfferService.queryContractOffers(isA(ContractOfferQuery.class))).thenReturn(Stream.empty());
+        when(contractOfferService.queryContractOffers(isA(ContractOfferQuery.class), any())).thenReturn(Stream.empty());
 
         var result = resourceDescriptionRequestHandler.handle(descriptionRequestMessage, claimToken, null);
 
@@ -104,6 +104,6 @@ public class ResourceDescriptionRequestHandlerTest {
         verify(resource).getId();
         verify(assetIndex).findById(anyString());
         verify(transformerRegistry).transform(isA(OfferedAsset.class), eq(Resource.class));
-        verify(contractOfferService).queryContractOffers(isA(ContractOfferQuery.class));
+        verify(contractOfferService).queryContractOffers(isA(ContractOfferQuery.class), any());
     }
 }

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImpl.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImpl.java
@@ -19,6 +19,7 @@ import org.eclipse.dataspaceconnector.ids.spi.service.CatalogService;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferQuery;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
+import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.jetbrains.annotations.NotNull;
@@ -48,10 +49,10 @@ public class CatalogServiceImpl implements CatalogService {
      */
     @Override
     @NotNull
-    public Catalog getDataCatalog(ClaimToken claimToken) {
+    public Catalog getDataCatalog(ClaimToken claimToken, Range range) {
         var query = ContractOfferQuery.Builder.newInstance().claimToken(claimToken).build();
 
-        var offers = contractOfferService.queryContractOffers(query).collect(toList());
+        var offers = contractOfferService.queryContractOffers(query, range).collect(toList());
 
         return Catalog.Builder.newInstance().id(dataCatalogId).contractOffers(offers).build();
     }

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImpl.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImpl.java
@@ -19,6 +19,7 @@ import org.eclipse.dataspaceconnector.ids.spi.service.CatalogService;
 import org.eclipse.dataspaceconnector.ids.spi.service.ConnectorService;
 import org.eclipse.dataspaceconnector.ids.spi.types.Connector;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
+import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.jetbrains.annotations.NotNull;
@@ -44,10 +45,10 @@ public class ConnectorServiceImpl implements ConnectorService {
 
     @NotNull
     @Override
-    public Connector getConnector(@NotNull ClaimToken claimToken) {
+    public Connector getConnector(@NotNull ClaimToken claimToken, Range range) {
         Objects.requireNonNull(claimToken);
 
-        Catalog catalog = dataCatalogService.getDataCatalog(claimToken);
+        Catalog catalog = dataCatalogService.getDataCatalog(claimToken, range);
 
         return Connector.Builder
                 .newInstance()

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImplTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImplTest.java
@@ -18,6 +18,7 @@ import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferQuery;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
+import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,14 +56,14 @@ class CatalogServiceImplTest {
                         .policy(Policy.Builder.newInstance().build())
                         .id("1")
                         .build());
-        when(contractOfferService.queryContractOffers(any(ContractOfferQuery.class))).thenReturn(offers.stream());
+        when(contractOfferService.queryContractOffers(any(ContractOfferQuery.class), any())).thenReturn(offers.stream());
 
-        var result = dataCatalogService.getDataCatalog(claimToken);
+        var result = dataCatalogService.getDataCatalog(claimToken, new Range(0, 100));
 
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(CATALOG_ID);
         assertThat(result.getContractOffers()).hasSameElementsAs(offers);
-        verify(contractOfferService).queryContractOffers(any(ContractOfferQuery.class));
+        verify(contractOfferService).queryContractOffers(any(ContractOfferQuery.class), any());
     }
 
 }

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImplTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImplTest.java
@@ -18,6 +18,7 @@ package org.eclipse.dataspaceconnector.ids.core.service;
 import org.eclipse.dataspaceconnector.ids.spi.service.CatalogService;
 import org.eclipse.dataspaceconnector.ids.spi.types.SecurityProfile;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
+import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,7 +53,7 @@ class ConnectorServiceImplTest {
 
     @Test
     void getConnector() {
-        when(dataCatalogService.getDataCatalog(any())).thenReturn(mock(Catalog.class));
+        when(dataCatalogService.getDataCatalog(any(), any())).thenReturn(mock(Catalog.class));
         when(connectorServiceSettings.getId()).thenReturn(CONNECTOR_ID);
         when(connectorServiceSettings.getTitle()).thenReturn(CONNECTOR_TITLE);
         when(connectorServiceSettings.getDescription()).thenReturn(CONNECTOR_DESCRIPTION);
@@ -62,7 +63,7 @@ class ConnectorServiceImplTest {
         when(connectorServiceSettings.getCurator()).thenReturn(CONNECTOR_CURATOR);
         var claimToken = ClaimToken.Builder.newInstance().build();
 
-        var result = connectorService.getConnector(claimToken);
+        var result = connectorService.getConnector(claimToken, new Range(0, 100));
 
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(CONNECTOR_ID);
@@ -73,7 +74,7 @@ class ConnectorServiceImplTest {
         assertThat(result.getMaintainer()).isEqualTo(CONNECTOR_MAINTAINER);
         assertThat(result.getCurator()).isEqualTo(CONNECTOR_CURATOR);
         assertThat(result.getConnectorVersion()).isEqualTo(CONNECTOR_VERSION);
-        verify(dataCatalogService).getDataCatalog(any());
+        verify(dataCatalogService).getDataCatalog(any(), any());
         verify(connectorServiceSettings).getId();
         verify(connectorServiceSettings).getTitle();
         verify(connectorServiceSettings).getDescription();

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/CatalogService.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/CatalogService.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.ids.spi.service;
 
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
+import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.jetbrains.annotations.NotNull;
 
@@ -29,5 +30,5 @@ public interface CatalogService {
      * @return data catalog
      */
     @NotNull
-    Catalog getDataCatalog(ClaimToken claimToken);
+    Catalog getDataCatalog(ClaimToken claimToken, Range range);
 }

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/ConnectorService.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/ConnectorService.java
@@ -17,11 +17,12 @@ package org.eclipse.dataspaceconnector.ids.spi.service;
 
 import org.eclipse.dataspaceconnector.ids.spi.types.Connector;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
+import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * The IDS service is able to create IDS compliant descriptions of resources.
- * These descriptions may be used to create a self-description or answer a Description Request Message.
+ * The IDS service is able to create IDS compliant descriptions of resources. These descriptions may be used to create a
+ * self-description or answer a Description Request Message.
  */
 public interface ConnectorService {
 
@@ -31,5 +32,5 @@ public interface ConnectorService {
      * @return connector description
      */
     @NotNull
-    Connector getConnector(@NotNull ClaimToken claimToken);
+    Connector getConnector(@NotNull ClaimToken claimToken, Range range);
 }

--- a/extensions/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApi.java
+++ b/extensions/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApi.java
@@ -20,7 +20,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.ws.rs.container.AsyncResponse;
+import org.eclipse.dataspaceconnector.api.query.QuerySpecDto;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 
 @OpenAPIDefinition
@@ -30,6 +32,6 @@ public interface CatalogApi {
     @Operation(responses = {
             @ApiResponse(content = @Content(mediaType = "application/json", schema = @Schema(implementation = Catalog.class)), description = "Gets contract offers (=catalog) of a single connector")
     })
-    void getCatalog(String provider, AsyncResponse response);
+    void getCatalog(String provider, @Valid QuerySpecDto querySpec, AsyncResponse response);
 
 }

--- a/extensions/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiController.java
+++ b/extensions/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiController.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.dataspaceconnector.api.datamanagement.catalog;
 
+import jakarta.validation.Valid;
+import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -22,21 +24,43 @@ import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.dataspaceconnector.api.datamanagement.catalog.service.CatalogService;
+import org.eclipse.dataspaceconnector.api.query.QuerySpecDto;
+import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.jetbrains.annotations.NotNull;
 
 @Path("/catalog")
 @Produces({ MediaType.APPLICATION_JSON })
 public class CatalogApiController implements CatalogApi {
 
     private final CatalogService service;
+    private final DtoTransformerRegistry transformerRegistry;
+    private final Monitor monitor;
 
-    public CatalogApiController(CatalogService service) {
+    public CatalogApiController(CatalogService service, DtoTransformerRegistry transformerRegistry, Monitor monitor) {
         this.service = service;
+        this.transformerRegistry = transformerRegistry;
+        this.monitor = monitor;
     }
 
     @Override
     @GET
-    public void getCatalog(@QueryParam("providerUrl") String providerUrl, @Suspended AsyncResponse response) {
-        service.getByProviderUrl(providerUrl)
+    public void getCatalog(@QueryParam("providerUrl") String providerUrl, @Valid @BeanParam QuerySpecDto querySpecDto, @Suspended AsyncResponse response) {
+
+        @NotNull QuerySpec spec;
+        if (querySpecDto != null) {
+            var result = transformerRegistry.transform(querySpecDto, QuerySpec.class);
+            if (result.failed()) {
+                monitor.warning("Error transforming QuerySpec: " + String.join(", ", result.getFailureMessages()));
+                throw new IllegalArgumentException("Cannot transform QuerySpecDto object");
+            }
+            spec = result.getContent();
+        } else {
+            spec = QuerySpec.max();
+            monitor.debug("No paging parameters were supplied, using 0...Integer.MAX_VALUE");
+        }
+        service.getByProviderUrl(providerUrl, spec)
                 .whenComplete((content, throwable) -> {
                     if (throwable == null) {
                         response.resume(content);

--- a/extensions/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiExtension.java
+++ b/extensions/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiExtension.java
@@ -16,6 +16,7 @@ package org.eclipse.dataspaceconnector.api.datamanagement.catalog;
 
 import org.eclipse.dataspaceconnector.api.datamanagement.catalog.service.CatalogServiceImpl;
 import org.eclipse.dataspaceconnector.api.datamanagement.configuration.DataManagementApiConfiguration;
+import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
 import org.eclipse.dataspaceconnector.spi.WebService;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
@@ -24,13 +25,16 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
 public class CatalogApiExtension implements ServiceExtension {
     @Inject
-    WebService webService;
+    private WebService webService;
 
     @Inject
-    DataManagementApiConfiguration config;
+    private DataManagementApiConfiguration config;
 
     @Inject
-    RemoteMessageDispatcherRegistry dispatcher;
+    private RemoteMessageDispatcherRegistry dispatcher;
+
+    @Inject
+    private DtoTransformerRegistry transformerRegistry;
 
     @Override
     public String name() {
@@ -40,6 +44,6 @@ public class CatalogApiExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var service = new CatalogServiceImpl(dispatcher);
-        webService.registerResource(config.getContextAlias(), new CatalogApiController(service));
+        webService.registerResource(config.getContextAlias(), new CatalogApiController(service, transformerRegistry, context.getMonitor()));
     }
 }

--- a/extensions/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/service/CatalogService.java
+++ b/extensions/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/service/CatalogService.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.api.datamanagement.catalog.service;
 
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 
 import java.util.concurrent.CompletableFuture;
@@ -25,5 +26,5 @@ public interface CatalogService {
      * @param providerUrl the url of the provider
      * @return the provider's catalog
      */
-    CompletableFuture<Catalog> getByProviderUrl(String providerUrl);
+    CompletableFuture<Catalog> getByProviderUrl(String providerUrl, QuerySpec spec);
 }

--- a/extensions/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/service/CatalogServiceImpl.java
+++ b/extensions/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/service/CatalogServiceImpl.java
@@ -15,12 +15,14 @@
 package org.eclipse.dataspaceconnector.api.datamanagement.catalog.service;
 
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.CatalogRequest;
 
 import java.util.concurrent.CompletableFuture;
 
 public class CatalogServiceImpl implements CatalogService {
+
     private final RemoteMessageDispatcherRegistry dispatcher;
 
     public CatalogServiceImpl(RemoteMessageDispatcherRegistry dispatcher) {
@@ -28,11 +30,12 @@ public class CatalogServiceImpl implements CatalogService {
     }
 
     @Override
-    public CompletableFuture<Catalog> getByProviderUrl(String providerUrl) {
+    public CompletableFuture<Catalog> getByProviderUrl(String providerUrl, QuerySpec spec) {
         var request = CatalogRequest.Builder.newInstance()
                 .protocol("ids-multipart")
                 .connectorId(providerUrl)
                 .connectorAddress(providerUrl)
+                .range(spec.getRange())
                 .build();
 
         return dispatcher.send(Catalog.class, request, () -> null);

--- a/extensions/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerIntegrationTest.java
@@ -63,6 +63,7 @@ public class CatalogApiControllerIntegrationTest {
                 "web.http.data.path", "/api/v1/data",
                 "edc.api.auth.key", authKey
         ));
+
     }
 
     @Test
@@ -73,7 +74,9 @@ public class CatalogApiControllerIntegrationTest {
                 .assetId(UUID.randomUUID().toString())
                 .build();
         var catalog = Catalog.Builder.newInstance().id("id").contractOffers(List.of(contractOffer)).build();
-        when(dispatcher.send(any(), any(), any())).thenReturn(completedFuture(catalog));
+        var emptyCatalog = Catalog.Builder.newInstance().id("id2").contractOffers(List.of()).build();
+        when(dispatcher.send(any(), any(), any())).thenReturn(completedFuture(catalog))
+                .thenReturn(completedFuture(emptyCatalog));
 
         baseRequest()
                 .queryParam("providerUrl", FAKER.internet().url())

--- a/extensions/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerTest.java
+++ b/extensions/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerTest.java
@@ -17,10 +17,16 @@ package org.eclipse.dataspaceconnector.api.datamanagement.catalog;
 import com.github.javafaker.Faker;
 import jakarta.ws.rs.container.AsyncResponse;
 import org.eclipse.dataspaceconnector.api.datamanagement.catalog.service.CatalogService;
+import org.eclipse.dataspaceconnector.api.query.QuerySpecDto;
+import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -29,6 +35,8 @@ import java.util.UUID;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.CompletableFuture.failedFuture;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -38,10 +46,19 @@ class CatalogApiControllerTest {
 
     private static final Faker FAKER = Faker.instance();
     private final CatalogService service = mock(CatalogService.class);
+    private final Monitor monitor = mock(Monitor.class);
+    private DtoTransformerRegistry transformerRegistry;
+
+    @BeforeEach
+    void setup() {
+        transformerRegistry = mock(DtoTransformerRegistry.class);
+        when(transformerRegistry.transform(any(), any())).thenReturn(Result.success(new QuerySpec()));
+    }
+
 
     @Test
     void shouldGetTheCatalog() {
-        var controller = new CatalogApiController(service);
+        var controller = new CatalogApiController(service, transformerRegistry, monitor);
         var response = mock(AsyncResponse.class);
         var offer = ContractOffer.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
@@ -50,21 +67,21 @@ class CatalogApiControllerTest {
                 .build();
         var catalog = Catalog.Builder.newInstance().id("any").contractOffers(List.of(offer)).build();
         var url = FAKER.internet().url();
-        when(service.getByProviderUrl(url)).thenReturn(completedFuture(catalog));
+        when(service.getByProviderUrl(eq(url), any())).thenReturn(completedFuture(catalog));
 
-        controller.getCatalog(url, response);
+        controller.getCatalog(url, new QuerySpecDto(), response);
 
         verify(response).resume(Mockito.<Catalog>argThat(c -> c.getContractOffers().equals(List.of(offer))));
     }
 
     @Test
     void shouldResumeWithExceptionIfGetCatalogFails() {
-        var controller = new CatalogApiController(service);
+        var controller = new CatalogApiController(service, transformerRegistry, monitor);
         var response = mock(AsyncResponse.class);
         var url = FAKER.internet().url();
-        when(service.getByProviderUrl(url)).thenReturn(failedFuture(new EdcException("error")));
+        when(service.getByProviderUrl(eq(url), any())).thenReturn(failedFuture(new EdcException("error")));
 
-        controller.getCatalog(url, response);
+        controller.getCatalog(url, new QuerySpecDto(), response);
 
         verify(response).resume(isA(EdcException.class));
     }

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/BatchedRequestFetcher.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/BatchedRequestFetcher.java
@@ -24,7 +24,11 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
-
+/**
+ * Helper class that runs through a loop and sends {@link CatalogRequest}s until no more {@link ContractOffer}s are
+ * received. This is useful to avoid overloading the provider connector by chunking the resulting response payload
+ * size.
+ */
 public class BatchedRequestFetcher {
     private final RemoteMessageDispatcherRegistry dispatcherRegistry;
 

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/BatchedRequestFetcher.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/BatchedRequestFetcher.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.catalog.cache.query;
+
+import org.eclipse.dataspaceconnector.spi.message.Range;
+import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
+import org.eclipse.dataspaceconnector.spi.types.domain.catalog.CatalogRequest;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class BatchedRequestFetcher {
+    private final RemoteMessageDispatcherRegistry dispatcherRegistry;
+
+    public BatchedRequestFetcher(RemoteMessageDispatcherRegistry dispatcherRegistry) {
+        this.dispatcherRegistry = dispatcherRegistry;
+    }
+
+    /**
+     * Gets all contract offers. Requests are split in digestible chunks to match {@code batchSize} until no more offers
+     * can be obtained.
+     *
+     * @param catalogRequest The catalog request. This will be copied for every request.
+     * @param from The (zero-based) index of the first item
+     * @param batchSize The size of one batch
+     * @return A list of {@link ContractOffer} objects
+     */
+    @NotNull
+    public List<ContractOffer> fetch(CatalogRequest catalogRequest, int from, int batchSize) {
+        int fetched;
+        List<ContractOffer> allOffers = new ArrayList<>();
+        var to = from + batchSize;
+
+        do {
+
+            Catalog catalog = getCatalog(catalogRequest, from, to);
+            fetched = catalog.getContractOffers().size();
+            allOffers.addAll(catalog.getContractOffers());
+            to += batchSize;
+            from += batchSize;
+        } while (fetched >= batchSize);
+
+        return allOffers;
+    }
+
+    private Catalog getCatalog(CatalogRequest catalogRequest, int from, int to) {
+        var future = dispatcherRegistry.send(Catalog.class, catalogRequest.toBuilder().range(new Range(from, to)).build(), () -> null);
+        return future.join();
+    }
+
+}

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/IdsMultipartNodeQueryAdapter.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/IdsMultipartNodeQueryAdapter.java
@@ -20,9 +20,7 @@ import org.eclipse.dataspaceconnector.catalog.spi.model.UpdateResponse;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.CatalogRequest;
-import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 
-import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -44,9 +42,9 @@ public class IdsMultipartNodeQueryAdapter implements NodeQueryAdapter {
                 .connectorAddress(getNodeUrl(updateRequest))
                 .connectorId(connectorId)
                 .build();
-        List<ContractOffer> allOffers = requestFetcher.fetch(catalogRequest, 0, 100);
+        var allOffers = requestFetcher.fetch(catalogRequest, 0, 100);
 
-        return CompletableFuture.completedFuture(new UpdateResponse(getNodeUrl(updateRequest), Catalog.Builder.newInstance().id(UUID.randomUUID().toString()).contractOffers(allOffers).build()));
+        return allOffers.thenApply(list -> new UpdateResponse(getNodeUrl(updateRequest), Catalog.Builder.newInstance().id(UUID.randomUUID().toString()).contractOffers(list).build()));
     }
 
 

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/IdsMultipartNodeQueryAdapter.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/IdsMultipartNodeQueryAdapter.java
@@ -20,33 +20,35 @@ import org.eclipse.dataspaceconnector.catalog.spi.model.UpdateResponse;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.CatalogRequest;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 
+import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-
-import static org.eclipse.dataspaceconnector.common.types.Cast.cast;
 
 public class IdsMultipartNodeQueryAdapter implements NodeQueryAdapter {
     public static final String IDS_MULTIPART_PROTOCOL = "ids-multipart";
     private final String connectorId;
-    private final RemoteMessageDispatcherRegistry dispatcherRegistry;
+    private final BatchedRequestFetcher requestFetcher;
 
     public IdsMultipartNodeQueryAdapter(String connectorId, RemoteMessageDispatcherRegistry dispatcherRegistry) {
         this.connectorId = connectorId;
-        this.dispatcherRegistry = dispatcherRegistry;
+        requestFetcher = new BatchedRequestFetcher(dispatcherRegistry);
     }
 
     @Override
     public CompletableFuture<UpdateResponse> sendRequest(UpdateRequest updateRequest) {
-        CatalogRequest catalogRequest = CatalogRequest.Builder.newInstance()
+
+        var catalogRequest = CatalogRequest.Builder.newInstance()
                 .protocol(IDS_MULTIPART_PROTOCOL)
                 .connectorAddress(getNodeUrl(updateRequest))
                 .connectorId(connectorId)
                 .build();
+        List<ContractOffer> allOffers = requestFetcher.fetch(catalogRequest, 0, 100);
 
-        CompletableFuture<Catalog> future = cast(dispatcherRegistry.send(Object.class, catalogRequest, () -> null));
-
-        return future.thenApply(catalog -> new UpdateResponse(getNodeUrl(updateRequest), catalog));
+        return CompletableFuture.completedFuture(new UpdateResponse(getNodeUrl(updateRequest), Catalog.Builder.newInstance().id(UUID.randomUUID().toString()).contractOffers(allOffers).build()));
     }
+
 
     // adds /api/ids/data if not already there
     private String getNodeUrl(UpdateRequest updateRequest) {

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FccTestExtension.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FccTestExtension.java
@@ -29,6 +29,7 @@ import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
 import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
 import org.eclipse.dataspaceconnector.spi.message.MessageContext;
+import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcher;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
@@ -101,7 +102,7 @@ public class FccTestExtension implements ServiceExtension {
 
         @Override
         @NotNull
-        public Stream<ContractOffer> queryContractOffers(ContractOfferQuery query) {
+        public Stream<ContractOffer> queryContractOffers(ContractOfferQuery query, Range range) {
             return assets.stream().map(asset ->
                     ContractOffer.Builder.newInstance()
                             .id("1")

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/query/BatchedRequestFetcherTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/query/BatchedRequestFetcherTest.java
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.catalog.query;
+
+import org.eclipse.dataspaceconnector.catalog.cache.query.BatchedRequestFetcher;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.message.Range;
+import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
+import org.eclipse.dataspaceconnector.spi.types.domain.catalog.CatalogRequest;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BatchedRequestFetcherTest {
+
+    private BatchedRequestFetcher fetcher;
+    private RemoteMessageDispatcherRegistry dispatcherMock;
+
+    @BeforeEach
+    void setup() {
+        dispatcherMock = mock(RemoteMessageDispatcherRegistry.class);
+        fetcher = new BatchedRequestFetcher(dispatcherMock);
+    }
+
+    @Test
+    void fetchAll() {
+        when(dispatcherMock.send(eq(Catalog.class), any(CatalogRequest.class), any()))
+                .thenReturn(completedFuture(createCatalog(5)))
+                .thenReturn(completedFuture(createCatalog(5)))
+                .thenReturn(completedFuture(createCatalog(3)))
+                .thenReturn(completedFuture(emptyCatalog()));
+
+        var request = createRequest();
+
+        var offers = fetcher.fetch(request, 0, 5);
+        assertThat(offers).hasSize(13)
+                .allSatisfy(offer -> assertThat(offer.getId()).matches("(id)\\d|1[0-3]")); //regex: 0 ... 13
+
+        var captor = forClass(CatalogRequest.class);
+        verify(dispatcherMock, times(3)).send(eq(Catalog.class), captor.capture(), any());
+
+        // verify the sequence of requests
+        assertThat(captor.getAllValues())
+                .extracting(CatalogRequest::getRange)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(new Range(0, 5), new Range(5, 10), new Range(10, 15));
+
+    }
+
+    private CatalogRequest createRequest() {
+        return CatalogRequest.Builder.newInstance()
+                .connectorId("test-connector")
+                .connectorAddress("test-address")
+                .protocol("ids-multipart")
+                .build();
+    }
+
+    private Catalog emptyCatalog() {
+        return Catalog.Builder.newInstance().id("id").contractOffers(Collections.emptyList()).build();
+    }
+
+    private Catalog createCatalog(int howManyOffers) {
+        var contractOffers = IntStream.range(0, howManyOffers)
+                .mapToObj(i -> ContractOffer.Builder.newInstance()
+                        .id("id" + i)
+                        .policy(Policy.Builder.newInstance().build())
+                        .assetId("asset" + i)
+                        .build())
+                .collect(Collectors.toList());
+
+        return Catalog.Builder.newInstance().id("catalog").contractOffers(contractOffers).build();
+    }
+}

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/query/BatchedRequestFetcherTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/query/BatchedRequestFetcherTest.java
@@ -60,17 +60,18 @@ class BatchedRequestFetcherTest {
         var request = createRequest();
 
         var offers = fetcher.fetch(request, 0, 5);
-        assertThat(offers).hasSize(13)
-                .allSatisfy(offer -> assertThat(offer.getId()).matches("(id)\\d|1[0-3]")); //regex: 0 ... 13
+        assertThat(offers).isCompletedWithValueMatching(list -> list.size() == 13 &&
+                list.stream().allMatch(o -> o.getId().matches("(id)\\d|1[0-3]")));
+
 
         var captor = forClass(CatalogRequest.class);
-        verify(dispatcherMock, times(3)).send(eq(Catalog.class), captor.capture(), any());
+        verify(dispatcherMock, times(4)).send(eq(Catalog.class), captor.capture(), any());
 
         // verify the sequence of requests
         assertThat(captor.getAllValues())
                 .extracting(CatalogRequest::getRange)
                 .usingRecursiveFieldByFieldElementComparator()
-                .containsExactly(new Range(0, 5), new Range(5, 10), new Range(10, 15));
+                .containsExactly(new Range(0, 5), new Range(5, 10), new Range(10, 15), new Range(15, 20));
 
     }
 

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -25,6 +25,242 @@ tags:
     \ path parameters and request body are supported (in the limits fixed by the HTTP\
     \ server) and can also conveyed to the actual data source."
 paths:
+  /identity-hub/collections:
+    post:
+      tags:
+      - Identity Hub
+      operationId: write
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
+  /identity-hub/collections-commit:
+    post:
+      tags:
+      - Identity Hub
+      operationId: writeCommit
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /identity-hub/query-commits:
+    post:
+      tags:
+      - Identity Hub
+      operationId: queryCommits
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
+  /identity-hub/query-objects:
+    post:
+      tags:
+      - Identity Hub
+      operationId: queryObjects
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
+  /instances:
+    get:
+      tags:
+      - Dataplane Selector
+      operationId: getAll
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DataPlaneInstance'
+    post:
+      tags:
+      - Dataplane Selector
+      operationId: addEntry
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataPlaneInstance'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /instances/select:
+    post:
+      tags:
+      - Dataplane Selector
+      operationId: find
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SelectionRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataPlaneInstance'
+  /catalog:
+    get:
+      tags:
+      - Catalog
+      operationId: getCatalog
+      parameters:
+      - name: providerUrl
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        default:
+          description: Gets contract offers (=catalog) of a single connector
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Catalog'
+  /federatedcatalog:
+    post:
+      operationId: getCachedCatalog
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FederatedCatalogCacheQuery'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractOffer'
+  /callback/{processId}/deprovision:
+    post:
+      tags:
+      - HTTP Provisioner Webhook
+      operationId: callDeprovisionWebhook
+      parameters:
+      - name: processId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeprovisionedResource'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /callback/{processId}/provision:
+    post:
+      tags:
+      - HTTP Provisioner Webhook
+      operationId: callProvisionWebhook
+      parameters:
+      - name: processId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProvisionerWebhookRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
   /assets:
     get:
       tags:
@@ -152,26 +388,6 @@ paths:
         "409":
           description: "The asset cannot be deleted, because it is referenced by a\
             \ contract agreement"
-  /catalog:
-    get:
-      tags:
-      - Catalog
-      operationId: getCatalog
-      parameters:
-      - name: providerUrl
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: Gets contract offers (=catalog) of a single connector
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Catalog'
   /contractagreements:
     get:
       tags:
@@ -713,137 +929,6 @@ paths:
           description: Request was malformed
         "403":
           description: Token is invalid
-  /federatedcatalog:
-    post:
-      operationId: getCachedCatalog
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/FederatedCatalogCacheQuery'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ContractOffer'
-  /callback/{processId}/deprovision:
-    post:
-      tags:
-      - HTTP Provisioner Webhook
-      operationId: callDeprovisionWebhook
-      parameters:
-      - name: processId
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DeprovisionedResource'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /callback/{processId}/provision:
-    post:
-      tags:
-      - HTTP Provisioner Webhook
-      operationId: callProvisionWebhook
-      parameters:
-      - name: processId
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ProvisionerWebhookRequest'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /identity-hub/collections:
-    post:
-      tags:
-      - Identity Hub
-      operationId: write
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: string
-  /identity-hub/collections-commit:
-    post:
-      tags:
-      - Identity Hub
-      operationId: writeCommit
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              additionalProperties:
-                type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /identity-hub/query-commits:
-    post:
-      tags:
-      - Identity Hub
-      operationId: queryCommits
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: string
-  /identity-hub/query-objects:
-    post:
-      tags:
-      - Identity Hub
-      operationId: queryObjects
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: string
   /check/health:
     get:
       tags:
@@ -1031,51 +1116,6 @@ paths:
         "409":
           description: "The policy definition cannot be deleted, because it is referenced\
             \ by a contract definition"
-  /instances:
-    get:
-      tags:
-      - Dataplane Selector
-      operationId: getAll
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/DataPlaneInstance'
-    post:
-      tags:
-      - Dataplane Selector
-      operationId: addEntry
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DataPlaneInstance'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /instances/select:
-    post:
-      tags:
-      - Dataplane Selector
-      operationId: find
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SelectionRequest'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DataPlaneInstance'
   /transferprocess:
     get:
       tags:

--- a/resources/openapi/yaml/catalog-api.yaml
+++ b/resources/openapi/yaml/catalog-api.yaml
@@ -8,6 +8,31 @@ paths:
         name: providerUrl
         schema:
           type: string
+      - in: query
+        name: offset
+        schema:
+          type: integer
+          format: int32
+      - in: query
+        name: limit
+        schema:
+          type: integer
+          format: int32
+      - in: query
+        name: filter
+        schema:
+          type: string
+      - in: query
+        name: sort
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - in: query
+        name: sortField
+        schema:
+          type: string
       responses:
         default:
           content:

--- a/spi/catalog-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/catalog/CatalogRequest.java
+++ b/spi/catalog-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/catalog/CatalogRequest.java
@@ -16,8 +16,10 @@ package org.eclipse.dataspaceconnector.spi.types.domain.catalog;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.types.domain.message.RemoteMessage;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
@@ -30,11 +32,13 @@ public class CatalogRequest implements RemoteMessage {
     private final String protocol;
     private final String connectorId;
     private final String connectorAddress;
+    private final Range range;
 
-    private CatalogRequest(@NotNull String protocol, @NotNull String connectorId, @NotNull String connectorAddress) {
+    private CatalogRequest(@NotNull String protocol, @NotNull String connectorId, @NotNull String connectorAddress, @Nullable Range range) {
         this.protocol = protocol;
         this.connectorId = connectorId;
         this.connectorAddress = connectorAddress;
+        this.range = range;
     }
 
     @NotNull
@@ -53,12 +57,30 @@ public class CatalogRequest implements RemoteMessage {
         return connectorAddress;
     }
 
+    public Range getRange() {
+        return range;
+    }
+
+
+    public Builder toBuilder() {
+        return new Builder(protocol, connectorId, connectorAddress, range);
+    }
+
     public static class Builder {
         private String protocol;
         private String connectorId;
         private String connectorAddress;
+        private Range range;
 
         private Builder() {
+
+        }
+
+        private Builder(String protocol, String connectorId, String connectorAddress, Range range) {
+            this.protocol = protocol;
+            this.connectorId = connectorId;
+            this.connectorAddress = connectorAddress;
+            this.range = range;
         }
 
         @JsonCreator
@@ -81,12 +103,17 @@ public class CatalogRequest implements RemoteMessage {
             return this;
         }
 
+        public CatalogRequest.Builder range(Range range) {
+            this.range = range;
+            return this;
+        }
+
         public CatalogRequest build() {
             Objects.requireNonNull(protocol, "protocol");
             Objects.requireNonNull(connectorId, "connectorId");
             Objects.requireNonNull(connectorAddress, "connectorAddress");
 
-            return new CatalogRequest(protocol, connectorId, connectorAddress);
+            return new CatalogRequest(protocol, connectorId, connectorAddress, range);
         }
     }
 }

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/ContractDefinitionService.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/ContractDefinitionService.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.spi.contract.offer;
 
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgent;
+import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.policy.PolicyScope;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
 import org.jetbrains.annotations.NotNull;
@@ -24,7 +25,7 @@ import java.util.stream.Stream;
 
 /**
  * Returns {@link ContractDefinition} for a given participant agent.
- *
+ * <p>
  * A runtime extension may implement custom logic to determine which contract definitions are returned.
  */
 public interface ContractDefinitionService {
@@ -36,11 +37,11 @@ public interface ContractDefinitionService {
      * Returns the definitions for the given participant agent.
      */
     @NotNull
-    Stream<ContractDefinition> definitionsFor(ParticipantAgent agent);
+    Stream<ContractDefinition> definitionsFor(ParticipantAgent agent, Range range);
 
     /**
-     * Returns a contract definition for the agent associated with the given contract definition id.
-     * If the definition does not exist or the agent is not authorized, the result will indicate the request is invalid.
+     * Returns a contract definition for the agent associated with the given contract definition id. If the definition
+     * does not exist or the agent is not authorized, the result will indicate the request is invalid.
      */
     @Nullable
     ContractDefinition definitionFor(ParticipantAgent agent, String definitionId);

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/ContractOfferService.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/ContractOfferService.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.spi.contract.offer;
 
+import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 
@@ -28,6 +29,6 @@ public interface ContractOfferService {
      * Resolves contract offers.
      */
     @NotNull
-    Stream<ContractOffer> queryContractOffers(ContractOfferQuery query);
+    Stream<ContractOffer> queryContractOffers(ContractOfferQuery query, Range range);
 
 }

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/message/Range.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/message/Range.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.message;
+
+/**
+ * Represents a particular section of a collection of items.
+ */
+public class Range {
+    public static final String FROM = "from";
+    public static final String TO = "to";
+    private final int from;
+    private final int to;
+
+    public Range(int from, int to) {
+        this.from = from;
+        this.to = to;
+    }
+
+    /**
+     * The maximum number of items. Note that the actual number may be lower if the range overshoots the bounds of the
+     * collection
+     */
+    public int getTo() {
+        return to;
+    }
+
+    /**
+     * The index of the first item to be included in the range.
+     */
+    public int getFrom() {
+        return from;
+    }
+
+    @Override
+    public String toString() {
+        return "Range{" +
+                "from " + from +
+                ", to " + to +
+                '}';
+    }
+}

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/message/Range.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/message/Range.java
@@ -29,8 +29,8 @@ public class Range {
     }
 
     /**
-     * The maximum number of items. Note that the actual number may be lower if the range overshoots the bounds of the
-     * collection
+     * The index of the last item to be included in the range. Note that the actual number may be lower if the range
+     * overshoots the bounds of the collection
      */
     public int getTo() {
         return to;

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/QuerySpec.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/QuerySpec.java
@@ -135,7 +135,7 @@ public class QuerySpec {
 
         public Builder range(Range range) {
             offset(range.getFrom());
-            limit(range.getTo());
+            limit(range.getTo() - range.getFrom());
             return this;
         }
 

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/QuerySpec.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/QuerySpec.java
@@ -14,6 +14,9 @@
 
 package org.eclipse.dataspaceconnector.spi.query;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.eclipse.dataspaceconnector.spi.message.Range;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -83,6 +86,11 @@ public class QuerySpec {
         return limit;
     }
 
+    @JsonIgnore
+    public Range getRange() {
+        return new Range(offset, offset + limit);
+    }
+
     public List<Criterion> getFilterExpression() {
         return filterExpression;
     }
@@ -122,6 +130,12 @@ public class QuerySpec {
             if (limit != null) {
                 querySpec.limit = limit;
             }
+            return this;
+        }
+
+        public Builder range(Range range) {
+            offset(range.getFrom());
+            limit(range.getTo());
             return this;
         }
 

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/query/QuerySpecTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/query/QuerySpecTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.spi.query;
 
+import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -106,6 +107,29 @@ class QuerySpecTest {
     void verify_filterWithValueContainsSpaces() {
         var spec = QuerySpec.Builder.newInstance().filter("key instanceof some value").build();
         assertThat(spec.getFilterExpression()).hasSize(1).containsOnly(new Criterion("key", "instanceof", "some value"));
+    }
+
+    @Test
+    void range_verifyCorrectConversion() {
+        var spec = QuerySpec.Builder.newInstance()
+                .range(new Range(37, 40))
+                .build();
+
+        assertThat(spec.getLimit()).isEqualTo(3);
+        assertThat(spec.getOffset()).isEqualTo(37);
+
+    }
+
+    @Test
+    void getRange_verifyCorrectConversion() {
+        var spec = QuerySpec.Builder.newInstance()
+                .limit(20)
+                .offset(37)
+                .build();
+
+        var range = spec.getRange();
+        assertThat(range.getFrom()).isEqualTo(37);
+        assertThat(range.getTo()).isEqualTo(57);
     }
 
 }


### PR DESCRIPTION
## What this PR changes/adds

This PR adds pagination to all `DescriptionRequestMessage`s. Specifically, this is needed to avoid very large response bodies when sending `CatalogRequest` messages.

This PR adds two major things:
1. pagination parameters are transmitted via IDS
2. on the client side pagination can either be leveraged by supplying the appropriate parameters to the DataManagementAPI or by using the `BatchedRequestFetcher`, that chunks the requests.

## Why it does that

Very large response bodies can lead to exceptions in Jetty, effectively limiting the maximum size of `ContractOffer`s etc. A fix was needed for that.

## Further notes

This PR is **NOT INTENDED FOR CODE REVIEW** yet, it will merely serve as basis for further discussion with the team.


## Linked Issue(s)

Closes #

## Checklist

- [x] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
