### PR TITLE
Bug Fix: Updated html table breaking javadoc task

### DIFF
--- a/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/ServiceResultHandler.java
+++ b/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/ServiceResultHandler.java
@@ -27,8 +27,11 @@ public class ServiceResultHandler {
      * Interprets a {@link ServiceResult} based on its {@link ServiceResult#reason()} property and returns the
      * appropriate exception:
      * <table>
-     *   <th>reason</th>
-     *   <th>exception</th>
+     *  <caption></caption>
+     *   <tr>
+     *      <th>reason</th>
+     *      <th>exception</th>
+     *   </tr>
      *   <tr>
      *     <td>NOT_FOUND </td> <td>ObjectNotFoundException</td>
      *   </tr>


### PR DESCRIPTION
## What this PR changes/adds

fix for #1691 

## Why it does that

To ensure that `javadoc` task completes without exceptions

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #1691 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
