### PR TITLE
Samples: add integration test to sample 04.2-modify-transferprocess

### DIFF
--- a/samples/04.0-file-transfer/integration-tests/build.gradle.kts
+++ b/samples/04.0-file-transfer/integration-tests/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
 
     testFixturesImplementation(project(":extensions:junit"))
     testFixturesImplementation(testFixtures(project(":common:util")))
+    testFixturesImplementation(project(":extensions:api:data-management:transferprocess"))
     testFixturesImplementation("io.rest-assured:rest-assured:${restAssured}")
     testFixturesImplementation("org.awaitility:awaitility:${awaitility}")
     testFixturesImplementation("org.assertj:assertj-core:${assertj}")

--- a/samples/04.0-file-transfer/integration-tests/src/testFixtures/java/org/eclipse/dataspaceconnector/extension/sample/test/FileTransferSampleTestCommon.java
+++ b/samples/04.0-file-transfer/integration-tests/src/testFixtures/java/org/eclipse/dataspaceconnector/extension/sample/test/FileTransferSampleTestCommon.java
@@ -19,6 +19,7 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.path.json.JsonPath;
 import org.apache.http.HttpStatus;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferProcessDto;
 import org.eclipse.dataspaceconnector.junit.testfixtures.TestUtils;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
@@ -35,7 +36,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
 /**
- * Encapsulates common settings, test steps, and helper methods for the test for samples 4.0 and 4.1.
+ * Encapsulates common settings, test steps, and helper methods for the test for samples 4.x.
  */
 public class FileTransferSampleTestCommon {
 
@@ -44,7 +45,7 @@ public class FileTransferSampleTestCommon {
     //region constant test settings
     static final String INITIATE_CONTRACT_NEGOTIATION_URI = "http://localhost:9192/api/v1/data/contractnegotiations";
     static final String LOOK_UP_CONTRACT_AGREEMENT_URI = "http://localhost:9192/api/v1/data/contractnegotiations/{id}";
-    static final String INITIATE_TRANSFER_PROCESS_URI = "http://localhost:9192/api/v1/data/transferprocess";
+    static final String TRANSFER_PROCESS_URI = "http://localhost:9192/api/v1/data/transferprocess";
     static final String CONTRACT_OFFER_FILE_PATH = "samples/04.0-file-transfer/contractoffer.json";
     static final String TRANSFER_FILE_PATH = "samples/04.0-file-transfer/filetransfer.json";
     static final String API_KEY_HEADER_KEY = "X-Api-Key";
@@ -69,7 +70,7 @@ public class FileTransferSampleTestCommon {
      * @param sampleAssetFilePath Relative path starting from the root of the project to a file which will be read from for transfer.
      * @param destinationFilePath Relative path starting from the root of the project where the transferred file will be written to.
      */
-    FileTransferSampleTestCommon(@NotNull String sampleAssetFilePath, @NotNull String destinationFilePath) {
+    public FileTransferSampleTestCommon(@NotNull String sampleAssetFilePath, @NotNull String destinationFilePath) {
         this.sampleAssetFilePath = sampleAssetFilePath;
         this.sampleAssetFile  = getFileFromRelativePath(sampleAssetFilePath);
 
@@ -98,7 +99,7 @@ public class FileTransferSampleTestCommon {
      * Resolves a {@link File} instance from a relative path.
      */
     @NotNull
-    static File getFileFromRelativePath(String relativePath) {
+    public static File getFileFromRelativePath(String relativePath) {
         return new File(TestUtils.findBuildRoot(), relativePath);
     }
 
@@ -129,6 +130,21 @@ public class FileTransferSampleTestCommon {
                 .extract()
                 .jsonPath()
                 .get("id");
+    }
+
+    /**
+     * Gets the first transfer process as returned by the data management API.
+     *
+     * @return The transfer process.
+     */
+    public TransferProcessDto getTransferProcess() {
+        return RestAssured.given()
+                .headers(API_KEY_HEADER_KEY, API_KEY_HEADER_VALUE)
+            .when()
+                .get(TRANSFER_PROCESS_URI)
+            .then()
+                .statusCode(HttpStatus.SC_OK)
+                .extract().jsonPath().getObject("[0]", TransferProcessDto.class);
     }
 
     /**
@@ -168,7 +184,7 @@ public class FileTransferSampleTestCommon {
                     .contentType(ContentType.JSON)
                     .body(sampleDataRequest)
                 .when()
-                    .post(INITIATE_TRANSFER_PROCESS_URI)
+                    .post(TRANSFER_PROCESS_URI)
                 .then()
                     .statusCode(HttpStatus.SC_OK)
                     .body("id", not(emptyString()))

--- a/samples/04.2-modify-transferprocess/modify-transferprocess-sample-integration-tests/build.gradle.kts
+++ b/samples/04.2-modify-transferprocess/modify-transferprocess-sample-integration-tests/build.gradle.kts
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial test implementation for sample
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+val restAssured: String by project
+val awaitility: String by project
+
+
+dependencies {
+    testImplementation(project(":extensions:junit"))
+    testImplementation(testFixtures(project(":common:util")))
+    testImplementation("io.rest-assured:rest-assured:${restAssured}")
+    testImplementation("org.awaitility:awaitility:${awaitility}")
+    testImplementation(project(":extensions:api:data-management:transferprocess"))
+
+    testImplementation(testFixtures(project(":samples:04.0-file-transfer:integration-tests")))
+
+    testCompileOnly(project(":samples:04.2-modify-transferprocess:consumer"))
+}

--- a/samples/04.2-modify-transferprocess/modify-transferprocess-sample-integration-tests/src/test/java/org/eclipse/dataspaceconnector/samples/sample042/test/ModifyTransferProcessSampleTest.java
+++ b/samples/04.2-modify-transferprocess/modify-transferprocess-sample-integration-tests/src/test/java/org/eclipse/dataspaceconnector/samples/sample042/test/ModifyTransferProcessSampleTest.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial test implementation for sample
+ *
+ */
+
+package org.eclipse.dataspaceconnector.samples.sample042.test;
+
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferProcessDto;
+import org.eclipse.dataspaceconnector.common.util.junit.annotations.EndToEndTest;
+import org.eclipse.dataspaceconnector.extension.sample.test.FileTransferSampleTestCommon;
+import org.eclipse.dataspaceconnector.junit.extensions.EdcRuntimeExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.eclipse.dataspaceconnector.extension.sample.test.FileTransferSampleTestCommon.getFileFromRelativePath;
+
+@EndToEndTest
+public class ModifyTransferProcessSampleTest {
+
+    static final String CONSUMER_CONFIG_PROPERTIES_FILE_PATH = "samples/04.2-modify-transferprocess/consumer/config.properties";
+    static final String EXPECTED_ID_PROPERTY_VALUE = "tp-sample-04.2";
+    static final String EXPECTED_STATE_PROPERTY_VALUE = "ERROR";
+    static final String EXPECTED_ERROR_DETAIL_PROPERTY_VALUE = "timeout by watchdog";
+    @RegisterExtension
+    static EdcRuntimeExtension consumer = new EdcRuntimeExtension(
+            ":samples:04.2-modify-transferprocess:consumer",
+            "consumer",
+            Map.of(
+                    "edc.fs.config", getFileFromRelativePath(CONSUMER_CONFIG_PROPERTIES_FILE_PATH).getAbsolutePath()
+            )
+    );
+    static final Duration DURATION = Duration.ofSeconds(15);
+    static final Duration POLL_INTERVAL = Duration.ofMillis(500);
+
+    final FileTransferSampleTestCommon testCommon = new FileTransferSampleTestCommon("", ""); // no sample asset transfer in this sample
+
+    /**
+     * Requests transfer processes from data management API and check for expected changes on the transfer process.
+     */
+    @Test
+    void runSample() {
+        await().atMost(DURATION).pollInterval(POLL_INTERVAL)
+                .untilAsserted(() ->
+                        assertThat(testCommon.getTransferProcess())
+                                .usingRecursiveComparison()
+                                .ignoringExpectedNullFields()
+                                .isEqualTo(TransferProcessDto.Builder.newInstance()
+                                        .id(EXPECTED_ID_PROPERTY_VALUE)
+                                        .state(EXPECTED_STATE_PROPERTY_VALUE)
+                                        .errorDetail(EXPECTED_ERROR_DETAIL_PROPERTY_VALUE)
+                                        .build()));
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -182,6 +182,7 @@ include(":samples:04.1-file-transfer-listener:file-transfer-listener-integration
 include(":samples:04.2-modify-transferprocess:consumer")
 include(":samples:04.2-modify-transferprocess:watchdog")
 include(":samples:04.2-modify-transferprocess:simulator")
+include(":samples:04.2-modify-transferprocess:modify-transferprocess-sample-integration-tests")
 
 include(":samples:04.3-open-telemetry:micrometer")
 include(":samples:04.3-open-telemetry:consumer")


### PR DESCRIPTION
## What this PR changes/adds

This PR adds an automated integration tests that run in CI to prevent the samples breaking due to changes in the EDC.

The scope of this story is to add automated integration tests for sample 04.2.

Added test class `ModifyTransferProcessSampleTest.java`

## Why it does that

Every step from sample 4.2 readme is reproduced in the automated tests to reduce the risk from sample guidance diverging from actual code base.

## Further notes

* No update to changelog as these changes apply to samples.

## Linked Issue(s)

Closes #1588

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
