### PR TITLE
fix: debug log output for ContractDefinition create and delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ in the detailed section referring to by linking pull requests or issues.
 * JWT audience claim check with DID (#1520)
 * Bump `failsafe` library to version 3.2.4 (#1559)
 * Harmonize logics of `HttpDataSource` and `HttpDataSink` (#1475)
+* Log correct type in contract-definition API (#1584)
 
 #### Removed
 

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiController.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiController.java
@@ -93,7 +93,7 @@ public class ContractDefinitionApiController implements ContractDefinitionApi {
     @POST
     @Override
     public void createContractDefinition(@Valid ContractDefinitionDto dto) {
-        monitor.debug("create new contract definition");
+        monitor.debug("Create new contract definition");
         var transformResult = transformerRegistry.transform(dto, ContractDefinition.class);
         if (transformResult.failed()) {
             throw new IllegalArgumentException("Request is not well formatted");
@@ -103,7 +103,7 @@ public class ContractDefinitionApiController implements ContractDefinitionApi {
 
         var result = service.create(contractDefinition);
         if (result.succeeded()) {
-            monitor.debug(format("Contract negotiation created %s", result.getContent().getId()));
+            monitor.debug(format("Contract definition created %s", result.getContent().getId()));
         } else {
             throw new ObjectExistsException(ContractDefinition.class, dto.getId());
         }
@@ -116,7 +116,7 @@ public class ContractDefinitionApiController implements ContractDefinitionApi {
         monitor.debug(format("Attempting to delete contract definition with id %s", id));
         var result = service.delete(id);
         if (result.succeeded()) {
-            monitor.debug(format("Contract negotiation deleted %s", result.getContent().getId()));
+            monitor.debug(format("Contract definition deleted %s", result.getContent().getId()));
         } else {
             handleFailedResult(result, id);
         }


### PR DESCRIPTION
## What this PR changes/adds

Fixed debug information in creating and deleting contract definitions via data-managment api

## Why it does that

Previously it was logged that a contract negotiation was created/deleted instead of a contract definition. 

## Linked Issue(s)

Closes #1584

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
