### PR TITLE
test: fix failure of TransferProcessEventDispatchTest (fixes #1616)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ in the detailed section referring to by linking pull requests or issues.
 
 #### Fixed
 
+* Fix failure of TransferProcessEventDispatchTest (#1616)
 * Fixed a dead link in contributor documentation (#1477)
 * Fix usage of `NAME` property in `HttpDataSourceFactory` (#1460)
 * Fix clearing Loaders in the FCC (#1495)

--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/CoreServicesExtension.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/CoreServicesExtension.java
@@ -23,6 +23,7 @@ import org.eclipse.dataspaceconnector.core.base.agent.ParticipantAgentServiceImp
 import org.eclipse.dataspaceconnector.core.base.policy.PolicyEngineImpl;
 import org.eclipse.dataspaceconnector.core.base.policy.RuleBindingRegistryImpl;
 import org.eclipse.dataspaceconnector.core.base.policy.ScopeFilter;
+import org.eclipse.dataspaceconnector.core.event.EventExecutorServiceContainer;
 import org.eclipse.dataspaceconnector.core.event.EventRouterImpl;
 import org.eclipse.dataspaceconnector.core.health.HealthCheckServiceConfiguration;
 import org.eclipse.dataspaceconnector.core.health.HealthCheckServiceImpl;
@@ -59,6 +60,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Optional.ofNullable;
@@ -211,7 +213,10 @@ public class CoreServicesExtension implements ServiceExtension {
 
     @Provider
     public EventRouter eventRouter(ServiceExtensionContext context) {
-        return new EventRouterImpl(context.getMonitor());
+        var executor = context.hasService(EventExecutorServiceContainer.class) ?
+                context.getService(EventExecutorServiceContainer.class).getExecutorService() :
+                Executors.newFixedThreadPool(1); // TODO: make configurable
+        return new EventRouterImpl(context.getMonitor(), executor);
     }
 
     @Provider(isDefault = true)

--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/CoreServicesExtension.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/CoreServicesExtension.java
@@ -111,7 +111,7 @@ public class CoreServicesExtension implements ServiceExtension {
     @Inject
     private PrivateKeyResolver privateKeyResolver;
 
-    @Inject
+    @Inject(required = false)
     private EventExecutorServiceContainer eventExecutorServiceContainer;
 
     private HealthCheckServiceImpl healthCheckService;
@@ -216,7 +216,15 @@ public class CoreServicesExtension implements ServiceExtension {
 
     @Provider
     public EventRouter eventRouter(ServiceExtensionContext context) {
+        if (eventExecutorServiceContainer == null) {
+            eventExecutorServiceContainer = eventExecutorServiceContainer();
+        }
         return new EventRouterImpl(context.getMonitor(), eventExecutorServiceContainer.getExecutorService());
+    }
+
+    @Provider(isDefault = true)
+    public EventExecutorServiceContainer eventExecutorServiceContainer() {
+        return new EventExecutorServiceContainer(Executors.newFixedThreadPool(1)); // TODO: make configurable
     }
 
     @Provider(isDefault = true)
@@ -232,11 +240,6 @@ public class CoreServicesExtension implements ServiceExtension {
     @Provider(isDefault = true)
     public CertificateResolver certificateResolver() {
         return new NoopCertificateResolver();
-    }
-
-    @Provider(isDefault = true)
-    public EventExecutorServiceContainer eventExecutorServiceContainer() {
-        return new EventExecutorServiceContainer(Executors.newFixedThreadPool(1)); // TODO: make configurable
     }
 
     private HealthCheckServiceConfiguration getHealthCheckConfig(ServiceExtensionContext context) {

--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/CoreServicesExtension.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/CoreServicesExtension.java
@@ -111,6 +111,9 @@ public class CoreServicesExtension implements ServiceExtension {
     @Inject
     private PrivateKeyResolver privateKeyResolver;
 
+    @Inject
+    private EventExecutorServiceContainer eventExecutorServiceContainer;
+
     private HealthCheckServiceImpl healthCheckService;
     private RuleBindingRegistryImpl ruleBindingRegistry;
     private ScopeFilter scopeFilter;
@@ -213,10 +216,7 @@ public class CoreServicesExtension implements ServiceExtension {
 
     @Provider
     public EventRouter eventRouter(ServiceExtensionContext context) {
-        var executor = context.hasService(EventExecutorServiceContainer.class) ?
-                context.getService(EventExecutorServiceContainer.class).getExecutorService() :
-                Executors.newFixedThreadPool(1); // TODO: make configurable
-        return new EventRouterImpl(context.getMonitor(), executor);
+        return new EventRouterImpl(context.getMonitor(), eventExecutorServiceContainer.getExecutorService());
     }
 
     @Provider(isDefault = true)
@@ -232,6 +232,11 @@ public class CoreServicesExtension implements ServiceExtension {
     @Provider(isDefault = true)
     public CertificateResolver certificateResolver() {
         return new NoopCertificateResolver();
+    }
+
+    @Provider(isDefault = true)
+    public EventExecutorServiceContainer eventExecutorServiceContainer() {
+        return new EventExecutorServiceContainer(Executors.newFixedThreadPool(1)); // TODO: make configurable
     }
 
     private HealthCheckServiceConfiguration getHealthCheckConfig(ServiceExtensionContext context) {

--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/event/EventExecutorServiceContainer.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/event/EventExecutorServiceContainer.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Masatake Iwasaki (NTT DATA) - initial code
+ *
+ */
+
+package org.eclipse.dataspaceconnector.core.event;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Holder class for a shared {@link ExecutorService} across event router implementations.
+ */
+public class EventExecutorServiceContainer {
+    private final ExecutorService executorService;
+
+    public EventExecutorServiceContainer(@NotNull ExecutorService executorService) {
+        this.executorService = executorService;
+    }
+
+    public @NotNull ExecutorService getExecutorService() {
+        return executorService;
+    }
+}

--- a/core/base/src/test/java/org/eclipse/dataspaceconnector/core/CoreServicesExtensionTest.java
+++ b/core/base/src/test/java/org/eclipse/dataspaceconnector/core/CoreServicesExtensionTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.core;
 
+import org.eclipse.dataspaceconnector.core.event.EventExecutorServiceContainer;
 import org.eclipse.dataspaceconnector.core.security.DefaultPrivateKeyParseFunction;
 import org.eclipse.dataspaceconnector.policy.model.PolicyRegistrationTypes;
 import org.eclipse.dataspaceconnector.spi.security.PrivateKeyResolver;
@@ -55,6 +56,8 @@ class CoreServicesExtensionTest {
     void setUp(ServiceExtensionContext context, ObjectFactory factory) {
         privateKeyResolverMock = mock(PrivateKeyResolver.class);
         context.registerService(PrivateKeyResolver.class, privateKeyResolverMock);
+
+        context.registerService(EventExecutorServiceContainer.class, mock(EventExecutorServiceContainer.class));
 
         typeManager = context.getTypeManager(); //is already a spy!
         context.registerService(ExecutorInstrumentation.class, mock(ExecutorInstrumentation.class));

--- a/core/base/src/test/java/org/eclipse/dataspaceconnector/core/CoreServicesExtensionTest.java
+++ b/core/base/src/test/java/org/eclipse/dataspaceconnector/core/CoreServicesExtensionTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.core;
 
-import org.eclipse.dataspaceconnector.core.event.EventExecutorServiceContainer;
 import org.eclipse.dataspaceconnector.core.security.DefaultPrivateKeyParseFunction;
 import org.eclipse.dataspaceconnector.policy.model.PolicyRegistrationTypes;
 import org.eclipse.dataspaceconnector.spi.security.PrivateKeyResolver;
@@ -56,8 +55,6 @@ class CoreServicesExtensionTest {
     void setUp(ServiceExtensionContext context, ObjectFactory factory) {
         privateKeyResolverMock = mock(PrivateKeyResolver.class);
         context.registerService(PrivateKeyResolver.class, privateKeyResolverMock);
-
-        context.registerService(EventExecutorServiceContainer.class, mock(EventExecutorServiceContainer.class));
 
         typeManager = context.getTypeManager(); //is already a spy!
         context.registerService(ExecutorInstrumentation.class, mock(ExecutorInstrumentation.class));

--- a/core/base/src/test/java/org/eclipse/dataspaceconnector/core/event/EventRouterImplTest.java
+++ b/core/base/src/test/java/org/eclipse/dataspaceconnector/core/event/EventRouterImplTest.java
@@ -21,6 +21,7 @@ import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.junit.jupiter.api.Test;
 
 import java.time.Clock;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static org.awaitility.Awaitility.await;
@@ -34,7 +35,7 @@ class EventRouterImplTest {
 
     private final Clock clock = Clock.systemUTC();
     private final Monitor monitor = mock(Monitor.class);
-    private final EventRouterImpl eventRouter = new EventRouterImpl(monitor);
+    private final EventRouterImpl eventRouter = new EventRouterImpl(monitor, Executors.newSingleThreadExecutor());
 
     @Test
     void shouldPublishToAllSubscribers() {


### PR DESCRIPTION
## What this PR changes/adds

* Setting retly.limit to higer values enables transision to expected state.
* Disabling exponentional make transition to expected failure state within 10 seconds (which is default timeout of Awaitility).
* Waiting completion of EventRouter tasks.

## Linked Issue(s)

Closes #1616

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [n/a] documented public classes/methods?
- [n/a] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
