### PR TITLE
docs(terminology): extended and updated terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Bump `failsafe` library to version 3.2.4 (#1559)
 * Harmonize logics of `HttpDataSource` and `HttpDataSink` (#1475)
 * Log correct type in contract-definition API (#1584)
+* Extended and updated terminology.md (##1306)
 
 #### Removed
 

--- a/docs/overview/terminology.md
+++ b/docs/overview/terminology.md
@@ -19,6 +19,7 @@
 | **Contract Offer Framework** | **Contract Offer Framework**<p>* generates **Contract Offer Templates**<p>* provided by **Extensions**<p>* may be implemented in custom extensions to created contract offers based on existing systems
 | **Contract Offer Template**  | Blueprint of a **Contract Offer**
 | **Consumer**                 |
+| **Consumer Pull**            |
 | **Data**                     |
 | **DataAddress**              |
 | **DataFlow**                 |
@@ -41,6 +42,8 @@
 | **Offer Framework**          | see **Contract Offer Framework**
 | **Monitor**                  |
 | **Policy**                   | logical collection of rules
+| **Policy Requirements**      |
+| **Policy Points**            |
 | **PolicyArchive**            |
 | **PolicyContext**            |
 | **PolicyDefinitionStore**    |
@@ -51,6 +54,7 @@
 | **Resource**                 |
 | **Resource Manifest**        |
 | **Rule**                     | **Rules**<p>* bound to a **Contract Offer**, **Contract Agreement** or **Contract Offer Framework**<p>* exist independent from an **Asset**
+| **State Machine**            |
 | **Transaction**              |
 | **TransactionContext**       |
 | **TransactionResource**      |
@@ -59,4 +63,5 @@
 | **TransformerContext**       |
 | **TypeManager**              |
 | **TypeTransformer**          |
+| **UsageControl**             |
 | **Vault**                    |

--- a/docs/overview/terminology.md
+++ b/docs/overview/terminology.md
@@ -1,54 +1,41 @@
 # Terminology
 
-| Name                         | Description                                         |
-|:-----------------------------|:---                                                 |
-| **Artifact**                 | The instance of code which can be modulized used by the EDC
-| **Asset**                    | An **asset** describes **data** that can add value to a **dataspace** and contains the **dataAddress**
-| **Asset Index**              | **Asset Index**<p>* manages assets<p>* provided by an extension<p>* may support external catalogs<p>* can be queried 
-| **Broker**                   | see **IDS Broker**
-| **Catalog**                  | **Catalog** is a directory about all meta-information about the **assets** a **data consumer** can reach in the **dataspace**
-| **Configuration**            | The EDC allows using a configuration file which will be loaded at every startup of an EDC instance
-| **Connector**                | **Connector** is the central instance for a participant to join a **dataspace**. The **connector** is the gateway from the user to the **dataspace**.
-| **Contract**                 | **Contract** is the finalized meta-information for a data transfer after a **contract negotiation** including the **policies** who have to be followed
-| **Contract Managment**       | Includes all parts of **contract offer**, **contract agreement** and **contract negotiation**
-| **Contract Agreement**       | **Contract Agreement**<p>* points to a **Contract Offer**<p>* results from a **Contract Negotiation Process**<p>* has a start date and may have a expiry date and a cancellation date
-| **Contract Negotiation**     | * MVP: only possible to accept already offered contracts. Counter offers are rejected automatically.
-| **Contract Offer**           | **Contract offer**<p>* set of obligations and permissions<p>* generated on the fly on provider side (see **Contract Offer Framework**)<p>* are immutable<p>* persisted in **contract negotiation process** once the negotiation has started<p>
-| **Contract Offer Framework** | **Contract offer framework**<p>* generates **contract offer templates**<p>* provided by **extensions**<p>* may be implemented in custom **extensions** to created **contract offers** based on existing systems
-| **Contract Offer Template**  | Blueprint of a **contract offer**
-| **Consumer**                 | see **data consumer**
-| **Consumer Pull**            | The data transfer is initilazied by the Consumer
-| **Data**                     | **Data** describes the properties of business objects
-| **Data Consumer**            | **Data consumer** are receiver of data in a data transfer
-| **Data Provider**            | **Data providers** produce data and are the source for data in a data transfer
-| **DataAddress**              | Reference to the physical Address of an **asset**
-| **DataFlow**                 | Transfer of **data** from **data producer** to **data consumer**.
-| **Dataspace**                | A **dataspace** is a space where different participants exchange **data** to get an benifit of this
-| **EDC Extension**            | A module piece of the EDC which can be customized used for the EDC
-| **EndpointDataReference**    | **EndpointDataReference** describes an endpoint at which one receives data
-| **Event**                    | An **event** is a action which is be observed in the EDC and published by the **Event Framework**
-| **Event Framework**          | **The event framework** is a way to react to actions in the EDC and can also be extended
-| **Event Router**             | **Event router** is the central part of the **event framework**, which collects all published **events**
-| **Extension**                | see **EDC Extension**
-| **Federated Catalog**        | A decentralized **catalog**
-| **Framework**                | see **contract offer framework**
-| **Health**                   | Infrastructure status of the EDC
-| **HTTPDataAddress**          | Specific type of **dataaddress** in context of HTTP-endpoints
-| **Identity Provider**        | Management of the correct identification of all participants in the **dataspace**.
-| **Injection**                | **Artifacts**/**EDC Extensions** can be injected in different parts of the EDC to be used 
-| **Offer**                    | see **contract offer**
-| **Offer Framework**          | see **contract offer framework**
-| **Monitor**                  | The **monitor** is an interface to realise different ways to put out logs and debug information
-| **Policy**                   | logical collection of rules
-| **PolicyArchive**            | Location to get **policies** by their ID
-| **PolicyDefinitionStore**    | Storing all **policy definitions** in the EDC
-| **PolicyEngine**             | Enforcing of **policies** in the EDC
-| **Provider**                 | The participant in an dataspace who is producing and publish sth. See **Data Provider**
-| **Resource**                 | Infrastructure component for data transmission
-| **Resource Manifest**        | Collection of **resources**
-| **Rule**                     | **Rules**<p>* bound to a **contract offer**, **contract agreement** or **contract offer framework**<p>* exist independent from an **asset**
-| **Transfer Process**         | **Transfer process**<p>* based on a **contract agreement**
-| **Transfer Process Store**   | Storing all informations about handled **transfer processes**
-| **TypeManager**              | **TypeManager** manages system types and is used to deserialize polymorphic types
-| **UsageControl**             | **Usage Control** is the part of the EDC that is responsible for ensuring that the **policies** for the **data** specified in the **contract** are adhered to.
-| **Vault**                    | Providing secrets
+| Name                        | Description                                         |
+|:----------------------------|:---                                                 |
+| **Artifact**                | The instance of code which can be modulized used by the EDC
+| **Asset**                   | An **asset** describes **data** that can add value to a **dataspace** and contains the **dataAddress**
+| **Asset Index**             | **Asset Index**<p>* manages assets<p>* provided by an extension<p>* may support external catalogs<p>* can be queried 
+| **Broker**                  | see **IDS Broker**
+| **Catalog**                 | The **catalog** is a standalone component of a **dataspace** that stores all meta-information of all **assets** of all **connectors** within a **dataspace** and makes it available to requesting **connectors**.
+| **Connector**               | **Connector** is the central instance for a participant to join a **dataspace**. The **connector** is the gateway from the user to the **dataspace**.
+| **Contract**                | **Contract** is the finalized meta-information for a data transfer after a **contract negotiation** including the **policies** who have to be followed
+| **Contract Managment**      | Includes all parts of **contract offer**, **contract agreement** and **contract negotiation**
+| **Contract Agreement**      | **Contract Agreement**<p>* points to a **Contract Offer**<p>* results from a **Contract Negotiation Process**<p>* has a start date and may have a expiry date and a cancellation date
+| **Contract Negotiation**    | * MVP: only possible to accept already offered contracts. Counter offers are rejected automatically.
+| **Contract Offer**          | **Contract offer**<p>* set of obligations and permissions<p>* generated on the fly on provider side (see **Contract Offer Framework**)<p>* are immutable<p>* persisted in **contract negotiation process** once the negotiation has started<p>
+| **Consumer**                | see **data consumer**
+| **Consumer Pull**           | Data transfer is initilazied by the Consumer
+| **Data**                    | **Data** is the representation of information (in particular information about business objects) that can be used for further processing in the field of information technology
+| **Data Consumer**           | **Data consumer** are receiver of data in a data transfer
+| **Data Provider**           | **Data providers** produce data and are the source for data in a data transfer
+| **DataFlow**                | Transfer of **data** from **data producer** to **data consumer**.
+| **Dataspace**               | A **dataspace** is a space where different participants exchange **data** to get an benifit of this
+| **EDC Extension**           | A module piece of the EDC which can be customized used for the EDC
+| **Event**                   | An **event** is a action which is be observed in the EDC and published by the **Event Framework**
+| **Event Framework**         | **The event framework** is a way to react to actions in the EDC and can also be extended
+| **Event Router**            | **Event router** is the central part of the **event framework**, which collects all published **events**
+| **Extension**               | see **EDC Extension**
+| **Federated Catalog**       | The **Federated Catalog** is a decentralized approach implemented directly within the **connectors** to make all meta-information of all **assets** within a **dataspace** available to the **connectors**
+| **Health**                  | Infrastructure status of the EDC
+| **Identity Provider**       | Management of the correct identification of all participants in the **dataspace**.
+| **Offer**                   | see **contract offer**
+| **Policy**                  | logical collection of rules
+| **PolicyDefinition**        | **PolicyDefinition** links a policy to 1 ..n assets via logical operations
+| **PolicyEngine**            | Enforcing of **policies** in the EDC
+| **Provider**                | The participant in an dataspace who is producing and publish sth. See **Data Provider**
+| **Resource**                | Infrastructure component for data transmission
+| **Resource Manifest**       | Collection of **resources**
+| **Rule**                    | **Rules**<p>* bound to a **contract offer**, **contract agreement** or **contract offer framework**<p>* exist independent from an **asset**
+| **Transfer Process**        | **Transfer process**<p>* based on a **contract agreement**
+| **UsageControl**            | **Usage Control** is the part of the EDC that is responsible for ensuring that the **policies** for the **data** specified in the **contract** are adhered to.
+| **Vault**                   | Providing secrets

--- a/docs/overview/terminology.md
+++ b/docs/overview/terminology.md
@@ -3,52 +3,52 @@
 | Name                         | Description                                         |
 |:-----------------------------|:---                                                 |
 | **Artifact**                 | The instance of code which can be modulized used by the EDC
-| **Asset**                    | An **asset** describes **data** that can add value to a **dataspace** and contains the **DataAddress**
+| **Asset**                    | An **asset** describes **data** that can add value to a **dataspace** and contains the **dataAddress**
 | **Asset Index**              | **Asset Index**<p>* manages assets<p>* provided by an extension<p>* may support external catalogs<p>* can be queried 
 | **Broker**                   | see **IDS Broker**
-| **Catalog**                  | **Catalog** is a directory about all meta-information about the assets a **data consumer** can reach in the **dataspace**
+| **Catalog**                  | **Catalog** is a directory about all meta-information about the **assets** a **data consumer** can reach in the **dataspace**
 | **Configuration**            | The EDC allows using a configuration file which will be loaded at every startup of an EDC instance
-| **Connector**                | Component to realize the communication between two participants within a **dataspace**
-| **Contract**                 | **Contract** is the finalized meta-information for a data transfer after a **contract negotiation** including the policies who have to be followed
-| **Contract Managment**       | Includes all parts of **Contract Offer**, **Contract Agreement** and **Contract Negotiation**
+| **Connector**                | **Connector** is the central instance for a participant to join a **dataspace**. The **connector** is the gateway from the user to the **dataspace**.
+| **Contract**                 | **Contract** is the finalized meta-information for a data transfer after a **contract negotiation** including the **policies** who have to be followed
+| **Contract Managment**       | Includes all parts of **contract offer**, **contract agreement** and **contract negotiation**
 | **Contract Agreement**       | **Contract Agreement**<p>* points to a **Contract Offer**<p>* results from a **Contract Negotiation Process**<p>* has a start date and may have a expiry date and a cancellation date
 | **Contract Negotiation**     | * MVP: only possible to accept already offered contracts. Counter offers are rejected automatically.
-| **Contract Offer**           | **Contract Offer**<p>* set of obligations and permissions<p>* generated on the fly on provider side (see **Contract Offer Framework**)<p>* are immutable<p>* persisted in **Contract Negotiation Process** once the negotiation has started<p>
-| **Contract Offer Framework** | **Contract Offer Framework**<p>* generates **Contract Offer Templates**<p>* provided by **Extensions**<p>* may be implemented in custom extensions to created contract offers based on existing systems
-| **Contract Offer Template**  | Blueprint of a **Contract Offer**
-| **Consumer**                 | see **Data Consumer**
-| **Consumer Pull**            | The data exchange of data is initilazied by the Consumer
+| **Contract Offer**           | **Contract offer**<p>* set of obligations and permissions<p>* generated on the fly on provider side (see **Contract Offer Framework**)<p>* are immutable<p>* persisted in **contract negotiation process** once the negotiation has started<p>
+| **Contract Offer Framework** | **Contract offer framework**<p>* generates **contract offer templates**<p>* provided by **extensions**<p>* may be implemented in custom **extensions** to created **contract offers** based on existing systems
+| **Contract Offer Template**  | Blueprint of a **contract offer**
+| **Consumer**                 | see **data consumer**
+| **Consumer Pull**            | The data transfer is initilazied by the Consumer
 | **Data**                     | **Data** describes the properties of business objects
-| **Data Consumer**            | **Data Consumer** are receiver of data in a data transfer.
-| **Data Provider**            | **Data Providers** produce data and are the source for data in a data transfer
-| **DataAddress**              | Reference to the physical Address of an **Asset**
-| **DataFlow**                 | Transfer of **data** from **Data Producer** to **Data Consumer**.
+| **Data Consumer**            | **Data consumer** are receiver of data in a data transfer
+| **Data Provider**            | **Data providers** produce data and are the source for data in a data transfer
+| **DataAddress**              | Reference to the physical Address of an **asset**
+| **DataFlow**                 | Transfer of **data** from **data producer** to **data consumer**.
 | **Dataspace**                | A **dataspace** is a space where different participants exchange **data** to get an benifit of this
-| **EDC Extension**            | A Module piece of the EDC which can be customized used for the EDC
-| **EndpointDataReference**    | Describes an endpoint at which one receives data
-| **Event**                    | An **Event** is a action which is be observed in the EDC and published by the **Event Framework**
-| **Event Framework**          | **The Event Framework** is a way to react to actions in the EDC and can also be extended
-| **Event Router**             | **Event Router** is the central part of the **Event Framework**, which collects all published **Events**
+| **EDC Extension**            | A module piece of the EDC which can be customized used for the EDC
+| **EndpointDataReference**    | **EndpointDataReference** describes an endpoint at which one receives data
+| **Event**                    | An **event** is a action which is be observed in the EDC and published by the **Event Framework**
+| **Event Framework**          | **The event framework** is a way to react to actions in the EDC and can also be extended
+| **Event Router**             | **Event router** is the central part of the **event framework**, which collects all published **events**
 | **Extension**                | see **EDC Extension**
 | **Federated Catalog**        | A decentralized **catalog**
-| **Framework**                | see **Contract Offer Framework**
-| **Health**                   | Infrastructure Status of the EDC
-| **HTTPDataAddress**          | Specific type of **DataAddress** in context of HTTP-endpoints
+| **Framework**                | see **contract offer framework**
+| **Health**                   | Infrastructure status of the EDC
+| **HTTPDataAddress**          | Specific type of **dataaddress** in context of HTTP-endpoints
 | **Identity Provider**        | Management of the correct identification of all participants in the **dataspace**.
 | **Injection**                | **Artifacts**/**EDC Extensions** can be injected in different parts of the EDC to be used 
-| **Offer**                    | see **Contract Offer**
-| **Offer Framework**          | see **Contract Offer Framework**
-| **Monitor**                  | The **Monitor** is an interface to realise different ways to put out logs and debug information
+| **Offer**                    | see **contract offer**
+| **Offer Framework**          | see **contract offer framework**
+| **Monitor**                  | The **monitor** is an interface to realise different ways to put out logs and debug information
 | **Policy**                   | logical collection of rules
-| **PolicyArchive**            | Location to get **Policies** by their ID
-| **PolicyDefinitionStore**    | Storing all **Policy Definitions** in the EDC
-| **PolicyEngine**             | Enforcing of Policies in the EDC
+| **PolicyArchive**            | Location to get **policies** by their ID
+| **PolicyDefinitionStore**    | Storing all **policy definitions** in the EDC
+| **PolicyEngine**             | Enforcing of **policies** in the EDC
 | **Provider**                 | The participant in an dataspace who is producing and publish sth. See **Data Provider**
-| **Resource**                 | Infrastructure Component for data transmission
-| **Resource Manifest**        | Collection of **Resources**
-| **Rule**                     | **Rules**<p>* bound to a **Contract Offer**, **Contract Agreement** or **Contract Offer Framework**<p>* exist independent from an **Asset**
-| **Transfer Process**         | **Transfer Process**<p>* based on a **Contract Agreement**
-| **Transfer Process Store**   | Storing all informations about handled **Transfer Processes**
-| **TypeManager**              | Way to make serialization possible in different contexts for the EDC
+| **Resource**                 | Infrastructure component for data transmission
+| **Resource Manifest**        | Collection of **resources**
+| **Rule**                     | **Rules**<p>* bound to a **contract offer**, **contract agreement** or **contract offer framework**<p>* exist independent from an **asset**
+| **Transfer Process**         | **Transfer process**<p>* based on a **contract agreement**
+| **Transfer Process Store**   | Storing all informations about handled **transfer processes**
+| **TypeManager**              | **TypeManager** manages system types and is used to deserialize polymorphic types
 | **UsageControl**             | **Usage Control** is the part of the EDC that is responsible for ensuring that the **policies** for the **data** specified in the **contract** are adhered to.
 | **Vault**                    | Providing secrets

--- a/docs/overview/terminology.md
+++ b/docs/overview/terminology.md
@@ -2,66 +2,53 @@
 
 | Name                         | Description                                         |
 |:-----------------------------|:---                                                 |
-| **Agent**                    |
-| **Artifact**                 |
-| **Asset**                    | **Assets**<p>* have one content type<p>* can be a finite as a (set of) file(s) or non finite as a service, stream</br>* are the _unit of sharing_<p>* can point to one or more (physical) asset elements
-| **Asset Element**            |
+| **Artifact**                 | The instance of code which can be modulized used by the EDC
+| **Asset**                    | An **asset** describes **data** that can add value to a **dataspace** and contains the **DataAddress**
 | **Asset Index**              | **Asset Index**<p>* manages assets<p>* provided by an extension<p>* may support external catalogs<p>* can be queried 
 | **Broker**                   | see **IDS Broker**
-| **Catalog**                  |
-| **Configuration**            |
-| **Connector**                |
-| **Connector Directory**      |
-| **Contract**                 |
+| **Catalog**                  | **Catalog** is a directory about all meta-information about the assets a **data consumer** can reach in the **dataspace**
+| **Configuration**            | The EDC allows using a configuration file which will be loaded at every startup of an EDC instance
+| **Connector**                | Component to realize the communication between two participants within a **dataspace**
+| **Contract**                 | **Contract** is the finalized meta-information for a data transfer after a **contract negotiation** including the policies who have to be followed
+| **Contract Managment**       | Includes all parts of **Contract Offer**, **Contract Agreement** and **Contract Negotiation**
 | **Contract Agreement**       | **Contract Agreement**<p>* points to a **Contract Offer**<p>* results from a **Contract Negotiation Process**<p>* has a start date and may have a expiry date and a cancellation date
 | **Contract Negotiation**     | * MVP: only possible to accept already offered contracts. Counter offers are rejected automatically.
 | **Contract Offer**           | **Contract Offer**<p>* set of obligations and permissions<p>* generated on the fly on provider side (see **Contract Offer Framework**)<p>* are immutable<p>* persisted in **Contract Negotiation Process** once the negotiation has started<p>
 | **Contract Offer Framework** | **Contract Offer Framework**<p>* generates **Contract Offer Templates**<p>* provided by **Extensions**<p>* may be implemented in custom extensions to created contract offers based on existing systems
 | **Contract Offer Template**  | Blueprint of a **Contract Offer**
-| **Consumer**                 |
-| **Consumer Pull**            |
-| **Data**                     |
-| **DataAddress**              |
-| **DataFlow**                 |
-| **DataFlowRequest**          |
-| **Dataspace**                |
-| **EDC Extension**            |
-| **Element**                  | see **Asset Element**
-| **EndpointDataReference**    |
-| **Event**                    | 
-| **Event Framework**          |
-| **Event Router**             |
+| **Consumer**                 | see **Data Consumer**
+| **Consumer Pull**            | The data exchange of data is initilazied by the Consumer
+| **Data**                     | **Data** describes the properties of business objects
+| **Data Consumer**            | **Data Consumer** are receiver of data in a data transfer.
+| **Data Provider**            | **Data Providers** produce data and are the source for data in a data transfer
+| **DataAddress**              | Reference to the physical Address of an **Asset**
+| **DataFlow**                 | Transfer of **data** from **Data Producer** to **Data Consumer**.
+| **Dataspace**                | A **dataspace** is a space where different participants exchange **data** to get an benifit of this
+| **EDC Extension**            | A Module piece of the EDC which can be customized used for the EDC
+| **EndpointDataReference**    | Describes an endpoint at which one receives data
+| **Event**                    | An **Event** is a action which is be observed in the EDC and published by the **Event Framework**
+| **Event Framework**          | **The Event Framework** is a way to react to actions in the EDC and can also be extended
+| **Event Router**             | **Event Router** is the central part of the **Event Framework**, which collects all published **Events**
 | **Extension**                | see **EDC Extension**
+| **Federated Catalog**        | A decentralized **catalog**
 | **Framework**                | see **Contract Offer Framework**
-| **Health**                   |
-| **HTTPDataAddress**          |
-| **Identity Provider**        |
-| **IDS Broker**               | IDS version of the **Connector Directory**
-| **Injection**                |
+| **Health**                   | Infrastructure Status of the EDC
+| **HTTPDataAddress**          | Specific type of **DataAddress** in context of HTTP-endpoints
+| **Identity Provider**        | Management of the correct identification of all participants in the **dataspace**.
+| **Injection**                | **Artifacts**/**EDC Extensions** can be injected in different parts of the EDC to be used 
 | **Offer**                    | see **Contract Offer**
 | **Offer Framework**          | see **Contract Offer Framework**
-| **Monitor**                  |
+| **Monitor**                  | The **Monitor** is an interface to realise different ways to put out logs and debug information
 | **Policy**                   | logical collection of rules
-| **Policy Requirements**      |
-| **Policy Points**            |
-| **PolicyArchive**            |
-| **PolicyContext**            |
-| **PolicyDefinitionStore**    |
-| **PolicyEngine**             |
-| **PolicyScope**              |
-| **Provider**                 |
-| **Provision**                |
-| **Resource**                 |
-| **Resource Manifest**        |
+| **PolicyArchive**            | Location to get **Policies** by their ID
+| **PolicyDefinitionStore**    | Storing all **Policy Definitions** in the EDC
+| **PolicyEngine**             | Enforcing of Policies in the EDC
+| **Provider**                 | The participant in an dataspace who is producing and publish sth. See **Data Provider**
+| **Resource**                 | Infrastructure Component for data transmission
+| **Resource Manifest**        | Collection of **Resources**
 | **Rule**                     | **Rules**<p>* bound to a **Contract Offer**, **Contract Agreement** or **Contract Offer Framework**<p>* exist independent from an **Asset**
-| **State Machine**            |
-| **Transaction**              |
-| **TransactionContext**       |
-| **TransactionResource**      |
 | **Transfer Process**         | **Transfer Process**<p>* based on a **Contract Agreement**
-| **Transfer Process Store**   |
-| **TransformerContext**       |
-| **TypeManager**              |
-| **TypeTransformer**          |
-| **UsageControl**             |
-| **Vault**                    |
+| **Transfer Process Store**   | Storing all informations about handled **Transfer Processes**
+| **TypeManager**              | Way to make serialization possible in different contexts for the EDC
+| **UsageControl**             | **Usage Control** is the part of the EDC that is responsible for ensuring that the **policies** for the **data** specified in the **contract** are adhered to.
+| **Vault**                    | Providing secrets

--- a/docs/overview/terminology.md
+++ b/docs/overview/terminology.md
@@ -1,34 +1,62 @@
 # Terminology
 
-| Name                                   | Description                                         |
-|:---                                    |:---                                                 |
-| **Artifact**                           |
-| **Asset**                              | **Assets**<p>* have one content type<p>* can be a finite as a (set of) file(s) or non finite as a service, stream</br>* are the _unit of sharing_<p>* can point to one or more (physical) asset elements
-| **Asset Element**                      |
-| **Asset Index**                        | **Asset Index**<p>* manages assets<p>* provided by an extension<p>* may support external catalogs<p>* can be queried 
-| **Broker**                             | see **IDS Broker**
-| **Connector**                          |
-| **Connector Directory**                |
-| **Contract**                           |
-| **Contract Agreement**                 | **Contract Agreement**<p>* points to a **Contract Offer**<p>* results from a **Contract Negotiation Process**<p>* has a start date and may have a expiry date and a cancellation date
-| **Contract Negotiation**               | * MVP: only possible to accept already offered contracts. Counter offers are rejected automatically.
-| **Contract Offer**                     | **Contract Offer**<p>* set of obligations and permissions<p>* generated on the fly on provider side (see **Contract Offer Framework**)<p>* are immutable<p>* persisted in **Contract Negotiation Process** once the negotiation has started<p>
-| **Contract Offer Framework**           | **Contract Offer Framework**<p>* generates **Contract Offer Templates**<p>* provided by **Extensions**<p>* may be implemented in custom extensions to created contract offers based on existing systems
-| **Contract Offer Template**            | Blueprint of a **Contract Offer**
-| **Consumer**                           |
-| **Data**                               |
-| **Dataspace**                          |
-| **EDC Extension**                      |
-| **Element**                            | see **Asset Element**
-| **Extension**                          | see **EDC Extension**
-| **Framework**                          | see **Contract Offer Framework**
-| **Identity Provider**                  |
-| **IDS Broker**                         | IDS version of the **Connector Directory**
-| **Offer**                              | see **Contract Offer**
-| **Offer Framework**                    | see **Contract Offer Framework**
-| **Policy**                             | logical collection of rules
-| **Provider**                           |
-| **Resource**                           |
-| **Resource Manifest**                  |
-| **Rule**                               | **Rules**<p>* bound to a **Contract Offer**, **Contract Agreement** or **Contract Offer Framework**<p>* exist independent from an **Asset**
-| **Transfer Process**                   | **Transfer Process**<p>* based on a **Contract Agreement**
+| Name                         | Description                                         |
+|:-----------------------------|:---                                                 |
+| **Agent**                    |
+| **Artifact**                 |
+| **Asset**                    | **Assets**<p>* have one content type<p>* can be a finite as a (set of) file(s) or non finite as a service, stream</br>* are the _unit of sharing_<p>* can point to one or more (physical) asset elements
+| **Asset Element**            |
+| **Asset Index**              | **Asset Index**<p>* manages assets<p>* provided by an extension<p>* may support external catalogs<p>* can be queried 
+| **Broker**                   | see **IDS Broker**
+| **Catalog**                  |
+| **Configuration**            |
+| **Connector**                |
+| **Connector Directory**      |
+| **Contract**                 |
+| **Contract Agreement**       | **Contract Agreement**<p>* points to a **Contract Offer**<p>* results from a **Contract Negotiation Process**<p>* has a start date and may have a expiry date and a cancellation date
+| **Contract Negotiation**     | * MVP: only possible to accept already offered contracts. Counter offers are rejected automatically.
+| **Contract Offer**           | **Contract Offer**<p>* set of obligations and permissions<p>* generated on the fly on provider side (see **Contract Offer Framework**)<p>* are immutable<p>* persisted in **Contract Negotiation Process** once the negotiation has started<p>
+| **Contract Offer Framework** | **Contract Offer Framework**<p>* generates **Contract Offer Templates**<p>* provided by **Extensions**<p>* may be implemented in custom extensions to created contract offers based on existing systems
+| **Contract Offer Template**  | Blueprint of a **Contract Offer**
+| **Consumer**                 |
+| **Data**                     |
+| **DataAddress**              |
+| **DataFlow**                 |
+| **DataFlowRequest**          |
+| **Dataspace**                |
+| **EDC Extension**            |
+| **Element**                  | see **Asset Element**
+| **EndpointDataReference**    |
+| **Event**                    | 
+| **Event Framework**          |
+| **Event Router**             |
+| **Extension**                | see **EDC Extension**
+| **Framework**                | see **Contract Offer Framework**
+| **Health**                   |
+| **HTTPDataAddress**          |
+| **Identity Provider**        |
+| **IDS Broker**               | IDS version of the **Connector Directory**
+| **Injection**                |
+| **Offer**                    | see **Contract Offer**
+| **Offer Framework**          | see **Contract Offer Framework**
+| **Monitor**                  |
+| **Policy**                   | logical collection of rules
+| **PolicyArchive**            |
+| **PolicyContext**            |
+| **PolicyDefinitionStore**    |
+| **PolicyEngine**             |
+| **PolicyScope**              |
+| **Provider**                 |
+| **Provision**                |
+| **Resource**                 |
+| **Resource Manifest**        |
+| **Rule**                     | **Rules**<p>* bound to a **Contract Offer**, **Contract Agreement** or **Contract Offer Framework**<p>* exist independent from an **Asset**
+| **Transaction**              |
+| **TransactionContext**       |
+| **TransactionResource**      |
+| **Transfer Process**         | **Transfer Process**<p>* based on a **Contract Agreement**
+| **Transfer Process Store**   |
+| **TransformerContext**       |
+| **TypeManager**              |
+| **TypeTransformer**          |
+| **Vault**                    |


### PR DESCRIPTION
## What this PR changes/adds

The documentation on terminology has been extended and adapted.

## Why it does that

The previous documentation under the area of terminology has not been complete so far and has been partly outdated.

## Linked Issue(s)

Closes #1306

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly?
