### PR TITLE
fix(docs): replace link to swagger ui

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -21,7 +21,7 @@ and https://github.com/docsifyjs/docsify/issues/1139)
     - <a href="#/architecture/domain-model">Domain Model</a>
     - <a href="#/architecture/identity-management/README">Identity Management</a>
     - <a href="#/architecture/ids/README">IDS Standard</a>
-    - <a href="/swaggerui/index.html" target="_blank" title="Swagger UI in new tab">OpenAPI Specification</a>
+    - <a href="/DataSpaceConnector/swaggerui/index.html" target="_blank" title="Swagger UI in new tab">OpenAPI Specification</a>
     - <a href="#/architecture/usage-control/README">Usage Control</a>
 
 - Appendix


### PR DESCRIPTION
## What this PR changes/adds

Replaces link to Swagger UI

## Why it does that

Link in GitHub pages is not working. It points to <https://eclipse-dataspaceconnector.github.io/swaggerui/index.html> but should point to <https://eclipse-dataspaceconnector.github.io/DataSpaceConnector/swaggerui/index.html>.

## Further notes

--

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
