### PR TITLE
cleanup: adapt logs to logging guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,8 @@ in the detailed section referring to by linking pull requests or issues.
 * Fix race condition in `ContractNegotiationIntegrationTest` (#1505)
 * Fix for change in Cosmos DB behavior on missing sort fields (#1514)
 * Effectively removed default LIMIT in SQL Contract Def Store (#1515)
-* Added query validation (#1605)
+* Add query validation (#1605)
+* Adapt logs to the logging guide (#1425)
 
 ## [milestone-4] - 2022-06-07
 

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/AbstractContractNegotiationManager.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/AbstractContractNegotiationManager.java
@@ -211,7 +211,7 @@ public abstract class AbstractContractNegotiationManager {
                     negotiation.transitionError("Retry limited exceeded: " + throwable.getMessage());
                     update(negotiation, l -> l.preError(negotiation));
                     observable.invokeForEach(l -> l.failed(negotiation));
-                    monitor.warning(format("[%s] attempt #%d failed to %s. Retry limit exceeded, ContractNegotiation %s moves to ERROR state",
+                    monitor.severe(format("[%s] attempt #%d failed to %s. Retry limit exceeded, ContractNegotiation %s moves to ERROR state",
                             getName(), negotiation.getStateCount(), operationDescription, negotiation.getId()), throwable);
                 } else {
                     onFailureHandler.accept(negotiation);

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
@@ -358,7 +358,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
         var checker = statusCheckerRegistry.resolve(process.getDataRequest().getDestinationType());
         if (checker == null) {
             if (process.getDataRequest().isManagedResources()) {
-                monitor.info(format("No checker found for process %s. The process will not advance to the COMPLETED state.", process.getId()));
+                monitor.warning(format("No checker found for process %s. The process will not advance to the COMPLETED state.", process.getId()));
                 return false;
             } else {
                 //no checker, transition the process to the COMPLETED state automatically
@@ -372,7 +372,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
                 return true;
             } else {
                 // Process is not finished yet, so it stays in the IN_PROGRESS state
-                monitor.info(format("Transfer process %s not COMPLETED yet. The process will not advance to the COMPLETED state.", process.getId()));
+                monitor.debug(format("Transfer process %s not COMPLETED yet. The process will not advance to the COMPLETED state.", process.getId()));
                 breakLease(process);
                 return false;
             }
@@ -631,13 +631,13 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
 
     private void sendCustomerRequestFailure(TransferProcess transferProcess, Throwable e) {
         if (sendRetryManager.retriesExhausted(transferProcess)) {
-            monitor.info(format("TransferProcessManager: attempt #%d failed to send transfer. Retry limit exceeded, TransferProcess %s moves to ERROR state.",
+            monitor.severe(format("TransferProcessManager: attempt #%d failed to send transfer. Retry limit exceeded, TransferProcess %s moves to ERROR state.",
                     transferProcess.getStateCount(),
                     transferProcess.getId()), e);
             transitionToError(transferProcess.getId(), e, "Retry limit exceeded");
             return;
         }
-        monitor.info(format("TransferProcessManager: attempt #%d failed to send transfer. TransferProcess %s stays in state %s.",
+        monitor.debug(format("TransferProcessManager: attempt #%d failed to send transfer. TransferProcess %s stays in state %s.",
                 transferProcess.getStateCount(),
                 transferProcess.getId(),
                 TransferProcessStates.from(transferProcess.getState())), e);

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ArtifactRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ArtifactRequestHandler.java
@@ -87,31 +87,31 @@ public class ArtifactRequestHandler implements Handler {
         var artifactUri = artifactRequestMessage.getRequestedArtifact();
         var artifactIdsId = IdsIdParser.parse(artifactUri.toString());
         if (artifactIdsId.getType() != IdsType.ARTIFACT) {
-            monitor.info("ArtifactRequestHandler: Requested artifact URI not of type artifact.");
+            monitor.debug("ArtifactRequestHandler: Requested artifact URI not of type artifact.");
             return createBadParametersErrorMultipartResponse(multipartRequest.getHeader());
         }
 
         var contractUri = artifactRequestMessage.getTransferContract();
         var contractIdsId = IdsIdParser.parse(contractUri.toString());
         if (contractIdsId.getType() != IdsType.CONTRACT) {
-            monitor.info("ArtifactRequestHandler: Requested artifact URI not of type contract.");
+            monitor.debug("ArtifactRequestHandler: Transfer contract URI not of type contract.");
             return createBadParametersErrorMultipartResponse(multipartRequest.getHeader());
         }
 
         var contractAgreement = contractNegotiationStore.findContractAgreement(contractIdsId.getValue());
         if (contractAgreement == null) {
-            monitor.info(String.format("ArtifactRequestHandler: No contract agreement with id %s found.", contractIdsId.getValue()));
+            monitor.debug(String.format("ArtifactRequestHandler: No contract agreement with id %s found.", contractIdsId.getValue()));
             return createBadParametersErrorMultipartResponse(multipartRequest.getHeader());
         }
 
         var isContractValid = contractValidationService.validate(claimToken, contractAgreement);
         if (!isContractValid) {
-            monitor.info("ArtifactRequestHandler: Contract is invalid");
+            monitor.debug("ArtifactRequestHandler: Contract is invalid");
             return createBadParametersErrorMultipartResponse(multipartRequest.getHeader());
         }
 
         if (!artifactIdsId.getValue().equals(contractAgreement.getAssetId())) {
-            monitor.info(String.format("ArtifactRequestHandler: invalid artifact id specified %s for contract: %s", artifactIdsId.getValue(), contractIdsId.getValue()));
+            monitor.debug(String.format("ArtifactRequestHandler: invalid artifact id specified %s for contract: %s", artifactIdsId.getValue(), contractIdsId.getValue()));
             return createBadParametersErrorMultipartResponse(multipartRequest.getHeader());
         }
 

--- a/extensions/aws/s3/s3-provision/src/main/java/org/eclipse/dataspaceconnector/aws/s3/provision/AwsProvisionExtension.java
+++ b/extensions/aws/s3/s3-provision/src/main/java/org/eclipse/dataspaceconnector/aws/s3/provision/AwsProvisionExtension.java
@@ -96,7 +96,7 @@ public class AwsProvisionExtension implements ServiceExtension {
         try {
             clientProvider.shutdown();
         } catch (Exception e) {
-            monitor.info("Error closing S3 client provider", e);
+            monitor.severe("Error closing S3 client provider", e);
         }
     }
 

--- a/extensions/azure/blobstorage/blob-provision/src/main/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageProvisioner.java
+++ b/extensions/azure/blobstorage/blob-provision/src/main/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageProvisioner.java
@@ -58,7 +58,7 @@ public class ObjectStorageProvisioner implements Provisioner<ObjectStorageResour
         String containerName = resourceDefinition.getContainerName();
         String accountName = resourceDefinition.getAccountName();
 
-        monitor.info("Azure Storage Container request submitted: " + containerName);
+        monitor.debug("Azure Storage Container request submitted: " + containerName);
 
         OffsetDateTime expiryTime = OffsetDateTime.now().plusHours(1);
 

--- a/extensions/azure/cosmos/transfer-process-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStoreExtension.java
+++ b/extensions/azure/cosmos/transfer-process-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStoreExtension.java
@@ -55,7 +55,7 @@ public class CosmosTransferProcessStoreExtension implements ServiceExtension {
 
         var connectorId = context.getConnectorId();
 
-        monitor.info("CosmosTransferProcessStore will use connector id '" + connectorId + "'");
+        monitor.debug("CosmosTransferProcessStore will use connector id '" + connectorId + "'");
         TransferProcessStoreCosmosConfig configuration = new TransferProcessStoreCosmosConfig(context);
         var client = clientProvider.createClient(vault, configuration);
         var cosmosDbApi = new CosmosDbApiImpl(configuration, client);

--- a/extensions/azure/data-plane/data-factory/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azuredatafactory/AzureDataFactoryTransferManager.java
+++ b/extensions/azure/data-plane/data-factory/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azuredatafactory/AzureDataFactoryTransferManager.java
@@ -92,7 +92,7 @@ public class AzureDataFactoryTransferManager {
 
         var runId = client.runPipeline(pipeline).runId();
 
-        monitor.info("Created ADF pipeline for " + request.getProcessId() + ". Run id is " + runId);
+        monitor.debug("Created ADF pipeline for " + request.getProcessId() + ". Run id is " + runId);
 
         return awaitRunCompletion(runId)
                 .thenApply(result -> {
@@ -110,14 +110,14 @@ public class AzureDataFactoryTransferManager {
 
     @NotNull
     private CompletableFuture<StatusResult<Void>> awaitRunCompletion(String runId) {
-        monitor.info("Awaiting ADF pipeline completion for run " + runId);
+        monitor.debug("Awaiting ADF pipeline completion for run " + runId);
 
         var timeout = clock.instant().plus(maxDuration);
         while (clock.instant().isBefore(timeout)) {
             var pipelineRun = client.getPipelineRun(runId);
             var runStatusValue = pipelineRun.status();
             var message = pipelineRun.message();
-            monitor.info("ADF run status is " + runStatusValue + " with message [" + message + "] for run " + runId);
+            monitor.debug("ADF run status is " + runStatusValue + " with message [" + message + "] for run " + runId);
             DataFactoryPipelineRunStates runStatus;
 
             try {

--- a/extensions/azure/events/src/main/java/org/eclipse/dataspaceconnector/events/azure/AzureEventExtension.java
+++ b/extensions/azure/events/src/main/java/org/eclipse/dataspaceconnector/events/azure/AzureEventExtension.java
@@ -40,11 +40,6 @@ public class AzureEventExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        monitor.info("AzureEventExtension: create event grid appender");
-        registerListeners(context);
-    }
-
-    private void registerListeners(ServiceExtensionContext context) {
         var config = new AzureEventGridConfig(context);
         var topicName = config.getTopic();
         var endpoint = config.getEndpoint(topicName);
@@ -56,13 +51,12 @@ public class AzureEventExtension implements ServiceExtension {
                 .buildEventGridEventPublisherAsyncClient();
 
 
-        AzureEventGridPublisher publisher = new AzureEventGridPublisher(context.getConnectorId(), monitor, publisherClient);
+        var publisher = new AzureEventGridPublisher(context.getConnectorId(), monitor, publisherClient);
 
         var processObservable = context.getService(TransferProcessObservable.class, true);
         if (processObservable != null) {
             processObservable.registerListener(publisher);
         }
     }
-
 
 }

--- a/extensions/azure/events/src/main/java/org/eclipse/dataspaceconnector/events/azure/AzureEventGridPublisher.java
+++ b/extensions/azure/events/src/main/java/org/eclipse/dataspaceconnector/events/azure/AzureEventGridPublisher.java
@@ -99,7 +99,7 @@ class AzureEventGridPublisher implements TransferProcessListener {
 
         @Override
         protected void hookOnComplete() {
-            monitor.info("AzureEventGrid: " + message);
+            monitor.debug("AzureEventGrid: " + message);
         }
 
         @Override

--- a/extensions/azure/vault/src/main/java/org/eclipse/dataspaceconnector/core/security/azure/AzureVault.java
+++ b/extensions/azure/vault/src/main/java/org/eclipse/dataspaceconnector/core/security/azure/AzureVault.java
@@ -137,7 +137,7 @@ public class AzureVault implements Vault {
     @NotNull
     private String sanitizeKey(String key) {
         if (key.contains(".")) {
-            monitor.info("AzureVault: key contained '.' which is not allowed. replaced with '-'");
+            monitor.debug("AzureVault: key contained '.' which is not allowed. replaced with '-'");
             key = key.replace(".", "-");
         }
         return key;

--- a/extensions/azure/vault/src/main/java/org/eclipse/dataspaceconnector/core/security/azure/AzureVaultExtension.java
+++ b/extensions/azure/vault/src/main/java/org/eclipse/dataspaceconnector/core/security/azure/AzureVaultExtension.java
@@ -64,8 +64,6 @@ public class AzureVaultExtension implements ServiceExtension {
                 ? AzureVault.authenticateWithCertificate(context.getMonitor(), clientId, tenantId, certPath, keyVaultName)
                 : AzureVault.authenticateWithSecret(context.getMonitor(), clientId, tenantId, clientSecret, keyVaultName);
 
-        context.getMonitor().info("AzureVaultExtension: authentication/initialization complete.");
-
         context.registerService(Vault.class, vault);
         context.registerService(PrivateKeyResolver.class, new VaultPrivateKeyResolver(vault));
         context.registerService(CertificateResolver.class, new AzureCertificateResolver(vault));

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/controller/FederatedCatalogApiController.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/controller/FederatedCatalogApiController.java
@@ -24,7 +24,6 @@ import org.eclipse.dataspaceconnector.catalog.cache.query.QueryNotAcceptedExcept
 import org.eclipse.dataspaceconnector.catalog.spi.QueryEngine;
 import org.eclipse.dataspaceconnector.catalog.spi.QueryResponse;
 import org.eclipse.dataspaceconnector.catalog.spi.model.FederatedCatalogCacheQuery;
-import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 
 import java.util.Collection;
@@ -34,17 +33,14 @@ import java.util.Collection;
 @Path("/federatedcatalog")
 public class FederatedCatalogApiController {
 
-    private final Monitor monitor;
     private final QueryEngine queryEngine;
 
-    public FederatedCatalogApiController(Monitor monitor, QueryEngine queryEngine) {
-        this.monitor = monitor;
+    public FederatedCatalogApiController(QueryEngine queryEngine) {
         this.queryEngine = queryEngine;
     }
 
     @POST
     public Collection<ContractOffer> getCachedCatalog(FederatedCatalogCacheQuery federatedCatalogCacheQuery) {
-        monitor.info("Received a catalog request");
         var queryResponse = queryEngine.getCatalog(federatedCatalogCacheQuery);
         // query not possible
         if (queryResponse.getStatus() == QueryResponse.Status.NO_ADAPTER_FOUND) {

--- a/extensions/filesystem/configuration-fs/src/main/java/org/eclipse/dataspaceconnector/configuration/fs/FsConfigurationExtension.java
+++ b/extensions/filesystem/configuration-fs/src/main/java/org/eclipse/dataspaceconnector/configuration/fs/FsConfigurationExtension.java
@@ -66,7 +66,7 @@ public class FsConfigurationExtension implements ConfigurationExtension {
         var configPath = configFile != null ? configFile : Paths.get(configLocation);
 
         if (!Files.exists(configPath)) {
-            monitor.info(format("Configuration file does not exist: %s. Ignoring.", configLocation));
+            monitor.warning(format("Configuration file does not exist: %s. Ignoring.", configLocation));
             return;
         }
 

--- a/extensions/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityService.java
+++ b/extensions/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityService.java
@@ -103,7 +103,7 @@ public class DecentralizedIdentityService implements IdentityService {
 
             return Result.success(claimToken);
         } catch (ParseException e) {
-            monitor.info("Error parsing JWT", e);
+            monitor.severe("Error parsing JWT", e);
             return Result.failure("Error parsing JWT");
         }
     }


### PR DESCRIPTION
## What this PR changes/adds

Adapt logs to the [logging guide](https://eclipse-dataspaceconnector.github.io/DataSpaceConnector/#/developer/logging)

## Why it does that

-

## Further notes

-

## Linked Issue(s)

Closes #1425

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
