### PR TITLE
fix: Fix incompatibility between `FsPrivateKeyResolver` and `DecentralizedIdentityServiceExtension`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Fix race condition in `ContractNegotiationIntegrationTest` (#1505)
 * Fix for change in Cosmos DB behavior on missing sort fields (#1514)
 * Effectively removed default LIMIT in SQL Contract Def Store (#1515)
+* Fix incompatibility `DecentralizedIdentityServiceExtension` and `FsPrivateKeyResolver` (#1618)
 
 ## [milestone-4] - 2022-06-07
 

--- a/extensions/filesystem/vault-fs/build.gradle.kts
+++ b/extensions/filesystem/vault-fs/build.gradle.kts
@@ -16,9 +16,13 @@ plugins {
     `java-library`
 }
 
+val bouncycastleVersion: String by project
+
 dependencies {
     api(project(":spi"))
     implementation(project(":common:util"))
+
+    implementation("org.bouncycastle:bcpkix-jdk15on:${bouncycastleVersion}")
 }
 
 publishing {

--- a/extensions/filesystem/vault-fs/src/test/java/org/eclipse/dataspaceconnector/core/security/fs/FsPrivateKeyResolverTest.java
+++ b/extensions/filesystem/vault-fs/src/test/java/org/eclipse/dataspaceconnector/core/security/fs/FsPrivateKeyResolverTest.java
@@ -18,37 +18,38 @@ package org.eclipse.dataspaceconnector.core.security.fs;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.InputStream;
 import java.security.KeyStore;
-import java.security.PrivateKey;
-import java.security.interfaces.RSAPrivateKey;
+import java.util.Objects;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-class FsRsaPrivateKeyResolverTest {
+class FsPrivateKeyResolverTest {
     private static final String PASSWORD = "test123";
     private static final String TEST_KEYSTORE = "edc-test-keystore.jks";
 
     private FsPrivateKeyResolver keyResolver;
 
     @Test
-    public void verifyResolution() {
-        assertNotNull(keyResolver.resolvePrivateKey("testkey", PrivateKey.class));
+    void verifyResolutionOk() {
+        assertThat(keyResolver.getEncodedKey("testkey"))
+                .isNotNull()
+                .contains("-----BEGIN RSA PRIVATE KEY-----");
     }
 
     @Test
-    public void verifyResolution_Rsa() {
-        assertNotNull(keyResolver.resolvePrivateKey("testkey", RSAPrivateKey.class));
+    void verifyResolutionKo() {
+        assertThat(keyResolver.getEncodedKey("testkeyxx"))
+                .isNull();
     }
 
     @BeforeEach
     void setUp() throws Exception {
-        var url = getClass().getClassLoader().getResource(FsRsaPrivateKeyResolverTest.TEST_KEYSTORE);
-        KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
-        assert url != null;
-        try (InputStream stream = url.openStream()) {
-            keyStore.load(stream, FsRsaPrivateKeyResolverTest.PASSWORD.toCharArray());
+        var url = getClass().getClassLoader().getResource(FsPrivateKeyResolverTest.TEST_KEYSTORE);
+        Objects.requireNonNull(url);
+        var keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        try (var stream = url.openStream()) {
+            keyStore.load(stream, FsPrivateKeyResolverTest.PASSWORD.toCharArray());
         }
-        keyResolver = new FsPrivateKeyResolver(FsRsaPrivateKeyResolverTest.PASSWORD, keyStore);
+        keyResolver = new FsPrivateKeyResolver(FsPrivateKeyResolverTest.PASSWORD, keyStore);
     }
 }

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/security/ConfigurablePrivateKeyResolver.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/security/ConfigurablePrivateKeyResolver.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - Initial implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.security;
+
+import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+public abstract class ConfigurablePrivateKeyResolver implements PrivateKeyResolver {
+
+    private final List<KeyParser<?>> parsers;
+
+    protected ConfigurablePrivateKeyResolver(KeyParser<?>... parsers) {
+        this.parsers = Arrays.asList(parsers);
+    }
+
+    protected ConfigurablePrivateKeyResolver() {
+        parsers = new ArrayList<>();
+    }
+
+    @Nullable
+    protected abstract String getEncodedKey(String id);
+
+    @Override
+    public @Nullable <T> T resolvePrivateKey(String id, Class<T> keyType) {
+        return Optional.ofNullable(getEncodedKey(id))
+                .map(encoded -> keyType.cast(getParser(keyType).parse(encoded)))
+                .orElse(null);
+    }
+
+    @Override
+    public <T> void addParser(KeyParser<T> parser) {
+        parsers.add(parser);
+    }
+
+    @Override
+    public <T> void addParser(Class<T> forType, Function<String, T> parseFunction) {
+        var p = new KeyParser<T>() {
+            @Override
+            public boolean canParse(Class<?> keyType) {
+                return Objects.equals(keyType, forType);
+            }
+
+            @Override
+            public T parse(String encoded) {
+                return parseFunction.apply(encoded);
+            }
+        };
+        addParser(p);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> KeyParser<T> getParser(Class<T> keyType) {
+        return (KeyParser<T>) parsers.stream().filter(p -> p.canParse(keyType))
+                .findFirst()
+                .orElseThrow(() -> new EdcException("Cannot find KeyParser for type " + keyType));
+    }
+}

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/security/VaultPrivateKeyResolver.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/security/VaultPrivateKeyResolver.java
@@ -14,73 +14,27 @@
 
 package org.eclipse.dataspaceconnector.spi.security;
 
-import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-import java.util.function.Function;
 
 /**
  * Implementation that returns private keys stored in a vault.
  */
-public class VaultPrivateKeyResolver implements PrivateKeyResolver {
+public class VaultPrivateKeyResolver extends ConfigurablePrivateKeyResolver {
 
     private final Vault vault;
-    private final List<KeyParser<?>> parsers;
 
     public VaultPrivateKeyResolver(Vault vault, KeyParser<?>... parsers) {
+        super(parsers);
         this.vault = vault;
-        this.parsers = Arrays.asList(parsers);
     }
 
     public VaultPrivateKeyResolver(Vault vault) {
-        // can't use this(vault) here because properties are final
+        super();
         this.vault = vault;
-        parsers = new ArrayList<>();
     }
 
     @Override
-    public @Nullable <T> T resolvePrivateKey(String id, Class<T> keyType) {
-        var encodedKey = vault.resolveSecret(id);
-
-        if (encodedKey == null) {
-            return null;
-        }
-
-        return keyType.cast(getParser(keyType).parse(encodedKey));
-    }
-
-    @Override
-    public <T> void addParser(KeyParser<T> parser) {
-        parsers.add(parser);
-    }
-
-    @Override
-    public <T> void addParser(Class<T> forType, Function<String, T> parseFunction) {
-        var p = new KeyParser<T>() {
-
-            @Override
-            public boolean canParse(Class<?> keyType) {
-                return Objects.equals(keyType, forType);
-            }
-
-            @Override
-            public T parse(String encoded) {
-                return parseFunction.apply(encoded);
-            }
-        };
-        addParser(p);
-    }
-
-    @SuppressWarnings("unchecked")
-    private <T> KeyParser<T> getParser(Class<T> keytype) {
-        return (KeyParser<T>) parsers.stream().filter(p -> p.canParse(keytype))
-                .findFirst().orElseThrow(() -> {
-                            throw new EdcException("Cannot find KeyParser for type " + keytype);
-                        }
-                );
+    protected @Nullable String getEncodedKey(String id) {
+        return vault.resolveSecret(id);
     }
 }

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/security/ConfigurablePrivateKeyResolverTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/security/ConfigurablePrivateKeyResolverTest.java
@@ -1,0 +1,148 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.security;
+
+import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import javax.crypto.interfaces.DHPrivateKey;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ConfigurablePrivateKeyResolverTest {
+
+    private static final String TEST_SECRET_ALIAS = "test-secret";
+
+    private Map<String, String> cache;
+    private ConfigurablePrivateKeyResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        cache = new HashMap<>();
+        resolver = new MockPrivateKeyResolver(cache);
+        resolver.addParser(new DummyParser());
+    }
+
+    @Test
+    void resolvePrivateKey() {
+        cache.put(TEST_SECRET_ALIAS, PrivateTestKeys.ENCODED_PRIVATE_KEY_HEADER);
+
+        var result = resolver.resolvePrivateKey(TEST_SECRET_ALIAS, RSAPrivateKey.class);
+
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    void resolvePrivateKey_encodedKeyNotFound() {
+        var result = resolver.resolvePrivateKey(TEST_SECRET_ALIAS, RSAPrivateKey.class);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void resolvePrivateKey_encodedKeyNotInCorrectFormat() {
+        cache.put(TEST_SECRET_ALIAS, PrivateTestKeys.ENCODED_PRIVATE_KEY_NOPEM);
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> resolver.resolvePrivateKey(TEST_SECRET_ALIAS, RSAPrivateKey.class));
+    }
+
+    @Test
+    void resolvePrivateKey_noParserFound() {
+        cache.put(TEST_SECRET_ALIAS, PrivateTestKeys.ENCODED_PRIVATE_KEY_HEADER);
+
+        assertThatExceptionOfType(EdcException.class)
+                .isThrownBy(() -> resolver.resolvePrivateKey(TEST_SECRET_ALIAS, DHPrivateKey.class))
+                .withMessageContaining("Cannot find KeyParser for type");
+    }
+
+    @Test
+    void addParser() {
+        cache.put(TEST_SECRET_ALIAS, PrivateTestKeys.ENCODED_PRIVATE_KEY_HEADER);
+
+        resolver = new MockPrivateKeyResolver(cache);
+        // no parsers present
+        assertThatThrownBy(() -> resolver.resolvePrivateKey(TEST_SECRET_ALIAS, RSAPrivateKey.class)).isInstanceOf(EdcException.class);
+        resolver.addParser(new DummyParser());
+
+        // same resolve call should work now
+        assertThat(resolver.resolvePrivateKey(TEST_SECRET_ALIAS, RSAPrivateKey.class)).isNotNull();
+    }
+
+    @Test
+    void testAddParser() {
+        cache.put(TEST_SECRET_ALIAS, PrivateTestKeys.ENCODED_PRIVATE_KEY_HEADER);
+
+        resolver = new MockPrivateKeyResolver(cache);
+        // no parsers present
+        assertThatThrownBy(() -> resolver.resolvePrivateKey(TEST_SECRET_ALIAS, RSAPrivateKey.class)).isInstanceOf(EdcException.class);
+        resolver.addParser(RSAPrivateKey.class, s -> new DummyParser().parse(s));
+
+        // same resolve call should work now
+        assertThat(resolver.resolvePrivateKey(TEST_SECRET_ALIAS, RSAPrivateKey.class)).isNotNull();
+    }
+
+    private static class MockPrivateKeyResolver extends ConfigurablePrivateKeyResolver {
+
+        private final Map<String, String> cache;
+
+        private MockPrivateKeyResolver(Map<String, String> cache) {
+            this.cache = cache;
+        }
+
+        @Override
+        protected @Nullable String getEncodedKey(String id) {
+            return cache.get(id);
+        }
+    }
+
+    private static class DummyParser implements KeyParser<RSAPrivateKey> {
+
+        private static final String PEM_HEADER = "-----BEGIN PRIVATE KEY-----";
+        private static final String PEM_FOOTER = "-----END PRIVATE KEY-----";
+
+        @Override
+        public boolean canParse(Class<?> keyType) {
+            return keyType.equals(RSAPrivateKey.class);
+        }
+
+        @Override
+        public RSAPrivateKey parse(String entirePemFileContent) {
+            entirePemFileContent = entirePemFileContent.replace(PEM_HEADER, "").replaceAll(System.lineSeparator(), "").replace(PEM_FOOTER, "");
+            entirePemFileContent = entirePemFileContent.replace("\n", ""); //base64 might complain if newlines are present
+
+            try {
+                KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+                return (RSAPrivateKey) keyFactory.generatePrivate(new PKCS8EncodedKeySpec(Base64.getDecoder().decode(entirePemFileContent.getBytes())));
+
+            } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}
+

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/security/VaultPrivateKeyResolverTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/security/VaultPrivateKeyResolverTest.java
@@ -14,21 +14,10 @@
 
 package org.eclipse.dataspaceconnector.spi.security;
 
-import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.security.KeyFactory;
-import java.security.NoSuchAlgorithmException;
-import java.security.interfaces.RSAPrivateKey;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.PKCS8EncodedKeySpec;
-import java.util.Base64;
-import javax.crypto.interfaces.DHPrivateKey;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -42,94 +31,26 @@ class VaultPrivateKeyResolverTest {
     @BeforeEach
     void setUp() {
         resolver = new VaultPrivateKeyResolver(vault);
-        resolver.addParser(new DummyParser());
     }
 
     @Test
-    void resolvePrivateKey() {
+    void verifyResolutionOk() {
         when(vault.resolveSecret(TEST_SECRET_ALIAS)).thenReturn(PrivateTestKeys.ENCODED_PRIVATE_KEY_HEADER);
 
-        var result = resolver.resolvePrivateKey(TEST_SECRET_ALIAS, RSAPrivateKey.class);
+        assertThat(resolver.getEncodedKey(TEST_SECRET_ALIAS))
+                .isNotNull()
+                .isEqualTo(PrivateTestKeys.ENCODED_PRIVATE_KEY_HEADER);
 
-        assertThat(result).isNotNull();
-        verify(vault, atLeastOnce()).resolveSecret(TEST_SECRET_ALIAS);
+        verify(vault).resolveSecret(TEST_SECRET_ALIAS);
     }
 
     @Test
-    void resolvePrivateKey_secretNotFound() {
-        var result = resolver.resolvePrivateKey(TEST_SECRET_ALIAS, RSAPrivateKey.class);
+    void verifyResolutionKo() {
+        when(vault.resolveSecret(TEST_SECRET_ALIAS)).thenReturn(null);
 
-        assertThat(result).isNull();
-    }
+        assertThat(resolver.getEncodedKey(TEST_SECRET_ALIAS)).isNull();
 
-    @Test
-    void resolvePrivateKey_secretNotInCorrectFormat() {
-        when(vault.resolveSecret(TEST_SECRET_ALIAS)).thenReturn(PrivateTestKeys.ENCODED_PRIVATE_KEY_NOPEM);
-
-        assertThatThrownBy(() -> resolver.resolvePrivateKey(TEST_SECRET_ALIAS, RSAPrivateKey.class)).isInstanceOf(IllegalArgumentException.class);
-        verify(vault, atLeastOnce()).resolveSecret(TEST_SECRET_ALIAS);
-    }
-
-    @Test
-    void resolvePrivateKey_noParserFound() {
-        when(vault.resolveSecret(TEST_SECRET_ALIAS)).thenReturn(PrivateTestKeys.ENCODED_PRIVATE_KEY_NOPEM);
-
-        assertThatThrownBy(() -> resolver.resolvePrivateKey(TEST_SECRET_ALIAS, DHPrivateKey.class)).isInstanceOf(EdcException.class)
-                .hasMessageStartingWith("Cannot find KeyParser for type");
-        verify(vault, atLeastOnce()).resolveSecret(TEST_SECRET_ALIAS);
-    }
-
-    @Test
-    void addParser() {
-        when(vault.resolveSecret(TEST_SECRET_ALIAS)).thenReturn(PrivateTestKeys.ENCODED_PRIVATE_KEY_HEADER);
-
-        resolver = new VaultPrivateKeyResolver(vault);
-        // no parsers present
-        assertThatThrownBy(() -> resolver.resolvePrivateKey(TEST_SECRET_ALIAS, RSAPrivateKey.class)).isInstanceOf(EdcException.class);
-        resolver.addParser(new DummyParser());
-
-        //same resolve call should work now
-        assertThat(resolver.resolvePrivateKey(TEST_SECRET_ALIAS, RSAPrivateKey.class)).isNotNull();
-        verify(vault, atLeastOnce()).resolveSecret(TEST_SECRET_ALIAS);
-    }
-
-    @Test
-    void testAddParser() {
-        when(vault.resolveSecret(TEST_SECRET_ALIAS)).thenReturn(PrivateTestKeys.ENCODED_PRIVATE_KEY_HEADER);
-
-        resolver = new VaultPrivateKeyResolver(vault);
-        // no parsers present
-        assertThatThrownBy(() -> resolver.resolvePrivateKey(TEST_SECRET_ALIAS, RSAPrivateKey.class)).isInstanceOf(EdcException.class);
-        resolver.addParser(RSAPrivateKey.class, s -> new DummyParser().parse(s));
-
-        //same resolve call should work now
-        assertThat(resolver.resolvePrivateKey(TEST_SECRET_ALIAS, RSAPrivateKey.class)).isNotNull();
-        verify(vault, atLeastOnce()).resolveSecret(TEST_SECRET_ALIAS);
-    }
-
-    private static class DummyParser implements KeyParser<RSAPrivateKey> {
-
-        private static final String PEM_HEADER = "-----BEGIN PRIVATE KEY-----";
-        private static final String PEM_FOOTER = "-----END PRIVATE KEY-----";
-
-        @Override
-        public boolean canParse(Class<?> keyType) {
-            return keyType.equals(RSAPrivateKey.class);
-        }
-
-        @Override
-        public RSAPrivateKey parse(String entirePemFileContent) {
-            entirePemFileContent = entirePemFileContent.replace(PEM_HEADER, "").replaceAll(System.lineSeparator(), "").replace(PEM_FOOTER, "");
-            entirePemFileContent = entirePemFileContent.replace("\n", ""); //base64 might complain if newlines are present
-
-            try {
-                KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-                return (RSAPrivateKey) keyFactory.generatePrivate(new PKCS8EncodedKeySpec(Base64.getDecoder().decode(entirePemFileContent.getBytes())));
-
-            } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
-                throw new RuntimeException(e);
-            }
-        }
+        verify(vault).resolveSecret(TEST_SECRET_ALIAS);
     }
 }
 


### PR DESCRIPTION
## What this PR changes/adds

This PR aligns the internal behavior of `FsPrivateKeyResolver` with the one of `VaultPrivateKeyResolver`. Especially it introduces the possibility, when using `FsPrivateKeyResolver` to define key parsing function, as it is already possible with `VaultPrivateKeyResolver`. 

This is obtained by converting the keys retrieved from the keystore into PEM string, before storing them into the internal cache of `FsPrivateKeyResolver`. 

## Why it does that

With current implementation, `FsPrivateKeyResolver` can only resolve keys to types `RsaPrivateKey` or `EcPrivateKey`, while `DecentralizedIdentityServiceExtension` actually requires to resolve to a `PrivateKeyWrapper`. This was resulting in an exception being thrown at startup when combining these extensions.

## Further notes

## Linked Issue(s)

Closes #1618 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
