### PR TITLE
docs: add decision-record about triggering releases from GitHub

### DIFF
--- a/docs/developer/decision-records/2022-07-06-release-automation/README.md
+++ b/docs/developer/decision-records/2022-07-06-release-automation/README.md
@@ -1,0 +1,40 @@
+# Automating the EDC release process
+
+## Decision
+
+We will use GitHub actions to automate the release of both `SNAPSHOT` and release versions to decrease the error
+surface.
+
+A dedicated `releases` branch will be created to host those.
+
+## Rationale
+
+This allows committers to simply trigger the creation of a version through GitHub actions and does not require logging
+in to our JIPP (EF Jenkins) instance and perform manual actions there.
+
+Having a dedicated branch for all releases will it make easier in the future to provide hotfixes for older versions.
+
+## Approach
+
+There will be a new branch called `releases`, which is only used to record the history of our releases, i.e. receive
+merge commits for every release. Then, a new GitHub workflow will be created that:
+
+- prompts the user to input version string. This must be a SemVer string.
+- creates a tag on `main` with that version string, e.g. `v0.0.1-SNAPSHOT`
+- creates a merge-commit `main`->`releases`, where the version string is used in the commit message
+- triggers the release job on JIPP supplying the version string as input parameter
+- creates a GitHub Release
+
+The JIPP then builds and publishes the version to MavenCentral, or OSSRH Snapshots if the version string ends
+with `-SNAPSHOT`. For that, a new job will be created on Jenkins, that does _not_ have a cron-based build trigger.
+
+## Future improvements
+
+- update `gradle.properties`: the GitHub action could commit the user input (version string) back
+  into `gradle.properties`. That would result in an additional commit and was therefor left out for now.
+- bump version automatically: instead of manually entering a version we could have an "auto-bump" feature, that
+  automatically increases the version in `gradle.properties`. This makes snapshots with metadata more difficult
+  (e.g. `0.0.1-foobar-SNAPSHOT`), and was therefore skipped for now.
+- use Jenkins' GitHub hook trigger for GITScm polling: GitHub calls a WebHook in Jenkins, who then in turn
+  one-time-polls the Git repo, and triggers a build when changes were detected. This would get rid of the busy waiting
+  of the GitHub Jenkins Action.

--- a/docs/developer/decision-records/2022-07-06-release-automation/README.md
+++ b/docs/developer/decision-records/2022-07-06-release-automation/README.md
@@ -17,13 +17,13 @@ Having a dedicated branch for all releases will it make easier in the future to 
 ## Approach
 
 There will be a new branch called `releases`, which is only used to record the history of our releases, i.e. receive
-merge commits for every release. Then, a new GitHub workflow will be created that:
+merge commits for every release. In addition, a new GitHub workflow will be created that:
 
-- prompts the user to input version string. This must be a SemVer string.
-- creates a tag on `main` with that version string, e.g. `v0.0.1-SNAPSHOT`
-- creates a merge-commit `main`->`releases`, where the version string is used in the commit message
-- triggers the release job on JIPP supplying the version string as input parameter
-- creates a GitHub Release
+1. prompts the user to input version string. This must be a SemVer string.
+2. creates a tag on `main` with that version string, e.g. `v0.0.1-SNAPSHOT`. This could be done automatically in step 5.
+3. creates a merge-commit `main`->`releases`, where the version string is used in the commit message
+4. triggers the release job on JIPP supplying the version string as input parameter
+5. creates a GitHub Release
 
 The JIPP then builds and publishes the version to MavenCentral, or OSSRH Snapshots if the version string ends
 with `-SNAPSHOT`. For that, a new job will be created on Jenkins, that does _not_ have a cron-based build trigger.


### PR DESCRIPTION
## What this PR changes/adds

Adds decision-record about why and how we want to trigger releases from within GitHub Actions.

## Why it does that

to have a traceable history

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
