### PR TITLE
chore: cleanup `Result` and `AbstractResult`

### DIFF
--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/result/AbstractResult.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/result/AbstractResult.java
@@ -15,16 +15,17 @@
 package org.eclipse.dataspaceconnector.spi.result;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Base result type used by services to indicate success or failure.
+ * <p>
+ * Service operations should generally never throw checked exceptions. Instead, they should return concrete result types
+ * and raise unchecked exceptions only when an unexpected event happens, such as a programming error.
  *
- * Service operations should generally never throw checked exceptions. Instead, they should return concrete result types and raise unchecked exceptions only when an
- * unexpected event happens, such as a programming error.
+ * @param <F> The type of {@link Failure}.
+ * @param <T> The type of the content
  */
 public abstract class AbstractResult<T, F extends Failure> {
 
@@ -36,7 +37,6 @@ public abstract class AbstractResult<T, F extends Failure> {
         this.failure = failure;
     }
 
-    @NotNull
     public T getContent() {
         return content;
     }
@@ -48,8 +48,7 @@ public abstract class AbstractResult<T, F extends Failure> {
     //will cause problems during JSON serialization if failure is null
     @JsonIgnore
     public List<String> getFailureMessages() {
-        Objects.requireNonNull(failure);
-        return failure.getMessages();
+        return failure == null ? List.of() : failure.getMessages();
     }
 
     public boolean succeeded() {
@@ -67,6 +66,6 @@ public abstract class AbstractResult<T, F extends Failure> {
      */
     @JsonIgnore // will cause problems during JSON serialization if failure is null
     public String getFailureDetail() {
-        return String.join(", ", getFailureMessages());
+        return failure == null ? null : String.join(", ", getFailureMessages());
     }
 }

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/result/ResultTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/result/ResultTest.java
@@ -20,12 +20,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ResultTest {
 
+
+    @Test
+    void verifyFailureMessages_whenSucceeded() {
+        var r = Result.success("Foobar");
+        assertThat(r.getFailureDetail()).isNull();
+        assertThat(r.getFailureMessages()).isEmpty();
+    }
+
     @Test
     void map_appliesFunctionToContent() {
         var result = Result.success("successful").map(it -> it + " and mapped");
 
         assertThat(result.succeeded()).isTrue();
         assertThat(result.getContent()).isEqualTo("successful and mapped");
+    }
+
+    @Test
+    void verifyContent_whenFailed() {
+        var r = Result.failure("random failure");
+        assertThat(r.getContent()).isNull();
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

Removes the `@NotNull` annotation on `AbstractResult#getContent` and the null-check on the `getFailureMessages()` method.

## Why it does that

Just some housekeeping

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #1655 

## Checklist

- [x] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
