### PR TITLE
core: dispatch `TransferProcess` events

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -22,7 +22,6 @@ jobs:
 
       # lets run Checkstyle explicitly (as opposed to within gradle) due to better reporting capabilities
       - name: Run Checkstyle
-        if: github.event_name == 'pull_request'
         uses: nikitasavinov/checkstyle-action@0.6.0
         with:
           checkstyle_config: resources/edc-checkstyle-config.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Event Framework for Asset entity (#1453)
 * Event Framework for ContractDefinition entity (#1436)
 * Event Framework for PolicyDefinition entity (#1437)
+* Event Framework for TransferProcess entity (#1439)
 * SQL Translation layer (#1357, #1459)
 * Permit API verbose error response (#1479)
 * Fix TODO and document `:extensions:data-plane-transfer` (#1519)

--- a/core/transfer/build.gradle.kts
+++ b/core/transfer/build.gradle.kts
@@ -12,6 +12,7 @@
  *
  */
 
+val awaitility: String by project
 val openTelemetryVersion: String by project
 
 plugins {
@@ -28,6 +29,7 @@ dependencies {
     testImplementation(project(":extensions:junit"))
     testImplementation(project(":core:defaults")) //used in the component test
     testImplementation(testFixtures(project(":common:util")))
+    testImplementation("org.awaitility:awaitility:${awaitility}")
 }
 
 

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
@@ -21,6 +21,7 @@ import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
 import org.eclipse.dataspaceconnector.spi.command.BoundedCommandQueue;
 import org.eclipse.dataspaceconnector.spi.command.CommandHandlerRegistry;
 import org.eclipse.dataspaceconnector.spi.command.CommandRunner;
+import org.eclipse.dataspaceconnector.spi.event.EventRouter;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyArchive;
 import org.eclipse.dataspaceconnector.spi.retry.ExponentialWaitStrategy;
@@ -51,6 +52,7 @@ import org.eclipse.dataspaceconnector.transfer.core.command.handlers.Deprovision
 import org.eclipse.dataspaceconnector.transfer.core.edr.EndpointDataReferenceReceiverRegistryImpl;
 import org.eclipse.dataspaceconnector.transfer.core.edr.EndpointDataReferenceTransformerRegistryImpl;
 import org.eclipse.dataspaceconnector.transfer.core.flow.DataFlowManagerImpl;
+import org.eclipse.dataspaceconnector.transfer.core.listener.EventTransferProcessListener;
 import org.eclipse.dataspaceconnector.transfer.core.observe.TransferProcessObservableImpl;
 import org.eclipse.dataspaceconnector.transfer.core.provision.ProvisionManagerImpl;
 import org.eclipse.dataspaceconnector.transfer.core.provision.ResourceManifestGeneratorImpl;
@@ -94,6 +96,12 @@ public class CoreTransferExtension implements ServiceExtension {
     @Inject
     private Vault vault;
 
+    @Inject
+    private EventRouter eventRouter;
+
+    @Inject
+    private Clock clock;
+
     private TransferProcessManagerImpl processManager;
 
     @Override
@@ -135,6 +143,8 @@ public class CoreTransferExtension implements ServiceExtension {
         var commandQueue = new BoundedCommandQueue<TransferProcessCommand>(10);
         var observable = new TransferProcessObservableImpl();
         context.registerService(TransferProcessObservable.class, observable);
+
+        observable.registerListener(new EventTransferProcessListener(eventRouter, clock));
 
         var retryLimit = context.getSetting(TRANSFER_SEND_RETRY_LIMIT, 7);
         var retryBaseDelay = context.getSetting(TRANSFER_SEND_RETRY_BASE_DELAY_MS, 100L);

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/TransferProcessCommandExtension.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/TransferProcessCommandExtension.java
@@ -17,9 +17,9 @@ package org.eclipse.dataspaceconnector.transfer.core;
 import org.eclipse.dataspaceconnector.spi.command.CommandHandlerRegistry;
 import org.eclipse.dataspaceconnector.spi.system.CoreExtension;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
-import org.eclipse.dataspaceconnector.spi.system.Provides;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.transfer.observe.TransferProcessObservable;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 import org.eclipse.dataspaceconnector.transfer.core.command.handlers.CancelTransferCommandHandler;
 import org.eclipse.dataspaceconnector.transfer.core.command.handlers.DeprovisionRequestHandler;
@@ -28,20 +28,19 @@ import org.eclipse.dataspaceconnector.transfer.core.command.handlers.Deprovision
  * Registers command handlers that the core provides
  */
 @CoreExtension
-@Provides({ CommandHandlerRegistry.class })
 public class TransferProcessCommandExtension implements ServiceExtension {
 
     @Inject
     private TransferProcessStore store;
 
+    @Inject
+    private TransferProcessObservable observable;
+
     @Override
     public void initialize(ServiceExtensionContext context) {
-        CommandHandlerRegistry registry = context.getService(CommandHandlerRegistry.class);
-        registerDefaultCommands(registry);
-    }
+        var registry = context.getService(CommandHandlerRegistry.class);
 
-    private void registerDefaultCommands(CommandHandlerRegistry registry) {
-        registry.register(new CancelTransferCommandHandler(store));
+        registry.register(new CancelTransferCommandHandler(store, observable));
         registry.register(new DeprovisionRequestHandler(store));
     }
 

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/CancelTransferCommandHandler.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/CancelTransferCommandHandler.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.dataspaceconnector.transfer.core.command.handlers;
 
+import org.eclipse.dataspaceconnector.spi.transfer.observe.TransferProcessObservable;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
@@ -25,8 +26,11 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.command.CancelTr
  */
 public class CancelTransferCommandHandler extends SingleTransferProcessCommandHandler<CancelTransferCommand> {
 
-    public CancelTransferCommandHandler(TransferProcessStore store) {
+    private final TransferProcessObservable observable;
+
+    public CancelTransferCommandHandler(TransferProcessStore store, TransferProcessObservable observable) {
         super(store);
+        this.observable = observable;
     }
 
     @Override
@@ -45,5 +49,10 @@ public class CancelTransferCommandHandler extends SingleTransferProcessCommandHa
         }
         process.transitionCancelled();
         return true;
+    }
+
+    @Override
+    protected void postAction(TransferProcess process) {
+        observable.invokeForEach(l -> l.cancelled(process));
     }
 }

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/DeprovisionRequestHandler.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/DeprovisionRequestHandler.java
@@ -39,4 +39,9 @@ public class DeprovisionRequestHandler extends SingleTransferProcessCommandHandl
         process.transitionDeprovisioning();
         return true;
     }
+
+    @Override
+    protected void postAction(TransferProcess process) {
+
+    }
 }

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/SingleTransferProcessCommandHandler.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/SingleTransferProcessCommandHandler.java
@@ -44,6 +44,7 @@ public abstract class SingleTransferProcessCommandHandler<T extends SingleTransf
         } else {
             if (modify(transferProcess)) {
                 store.update(transferProcess);
+                postAction(transferProcess);
             }
         }
     }
@@ -57,4 +58,11 @@ public abstract class SingleTransferProcessCommandHandler<T extends SingleTransf
      * @return true if the process was actually modified, false otherwise.
      */
     protected abstract boolean modify(TransferProcess process);
+
+    /**
+     * Method that would be called after the entity update has been persisted.
+     *
+     * @param process the modified TransferProcess
+     */
+    protected abstract void postAction(TransferProcess process);
 }

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/listener/EventTransferProcessListener.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/listener/EventTransferProcessListener.java
@@ -1,0 +1,122 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.transfer.core.listener;
+
+import org.eclipse.dataspaceconnector.spi.event.EventRouter;
+import org.eclipse.dataspaceconnector.spi.event.transferprocess.TransferProcessCancelled;
+import org.eclipse.dataspaceconnector.spi.event.transferprocess.TransferProcessCompleted;
+import org.eclipse.dataspaceconnector.spi.event.transferprocess.TransferProcessDeprovisioned;
+import org.eclipse.dataspaceconnector.spi.event.transferprocess.TransferProcessEnded;
+import org.eclipse.dataspaceconnector.spi.event.transferprocess.TransferProcessFailed;
+import org.eclipse.dataspaceconnector.spi.event.transferprocess.TransferProcessInitialized;
+import org.eclipse.dataspaceconnector.spi.event.transferprocess.TransferProcessProvisioned;
+import org.eclipse.dataspaceconnector.spi.event.transferprocess.TransferProcessRequested;
+import org.eclipse.dataspaceconnector.spi.transfer.observe.TransferProcessListener;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+
+import java.time.Clock;
+
+/**
+ * Listener responsible for creating and publishing events regarding TransferProcess state changes
+ */
+public class EventTransferProcessListener implements TransferProcessListener {
+    private final EventRouter eventRouter;
+    private final Clock clock;
+
+    public EventTransferProcessListener(EventRouter eventRouter, Clock clock) {
+        this.eventRouter = eventRouter;
+        this.clock = clock;
+    }
+
+    @Override
+    public void initialized(TransferProcess process) {
+        var event = TransferProcessInitialized.Builder.newInstance()
+                .transferProcessId(process.getId())
+                .at(clock.millis())
+                .build();
+
+        eventRouter.publish(event);
+    }
+
+    @Override
+    public void provisioned(TransferProcess process) {
+        var event = TransferProcessProvisioned.Builder.newInstance()
+                .transferProcessId(process.getId())
+                .at(clock.millis())
+                .build();
+
+        eventRouter.publish(event);
+    }
+
+    @Override
+    public void requested(TransferProcess process) {
+        var event = TransferProcessRequested.Builder.newInstance()
+                .transferProcessId(process.getId())
+                .at(clock.millis())
+                .build();
+
+        eventRouter.publish(event);
+    }
+
+    @Override
+    public void completed(TransferProcess process) {
+        var event = TransferProcessCompleted.Builder.newInstance()
+                .transferProcessId(process.getId())
+                .at(clock.millis())
+                .build();
+
+        eventRouter.publish(event);
+    }
+
+    @Override
+    public void deprovisioned(TransferProcess process) {
+        var event = TransferProcessDeprovisioned.Builder.newInstance()
+                .transferProcessId(process.getId())
+                .at(clock.millis())
+                .build();
+
+        eventRouter.publish(event);
+    }
+
+    @Override
+    public void ended(TransferProcess process) {
+        var event = TransferProcessEnded.Builder.newInstance()
+                .transferProcessId(process.getId())
+                .at(clock.millis())
+                .build();
+
+        eventRouter.publish(event);
+    }
+
+    @Override
+    public void cancelled(TransferProcess process) {
+        var event = TransferProcessCancelled.Builder.newInstance()
+                .transferProcessId(process.getId())
+                .at(clock.millis())
+                .build();
+
+        eventRouter.publish(event);
+    }
+
+    @Override
+    public void failed(TransferProcess process) {
+        var event = TransferProcessFailed.Builder.newInstance()
+                .transferProcessId(process.getId())
+                .at(clock.millis())
+                .build();
+
+        eventRouter.publish(event);
+    }
+}

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
@@ -35,7 +35,7 @@ import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.retry.ExponentialWaitStrategy;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowManager;
-import org.eclipse.dataspaceconnector.spi.transfer.observe.TransferProcessObservable;
+import org.eclipse.dataspaceconnector.spi.transfer.observe.TransferProcessListener;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ProvisionManager;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ResourceManifestGenerator;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
@@ -55,6 +55,7 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessS
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferType;
 import org.eclipse.dataspaceconnector.transfer.core.TestProvisionedDataDestinationResource;
 import org.eclipse.dataspaceconnector.transfer.core.TestResourceDefinition;
+import org.eclipse.dataspaceconnector.transfer.core.observe.TransferProcessObservableImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -65,13 +66,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import static java.time.ZoneOffset.UTC;
 import static java.util.Collections.emptyList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.CompletableFuture.failedFuture;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess.Type.CONSUMER;
 import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess.Type.PROVIDER;
 import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.COMPLETED;
@@ -93,7 +93,6 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -105,7 +104,6 @@ import static org.mockito.Mockito.when;
 class TransferProcessManagerImplTest {
 
     private static final String DESTINATION_TYPE = "test-type";
-    private static final long TIMEOUT = 5;
     private static final int TRANSFER_MANAGER_BATCHSIZE = 10;
     private static final String PROVISIONED_RESOURCE_ID = "1";
 
@@ -121,12 +119,15 @@ class TransferProcessManagerImplTest {
     private final Vault vault = mock(Vault.class);
     @SuppressWarnings("unchecked")
     private final SendRetryManager<StatefulEntity> sendRetryManager = mock(SendRetryManager.class);
+    private final TransferProcessListener listener = mock(TransferProcessListener.class);
 
     private TransferProcessManagerImpl manager;
 
     @SuppressWarnings("unchecked")
     @BeforeEach
     void setup() {
+        var observable = new TransferProcessObservableImpl();
+        observable.registerListener(listener);
         manager = TransferProcessManagerImpl.Builder.newInstance()
                 .provisionManager(provisionManager)
                 .dataFlowManager(dataFlowManager)
@@ -140,7 +141,7 @@ class TransferProcessManagerImplTest {
                 .typeManager(new TypeManager())
                 .clock(Clock.fixed(Instant.ofEpochMilli(currentTime), UTC))
                 .statusCheckerRegistry(statusCheckerRegistry)
-                .observable(mock(TransferProcessObservable.class))
+                .observable(observable)
                 .transferProcessStore(transferProcessStore)
                 .policyArchive(policyArchive)
                 .vault(vault)
@@ -176,10 +177,11 @@ class TransferProcessManagerImplTest {
         manager.stop();
 
         verify(transferProcessStore, times(1)).create(argThat(p -> p.getCreatedTimestamp() == currentTime));
+        verify(listener).initialized(any());
     }
 
     @Test
-    void initial_shouldTransitionToProvisioning() throws InterruptedException {
+    void initial_shouldTransitionToProvisioning() {
         var process = createTransferProcess(INITIAL);
 
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
@@ -189,19 +191,17 @@ class TransferProcessManagerImplTest {
         var resourceManifest = ResourceManifest.Builder.newInstance().definitions(List.of(new TestResourceDefinition())).build();
         when(manifestGenerator.generateConsumerResourceManifest(any(DataRequest.class), any(Policy.class))).thenReturn(resourceManifest);
 
-        var latch = countDownOnUpdateLatch();
-
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-
-        verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-        verifyNoInteractions(provisionManager);
-        verify(transferProcessStore).update(argThat(p -> p.getState() == PROVISIONING.code()));
+        await().untilAsserted(() -> {
+            verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
+            verifyNoInteractions(provisionManager);
+            verify(transferProcessStore).update(argThat(p -> p.getState() == PROVISIONING.code()));
+        });
     }
 
     @Test
-    void provisioning_shouldTransitionToProvisionedOnDataDestination() throws InterruptedException {
+    void provisioning_shouldTransitionToProvisionedOnDataDestination() {
         var process = createTransferProcess(PROVISIONING).toBuilder()
                 .resourceManifest(ResourceManifest.Builder.newInstance().definitions(List.of(new TestResourceDefinition())).build())
                 .build();
@@ -213,19 +213,19 @@ class TransferProcessManagerImplTest {
         when(provisionManager.provision(any(), isA(Policy.class))).thenReturn(completedFuture(List.of(provisionResult)));
         when(transferProcessStore.nextForState(eq(PROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
         when(transferProcessStore.find(process.getId())).thenReturn(process);
-        var latch = countDownOnUpdateLatch();
 
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-
-        verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-        verify(transferProcessStore).find(process.getId());
-        verify(transferProcessStore).update(argThat(p -> p.getState() == PROVISIONED.code()));
+        await().untilAsserted(() -> {
+            verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
+            verify(transferProcessStore).find(process.getId());
+            verify(transferProcessStore).update(argThat(p -> p.getState() == PROVISIONED.code()));
+            verify(listener).provisioned(process);
+        });
     }
 
     @Test
-    void provisioning_shouldTransitionToProvisionedOnContentAddress() throws InterruptedException {
+    void provisioning_shouldTransitionToProvisionedOnContentAddress() {
         var resourceDefinition = TestResourceDefinition.Builder.newInstance().id("3").build();
 
         var process = createTransferProcess(PROVISIONING).toBuilder()
@@ -253,20 +253,18 @@ class TransferProcessManagerImplTest {
         when(transferProcessStore.nextForState(eq(PROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
         when(transferProcessStore.find(process.getId())).thenReturn(process);
 
-
-        var latch = countDownOnUpdateLatch();
-
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-
-        verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-        verify(transferProcessStore).update(argThat(p -> p.getState() == PROVISIONED.code()));
-        verify(vault).storeSecret(any(), any());
+        await().untilAsserted(() -> {
+            verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
+            verify(transferProcessStore).update(argThat(p -> p.getState() == PROVISIONED.code()));
+            verify(vault).storeSecret(any(), any());
+            verify(listener).provisioned(process);
+        });
     }
 
     @Test
-    void provisioning_shouldTransitionToErrorOnProvisionError() throws InterruptedException {
+    void provisioning_shouldTransitionToErrorOnProvisionError() {
         var process = createTransferProcess(PROVISIONING).toBuilder()
                 .resourceManifest(ResourceManifest.Builder.newInstance().definitions(List.of(new TestResourceDefinition())).build())
                 .build();
@@ -276,17 +274,17 @@ class TransferProcessManagerImplTest {
         when(transferProcessStore.nextForState(eq(PROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
         when(transferProcessStore.find(process.getId())).thenReturn(process);
 
-        var latch = countDownOnUpdateLatch();
-
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-        verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-        verify(transferProcessStore).update(argThat(p -> p.getState() == ERROR.code()));
+        await().untilAsserted(() -> {
+            verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
+            verify(transferProcessStore).update(argThat(p -> p.getState() == ERROR.code()));
+            verify(listener).failed(process);
+        });
     }
 
     @Test
-    void provisioning_shouldTransitionToErrorOnFatalProvisionError() throws InterruptedException {
+    void provisioning_shouldTransitionToErrorOnFatalProvisionError() {
         var process = createTransferProcess(PROVISIONING).toBuilder()
                 .resourceManifest(ResourceManifest.Builder.newInstance().definitions(List.of(new TestResourceDefinition())).build())
                 .build();
@@ -297,17 +295,17 @@ class TransferProcessManagerImplTest {
         when(transferProcessStore.nextForState(eq(PROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
         when(transferProcessStore.find(process.getId())).thenReturn(process);
 
-        var latch = countDownOnUpdateLatch();
-
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-        verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-        verify(transferProcessStore).update(argThat(p -> p.getState() == ERROR.code()));
+        await().untilAsserted(() -> {
+            verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
+            verify(transferProcessStore).update(argThat(p -> p.getState() == ERROR.code()));
+            verify(listener).failed(process);
+        });
     }
 
     @Test
-    void provisioning_shouldContinueOnRetryProvisionError() throws InterruptedException {
+    void provisioning_shouldContinueOnRetryProvisionError() {
         var process = createTransferProcess(PROVISIONING).toBuilder()
                 .resourceManifest(ResourceManifest.Builder.newInstance().definitions(List.of(new TestResourceDefinition())).build())
                 .build();
@@ -317,79 +315,77 @@ class TransferProcessManagerImplTest {
         when(provisionManager.provision(any(), isA(Policy.class))).thenReturn(completedFuture(List.of(provisionResult)));
         when(transferProcessStore.nextForState(eq(PROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
         when(transferProcessStore.find(process.getId())).thenReturn(process);
-        var latch = countDownOnUpdateLatch();
 
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-        verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-        verify(transferProcessStore).update(argThat(p -> p.getState() == PROVISIONING.code()));
+        await().untilAsserted(() -> {
+            verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
+            verify(transferProcessStore).update(argThat(p -> p.getState() == PROVISIONING.code()));
+        });
     }
 
     @Test
-    void provisionedConsumer_shouldTransitionToRequesting() throws InterruptedException {
+    void provisionedConsumer_shouldTransitionToRequesting() {
         var process = createTransferProcess(PROVISIONED).toBuilder().type(CONSUMER).build();
-
         when(transferProcessStore.nextForState(eq(PROVISIONED.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
 
-        var latch = countDownOnUpdateLatch();
-
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-        verify(transferProcessStore, atLeastOnce()).nextForState(eq(PROVISIONED.code()), anyInt());
-        verify(transferProcessStore).update(argThat(p -> p.getState() == REQUESTING.code()));
+        await().untilAsserted(() -> {
+            verify(transferProcessStore, atLeastOnce()).nextForState(eq(PROVISIONED.code()), anyInt());
+            verify(transferProcessStore).update(argThat(p -> p.getState() == REQUESTING.code()));
+        });
     }
 
     @Test
-    void provisionedProvider_shouldTransitionToInProgress() throws InterruptedException {
+    void provisionedProvider_shouldTransitionToInProgress() {
         var process = createTransferProcess(PROVISIONED).toBuilder().type(PROVIDER).build();
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
         when(transferProcessStore.nextForState(eq(PROVISIONED.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
         when(dataFlowManager.initiate(any(), any(), any())).thenReturn(StatusResult.success());
-        var latch = countDownOnUpdateLatch();
 
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-        verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-        verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-        verify(transferProcessStore).update(argThat(p -> p.getState() == IN_PROGRESS.code()));
+        await().untilAsserted(() -> {
+            verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
+            verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
+            verify(transferProcessStore).update(argThat(p -> p.getState() == IN_PROGRESS.code()));
+        });
     }
 
     @Test
-    void requesting_shouldTransitionToRequested() throws InterruptedException {
+    void requesting_shouldTransitionToRequested() {
         var process = createTransferProcess(REQUESTING);
-        var latch = countDownOnUpdateLatch(1);
         when(dispatcherRegistry.send(eq(Object.class), any(), any())).thenReturn(completedFuture("any"));
         when(transferProcessStore.nextForState(eq(REQUESTING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
         when(transferProcessStore.find(process.getId())).thenReturn(process, process.toBuilder().state(REQUESTING.code()).build());
 
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-        verify(transferProcessStore, times(1)).update(argThat(p -> p.getState() == REQUESTED.code()));
+        await().untilAsserted(() -> {
+            verify(transferProcessStore, times(1)).update(argThat(p -> p.getState() == REQUESTED.code()));
+            verify(listener).requested(process);
+        });
     }
 
     @Test
-    void requesting_OnFailureAndRetriesNotExhausted_updatesStateCountForRetry() throws InterruptedException {
+    void requesting_OnFailureAndRetriesNotExhausted_updatesStateCountForRetry() {
         var process = createTransferProcess(REQUESTING);
-        var latch = countDownOnUpdateLatch(1);
         when(dispatcherRegistry.send(eq(Object.class), any(), any())).thenReturn(failedFuture(new EdcException("send failed")));
         when(transferProcessStore.nextForState(eq(REQUESTING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
         when(transferProcessStore.find(process.getId())).thenReturn(process, process.toBuilder().state(REQUESTING.code()).build());
 
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-        verify(transferProcessStore, times(1)).update(argThat(p -> p.getState() == REQUESTING.code()));
+        await().untilAsserted(() -> {
+            verify(transferProcessStore, times(1)).update(argThat(p -> p.getState() == REQUESTING.code()));
+        });
     }
 
     @Test
-    void requesting_OnFailureAndRetriesExhausted_updatesStateCountForRetry() throws InterruptedException {
+    void requesting_OnFailureAndRetriesExhausted_updatesStateCountForRetry() {
         var process = createTransferProcess(REQUESTING);
-        var latch = countDownOnUpdateLatch(1);
         when(dispatcherRegistry.send(eq(Object.class), any(), any())).thenReturn(failedFuture(new EdcException("send failed")));
         when(transferProcessStore.nextForState(eq(REQUESTING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
         when(transferProcessStore.find(process.getId())).thenReturn(process, process.toBuilder().state(REQUESTING.code()).build());
@@ -397,78 +393,72 @@ class TransferProcessManagerImplTest {
 
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-        verify(transferProcessStore, times(1)).update(argThat(p -> p.getState() == ERROR.code()));
+        await().untilAsserted(() -> {
+            verify(transferProcessStore, times(1)).update(argThat(p -> p.getState() == ERROR.code()));
+            verify(listener).failed(process);
+        });
     }
 
     @Test
-    void requesting_whenShouldWait_updatesStateCount() throws InterruptedException {
+    void requesting_whenShouldWait_updatesStateCount() {
         var process = createTransferProcess(REQUESTING);
         when(sendRetryManager.shouldDelay(process)).thenReturn(true);
-        var latch = countDownOnUpdateLatch(1);
         when(dispatcherRegistry.send(eq(Object.class), any(), any())).thenReturn(completedFuture("any"));
         when(transferProcessStore.nextForState(eq(REQUESTING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
         when(transferProcessStore.find(process.getId())).thenReturn(process, process.toBuilder().state(REQUESTING.code()).build());
 
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-        verifyNoInteractions(dispatcherRegistry);
-        verify(transferProcessStore, times(1)).update(argThat(p -> p.getState() == REQUESTING.code()));
+        await().untilAsserted(() -> {
+            verifyNoInteractions(dispatcherRegistry);
+            verify(transferProcessStore, times(1)).update(argThat(p -> p.getState() == REQUESTING.code()));
+        });
     }
 
     @Test
-    void requested_shouldTransitionToInProgressIfTransferIsFinite() throws InterruptedException {
+    void requested_shouldTransitionToInProgressIfTransferIsFinite() {
         var process = createTransferProcess(REQUESTED);
         process.getProvisionedResourceSet().addResource(provisionedDataDestinationResource());
         when(transferProcessStore.nextForState(eq(REQUESTED.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
 
-        var latch = countDownOnUpdateLatch();
-
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-        verify(transferProcessStore).update(argThat(p -> p.getState() == IN_PROGRESS.code()));
+        await().untilAsserted(() -> {
+            verify(transferProcessStore).update(argThat(p -> p.getState() == IN_PROGRESS.code()));
+        });
     }
 
     @Test
-    void requested_shouldTransitionToStreamingIfTransferIsNonFinite() throws InterruptedException {
+    void requested_shouldTransitionToStreamingIfTransferIsNonFinite() {
         var nonFinite = TransferType.Builder.transferType().isFinite(false).build();
         var process = createTransferProcess(REQUESTED, nonFinite, true);
         process.getProvisionedResourceSet().addResource(provisionedDataDestinationResource());
-
-        var latch = countDownOnUpdateLatch();
-
         when(transferProcessStore.nextForState(eq(REQUESTED.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
 
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-        verify(transferProcessStore).update(argThat(p -> p.getState() == STREAMING.code()));
+        await().untilAsserted(() -> {
+            verify(transferProcessStore).update(argThat(p -> p.getState() == STREAMING.code()));
+        });
     }
 
     @Test
-    void requested_shouldNotTransitionIfProvisionedResourcesAreEmpty() throws InterruptedException {
+    void requested_shouldNotTransitionIfProvisionedResourcesAreEmpty() {
         var process = createTransferProcess(REQUESTED);
-
-        var latch = new CountDownLatch(1);
-
-        when(transferProcessStore.nextForState(eq(REQUESTED.code()), anyInt())).thenAnswer(i -> {
-            latch.countDown();
-            return List.of(process);
-        });
+        when(transferProcessStore.nextForState(eq(REQUESTED.code()), anyInt())).thenReturn(List.of(process));
         doThrow(new AssertionError("update() should not be called as process was not updated"))
                 .when(transferProcessStore).update(process);
 
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-        verify(transferProcessStore, never()).update(any());
+        await().untilAsserted(() -> {
+            verify(transferProcessStore, never()).update(any());
+        });
     }
 
     @Test
     @DisplayName("checkComplete: should transition process with managed resources if checker returns completed")
-    void verifyCompletedManagedResources() throws InterruptedException {
+    void verifyCompletedManagedResources() {
         var process = createTransferProcess(IN_PROGRESS);
         process.getProvisionedResourceSet().addResource(provisionedDataDestinationResource());
         process.getProvisionedResourceSet().addResource(provisionedDataDestinationResource());
@@ -476,96 +466,93 @@ class TransferProcessManagerImplTest {
         when(transferProcessStore.nextForState(eq(IN_PROGRESS.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
         when(statusCheckerRegistry.resolve(anyString())).thenReturn((tp, resources) -> true);
 
-        var latch = countDownOnUpdateLatch();
-
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-        verify(statusCheckerRegistry, atLeastOnce()).resolve(any());
-        verify(transferProcessStore).update(argThat(p -> p.getState() == COMPLETED.code()));
+        await().untilAsserted(() -> {
+            verify(statusCheckerRegistry, atLeastOnce()).resolve(any());
+            verify(transferProcessStore).update(argThat(p -> p.getState() == COMPLETED.code()));
+            verify(listener).completed(process);
+        });
     }
 
     @Test
     @DisplayName("checkComplete: should transition process with no managed resources if checker returns completed")
-    void verifyCompletedNonManagedResources() throws InterruptedException {
+    void verifyCompletedNonManagedResources() {
         TransferProcess process = createTransferProcess(REQUESTED, new TransferType(), false);
         process.getProvisionedResourceSet().addResource(provisionedDataDestinationResource());
         process.getProvisionedResourceSet().addResource(provisionedDataDestinationResource());
 
         when(transferProcessStore.nextForState(eq(IN_PROGRESS.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
         when(statusCheckerRegistry.resolve(anyString())).thenReturn((tp, resources) -> true);
-        var latch = countDownOnUpdateLatch();
 
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-        verify(statusCheckerRegistry, atLeastOnce()).resolve(any());
-        verify(transferProcessStore).update(argThat(p -> p.getState() == COMPLETED.code()));
+        await().untilAsserted(() -> {
+            verify(statusCheckerRegistry, atLeastOnce()).resolve(any());
+            verify(transferProcessStore).update(argThat(p -> p.getState() == COMPLETED.code()));
+            verify(listener).completed(process);
+        });
     }
 
     @Test
     @DisplayName("checkComplete: should break lease and not transition process if checker returns not yet completed")
-    void verifyCompleted_notAllYetCompleted() throws InterruptedException {
+    void verifyCompleted_notAllYetCompleted() {
         var process = createTransferProcess(IN_PROGRESS);
         process.getProvisionedResourceSet().addResource(provisionedDataDestinationResource());
         process.getProvisionedResourceSet().addResource(provisionedDataDestinationResource());
-
-        var latch = countDownOnUpdateLatch();
 
         when(transferProcessStore.nextForState(eq(IN_PROGRESS.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
         when(statusCheckerRegistry.resolve(anyString())).thenReturn((tp, resources) -> false);
 
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-        verify(transferProcessStore).update(argThat(p -> p.getState() == IN_PROGRESS.code()));
+        await().untilAsserted(() -> {
+            verify(transferProcessStore).update(argThat(p -> p.getState() == IN_PROGRESS.code()));
+        });
     }
 
     @Test
     @DisplayName("checkComplete: should not transition process with managed resources but no status checker")
-    void verifyCompleted_noCheckerForManaged() throws InterruptedException {
+    void verifyCompleted_noCheckerForManaged() {
         var process = createTransferProcess(IN_PROGRESS);
         process.getProvisionedResourceSet().addResource(provisionedDataDestinationResource());
         process.getProvisionedResourceSet().addResource(provisionedDataDestinationResource());
         var latch = new CountDownLatch(1);
-        when(transferProcessStore.nextForState(eq(IN_PROGRESS.code()), anyInt())).thenAnswer(i -> {
-            latch.countDown();
-            return List.of(process);
-        });
+        when(transferProcessStore.nextForState(eq(IN_PROGRESS.code()), anyInt())).thenReturn(List.of(process));
         doThrow(new AssertionError("update() should not be called as process was not updated"))
                 .when(transferProcessStore).update(process);
 
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-        verify(transferProcessStore, never()).update(any());
+        await().untilAsserted(() -> {
+            verify(transferProcessStore, never()).update(any());
+        });
     }
 
     @Test
     @DisplayName("checkComplete: should automatically transition process with no managed resources if no checker")
-    void verifyCompleted_noCheckerForSomeResources() throws InterruptedException {
+    void verifyCompleted_noCheckerForSomeResources() {
         var process = createTransferProcess(IN_PROGRESS, new TransferType(), false);
         process.getProvisionedResourceSet().addResource(provisionedDataDestinationResource());
         process.getProvisionedResourceSet().addResource(provisionedDataDestinationResource());
-
-        var latch = countDownOnUpdateLatch();
 
         when(transferProcessStore.nextForState(eq(IN_PROGRESS.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
         when(statusCheckerRegistry.resolve(anyString())).thenReturn(null);
 
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-        verify(statusCheckerRegistry, atLeastOnce()).resolve(any());
-        verify(transferProcessStore).update(argThat(p -> p.getState() == COMPLETED.code()));
+        await().untilAsserted(() -> {
+            verify(statusCheckerRegistry, atLeastOnce()).resolve(any());
+            verify(transferProcessStore).update(argThat(p -> p.getState() == COMPLETED.code()));
+            verify(listener).completed(process);
+        });
     }
 
     @Test
-    void deprovisioning_shouldTransitionToDeprovisioned() throws InterruptedException {
+    void deprovisioning_shouldTransitionToDeprovisioned() {
         var manifest = ResourceManifest.Builder.newInstance()
                 .definitions(List.of(new TestResourceDefinition()))
                 .build();
-
 
         var resourceSet = ProvisionedResourceSet.Builder.newInstance()
                 .resources(List.of(new TokenTestProvisionResource("test", PROVISIONED_RESOURCE_ID)))
@@ -586,19 +573,19 @@ class TransferProcessManagerImplTest {
         when(transferProcessStore.nextForState(eq(DEPROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
         when(transferProcessStore.find(process.getId())).thenReturn(process);
 
-        var latch = countDownOnUpdateLatch();
-
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-        verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-        verify(transferProcessStore).find(process.getId());
-        verify(transferProcessStore).update(argThat(p -> p.getState() == DEPROVISIONED.code()));
-        verify(vault).deleteSecret(any());
+        await().untilAsserted(() -> {
+            verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
+            verify(transferProcessStore).find(process.getId());
+            verify(transferProcessStore).update(argThat(p -> p.getState() == DEPROVISIONED.code()));
+            verify(vault).deleteSecret(any());
+            verify(listener).deprovisioned(process);
+        });
     }
 
     @Test
-    void deprovisioning_shouldTransitionToErrorOnFatalDeprovisionError() throws InterruptedException {
+    void deprovisioning_shouldTransitionToErrorOnFatalDeprovisionError() {
         var manifest = ResourceManifest.Builder.newInstance()
                 .definitions(List.of(new TestResourceDefinition()))
                 .build();
@@ -618,17 +605,18 @@ class TransferProcessManagerImplTest {
         when(provisionManager.deprovision(any(), isA(Policy.class))).thenReturn(completedFuture(List.of(deprovisionResult)));
         when(transferProcessStore.nextForState(eq(DEPROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
         when(transferProcessStore.find(process.getId())).thenReturn(process);
-        var latch = countDownOnUpdateLatch();
 
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-        verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-        verify(transferProcessStore).update(argThat(p -> p.getState() == ERROR.code()));
+        await().untilAsserted(() -> {
+            verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
+            verify(transferProcessStore).update(argThat(p -> p.getState() == ERROR.code()));
+            verify(listener).failed(process);
+        });
     }
 
     @Test
-    void deprovisioning_shouldNotTransitionOnRetriableDeprovisionError() throws InterruptedException {
+    void deprovisioning_shouldNotTransitionOnRetriableDeprovisionError() {
         var manifest = ResourceManifest.Builder.newInstance()
                 .definitions(List.of(new TestResourceDefinition()))
                 .build();
@@ -648,17 +636,17 @@ class TransferProcessManagerImplTest {
         when(provisionManager.deprovision(any(), isA(Policy.class))).thenReturn(completedFuture(List.of(deprovisionResult)));
         when(transferProcessStore.nextForState(eq(DEPROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
         when(transferProcessStore.find(process.getId())).thenReturn(process);
-        var latch = countDownOnUpdateLatch();
 
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-        verify(transferProcessStore).update(argThat(p -> p.getState() == DEPROVISIONING.code()));
-        verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
+        await().untilAsserted(() -> {
+            verify(transferProcessStore).update(argThat(p -> p.getState() == DEPROVISIONING.code()));
+            verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
+        });
     }
 
     @Test
-    void deprovisioning_shouldTransitionToErrorOnDeprovisionException() throws InterruptedException {
+    void deprovisioning_shouldTransitionToErrorOnDeprovisionException() {
         var process = createTransferProcess(DEPROVISIONING).toBuilder()
                 .resourceManifest(ResourceManifest.Builder.newInstance().definitions(List.of(new TestResourceDefinition())).build())
                 .build();
@@ -666,25 +654,27 @@ class TransferProcessManagerImplTest {
         when(provisionManager.deprovision(any(), isA(Policy.class))).thenReturn(failedFuture(new EdcException("provision failed")));
         when(transferProcessStore.nextForState(eq(DEPROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
         when(transferProcessStore.find(process.getId())).thenReturn(process);
-        var latch = countDownOnUpdateLatch();
 
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-        verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-        verify(transferProcessStore).update(argThat(p -> p.getState() == ERROR.code()));
+        await().untilAsserted(() -> {
+            verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
+            verify(transferProcessStore).update(argThat(p -> p.getState() == ERROR.code()));
+            verify(listener).failed(process);
+        });
     }
 
     @Test
-    void deprovisioned_shouldTransitionToEnded() throws InterruptedException {
+    void deprovisioned_shouldTransitionToEnded() {
         var process = createTransferProcess(DEPROVISIONED);
         when(transferProcessStore.nextForState(eq(DEPROVISIONED.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        var latch = countDownOnUpdateLatch();
 
         manager.start();
 
-        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-        verify(transferProcessStore).update(argThat(p -> p.getState() == ENDED.code()));
+        await().untilAsserted(() -> {
+            verify(transferProcessStore).update(argThat(p -> p.getState() == ENDED.code()));
+            verify(listener).ended(process);
+        });
     }
 
     private TransferProcess createTransferProcess(TransferProcessStates inState) {
@@ -713,21 +703,6 @@ class TransferProcessManagerImplTest {
 
     private ProvisionedDataDestinationResource provisionedDataDestinationResource() {
         return new TestProvisionedDataDestinationResource("test-resource", PROVISIONED_RESOURCE_ID);
-    }
-
-    private CountDownLatch countDownOnUpdateLatch() {
-        return countDownOnUpdateLatch(1);
-    }
-
-    private CountDownLatch countDownOnUpdateLatch(int count) {
-        var latch = new CountDownLatch(count);
-
-        doAnswer(i -> {
-            latch.countDown();
-            return null;
-        }).when(transferProcessStore).update(any());
-
-        return latch;
     }
 
     @JsonTypeName("dataspaceconnector:testprovisioneddcontentresource")

--- a/extensions/api/data-management/transferprocess/build.gradle.kts
+++ b/extensions/api/data-management/transferprocess/build.gradle.kts
@@ -12,11 +12,11 @@
  *
  */
 
-
+val awaitility: String by project
 val infoModelVersion: String by project
-val rsApi: String by project
 val jerseyVersion: String by project
 val restAssured: String by project
+val rsApi: String by project
 
 plugins {
     `java-library`
@@ -40,6 +40,7 @@ dependencies {
     testImplementation(project(":extensions:junit"))
 
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
+    testImplementation("org.awaitility:awaitility:${awaitility}")
 }
 
 publishing {

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiExtension.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiExtension.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess;
 
 import org.eclipse.dataspaceconnector.api.datamanagement.configuration.DataManagementApiConfiguration;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.service.TransferProcessService;
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.service.TransferProcessServiceImpl;
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform.DataRequestToDataRequestDtoTransformer;
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform.TransferProcessToTransferProcessDtoTransformer;
@@ -22,12 +23,14 @@ import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transfo
 import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
 import org.eclipse.dataspaceconnector.spi.WebService;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
+import org.eclipse.dataspaceconnector.spi.system.Provides;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 
+@Provides(TransferProcessService.class)
 public class TransferProcessApiExtension implements ServiceExtension {
     @Inject
     private WebService webService;
@@ -47,7 +50,6 @@ public class TransferProcessApiExtension implements ServiceExtension {
     @Inject
     private TransactionContext transactionContext;
 
-
     @Override
     public String name() {
         return "Data Management API: Transfer Process";
@@ -55,8 +57,11 @@ public class TransferProcessApiExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        webService.registerResource(configuration.getContextAlias(), new TransferProcessApiController(context.getMonitor(),
-                new TransferProcessServiceImpl(transferProcessStore, manager, transactionContext), transformerRegistry));
+        var service = new TransferProcessServiceImpl(transferProcessStore, manager, transactionContext);
+        context.registerService(TransferProcessService.class, service);
+
+        var controller = new TransferProcessApiController(context.getMonitor(), service, transformerRegistry);
+        webService.registerResource(configuration.getContextAlias(), controller);
 
         transformerRegistry.register(new DataRequestToDataRequestDtoTransformer());
         transformerRegistry.register(new TransferProcessToTransferProcessDtoTransformer());

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessEventDispatchTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessEventDispatchTest.java
@@ -1,0 +1,128 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.service;
+
+import org.eclipse.dataspaceconnector.junit.extensions.EdcExtension;
+import org.eclipse.dataspaceconnector.spi.event.EventRouter;
+import org.eclipse.dataspaceconnector.spi.event.EventSubscriber;
+import org.eclipse.dataspaceconnector.spi.event.transferprocess.TransferProcessCancelled;
+import org.eclipse.dataspaceconnector.spi.event.transferprocess.TransferProcessCompleted;
+import org.eclipse.dataspaceconnector.spi.event.transferprocess.TransferProcessDeprovisioned;
+import org.eclipse.dataspaceconnector.spi.event.transferprocess.TransferProcessEnded;
+import org.eclipse.dataspaceconnector.spi.event.transferprocess.TransferProcessFailed;
+import org.eclipse.dataspaceconnector.spi.event.transferprocess.TransferProcessInitialized;
+import org.eclipse.dataspaceconnector.spi.event.transferprocess.TransferProcessProvisioned;
+import org.eclipse.dataspaceconnector.spi.event.transferprocess.TransferProcessRequested;
+import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcher;
+import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(EdcExtension.class)
+public class TransferProcessEventDispatchTest {
+
+    private final EventSubscriber eventSubscriber = mock(EventSubscriber.class);
+
+    @BeforeEach
+    void setUp(EdcExtension extension) {
+        extension.setConfiguration(Map.of("edc.transfer.send.retry.limit", "0"));
+    }
+
+    @Test
+    void shouldDispatchEventsOnTransferProcessStateChanges(TransferProcessService service, EventRouter eventRouter, RemoteMessageDispatcherRegistry dispatcherRegistry) {
+        var testDispatcher = mock(RemoteMessageDispatcher.class);
+        when(testDispatcher.protocol()).thenReturn("test");
+        when(testDispatcher.send(any(), any(), any())).thenReturn(CompletableFuture.completedFuture("any"));
+        dispatcherRegistry.register(testDispatcher);
+        eventRouter.register(eventSubscriber);
+
+        var dataRequest = DataRequest.Builder.newInstance()
+                .assetId("assetId")
+                .destinationType("any")
+                .protocol("test")
+                .managedResources(false)
+                .build();
+
+        var initiateResult = service.initiateTransfer(dataRequest);
+
+        await().untilAsserted(() -> {
+            verify(eventSubscriber).on(isA(TransferProcessInitialized.class));
+            verify(eventSubscriber).on(isA(TransferProcessProvisioned.class));
+            verify(eventSubscriber).on(isA(TransferProcessRequested.class));
+            verify(eventSubscriber).on(isA(TransferProcessCompleted.class));
+        });
+
+        service.deprovision(initiateResult.getContent());
+
+        await().untilAsserted(() -> {
+            verify(eventSubscriber).on(isA(TransferProcessDeprovisioned.class));
+            verify(eventSubscriber).on(isA(TransferProcessEnded.class));
+        });
+    }
+
+    @Test
+    void shouldDispatchEventOnTransferProcessCanceled(TransferProcessService service, EventRouter eventRouter, RemoteMessageDispatcherRegistry dispatcherRegistry) {
+        var testDispatcher = mock(RemoteMessageDispatcher.class);
+        when(testDispatcher.protocol()).thenReturn("test");
+        when(testDispatcher.send(any(), any(), any())).thenReturn(CompletableFuture.completedFuture("any"));
+        dispatcherRegistry.register(testDispatcher);
+        eventRouter.register(eventSubscriber);
+
+        var dataRequest = DataRequest.Builder.newInstance()
+                .assetId("assetId")
+                .destinationType("any")
+                .protocol("test")
+                .managedResources(true)
+                .build();
+
+        var initiateResult = service.initiateTransfer(dataRequest);
+
+        service.cancel(initiateResult.getContent());
+
+        await().untilAsserted(() -> verify(eventSubscriber).on(isA(TransferProcessCancelled.class)));
+    }
+
+    @Test
+    void shouldDispatchEventOnTransferProcessFailure(TransferProcessService service, EventRouter eventRouter, RemoteMessageDispatcherRegistry dispatcherRegistry) {
+        var testDispatcher = mock(RemoteMessageDispatcher.class);
+        when(testDispatcher.protocol()).thenReturn("test");
+        when(testDispatcher.send(any(), any(), any())).thenReturn(CompletableFuture.failedFuture(new RuntimeException("an error")));
+        dispatcherRegistry.register(testDispatcher);
+        eventRouter.register(eventSubscriber);
+
+        var dataRequest = DataRequest.Builder.newInstance()
+                .assetId("assetId")
+                .destinationType("any")
+                .protocol("test")
+                .managedResources(true)
+                .build();
+
+        service.initiateTransfer(dataRequest);
+
+        await().untilAsserted(() -> verify(eventSubscriber).on(isA(TransferProcessFailed.class)));
+    }
+}

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessCancelled.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessCancelled.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.event.transferprocess;
+
+import org.eclipse.dataspaceconnector.spi.event.Event;
+import org.eclipse.dataspaceconnector.spi.event.EventPayload;
+
+import java.util.Objects;
+
+/**
+ * This event is raised when the TransferProcess has been cancelled.
+ */
+public class TransferProcessCancelled extends Event<TransferProcessCancelled.Payload> {
+
+    private TransferProcessCancelled() {
+    }
+
+    public static class Builder extends Event.Builder<TransferProcessCancelled, Payload, Builder> {
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        private Builder() {
+            super(new TransferProcessCancelled(), new Payload());
+        }
+
+        public Builder transferProcessId(String contractDefinitionId) {
+            event.payload.transferProcessId = contractDefinitionId;
+            return this;
+        }
+
+        @Override
+        protected void validate() {
+            Objects.requireNonNull(event.payload.transferProcessId);
+        }
+    }
+
+    public static class Payload extends EventPayload {
+        private String transferProcessId;
+
+        public String getTransferProcessId() {
+            return transferProcessId;
+        }
+    }
+}

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessCompleted.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessCompleted.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.event.transferprocess;
+
+import org.eclipse.dataspaceconnector.spi.event.Event;
+import org.eclipse.dataspaceconnector.spi.event.EventPayload;
+
+import java.util.Objects;
+
+/**
+ * This event is raised when the TransferProcess has been completed.
+ */
+public class TransferProcessCompleted extends Event<TransferProcessCompleted.Payload> {
+
+    private TransferProcessCompleted() {
+    }
+
+    public static class Builder extends Event.Builder<TransferProcessCompleted, Payload, Builder> {
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        private Builder() {
+            super(new TransferProcessCompleted(), new Payload());
+        }
+
+        public Builder transferProcessId(String contractDefinitionId) {
+            event.payload.transferProcessId = contractDefinitionId;
+            return this;
+        }
+
+        @Override
+        protected void validate() {
+            Objects.requireNonNull(event.payload.transferProcessId);
+        }
+    }
+
+    public static class Payload extends EventPayload {
+        private String transferProcessId;
+
+        public String getTransferProcessId() {
+            return transferProcessId;
+        }
+    }
+}

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessDeprovisioned.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessDeprovisioned.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.event.transferprocess;
+
+import org.eclipse.dataspaceconnector.spi.event.Event;
+import org.eclipse.dataspaceconnector.spi.event.EventPayload;
+
+import java.util.Objects;
+
+/**
+ * This event is raised when the TransferProcess has been deprovisioned.
+ */
+public class TransferProcessDeprovisioned extends Event<TransferProcessDeprovisioned.Payload> {
+
+    private TransferProcessDeprovisioned() {
+    }
+
+    public static class Builder extends Event.Builder<TransferProcessDeprovisioned, Payload, Builder> {
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        private Builder() {
+            super(new TransferProcessDeprovisioned(), new Payload());
+        }
+
+        public Builder transferProcessId(String contractDefinitionId) {
+            event.payload.transferProcessId = contractDefinitionId;
+            return this;
+        }
+
+        @Override
+        protected void validate() {
+            Objects.requireNonNull(event.payload.transferProcessId);
+        }
+    }
+
+    public static class Payload extends EventPayload {
+        private String transferProcessId;
+
+        public String getTransferProcessId() {
+            return transferProcessId;
+        }
+    }
+}

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessEnded.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessEnded.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.event.transferprocess;
+
+import org.eclipse.dataspaceconnector.spi.event.Event;
+import org.eclipse.dataspaceconnector.spi.event.EventPayload;
+
+import java.util.Objects;
+
+/**
+ * This event is raised when the TransferProcess has been ended.
+ */
+public class TransferProcessEnded extends Event<TransferProcessEnded.Payload> {
+
+    private TransferProcessEnded() {
+    }
+
+    public static class Builder extends Event.Builder<TransferProcessEnded, Payload, Builder> {
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        private Builder() {
+            super(new TransferProcessEnded(), new Payload());
+        }
+
+        public Builder transferProcessId(String contractDefinitionId) {
+            event.payload.transferProcessId = contractDefinitionId;
+            return this;
+        }
+
+        @Override
+        protected void validate() {
+            Objects.requireNonNull(event.payload.transferProcessId);
+        }
+    }
+
+    public static class Payload extends EventPayload {
+        private String transferProcessId;
+
+        public String getTransferProcessId() {
+            return transferProcessId;
+        }
+    }
+}

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessFailed.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessFailed.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.event.transferprocess;
+
+import org.eclipse.dataspaceconnector.spi.event.Event;
+import org.eclipse.dataspaceconnector.spi.event.EventPayload;
+
+import java.util.Objects;
+
+/**
+ * This event is raised when the TransferProcess has failed.
+ */
+public class TransferProcessFailed extends Event<TransferProcessFailed.Payload> {
+
+    private TransferProcessFailed() {
+    }
+
+    public static class Builder extends Event.Builder<TransferProcessFailed, Payload, Builder> {
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        private Builder() {
+            super(new TransferProcessFailed(), new Payload());
+        }
+
+        public Builder transferProcessId(String contractDefinitionId) {
+            event.payload.transferProcessId = contractDefinitionId;
+            return this;
+        }
+
+        @Override
+        protected void validate() {
+            Objects.requireNonNull(event.payload.transferProcessId);
+        }
+    }
+
+    public static class Payload extends EventPayload {
+        private String transferProcessId;
+
+        public String getTransferProcessId() {
+            return transferProcessId;
+        }
+    }
+}

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessInitialized.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessInitialized.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.event.transferprocess;
+
+import org.eclipse.dataspaceconnector.spi.event.Event;
+import org.eclipse.dataspaceconnector.spi.event.EventPayload;
+
+import java.util.Objects;
+
+/**
+ * This event is raised when the TransferProcess has been initialized.
+ */
+public class TransferProcessInitialized extends Event<TransferProcessInitialized.Payload> {
+
+    private TransferProcessInitialized() {
+    }
+
+    public static class Builder extends Event.Builder<TransferProcessInitialized, Payload, Builder> {
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        private Builder() {
+            super(new TransferProcessInitialized(), new Payload());
+        }
+
+        public Builder transferProcessId(String contractDefinitionId) {
+            event.payload.transferProcessId = contractDefinitionId;
+            return this;
+        }
+
+        @Override
+        protected void validate() {
+            Objects.requireNonNull(event.payload.transferProcessId);
+        }
+    }
+
+    public static class Payload extends EventPayload {
+        private String transferProcessId;
+
+        public String getTransferProcessId() {
+            return transferProcessId;
+        }
+    }
+}

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessProvisioned.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessProvisioned.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.event.transferprocess;
+
+import org.eclipse.dataspaceconnector.spi.event.Event;
+import org.eclipse.dataspaceconnector.spi.event.EventPayload;
+
+import java.util.Objects;
+
+/**
+ *  This event is raised when the TransferProcess has been provisioned.
+ */
+public class TransferProcessProvisioned extends Event<TransferProcessProvisioned.Payload> {
+
+    private TransferProcessProvisioned() {
+    }
+
+    public static class Builder extends Event.Builder<TransferProcessProvisioned, Payload, Builder> {
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        private Builder() {
+            super(new TransferProcessProvisioned(), new Payload());
+        }
+
+        public Builder transferProcessId(String contractDefinitionId) {
+            event.payload.transferProcessId = contractDefinitionId;
+            return this;
+        }
+
+        @Override
+        protected void validate() {
+            Objects.requireNonNull(event.payload.transferProcessId);
+        }
+    }
+
+    public static class Payload extends EventPayload {
+        private String transferProcessId;
+
+        public String getTransferProcessId() {
+            return transferProcessId;
+        }
+    }
+}

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessRequested.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessRequested.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.event.transferprocess;
+
+import org.eclipse.dataspaceconnector.spi.event.Event;
+import org.eclipse.dataspaceconnector.spi.event.EventPayload;
+
+import java.util.Objects;
+
+/**
+ * This event is raised when the TransferProcess has been requested to the provider.
+ */
+public class TransferProcessRequested extends Event<TransferProcessRequested.Payload> {
+
+    private TransferProcessRequested() {
+    }
+
+    public static class Builder extends Event.Builder<TransferProcessRequested, Payload, Builder> {
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        private Builder() {
+            super(new TransferProcessRequested(), new Payload());
+        }
+
+        public Builder transferProcessId(String contractDefinitionId) {
+            event.payload.transferProcessId = contractDefinitionId;
+            return this;
+        }
+
+        @Override
+        protected void validate() {
+            Objects.requireNonNull(event.payload.transferProcessId);
+        }
+    }
+
+    public static class Payload extends EventPayload {
+        private String transferProcessId;
+
+        public String getTransferProcessId() {
+            return transferProcessId;
+        }
+    }
+}

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/observe/TransferProcessListener.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/observe/TransferProcessListener.java
@@ -126,4 +126,75 @@ public interface TransferProcessListener {
     default void preError(TransferProcess process) {
     }
 
+    /**
+     * Called after a {@link TransferProcess} was initialized.
+     *
+     * @param process the transfer process that has been initialized.
+     */
+    default void initialized(TransferProcess process) {
+
+    }
+
+    /**
+     * Called after a {@link TransferProcess} was provisioned.
+     *
+     * @param process the transfer process that has been provisioned.
+     */
+    default void provisioned(TransferProcess process) {
+
+    }
+
+    /**
+     * Called after a {@link TransferProcess} was requested.
+     *
+     * @param process the transfer process that has been requested.
+     */
+    default void requested(TransferProcess process) {
+
+    }
+
+    /**
+     * Called after a {@link TransferProcess} was completed.
+     *
+     * @param process the transfer process that has been completed.
+     */
+    default void completed(TransferProcess process) {
+
+    }
+
+    /**
+     * Called after a {@link TransferProcess} was deprovisioned.
+     *
+     * @param process the transfer process that has been deprovisioned.
+     */
+    default void deprovisioned(TransferProcess process) {
+
+    }
+
+    /**
+     * Called after a {@link TransferProcess} was ended.
+     *
+     * @param process the transfer process that has been ended.
+     */
+    default void ended(TransferProcess process) {
+
+    }
+
+    /**
+     * Called after a {@link TransferProcess} was cancelled.
+     *
+     * @param process the transfer process that has been cancelled.
+     */
+    default void cancelled(TransferProcess process) {
+
+    }
+
+    /**
+     * Called after a {@link TransferProcess} was failed.
+     *
+     * @param process the transfer process that has been failed.
+     */
+    default void failed(TransferProcess process) {
+
+    }
 }


### PR DESCRIPTION
## What this PR changes/adds

Dispatch `TransferProcess` events

## Why it does that

To permit asynchronous notifications

## Further notes

- <s>Removed the check on checkstyle job on CI, that should fix 1567 already</s>
- Introduced `awaitility` on `TransferProcessManagerImplTest`, as it was pretty mandatory to have the tests working. It's already a little part of #1583 
- Had to add a `postAction` method on the `SingleTransferProcessCommandHandler` to make the `CancelTransferProcess` command being able to notify the observable about the cancellation.

## Linked Issue(s)

Closes #1439

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
