### PR TITLE
CI: Execute checkstyle CI step on each run

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -22,7 +22,6 @@ jobs:
 
       # lets run Checkstyle explicitly (as opposed to within gradle) due to better reporting capabilities
       - name: Run Checkstyle
-        if: github.event_name == 'pull_request'
         uses: nikitasavinov/checkstyle-action@0.6.0
         with:
           checkstyle_config: resources/edc-checkstyle-config.xml
@@ -30,10 +29,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tool_name: 'checkstyle'
           checkstyle_version: '9.0'
-          # Filtering does not work on github-check, needs github-pr-check
-          reporter: 'github-pr-check'
+          reporter: 'github-check'
           # Include only violations on added or modified files
           filter_mode: 'file'
+          # Only works when level is set to error
+          fail_on_error: true
 
   Dependency-analysis:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What this PR changes/adds

checkstyle check was not getting executed in downstram forks as it was configured to run on PR against main branch only. This PR removes this restriction so that checkstyle step gets execute on every CI run and also marks checkstyle step as failure in case of any checkstyle errors.

checkstyle step executed successfully on downstream fork.

- https://github.com/agera-edc/DataSpaceConnector/runs/7196648638?check_suite_focus=true
- https://github.com/agera-edc/DataSpaceConnector/runs/7196658195?check_suite_focus=true

## Why it does that

Detect checkstyle related errors earlier e.g. downstream forks.

## Linked Issue(s)

Closes #1567 

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
