### PR TITLE
logs: Add relevant information in HttpDataSource logs

### DIFF
--- a/extensions/data-plane/data-plane-api/src/main/java/org/eclipse/dataspaceconnector/dataplane/api/validation/TokenValidationClientImpl.java
+++ b/extensions/data-plane/data-plane-api/src/main/java/org/eclipse/dataspaceconnector/dataplane/api/validation/TokenValidationClientImpl.java
@@ -25,6 +25,8 @@ import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 
 import java.io.IOException;
 
+import static java.lang.String.format;
+
 public class TokenValidationClientImpl implements TokenValidationClient {
 
     private final OkHttpClient httpClient;
@@ -38,11 +40,9 @@ public class TokenValidationClientImpl implements TokenValidationClient {
         this.mapper = mapper;
         this.monitor = monitor;
     }
-    
+
     @Override
     public Result<DataAddress> call(String token) {
-        monitor.debug("Start call to validation server");
-
         var request = new Request.Builder().url(endpoint).header(HttpHeaders.AUTHORIZATION, token).get().build();
         try (var response = httpClient.newCall(request).execute()) {
             var body = response.body();
@@ -54,7 +54,7 @@ public class TokenValidationClientImpl implements TokenValidationClient {
             if (response.isSuccessful()) {
                 return Result.success(mapper.readValue(stringBody, DataAddress.class));
             } else {
-                return Result.failure(String.format("Call to token validation sever failed: %s - %s. %s", response.code(), response.message(), stringBody));
+                return Result.failure(format("Call to token validation sever failed: %s - %s. %s", response.code(), response.message(), stringBody));
             }
         } catch (IOException e) {
             return Result.failure("Unhandled exception occurred during call to token validation server: " + e.getMessage());

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpDataSourceTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpDataSourceTest.java
@@ -82,7 +82,8 @@ class HttpDataSourceTest {
     @Test
     void verifyExceptionIsThrownIfCallFailed() {
         var message = FAKER.lorem().word();
-        var interceptor = new CustomInterceptor(400, ResponseBody.create(FAKER.lorem().word(), MediaType.parse("text/plain")), message);
+        var body = FAKER.lorem().word();
+        var interceptor = new CustomInterceptor(400, ResponseBody.create(body, MediaType.parse("text/plain")), message);
         var params = mock(HttpRequestParams.class);
         var request = new Request.Builder().url(url).get().build();
         var source = defaultBuilder(interceptor).params(params).build();
@@ -91,7 +92,7 @@ class HttpDataSourceTest {
 
         assertThatExceptionOfType(EdcException.class)
                 .isThrownBy(source::openPartStream)
-                .withMessageContaining("Received code transferring HTTP data for request %s: %d - %s", requestId, 400, message);
+                .withMessage("Received code transferring HTTP data for request %s: %d - %s. %s", requestId, 400, message, body);
 
         verify(params).toRequest();
     }


### PR DESCRIPTION
## What this PR changes/adds

Add http response body into the error logs of HttpDataSource.

## Why it does that

Response body generally contains reason why the call was unsuccessful, e.g. access token expired, malformed request...

## Further notes

## Linked Issue(s)

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
