### PR TITLE
Feature: refactor API services (query methods)

### DIFF
--- a/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/ServiceResultHandler.java
+++ b/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/ServiceResultHandler.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.Nullable;
 public class ServiceResultHandler {
 
     /**
-     * Interprets a {@link ServiceResult} based on its {@link ServiceResult#reason()} property and throws the
+     * Interprets a {@link ServiceResult} based on its {@link ServiceResult#reason()} property and returns the
      * appropriate exception:
      * <table>
      *   <th>reason</th>
@@ -48,16 +48,16 @@ public class ServiceResultHandler {
      * @param id The id of the entity which was involved in the failure. Can be null for
      *         {@link org.eclipse.dataspaceconnector.api.result.ServiceFailure.Reason#BAD_REQUEST}.
      */
-    public static void handleFailedResult(@NotNull ServiceResult<?> result, @NotNull Class<?> clazz, @Nullable String id) {
+    public static RuntimeException mapToException(@NotNull ServiceResult<?> result, @NotNull Class<?> clazz, @Nullable String id) {
         switch (result.reason()) {
             case NOT_FOUND:
-                throw new ObjectNotFoundException(clazz, id);
+                return new ObjectNotFoundException(clazz, id);
             case CONFLICT:
-                throw new ObjectExistsException(clazz, id);
+                return new ObjectExistsException(clazz, id);
             case BAD_REQUEST:
-                throw new IllegalArgumentException(result.getFailureDetail());
+                return new IllegalArgumentException(result.getFailureDetail());
             default:
-                throw new EdcException("unexpected error");
+                return new EdcException("unexpected error");
         }
     }
 }

--- a/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/ServiceResultHandler.java
+++ b/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/ServiceResultHandler.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api;
+
+import org.eclipse.dataspaceconnector.api.result.ServiceResult;
+import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.exception.ObjectExistsException;
+import org.eclipse.dataspaceconnector.spi.exception.ObjectNotFoundException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class ServiceResultHandler {
+
+    /**
+     * Interprets a {@link ServiceResult} based on its {@link ServiceResult#reason()} property and throws the
+     * appropriate exception:
+     * <table>
+     *   <th>reason</th>
+     *   <th>exception</th>
+     *   <tr>
+     *     <td>NOT_FOUND </td> <td>ObjectNotFoundException</td>
+     *   </tr>
+     *   <tr>
+     *     <td>CONFLICT</td> <td>ObjectExistsException</td>
+     *   </tr>
+     *   <tr>
+     *     <td>BAD_REQUEST</td> <td>IllegalArgumentException</td>
+     *   </tr>
+     *   <tr>
+     *     <td>other</td> <td>EdcException</td>
+     *   </tr>
+     * </table>
+     *
+     * @param result The {@link ServiceResult}
+     * @param clazz The type in whose context the failure occurred. Must not be null.
+     * @param id The id of the entity which was involved in the failure. Can be null for
+     *         {@link org.eclipse.dataspaceconnector.api.result.ServiceFailure.Reason#BAD_REQUEST}.
+     */
+    public static void handleFailedResult(@NotNull ServiceResult<?> result, @NotNull Class<?> clazz, @Nullable String id) {
+        switch (result.reason()) {
+            case NOT_FOUND:
+                throw new ObjectNotFoundException(clazz, id);
+            case CONFLICT:
+                throw new ObjectExistsException(clazz, id);
+            case BAD_REQUEST:
+                throw new IllegalArgumentException(result.getFailureDetail());
+            default:
+                throw new EdcException("unexpected error");
+        }
+    }
+}

--- a/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/result/ServiceFailure.java
+++ b/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/result/ServiceFailure.java
@@ -31,6 +31,6 @@ public class ServiceFailure extends Failure {
     }
 
     public enum Reason {
-        NOT_FOUND, CONFLICT
+        NOT_FOUND, CONFLICT, BAD_REQUEST
     }
 }

--- a/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/result/ServiceResult.java
+++ b/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/result/ServiceResult.java
@@ -18,10 +18,15 @@ import org.eclipse.dataspaceconnector.spi.result.AbstractResult;
 
 import java.util.List;
 
+import static org.eclipse.dataspaceconnector.api.result.ServiceFailure.Reason.BAD_REQUEST;
 import static org.eclipse.dataspaceconnector.api.result.ServiceFailure.Reason.CONFLICT;
 import static org.eclipse.dataspaceconnector.api.result.ServiceFailure.Reason.NOT_FOUND;
 
 public class ServiceResult<T> extends AbstractResult<T, ServiceFailure> {
+
+    protected ServiceResult(T content, ServiceFailure failure) {
+        super(content, failure);
+    }
 
     public static <T> ServiceResult<T> success(T content) {
         return new ServiceResult<>(content, null);
@@ -35,8 +40,8 @@ public class ServiceResult<T> extends AbstractResult<T, ServiceFailure> {
         return new ServiceResult<>(null, new ServiceFailure(List.of(message), NOT_FOUND));
     }
 
-    protected ServiceResult(T content, ServiceFailure failure) {
-        super(content, failure);
+    public static <T> ServiceResult<T> badRequest(String... message) {
+        return new ServiceResult<>(null, new ServiceFailure(List.of(message), BAD_REQUEST));
     }
 
     public ServiceFailure.Reason reason() {

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiController.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiController.java
@@ -43,7 +43,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
-import static org.eclipse.dataspaceconnector.api.ServiceResultHandler.handleFailedResult;
+import static org.eclipse.dataspaceconnector.api.ServiceResultHandler.mapToException;
 
 @Consumes({ MediaType.APPLICATION_JSON })
 @Produces({ MediaType.APPLICATION_JSON })
@@ -78,7 +78,7 @@ public class AssetApiController implements AssetApi {
         if (result.succeeded()) {
             monitor.debug(format("Asset created %s", assetEntryDto.getAsset()));
         } else {
-            handleFailedResult(result, Asset.class, asset.getId());
+            throw mapToException(result, Asset.class, asset.getId());
         }
     }
 
@@ -124,7 +124,7 @@ public class AssetApiController implements AssetApi {
         if (result.succeeded()) {
             monitor.debug(format("Asset deleted %s", id));
         } else {
-            handleFailedResult(result, Asset.class, id);
+            throw mapToException(result, Asset.class, id);
         }
     }
 }

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiController.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiController.java
@@ -30,10 +30,7 @@ import org.eclipse.dataspaceconnector.api.datamanagement.asset.model.AssetDto;
 import org.eclipse.dataspaceconnector.api.datamanagement.asset.model.AssetEntryDto;
 import org.eclipse.dataspaceconnector.api.datamanagement.asset.service.AssetService;
 import org.eclipse.dataspaceconnector.api.query.QuerySpecDto;
-import org.eclipse.dataspaceconnector.api.result.ServiceResult;
 import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
-import org.eclipse.dataspaceconnector.spi.EdcException;
-import org.eclipse.dataspaceconnector.spi.exception.ObjectExistsException;
 import org.eclipse.dataspaceconnector.spi.exception.ObjectNotFoundException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
@@ -46,6 +43,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
+import static org.eclipse.dataspaceconnector.api.ServiceResultHandler.handleFailedResult;
 
 @Consumes({ MediaType.APPLICATION_JSON })
 @Produces({ MediaType.APPLICATION_JSON })
@@ -80,7 +78,7 @@ public class AssetApiController implements AssetApi {
         if (result.succeeded()) {
             monitor.debug(format("Asset created %s", assetEntryDto.getAsset()));
         } else {
-            handleFailedResult(result, asset.getId());
+            handleFailedResult(result, Asset.class, asset.getId());
         }
     }
 
@@ -126,19 +124,7 @@ public class AssetApiController implements AssetApi {
         if (result.succeeded()) {
             monitor.debug(format("Asset deleted %s", id));
         } else {
-            handleFailedResult(result, id);
+            handleFailedResult(result, Asset.class, id);
         }
     }
-
-    private void handleFailedResult(ServiceResult<Asset> result, String id) {
-        switch (result.reason()) {
-            case NOT_FOUND:
-                throw new ObjectNotFoundException(Asset.class, id);
-            case CONFLICT:
-                throw new ObjectExistsException(Asset.class, id);
-            default:
-                throw new EdcException("unexpected error");
-        }
-    }
-
 }

--- a/extensions/api/data-management/contractagreement/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApiController.java
+++ b/extensions/api/data-management/contractagreement/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApiController.java
@@ -38,7 +38,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
-import static org.eclipse.dataspaceconnector.api.ServiceResultHandler.handleFailedResult;
+import static org.eclipse.dataspaceconnector.api.ServiceResultHandler.mapToException;
 
 @Produces({ MediaType.APPLICATION_JSON })
 @Path("/contractagreements")
@@ -70,7 +70,7 @@ public class ContractAgreementApiController implements ContractAgreementApi {
 
         //will throw an exception
         if (queryResult.failed()) {
-            handleFailedResult(queryResult, ContractDefinition.class, null);
+            throw mapToException(queryResult, ContractDefinition.class, null);
         }
 
         return queryResult.getContent().stream()

--- a/extensions/api/data-management/contractagreement/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/service/ContractAgreementService.java
+++ b/extensions/api/data-management/contractagreement/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/service/ContractAgreementService.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.api.datamanagement.contractagreement.service;
 
+import org.eclipse.dataspaceconnector.api.result.ServiceResult;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 
@@ -21,7 +22,6 @@ import java.util.Collection;
 
 /**
  * Service that permits actions and queries on ContractAgreement entity.
- *
  */
 public interface ContractAgreementService {
 
@@ -39,6 +39,6 @@ public interface ContractAgreementService {
      * @param query request
      * @return the collection of contract agreements that match the query
      */
-    Collection<ContractAgreement> query(QuerySpec query);
+    ServiceResult<Collection<ContractAgreement>> query(QuerySpec query);
 
 }

--- a/extensions/api/data-management/contractagreement/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/service/ContractAgreementServiceImplTest.java
+++ b/extensions/api/data-management/contractagreement/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/service/ContractAgreementServiceImplTest.java
@@ -62,7 +62,8 @@ class ContractAgreementServiceImplTest {
 
         var result = service.query(QuerySpec.none());
 
-        assertThat(result).hasSize(1).first().matches(it -> it.getId().equals("agreementId"));
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent()).hasSize(1).first().matches(it -> it.getId().equals("agreementId"));
     }
 
     private ContractAgreement createContractAgreement(String agreementId) {

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiController.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiController.java
@@ -27,9 +27,7 @@ import jakarta.ws.rs.core.MediaType;
 import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model.ContractDefinitionDto;
 import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.service.ContractDefinitionService;
 import org.eclipse.dataspaceconnector.api.query.QuerySpecDto;
-import org.eclipse.dataspaceconnector.api.result.ServiceResult;
 import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
-import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.exception.ObjectExistsException;
 import org.eclipse.dataspaceconnector.spi.exception.ObjectNotFoundException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
@@ -42,6 +40,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
+import static org.eclipse.dataspaceconnector.api.ServiceResultHandler.handleFailedResult;
 
 @Produces({ MediaType.APPLICATION_JSON })
 @Path("/contractdefinitions")
@@ -71,7 +70,7 @@ public class ContractDefinitionApiController implements ContractDefinitionApi {
 
         var queryResult = service.query(spec);
         if (queryResult.failed()) {
-            handleFailedResult(queryResult, null);
+            handleFailedResult(queryResult, ContractDefinition.class, null);
         }
 
         return queryResult.getContent()
@@ -124,20 +123,7 @@ public class ContractDefinitionApiController implements ContractDefinitionApi {
         if (result.succeeded()) {
             monitor.debug(format("Contract definition deleted %s", result.getContent().getId()));
         } else {
-            handleFailedResult(result, id);
-        }
-    }
-
-    private void handleFailedResult(ServiceResult<?> result, String id) {
-        switch (result.reason()) {
-            case NOT_FOUND:
-                throw new ObjectNotFoundException(ContractDefinition.class, id);
-            case CONFLICT:
-                throw new ObjectExistsException(ContractDefinition.class, id);
-            case BAD_REQUEST:
-                throw new IllegalArgumentException(result.getFailureDetail());
-            default:
-                throw new EdcException("unexpected error");
+            handleFailedResult(result, ContractDefinition.class, id);
         }
     }
 

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiController.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiController.java
@@ -40,7 +40,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
-import static org.eclipse.dataspaceconnector.api.ServiceResultHandler.handleFailedResult;
+import static org.eclipse.dataspaceconnector.api.ServiceResultHandler.mapToException;
 
 @Produces({ MediaType.APPLICATION_JSON })
 @Path("/contractdefinitions")
@@ -70,7 +70,7 @@ public class ContractDefinitionApiController implements ContractDefinitionApi {
 
         var queryResult = service.query(spec);
         if (queryResult.failed()) {
-            handleFailedResult(queryResult, ContractDefinition.class, null);
+            throw mapToException(queryResult, ContractDefinition.class, null);
         }
 
         return queryResult.getContent()
@@ -123,7 +123,7 @@ public class ContractDefinitionApiController implements ContractDefinitionApi {
         if (result.succeeded()) {
             monitor.debug(format("Contract definition deleted %s", result.getContent().getId()));
         } else {
-            handleFailedResult(result, ContractDefinition.class, id);
+            throw mapToException(result, ContractDefinition.class, id);
         }
     }
 

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiController.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiController.java
@@ -128,7 +128,7 @@ public class ContractDefinitionApiController implements ContractDefinitionApi {
         }
     }
 
-    private <T> void handleFailedResult(ServiceResult<T> result, String id) {
+    private void handleFailedResult(ServiceResult<?> result, String id) {
         switch (result.reason()) {
             case NOT_FOUND:
                 throw new ObjectNotFoundException(ContractDefinition.class, id);

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/service/ContractDefinitionService.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/service/ContractDefinitionService.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 
 /**
  * Service that permits actions and queries on ContractDefinition entity.
- *
  */
 public interface ContractDefinitionService {
 
@@ -40,11 +39,11 @@ public interface ContractDefinitionService {
      * @param query request
      * @return the collection of contract definitions that match the query
      */
-    Collection<ContractDefinition> query(QuerySpec query);
+    ServiceResult<Collection<ContractDefinition>> query(QuerySpec query);
 
     /**
-     * Create a contract definition with its related data address.
-     * If a definition with the same id exists, returns CONFLICT failure.
+     * Create a contract definition with its related data address. If a definition with the same id exists, returns
+     * CONFLICT failure.
      *
      * @param contractDefinition the contract definition
      * @return successful result if the contract definition is created correctly, failure otherwise
@@ -52,9 +51,8 @@ public interface ContractDefinitionService {
     ServiceResult<ContractDefinition> create(ContractDefinition contractDefinition);
 
     /**
-     * Delete a contract definition.
-     * If the definition is already referenced by a contract agreement, returns CONFLICT failure.
-     * If the definition does not exist, returns NOT_FOUND failure.
+     * Delete a contract definition. If the definition is already referenced by a contract agreement, returns CONFLICT
+     * failure. If the definition does not exist, returns NOT_FOUND failure.
      *
      * @param contractDefinitionId the id of the contract definition to be deleted
      * @return successful result if the contract definition is deleted correctly, failure otherwise

--- a/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/service/ContractDefinitionServiceImpl.java
+++ b/extensions/api/data-management/contractdefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/service/ContractDefinitionServiceImpl.java
@@ -22,7 +22,6 @@ import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.QueryValidator;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
-import org.eclipse.dataspaceconnector.sql.translation.EdcQueryException;
 
 import java.util.Collection;
 
@@ -50,13 +49,13 @@ public class ContractDefinitionServiceImpl implements ContractDefinitionService 
     }
 
     @Override
-    public Collection<ContractDefinition> query(QuerySpec query) {
+    public ServiceResult<Collection<ContractDefinition>> query(QuerySpec query) {
         var result = queryValidator.validate(query);
 
         if (result.failed()) {
-            throw new EdcQueryException(format("Error validating schema: %s", result.getFailureDetail()));
+            return ServiceResult.badRequest(format("Error validating schema: %s", result.getFailureDetail()));
         }
-        return transactionContext.execute(() -> store.findAll(query).collect(toList()));
+        return ServiceResult.success(transactionContext.execute(() -> store.findAll(query).collect(toList())));
     }
 
     @Override

--- a/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiControllerTest.java
+++ b/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiControllerTest.java
@@ -58,7 +58,7 @@ class ContractDefinitionApiControllerTest {
     @Test
     void getAll() {
         var contractDefinition = createContractDefinition();
-        when(service.query(any())).thenReturn(List.of(contractDefinition));
+        when(service.query(any())).thenReturn(ServiceResult.success(List.of(contractDefinition)));
         var dto = ContractDefinitionDto.Builder.newInstance().id(contractDefinition.getId()).build();
         when(transformerRegistry.transform(any(), eq(ContractDefinitionDto.class))).thenReturn(Result.success(dto));
         when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
@@ -76,7 +76,7 @@ class ContractDefinitionApiControllerTest {
     @Test
     void getAll_filtersOutFailedTransforms() {
         var contractDefinition = createContractDefinition();
-        when(service.query(any())).thenReturn(List.of(contractDefinition));
+        when(service.query(any())).thenReturn(ServiceResult.success(List.of(contractDefinition)));
         when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
                 .thenReturn(Result.success(QuerySpec.Builder.newInstance().offset(10).build()));
         when(transformerRegistry.transform(isA(ContractDefinition.class), eq(ContractDefinitionDto.class)))

--- a/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/service/ContractDefinitionServiceImplTest.java
+++ b/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/service/ContractDefinitionServiceImplTest.java
@@ -24,7 +24,6 @@ import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.transaction.NoopTransactionContext;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
-import org.eclipse.dataspaceconnector.sql.translation.EdcQueryException;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,7 +35,6 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.dataspaceconnector.api.result.ServiceFailure.Reason.CONFLICT;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -89,7 +87,8 @@ class ContractDefinitionServiceImplTest {
         var result = service.query(QuerySpec.none());
 
         String id = definition.getId();
-        assertThat(result).hasSize(1).first().matches(hasId(id));
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent()).hasSize(1).first().matches(hasId(id));
     }
 
     @ParameterizedTest
@@ -101,7 +100,7 @@ class ContractDefinitionServiceImplTest {
         var query = QuerySpec.Builder.newInstance()
                 .filter(invalidFilter)
                 .build();
-        assertThatThrownBy(() -> service.query(query)).isInstanceOf(EdcQueryException.class);
+        assertThat(service.query(query).failed()).isTrue();
     }
 
     @ParameterizedTest

--- a/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiController.java
+++ b/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiController.java
@@ -47,7 +47,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
-import static org.eclipse.dataspaceconnector.api.ServiceResultHandler.handleFailedResult;
+import static org.eclipse.dataspaceconnector.api.ServiceResultHandler.mapToException;
 
 @Consumes({ MediaType.APPLICATION_JSON })
 @Produces({ MediaType.APPLICATION_JSON })
@@ -79,7 +79,7 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
 
         var queryResult = service.query(spec);
         if (queryResult.failed()) {
-            handleFailedResult(queryResult, ContractNegotiation.class, null);
+            throw mapToException(queryResult, ContractNegotiation.class, null);
         }
         return queryResult.getContent().stream()
                 .map(it -> transformerRegistry.transform(it, ContractNegotiationDto.class))
@@ -154,7 +154,7 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
         if (result.succeeded()) {
             monitor.debug(format("Contract negotiation canceled %s", result.getContent().getId()));
         } else {
-            handleFailedResult(result, ContractNegotiation.class, id);
+            throw mapToException(result, ContractNegotiation.class, id);
         }
     }
 
@@ -167,7 +167,7 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
         if (result.succeeded()) {
             monitor.debug(format("Contract negotiation declined %s", result.getContent().getId()));
         } else {
-            handleFailedResult(result, ContractNegotiation.class, id);
+            throw mapToException(result, ContractNegotiation.class, id);
         }
     }
 

--- a/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/service/ContractNegotiationService.java
+++ b/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/service/ContractNegotiationService.java
@@ -38,7 +38,7 @@ public interface ContractNegotiationService {
      * @param query request
      * @return the collection of contract negotiations that match the query
      */
-    Collection<ContractNegotiation> query(QuerySpec query);
+    ServiceResult<Collection<ContractNegotiation>> query(QuerySpec query);
 
     /**
      * Get negotiation state
@@ -49,8 +49,8 @@ public interface ContractNegotiationService {
     String getState(String negotiationId);
 
     /**
-     * Fetches the {@linkplain ContractAgreement} for a given {@linkplain ContractNegotiation},
-     * or null if either the negotiation does not exist, or no agreement has yet been reached.
+     * Fetches the {@linkplain ContractAgreement} for a given {@linkplain ContractNegotiation}, or null if either the
+     * negotiation does not exist, or no agreement has yet been reached.
      *
      * @param negotiationId the id of contract negotiation
      * @return the contract agreement, null if the negotiation does not exist or no agreement attached.

--- a/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/service/ContractNegotiationServiceImpl.java
+++ b/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/service/ContractNegotiationServiceImpl.java
@@ -26,7 +26,6 @@ import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.Contra
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractOfferRequest;
-import org.eclipse.dataspaceconnector.sql.translation.EdcQueryException;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -55,13 +54,13 @@ public class ContractNegotiationServiceImpl implements ContractNegotiationServic
     }
 
     @Override
-    public Collection<ContractNegotiation> query(QuerySpec query) {
+    public ServiceResult<Collection<ContractNegotiation>> query(QuerySpec query) {
         var result = queryValidator.validate(query);
 
         if (result.failed()) {
-            throw new EdcQueryException(format("Error validating schema: %s", result.getFailureDetail()));
+            return ServiceResult.badRequest(format("Error validating schema: %s", result.getFailureDetail()));
         }
-        return transactionContext.execute(() -> store.queryNegotiations(query).collect(toList()));
+        return ServiceResult.success(transactionContext.execute(() -> store.queryNegotiations(query).collect(toList())));
     }
 
     @Override

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerTest.java
@@ -72,7 +72,7 @@ class ContractNegotiationApiControllerTest {
     @Test
     void getAll() {
         var contractNegotiation = createContractNegotiation("negotiationId");
-        when(service.query(any())).thenReturn(List.of(contractNegotiation));
+        when(service.query(any())).thenReturn(ServiceResult.success(List.of(contractNegotiation)));
         var dto = ContractNegotiationDto.Builder.newInstance().id(contractNegotiation.getId()).build();
         when(transformerRegistry.transform(any(), eq(ContractNegotiationDto.class))).thenReturn(Result.success(dto));
         when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
@@ -90,7 +90,7 @@ class ContractNegotiationApiControllerTest {
     @Test
     void getAll_filtersOutFailedTransforms() {
         var contractNegotiation = createContractNegotiation("negotiationId");
-        when(service.query(any())).thenReturn(List.of(contractNegotiation));
+        when(service.query(any())).thenReturn(ServiceResult.success(List.of(contractNegotiation)));
         when(transformerRegistry.transform(isA(ContractNegotiation.class), eq(ContractNegotiationDto.class)))
                 .thenReturn(Result.failure("failure"));
         when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/service/ContractNegotiationServiceImplTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/service/ContractNegotiationServiceImplTest.java
@@ -28,7 +28,6 @@ import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.Cont
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractOfferRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.command.ContractNegotiationCommand;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
-import org.eclipse.dataspaceconnector.sql.translation.EdcQueryException;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -39,7 +38,6 @@ import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.dataspaceconnector.api.result.ServiceFailure.Reason.CONFLICT;
 import static org.eclipse.dataspaceconnector.api.result.ServiceFailure.Reason.NOT_FOUND;
 import static org.eclipse.dataspaceconnector.spi.response.ResponseStatus.FATAL_ERROR;
@@ -87,7 +85,8 @@ class ContractNegotiationServiceImplTest {
 
         var result = service.query(QuerySpec.none());
 
-        assertThat(result).hasSize(1).first().matches(it -> it.getId().equals("negotiationId"));
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent()).hasSize(1).first().matches(it -> it.getId().equals("negotiationId"));
     }
 
     @ParameterizedTest
@@ -102,7 +101,7 @@ class ContractNegotiationServiceImplTest {
                 .filter(invalidFilter)
                 .build();
 
-        assertThatThrownBy(() -> service.query(query)).isInstanceOf(EdcQueryException.class);
+        assertThat(service.query(query).failed()).isTrue();
     }
 
     @ParameterizedTest

--- a/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyDefinitionApiController.java
+++ b/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyDefinitionApiController.java
@@ -39,7 +39,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static java.lang.String.format;
-import static org.eclipse.dataspaceconnector.api.ServiceResultHandler.handleFailedResult;
+import static org.eclipse.dataspaceconnector.api.ServiceResultHandler.mapToException;
 
 @Produces({ MediaType.APPLICATION_JSON })
 @Consumes({ MediaType.APPLICATION_JSON })
@@ -71,7 +71,7 @@ public class PolicyDefinitionApiController implements PolicyDefinitionApi {
 
         var queryResult = policyDefinitionService.query(spec);
         if (queryResult.failed()) {
-            handleFailedResult(queryResult, PolicyDefinition.class, null);
+            throw mapToException(queryResult, PolicyDefinition.class, null);
         }
         return new ArrayList<>(queryResult.getContent());
 
@@ -96,7 +96,7 @@ public class PolicyDefinitionApiController implements PolicyDefinitionApi {
         if (result.succeeded()) {
             monitor.debug(format("Policy created %s", policy.getUid()));
         } else {
-            handleFailedResult(result, PolicyDefinition.class, policy.getUid());
+            throw mapToException(result, PolicyDefinition.class, policy.getUid());
         }
     }
 
@@ -109,7 +109,7 @@ public class PolicyDefinitionApiController implements PolicyDefinitionApi {
         if (result.succeeded()) {
             monitor.debug(format("Policy deleted %s", id));
         } else {
-            handleFailedResult(result, PolicyDefinition.class, id);
+            throw mapToException(result, PolicyDefinition.class, id);
         }
     }
 

--- a/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyDefinitionApiController.java
+++ b/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyDefinitionApiController.java
@@ -27,12 +27,9 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.dataspaceconnector.api.datamanagement.policy.service.PolicyDefinitionService;
 import org.eclipse.dataspaceconnector.api.query.QuerySpecDto;
-import org.eclipse.dataspaceconnector.api.result.ServiceResult;
 import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.policy.model.PolicyDefinition;
-import org.eclipse.dataspaceconnector.spi.EdcException;
-import org.eclipse.dataspaceconnector.spi.exception.ObjectExistsException;
 import org.eclipse.dataspaceconnector.spi.exception.ObjectNotFoundException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
@@ -42,6 +39,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static java.lang.String.format;
+import static org.eclipse.dataspaceconnector.api.ServiceResultHandler.handleFailedResult;
 
 @Produces({ MediaType.APPLICATION_JSON })
 @Consumes({ MediaType.APPLICATION_JSON })
@@ -73,7 +71,7 @@ public class PolicyDefinitionApiController implements PolicyDefinitionApi {
 
         var queryResult = policyDefinitionService.query(spec);
         if (queryResult.failed()) {
-            handleFailedResult(queryResult, null);
+            handleFailedResult(queryResult, PolicyDefinition.class, null);
         }
         return new ArrayList<>(queryResult.getContent());
 
@@ -98,7 +96,7 @@ public class PolicyDefinitionApiController implements PolicyDefinitionApi {
         if (result.succeeded()) {
             monitor.debug(format("Policy created %s", policy.getUid()));
         } else {
-            handleFailedResult(result, policy.getUid());
+            handleFailedResult(result, PolicyDefinition.class, policy.getUid());
         }
     }
 
@@ -111,20 +109,7 @@ public class PolicyDefinitionApiController implements PolicyDefinitionApi {
         if (result.succeeded()) {
             monitor.debug(format("Policy deleted %s", id));
         } else {
-            handleFailedResult(result, id);
-        }
-    }
-
-    private void handleFailedResult(ServiceResult<?> result, String id) {
-        switch (result.reason()) {
-            case NOT_FOUND:
-                throw new ObjectNotFoundException(Policy.class, id);
-            case CONFLICT:
-                throw new ObjectExistsException(Policy.class, id);
-            case BAD_REQUEST:
-                throw new IllegalArgumentException(result.getFailureDetail());
-            default:
-                throw new EdcException("unexpected error");
+            handleFailedResult(result, PolicyDefinition.class, id);
         }
     }
 

--- a/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/service/PolicyDefinitionService.java
+++ b/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/service/PolicyDefinitionService.java
@@ -43,8 +43,7 @@ public interface PolicyDefinitionService {
      * @return the collection of policies that match the query
      */
 
-    @NotNull
-    Collection<PolicyDefinition> query(QuerySpec query);
+    ServiceResult<Collection<PolicyDefinition>> query(QuerySpec query);
 
     /**
      * Delete a policy

--- a/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/service/PolicyDefinitionServiceImpl.java
+++ b/extensions/api/data-management/policydefinition/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/service/PolicyDefinitionServiceImpl.java
@@ -30,7 +30,6 @@ import org.eclipse.dataspaceconnector.spi.policy.store.PolicyDefinitionStore;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.QueryValidator;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
-import org.eclipse.dataspaceconnector.sql.translation.EdcQueryException;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
@@ -64,14 +63,14 @@ public class PolicyDefinitionServiceImpl implements PolicyDefinitionService {
     }
 
     @Override
-    public @NotNull Collection<PolicyDefinition> query(QuerySpec query) {
+    public ServiceResult<Collection<PolicyDefinition>> query(QuerySpec query) {
         var result = queryValidator.validate(query);
 
         if (result.failed()) {
-            throw new EdcQueryException(format("Error validating schema: %s", result.getFailureDetail()));
+            return ServiceResult.badRequest(format("Error validating schema: %s", result.getFailureDetail()));
         }
-        return transactionContext.execute(() ->
-                policyStore.findAll(query).collect(toList()));
+        return ServiceResult.success(transactionContext.execute(() ->
+                policyStore.findAll(query).collect(toList())));
     }
 
 

--- a/extensions/api/data-management/policydefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyDefinitionApiControllerTest.java
+++ b/extensions/api/data-management/policydefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyDefinitionApiControllerTest.java
@@ -71,7 +71,7 @@ class PolicyDefinitionApiControllerTest {
 
     @Test
     void getAllPolicies() {
-        when(service.query(any())).thenReturn(List.of(TestFunctions.createPolicy("id")));
+        when(service.query(any())).thenReturn(ServiceResult.success(List.of(TestFunctions.createPolicy("id"))));
         when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
                 .thenReturn(Result.success(QuerySpec.Builder.newInstance().offset(10).build()));
         var querySpec = QuerySpecDto.Builder.newInstance().build();

--- a/extensions/api/data-management/policydefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/service/PolicyDefinitionServiceImplTest.java
+++ b/extensions/api/data-management/policydefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/service/PolicyDefinitionServiceImplTest.java
@@ -24,7 +24,6 @@ import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.transaction.NoopTransactionContext;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
-import org.eclipse.dataspaceconnector.sql.translation.EdcQueryException;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -34,7 +33,6 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.dataspaceconnector.api.result.ServiceFailure.Reason.NOT_FOUND;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -67,7 +65,8 @@ public class PolicyDefinitionServiceImplTest {
         when(policyStore.findAll(any(QuerySpec.class))).thenReturn(Stream.of(policy));
         var policies = policyServiceImpl.query(QuerySpec.none());
 
-        assertThat(policies).containsExactly(policy);
+        assertThat(policies.succeeded()).isTrue();
+        assertThat(policies.getContent()).containsExactly(policy);
     }
 
     @ParameterizedTest
@@ -81,7 +80,7 @@ public class PolicyDefinitionServiceImplTest {
                 .filter(invalidFilter)
                 .build();
 
-        assertThatThrownBy(() -> policyServiceImpl.query(query)).isInstanceOf(EdcQueryException.class);
+        assertThat(policyServiceImpl.query(query).failed()).isTrue();
     }
 
     @Test

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiController.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiController.java
@@ -45,7 +45,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
-import static org.eclipse.dataspaceconnector.api.ServiceResultHandler.handleFailedResult;
+import static org.eclipse.dataspaceconnector.api.ServiceResultHandler.mapToException;
 
 @Produces({ MediaType.APPLICATION_JSON })
 @Consumes({ MediaType.APPLICATION_JSON })
@@ -74,7 +74,7 @@ public class TransferProcessApiController implements TransferProcessApi {
 
         var queryResult = service.query(spec);
         if (queryResult.failed()) {
-            handleFailedResult(queryResult, TransferProcess.class, null);
+            throw mapToException(queryResult, TransferProcess.class, null);
         }
         return queryResult.getContent().stream()
                 .map(tp -> transformerRegistry.transform(tp, TransferProcessDto.class))
@@ -114,7 +114,7 @@ public class TransferProcessApiController implements TransferProcessApi {
         if (result.succeeded()) {
             monitor.debug(format("Transfer process canceled %s", result.getContent().getId()));
         } else {
-            handleFailedResult(result, TransferProcess.class, id);
+            throw mapToException(result, TransferProcess.class, id);
         }
     }
 
@@ -127,7 +127,7 @@ public class TransferProcessApiController implements TransferProcessApi {
         if (result.succeeded()) {
             monitor.debug(format("Transfer process deprovisioned %s", result.getContent().getId()));
         } else {
-            handleFailedResult(result, TransferProcess.class, id);
+            throw mapToException(result, TransferProcess.class, id);
         }
     }
 

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessService.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessService.java
@@ -43,8 +43,7 @@ public interface TransferProcessService {
      * @param query request
      * @return the collection of transferProcesses that match the query
      */
-    @NotNull
-    Collection<TransferProcess> query(QuerySpec query);
+    ServiceResult<Collection<TransferProcess>> query(QuerySpec query);
 
     /**
      * Returns the state of a transferProcess by its id.
@@ -72,7 +71,8 @@ public interface TransferProcessService {
      * The return result status only reflects the successful submission of the command.
      *
      * @param transferProcessId id of the transferProcess
-     * @return a result that is successful if the transfer process was found and is in a state that can be deprovisioned
+     * @return a result that is successful if the transfer process was found and is in a state that can be
+     *         deprovisioned
      */
     @NotNull
     ServiceResult<TransferProcess> deprovision(String transferProcessId);

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImpl.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImpl.java
@@ -30,7 +30,6 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.command.CancelTransferCommand;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.command.DeprovisionRequest;
-import org.eclipse.dataspaceconnector.sql.translation.EdcQueryException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -62,13 +61,13 @@ public class TransferProcessServiceImpl implements TransferProcessService {
     }
 
     @Override
-    public @NotNull Collection<TransferProcess> query(QuerySpec query) {
+    public ServiceResult<Collection<TransferProcess>> query(QuerySpec query) {
         var result = queryValidator.validate(query);
 
         if (result.failed()) {
-            throw new EdcQueryException(format("Error validating schema: %s", result.getFailureDetail()));
+            return ServiceResult.badRequest(format("Error validating schema: %s", result.getFailureDetail()));
         }
-        return transactionContext.execute(() -> transferProcessStore.findAll(query).collect(toList()));
+        return ServiceResult.success(transactionContext.execute(() -> transferProcessStore.findAll(query).collect(toList())));
     }
 
     @Override

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerTest.java
@@ -73,7 +73,7 @@ class TransferProcessApiControllerTest {
         when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
                 .thenReturn(Result.success(QuerySpec.Builder.newInstance().offset(10).build()));
         var querySpec = QuerySpecDto.Builder.newInstance().build();
-        when(service.query(any())).thenReturn(List.of(transferProcess));
+        when(service.query(any())).thenReturn(ServiceResult.success(List.of(transferProcess)));
 
         var transferProcesses = controller.getAllTransferProcesses(querySpec);
 
@@ -88,7 +88,7 @@ class TransferProcessApiControllerTest {
         when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
                 .thenReturn(Result.success(QuerySpec.Builder.newInstance().offset(10).build()));
         when(transformerRegistry.transform(isA(TransferProcess.class), eq(TransferProcessDto.class))).thenReturn(Result.failure("failure"));
-        when(service.query(any())).thenReturn(List.of(transferProcess));
+        when(service.query(any())).thenReturn(ServiceResult.success(List.of(transferProcess)));
 
         var transferProcesses = controller.getAllTransferProcesses(QuerySpecDto.Builder.newInstance().build());
 

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImplTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImplTest.java
@@ -27,7 +27,6 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessS
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.command.CancelTransferCommand;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.command.DeprovisionRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.command.SingleTransferProcessCommand;
-import org.eclipse.dataspaceconnector.sql.translation.EdcQueryException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -39,7 +38,6 @@ import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.INCLUDE;
 import static org.mockito.ArgumentMatchers.any;
@@ -86,7 +84,7 @@ class TransferProcessServiceImplTest {
     @Test
     void query() {
         when(store.findAll(query)).thenReturn(Stream.of(process1, process2));
-        assertThat(service.query(query)).containsExactly(process1, process2);
+        assertThat(service.query(query).getContent()).containsExactly(process1, process2);
         verify(transactionContext).execute(any(TransactionContext.ResultTransactionBlock.class));
     }
 
@@ -98,7 +96,7 @@ class TransferProcessServiceImplTest {
     })
     void query_invalidFilter_raiseException(String invalidFilter) {
         var spec = QuerySpec.Builder.newInstance().filter(invalidFilter).build();
-        assertThatThrownBy(() -> service.query(spec)).isInstanceOf(EdcQueryException.class);
+        assertThat(service.query(spec).failed()).isTrue();
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## What this PR changes/adds

this PR changes the signature of all API services (the ones used by the controllers) to use `ServiceResult`s when querying.


## Why it does that

`ServiceResults` (or `Result`s in general) are a pattern in EDC and should be used wherever possible.

## Further notes

- moved the `handleFailureResult` methods into a helper class `ServiceResultHandler`.
- removed the `EdcQueryException` from the `EdcExceptionMapper` again.

## Linked Issue(s)

Closes #1654 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
