### PR TITLE
action: add bot for first interactions

### DIFF
--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -1,0 +1,21 @@
+name: First Interaction
+
+on:
+  issues:
+    types: [ opened ]
+  pull_request_target:
+    types: [ opened ]
+
+jobs:
+  add-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: 'Thanks for your contribution :fire: We will take a look asap :rocket:'
+          pr-message: >-
+          'We are always happy to welcome new contributors :heart: To make things easier for everyone, please
+          - make sure to follow our [contribution guidelines](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md),
+          - check if you have already signed the [ECA](http://www.eclipse.org/legal/ecafaq.php), and
+          - relate this pull request to an existing issue or discussion.'


### PR DESCRIPTION
## What this PR changes/adds

Adds an action to comment issues and PRs of new contributors.

## Why it does that

In the context of our discussion yesterday, I remembered this action. Maybe it will help. 

## Further notes

--

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
