### PR TITLE
feat: add check for ids message response type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Full Query capabilities for SQL PolicyDefinition Store (#1484)
 * Documentation for `:extensions:data-plane:data-plane-api` (#1579)
 * Allow `TypeManager` to support multiple serialization contexts (#1581)
+* Check response type of IDS multipart messages (#1695)
 
 #### Changed
 

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/IdsMultipartSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/IdsMultipartSender.java
@@ -30,6 +30,7 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.response.IdsMultipartParts;
+import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.response.MultipartResponse;
 import org.eclipse.dataspaceconnector.ids.core.message.FutureCallback;
 import org.eclipse.dataspaceconnector.ids.core.message.IdsMessageSender;
 import org.eclipse.dataspaceconnector.ids.spi.IdsIdParser;
@@ -49,6 +50,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpHeaders;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
@@ -202,8 +204,12 @@ abstract class IdsMultipartSender<M extends RemoteMessage, R> implements IdsMess
                         if (body == null) {
                             future.completeExceptionally(new EdcException("Received an empty body response from connector"));
                         } else {
-                            IdsMultipartParts parts = extractResponseParts(body);
-                            return getResponseContent(parts);
+                            var parts = extractResponseParts(body);
+                            var response = getResponseContent(parts);
+
+                            checkResponseType(response);
+
+                            return response.getPayload();
                         }
                     } catch (Exception e) {
                         future.completeExceptionally(e);
@@ -270,7 +276,14 @@ abstract class IdsMultipartSender<M extends RemoteMessage, R> implements IdsMess
      * @return an instance of the sub class's return type.
      * @throws Exception if parsing the response fails.
      */
-    protected abstract R getResponseContent(IdsMultipartParts parts) throws Exception;
+    protected abstract MultipartResponse<R> getResponseContent(IdsMultipartParts parts) throws Exception;
+
+    /**
+     * Return expected response type.
+     *
+     * @return the response type class.
+     */
+    protected abstract List<Class<? extends Message>> getAllowedResponseTypes();
 
     /**
      * Parses the multipart response. Extracts header and payload as input stream and wraps them
@@ -311,6 +324,13 @@ abstract class IdsMultipartSender<M extends RemoteMessage, R> implements IdsMess
                 .header(header)
                 .payload(payload)
                 .build();
+    }
+
+    private void checkResponseType(@NotNull MultipartResponse<?> response) {
+        var type = getAllowedResponseTypes();
+        if (!type.contains(response.getHeader().getClass())) {
+            throw new EdcException("Received unexpected response type.");
+        }
     }
 
 }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartArtifactRequestSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartArtifactRequestSender.java
@@ -18,7 +18,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import de.fraunhofer.iais.eis.ArtifactRequestMessageBuilder;
 import de.fraunhofer.iais.eis.DynamicAttributeToken;
 import de.fraunhofer.iais.eis.Message;
-import de.fraunhofer.iais.eis.RejectionMessage;
+import de.fraunhofer.iais.eis.RequestInProcessMessageImpl;
+import de.fraunhofer.iais.eis.ResponseMessageImpl;
 import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.response.IdsMultipartParts;
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.response.MultipartResponse;
@@ -37,16 +38,18 @@ import org.jetbrains.annotations.NotNull;
 
 import java.net.URI;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
+import static org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.util.ResponseUtil.parseMultipartStringResponse;
 import static org.eclipse.dataspaceconnector.ids.spi.IdsConstants.IDS_WEBHOOK_ADDRESS_PROPERTY;
 
 /**
  * IdsMultipartSender implementation for data requests. Sends IDS ArtifactRequestMessages and
  * expects an IDS RequestInProcessMessage as the response.
  */
-public class MultipartArtifactRequestSender extends IdsMultipartSender<DataRequest, MultipartResponse<String>> {
+public class MultipartArtifactRequestSender extends IdsMultipartSender<DataRequest, String> {
 
     private final Vault vault;
     private final String idsWebhookAddress;
@@ -148,21 +151,15 @@ public class MultipartArtifactRequestSender extends IdsMultipartSender<DataReque
      *
      * @param parts container object for response header and payload input streams.
      * @return a MultipartResponse containing the message header and the response payload as string.
-     * @throws Exception if parsing header or payload fails or if the response header is not of type
-     *                   RequestInProcessMessage.
+     * @throws Exception if parsing header or payload fails.
      */
     @Override
     protected MultipartResponse<String> getResponseContent(IdsMultipartParts parts) throws Exception {
-        var header = getObjectMapper().readValue(parts.getHeader(), Message.class);
-        String payload = null;
-        if (parts.getPayload() != null) {
-            payload = new String(parts.getPayload().readAllBytes());
-        }
+        return parseMultipartStringResponse(parts, getObjectMapper());
+    }
 
-        if (header instanceof RejectionMessage) {
-            throw new EdcException("Received rejection message as response to artifact request.");
-        }
-
-        return new MultipartResponse<>(header, payload);
+    @Override
+    protected List<Class<? extends Message>> getAllowedResponseTypes() {
+        return List.of(ResponseMessageImpl.class, RequestInProcessMessageImpl.class); // TODO remove ResponseMessage.class
     }
 }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractAgreementSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractAgreementSender.java
@@ -19,6 +19,7 @@ import de.fraunhofer.iais.eis.ContractAgreement;
 import de.fraunhofer.iais.eis.ContractAgreementMessageBuilder;
 import de.fraunhofer.iais.eis.DynamicAttributeToken;
 import de.fraunhofer.iais.eis.Message;
+import de.fraunhofer.iais.eis.MessageProcessedNotificationMessageImpl;
 import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.response.IdsMultipartParts;
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.response.MultipartResponse;
@@ -35,6 +36,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.net.URI;
 import java.util.Collections;
+import java.util.List;
 
 import static org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.util.ResponseUtil.parseMultipartStringResponse;
 import static org.eclipse.dataspaceconnector.ids.spi.IdsConstants.IDS_WEBHOOK_ADDRESS_PROPERTY;
@@ -43,7 +45,7 @@ import static org.eclipse.dataspaceconnector.ids.spi.IdsConstants.IDS_WEBHOOK_AD
  * IdsMultipartSender implementation for contract agreements. Sends IDS ContractAgreementMessages and
  * expects an IDS RequestInProcessMessage as the response.
  */
-public class MultipartContractAgreementSender extends IdsMultipartSender<ContractAgreementRequest, MultipartResponse<String>> {
+public class MultipartContractAgreementSender extends IdsMultipartSender<ContractAgreementRequest, String> {
 
     private final String idsWebhookAddress;
 
@@ -131,5 +133,9 @@ public class MultipartContractAgreementSender extends IdsMultipartSender<Contrac
         return parseMultipartStringResponse(parts, getObjectMapper());
     }
 
+    @Override
+    protected List<Class<? extends Message>> getAllowedResponseTypes() {
+        return List.of(MessageProcessedNotificationMessageImpl.class);
+    }
 
 }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractOfferSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractOfferSender.java
@@ -20,6 +20,7 @@ import de.fraunhofer.iais.eis.ContractRequestBuilder;
 import de.fraunhofer.iais.eis.ContractRequestMessageBuilder;
 import de.fraunhofer.iais.eis.DynamicAttributeToken;
 import de.fraunhofer.iais.eis.Message;
+import de.fraunhofer.iais.eis.RequestInProcessMessageImpl;
 import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.response.IdsMultipartParts;
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.response.MultipartResponse;
@@ -35,6 +36,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.net.URI;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 import static org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.util.ResponseUtil.parseMultipartStringResponse;
@@ -44,7 +46,7 @@ import static org.eclipse.dataspaceconnector.ids.spi.IdsConstants.IDS_WEBHOOK_AD
  * IdsMultipartSender implementation for contract requests. Sends IDS ContractRequestMessages and
  * expects an IDS RequestInProcessMessage as the response.
  */
-public class MultipartContractOfferSender extends IdsMultipartSender<ContractOfferRequest, MultipartResponse<String>> {
+public class MultipartContractOfferSender extends IdsMultipartSender<ContractOfferRequest, String> {
 
     private final String idsWebhookAddress;
 
@@ -138,6 +140,11 @@ public class MultipartContractOfferSender extends IdsMultipartSender<ContractOff
     @Override
     protected MultipartResponse<String> getResponseContent(IdsMultipartParts parts) throws Exception {
         return parseMultipartStringResponse(parts, getObjectMapper());
+    }
+
+    @Override
+    protected List<Class<? extends Message>> getAllowedResponseTypes() {
+        return List.of(RequestInProcessMessageImpl.class);
     }
 
     private de.fraunhofer.iais.eis.ContractRequest createContractRequest(ContractOffer offer) {

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractRejectionSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractRejectionSender.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import de.fraunhofer.iais.eis.ContractRejectionMessageBuilder;
 import de.fraunhofer.iais.eis.DynamicAttributeToken;
 import de.fraunhofer.iais.eis.Message;
+import de.fraunhofer.iais.eis.MessageProcessedNotificationMessageImpl;
 import de.fraunhofer.iais.eis.util.TypedLiteral;
 import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.response.IdsMultipartParts;
@@ -32,6 +33,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.net.URI;
 import java.util.Collections;
+import java.util.List;
 
 import static org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.util.ResponseUtil.parseMultipartStringResponse;
 
@@ -39,7 +41,7 @@ import static org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender
  * IdsMultipartSender implementation for contract rejections. Sends IDS ContractRequestMessages and
  * expects an IDS RequestInProcessMessage as the response.
  */
-public class MultipartContractRejectionSender extends IdsMultipartSender<ContractRejection, MultipartResponse<String>> {
+public class MultipartContractRejectionSender extends IdsMultipartSender<ContractRejection, String> {
 
     public MultipartContractRejectionSender(@NotNull String connectorId,
                                             @NotNull OkHttpClient httpClient,
@@ -102,5 +104,10 @@ public class MultipartContractRejectionSender extends IdsMultipartSender<Contrac
     @Override
     protected MultipartResponse<String> getResponseContent(IdsMultipartParts parts) throws Exception {
         return parseMultipartStringResponse(parts, getObjectMapper());
+    }
+
+    @Override
+    protected List<Class<? extends Message>> getAllowedResponseTypes() {
+        return List.of(MessageProcessedNotificationMessageImpl.class);
     }
 }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartDescriptionRequestSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartDescriptionRequestSender.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import de.fraunhofer.iais.eis.Artifact;
 import de.fraunhofer.iais.eis.BaseConnector;
 import de.fraunhofer.iais.eis.DescriptionRequestMessageBuilder;
+import de.fraunhofer.iais.eis.DescriptionResponseMessageImpl;
 import de.fraunhofer.iais.eis.DynamicAttributeToken;
 import de.fraunhofer.iais.eis.Message;
 import de.fraunhofer.iais.eis.ModelClass;
@@ -40,12 +41,13 @@ import org.jetbrains.annotations.NotNull;
 
 import java.net.URI;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * IdsMultipartSender implementation for metadata requests. Sends IDS DescriptionRequestMessages and
  * expects an IDS DescriptionResponseMessage as the response.
  */
-public class MultipartDescriptionRequestSender extends IdsMultipartSender<MetadataRequest, MultipartResponse<ModelClass>> {
+public class MultipartDescriptionRequestSender extends IdsMultipartSender<MetadataRequest, ModelClass> {
 
     public MultipartDescriptionRequestSender(@NotNull String connectorId,
                                              @NotNull OkHttpClient httpClient,
@@ -126,5 +128,10 @@ public class MultipartDescriptionRequestSender extends IdsMultipartSender<Metada
         }
 
         return new MultipartResponse<>(header, payload);
+    }
+
+    @Override
+    protected List<Class<? extends Message>> getAllowedResponseTypes() {
+        return List.of(DescriptionResponseMessageImpl.class);
     }
 }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartEndpointDataReferenceRequestSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartEndpointDataReferenceRequestSender.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.fraunhofer.iais.eis.DynamicAttributeToken;
 import de.fraunhofer.iais.eis.Message;
+import de.fraunhofer.iais.eis.MessageProcessedNotificationMessageImpl;
 import de.fraunhofer.iais.eis.ParticipantUpdateMessageBuilder;
 import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.response.IdsMultipartParts;
@@ -30,6 +31,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.net.URI;
 import java.util.Collections;
+import java.util.List;
 
 import static org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.util.ResponseUtil.parseMultipartStringResponse;
 
@@ -37,7 +39,7 @@ import static org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender
  * IdsMultipartSender implementation for transferring Endpoint Data Reference (EDR). Sends IDS NotificationMessage and
  * expects an IDS MessageProcessedMessage as the response.
  */
-public class MultipartEndpointDataReferenceRequestSender extends IdsMultipartSender<EndpointDataReferenceMessage, MultipartResponse<String>> {
+public class MultipartEndpointDataReferenceRequestSender extends IdsMultipartSender<EndpointDataReferenceMessage, String> {
 
     public MultipartEndpointDataReferenceRequestSender(@NotNull String connectorId,
                                                        @NotNull OkHttpClient httpClient,
@@ -98,5 +100,10 @@ public class MultipartEndpointDataReferenceRequestSender extends IdsMultipartSen
     @Override
     protected MultipartResponse<String> getResponseContent(IdsMultipartParts parts) throws Exception {
         return parseMultipartStringResponse(parts, getObjectMapper());
+    }
+
+    @Override
+    protected List<Class<? extends Message>> getAllowedResponseTypes() {
+        return List.of(MessageProcessedNotificationMessageImpl.class);
     }
 }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/IdsMultipartSenderTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/IdsMultipartSenderTest.java
@@ -20,6 +20,7 @@ import de.fraunhofer.iais.eis.DynamicAttributeToken;
 import de.fraunhofer.iais.eis.Message;
 import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.response.IdsMultipartParts;
+import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.response.MultipartResponse;
 import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTransformerRegistry;
 import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
@@ -27,6 +28,7 @@ import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.message.RemoteMessage;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -49,7 +51,7 @@ class IdsMultipartSenderTest {
         assertThat(result).failsWithin(1, TimeUnit.SECONDS);
     }
 
-    private class TestIdsMultipartSender extends IdsMultipartSender<TestRemoteMessage, Object> {
+    private class TestIdsMultipartSender extends IdsMultipartSender<TestRemoteMessage, MultipartResponse> {
 
         protected TestIdsMultipartSender(String connectorId, OkHttpClient httpClient, ObjectMapper objectMapper,
                                          Monitor monitor, IdentityService identityService, IdsTransformerRegistry transformerRegistry) {
@@ -72,7 +74,12 @@ class IdsMultipartSenderTest {
         }
 
         @Override
-        protected Object getResponseContent(IdsMultipartParts parts) {
+        protected MultipartResponse getResponseContent(IdsMultipartParts parts) {
+            return null;
+        }
+
+        @Override
+        protected List<Class<? extends Message>> getAllowedResponseTypes() {
             return null;
         }
     }


### PR DESCRIPTION
## What this PR changes/adds

Adds a type check for IDS mulitpart message responses. 

## Why it does that

Before, any IDS message was allowed as a response, although the further proccesing requires certain message types and contents. E.g. a state change would have been triggered in any case of a valid IDS response message, also for rejection messages.

## Further notes

Idea was not to check explicitly for rejection messages but to prevent processing unexpected responses.

## Linked Issue(s)

Relates #1600

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
