### PR TITLE
feat(build): automate release process

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,16 @@
+changelog:
+  exclude:
+    labels:
+      - no-changelog
+    authors:
+      - dependabot[bot]
+  categories:
+    - title: Bugs
+      labels:
+        - bug
+    - title: New Features & Improvements
+      labels:
+        - "*"
+    - title: Documentation
+      labels:
+        - documentation

--- a/.github/workflows/release-edc.yml
+++ b/.github/workflows/release-edc.yml
@@ -1,0 +1,74 @@
+name: Create EDC Release
+on:
+  workflow_dispatch:
+    inputs:
+      edc_version:
+        description: 'Version string that is used for publishing. Appending -SNAPSHOT will create a snapshot release.'
+        required: true
+        type: string
+
+
+env:
+  EDC_VERSION: ${{ github.event.inputs.edc_version || inputs.edc_version }}
+
+jobs:
+  Prepare-Release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: releases
+
+      # create tag using Github's own API
+      - name: Create tag on current branch (main)
+        uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/v${{ env.EDC_VERSION }}',
+              sha: context.sha
+            })
+
+      # create merge commit
+      - name: Merge main -> releases
+        uses: everlytic/branch-merge@1.1.2
+        with:
+          github_token: ${{ github.token }}
+          source_ref: ${{ github.ref }}
+          target_branch: 'releases'
+          commit_message_template: 'Merge commit for release of version v${{ env.EDC_VERSION }}'
+
+      # Trigger EF Jenkins
+      - name: Trigger Release on EF Jenkins
+        uses: toptal/jenkins-job-trigger-action@master
+        with:
+          jenkins_url: "https://ci.eclipse.org/dataspaceconnector/"
+          jenkins_user: ${{ secrets.EF_JENKINS_USER }}
+          jenkins_token: ${{ secrets.EF_JENKINS_TOKEN }}
+          job_name: "EDC-Autobuild-Release"
+          job_params: |
+            {
+              "VERSION": "${{ env.EDC_VERSION }}"
+            }
+          job_timeout: "3600" # Default 30 sec. (optional)
+
+
+  Github-Release:
+    needs:
+      - Prepare-Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: main
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          generateReleaseNotes: true
+          tag: "v${{ env.EDC_VERSION }}"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          removeArtifacts: true

--- a/docs/developer/modules.md
+++ b/docs/developer/modules.md
@@ -122,3 +122,17 @@ org.eclipse.dataspaceconnector:identity-did-web:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:oauth2-core:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:oauth2-spi:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:apache-commons-pool-sql:0.0.1-SNAPSHOT
+org.eclipse.dataspaceconnector:policy-store-cosmos:0.0.1-SNAPSHOT
+org.eclipse.dataspaceconnector:transfer-process-store-cosmos:0.0.1-SNAPSHOT
+org.eclipse.dataspaceconnector:data-plane-azure-data-factory:0.0.1-SNAPSHOT
+org.eclipse.dataspaceconnector:data-plane-azure-storage:0.0.1-SNAPSHOT
+org.eclipse.dataspaceconnector:dummy-credentials-verifier:0.0.1-SNAPSHOT
+org.eclipse.dataspaceconnector:identity-common-test:0.0.1-SNAPSHOT
+org.eclipse.dataspaceconnector:identity-did-core:0.0.1-SNAPSHOT
+org.eclipse.dataspaceconnector:identity-did-crypto:0.0.1-SNAPSHOT
+org.eclipse.dataspaceconnector:identity-did-service:0.0.1-SNAPSHOT
+org.eclipse.dataspaceconnector:identity-did-spi:0.0.1-SNAPSHOT
+org.eclipse.dataspaceconnector:identity-did-web:0.0.1-SNAPSHOT
+org.eclipse.dataspaceconnector:oauth2-core:0.0.1-SNAPSHOT
+org.eclipse.dataspaceconnector:oauth2-spi:0.0.1-SNAPSHOT
+org.eclipse.dataspaceconnector:apache-commons-pool-sql:0.0.1-SNAPSHOT

--- a/docs/developer/releases.md
+++ b/docs/developer/releases.md
@@ -45,7 +45,7 @@ as communication endpoints (e.g., based on HTTP). To support a fast-paced develo
 impacting the connector's core release cycle, modules contributing this type of public-facing API can be managed within
 a separate repository.
 
-The following modules are also distributed as individual artifact to support a convenient customisation of connectors
+The following modules are also distributed as individual artifacts to support a convenient customisation of connectors
 and are, however, not considered public APIs:
 
 - core/*
@@ -141,3 +141,35 @@ org.eclipse.dataspaceconnector:common-util
 ```
 
 A comprehensive list can be found [here](modules.md)
+
+#### Release guide
+
+_Note: the intended audience for this section are individuals who are eligible to author the release process. At the
+time of this writing these are the committers of the project._
+
+To trigger a new release please follow these simple steps:
+
+- update `CHANGELOG.md`: put the current "Unreleased" section under a new headline containing the new version string
+- update `gradle.properties`: set the `defaultVersion` entry to the new version
+- trigger the actual release in GitHub:
+    - on the `Actions` tab pick the `Create EDC Release` workflow
+    - Select the `main` branch
+    - clicking on `Run workflow` should bring up a prompt for the version string. Please enter the version string in
+      SemVer format without any prefixes: `0.0.4-something-SNAPSHOT` would be valid, whereas `v0.0.4-rc1` would not.
+    - start the workflow
+
+The GitHub workflow then performs these steps
+
+1. creates a tag on the current branch, e.g. `v0.0.4-something-SNAPSHOT` (note the `v` prefix). This is done using the
+   GitHub API.
+2. creates a merge commit from source branch to `releases`. The version information is encoded into the commit message.
+3. triggers the Eclipse Foundation Jenkins instance ("JIPP"). This is where the actual publishing to MavenCentral
+   happens. Note that this process may take quite a bit of time, as every module is signed and uploaded. **Important: if
+   the version string contains the `-SNAPSHOT` suffix, the version is uploaded to OSSRH Snapshots instead of
+   MavenCentral!**
+4. Creates a GitHub release including an automatically generated changelog. This is only for informational purposes, no
+   artifacts are uploaded. In addition, the GitHub Release has the following properties:
+    - always created off of `main` branch
+    - the release notes are auto-generated based on the last available tag and the `.github/releases.yaml` file
+    - no pre-releases are supported
+    - no discussions are created


### PR DESCRIPTION
## What this PR changes/adds

This PR introduces a new GitHub Actions workflow that automates the release process to OSSRH Staging and/or MavenCentral.

## Why it does that

To make the release process less manual and reduce the error surface. 

## Further notes

- The action is manual, only committers should be able to trigger it
- a valid SemVer must be entered
- The Jenkins publish action takes a long time and cannot be cancelled directly from GitHub.
- I haven't been able to test the auto-generated release notes, as I did not have any pull-requests in my fork

## Linked Issue(s)

Closes #1433 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
