### PR TITLE
feat: additional policy scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Allow `TypeManager` to support multiple serialization contexts (#1581)
 * Check response type of IDS multipart messages (#1695)
 * Define api error detail message schema (#1490)
+* Policy scopes: `contract.cataloging`, `provision.manifest.verify` (#1446)
 
 #### Changed
 

--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/policy/PolicyContextImpl.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/policy/PolicyContextImpl.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - context data
  *
  */
 
@@ -19,7 +20,9 @@ import org.eclipse.dataspaceconnector.spi.policy.PolicyContext;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Default context implementation.
@@ -27,6 +30,7 @@ import java.util.List;
 public class PolicyContextImpl implements PolicyContext {
     private final ParticipantAgent agent;
     private final List<String> problems = new ArrayList<>();
+    private Map<Class<?>, Object> additional = new HashMap<>();
 
     public PolicyContextImpl(ParticipantAgent agent) {
         this.agent = agent;
@@ -50,5 +54,15 @@ public class PolicyContextImpl implements PolicyContext {
     @Override
     public ParticipantAgent getParticipantAgent() {
         return agent;
+    }
+    
+    @Override
+    public <T> T getContextData(Class<T> type) {
+        return (T) additional.get(type);
+    }
+    
+    @Override
+    public <T> void putContextData(Class<T> type, T data) {
+        additional.put(type, data);
     }
 }

--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/policy/PolicyContextImpl.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/policy/PolicyContextImpl.java
@@ -31,9 +31,24 @@ public class PolicyContextImpl implements PolicyContext {
     private final ParticipantAgent agent;
     private final List<String> problems = new ArrayList<>();
     private Map<Class<?>, Object> additional = new HashMap<>();
-
-    public PolicyContextImpl(ParticipantAgent agent) {
+    
+    /**
+     * Creates a new PolicyContextImpl with the given participant agent and additional context
+     * data. Values in the additional map need to be of the same type defined by the key, otherwise
+     * they will be omitted.
+     *
+     * @param agent the requesting participant agent.
+     * @param additionalData additional context data.
+     */
+    public PolicyContextImpl(ParticipantAgent agent, Map<Class, Object> additionalData) {
         this.agent = agent;
+        additionalData.forEach((key, value) -> {
+            try {
+                this.putContextData(key, key.cast(value));
+            } catch (ClassCastException ignore) {
+                // invalid entry
+            }
+        });
     }
 
     @Override

--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/policy/PolicyEngineImpl.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/policy/PolicyEngineImpl.java
@@ -29,6 +29,7 @@ import org.eclipse.dataspaceconnector.spi.policy.RuleFunction;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -58,10 +59,22 @@ public class PolicyEngineImpl implements PolicyEngine {
     public Policy filter(Policy policy, String scope) {
         return scopeFilter.applyScope(policy, scope);
     }
-
+    
     @Override
     public Result<Policy> evaluate(String scope, Policy policy, ParticipantAgent agent) {
+        return evaluate(scope, policy, agent, new HashMap<>());
+    }
+
+    @Override
+    public Result<Policy> evaluate(String scope, Policy policy, ParticipantAgent agent, Map<Class, Object> contextInformation) {
         var context = new PolicyContextImpl(agent);
+        contextInformation.forEach((key, value) -> {
+            try {
+                context.putContextData(key, key.cast(value));
+            } catch (ClassCastException ignore) {
+                // invalid entry
+            }
+        });
 
         for (BiFunction<Policy, PolicyContext, Boolean> validator : preValidators) {
             if (!validator.apply(policy, context)) {
@@ -105,10 +118,23 @@ public class PolicyEngineImpl implements PolicyEngine {
                     return Result.failure(context.hasProblems() ? context.getProblems() : List.of("Post-validator failed: " + validator.getClass().getName()));
                 }
             }
+    
+            updateContextInformation(context, contextInformation);
             return Result.success(policy);
         } else {
+            updateContextInformation(context, contextInformation);
             return Result.failure(result.getProblems().stream().map(RuleProblem::getDescription).collect(toList()));
         }
+    }
+    
+    /**
+     * Updates the initially supplied context data from the policy context.
+     *
+     * @param context the policy context.
+     * @param contextInformation the initial context data.
+     */
+    private void updateContextInformation(PolicyContext context, Map<Class, Object> contextInformation) {
+        contextInformation.keySet().forEach(key -> contextInformation.put(key, context.getContextData(key)));
     }
 
     @Override

--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/policy/PolicyEngineImpl.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/base/policy/PolicyEngineImpl.java
@@ -67,14 +67,7 @@ public class PolicyEngineImpl implements PolicyEngine {
 
     @Override
     public Result<Policy> evaluate(String scope, Policy policy, ParticipantAgent agent, Map<Class, Object> contextInformation) {
-        var context = new PolicyContextImpl(agent);
-        contextInformation.forEach((key, value) -> {
-            try {
-                context.putContextData(key, key.cast(value));
-            } catch (ClassCastException ignore) {
-                // invalid entry
-            }
-        });
+        var context = new PolicyContextImpl(agent, contextInformation);
 
         for (BiFunction<Policy, PolicyContext, Boolean> validator : preValidators) {
             if (!validator.apply(policy, context)) {

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
@@ -158,7 +158,7 @@ public class ContractServiceExtension implements ServiceExtension {
         var contractOfferService = new ContractOfferServiceImpl(agentService, definitionService, assetIndex, policyStore);
         context.registerService(ContractOfferService.class, contractOfferService);
 
-        var validationService = new ContractValidationServiceImpl(agentService, definitionService, assetIndex, policyStore, clock);
+        var validationService = new ContractValidationServiceImpl(agentService, definitionService, assetIndex, policyStore, clock, policyEngine);
         context.registerService(ContractValidationService.class, validationService);
 
         var waitStrategy = context.hasService(NegotiationWaitStrategy.class) ? context.getService(NegotiationWaitStrategy.class) : new ExponentialWaitStrategy(DEFAULT_ITERATION_WAIT);

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractDefinitionServiceImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractDefinitionServiceImplTest.java
@@ -34,7 +34,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression.SELECT_ALL;
-import static org.eclipse.dataspaceconnector.spi.contract.offer.ContractDefinitionService.NEGOTIATION_SCOPE;
+import static org.eclipse.dataspaceconnector.spi.contract.offer.ContractDefinitionService.CATALOGING_SCOPE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -63,13 +63,13 @@ class ContractDefinitionServiceImplTest {
         var agent = new ParticipantAgent(Map.of(), Map.of());
         var def = PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build();
         when(policyStore.findById(any())).thenReturn(def);
-        when(policyEngine.evaluate(NEGOTIATION_SCOPE, def.getPolicy(), agent)).thenReturn(Result.success(def.getPolicy()));
+        when(policyEngine.evaluate(CATALOGING_SCOPE, def.getPolicy(), agent)).thenReturn(Result.success(def.getPolicy()));
         when(definitionStore.findAll(any())).thenReturn(Stream.of(ContractDefinition.Builder.newInstance().id("1").accessPolicyId("access").contractPolicyId("contract").selectorExpression(SELECT_ALL).build()));
 
         var definitions = definitionService.definitionsFor(agent, DEFAULT_RANGE);
 
         assertThat(definitions).hasSize(1);
-        verify(policyEngine, atLeastOnce()).evaluate(NEGOTIATION_SCOPE, def.getPolicy(), agent);
+        verify(policyEngine, atLeastOnce()).evaluate(CATALOGING_SCOPE, def.getPolicy(), agent);
         verify(definitionStore).findAll(any());
     }
 
@@ -85,26 +85,7 @@ class ContractDefinitionServiceImplTest {
         var result = definitionService.definitionsFor(agent, DEFAULT_RANGE);
 
         assertThat(result).isEmpty();
-        verify(policyEngine, atLeastOnce()).evaluate(NEGOTIATION_SCOPE, definition.getPolicy(), agent);
-        verify(definitionStore).findAll(any());
-    }
-
-    @Test
-    void definitionsFor_verifyDoesNotSatisfyUsagePolicy() {
-        var agent = new ParticipantAgent(Map.of(), Map.of());
-        var definition = PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).uid("access").build();
-        var contractDefinition = ContractDefinition.Builder.newInstance().id("1")
-                .accessPolicyId("access").contractPolicyId("contract").selectorExpression(SELECT_ALL).build();
-        when(policyStore.findById(any())).thenReturn(definition);
-        when(policyEngine.evaluate(eq(NEGOTIATION_SCOPE), any(), any()))
-                .thenReturn(Result.success(definition.getPolicy()))
-                .thenReturn(Result.failure("invalid"));
-        when(definitionStore.findAll(any())).thenReturn(Stream.of(contractDefinition));
-
-        var result = definitionService.definitionsFor(agent, DEFAULT_RANGE);
-
-        assertThat(result).isEmpty();
-        verify(policyEngine, atLeastOnce()).evaluate(NEGOTIATION_SCOPE, definition.getPolicy(), agent);
+        verify(policyEngine, atLeastOnce()).evaluate(CATALOGING_SCOPE, definition.getPolicy(), agent);
         verify(definitionStore).findAll(any());
     }
 
@@ -113,7 +94,7 @@ class ContractDefinitionServiceImplTest {
         var agent = new ParticipantAgent(Map.of(), Map.of());
         var policy = Policy.Builder.newInstance().build();
         when(policyStore.findById(any())).thenReturn(null);
-        when(policyEngine.evaluate(NEGOTIATION_SCOPE, policy, agent)).thenReturn(Result.success(policy));
+        when(policyEngine.evaluate(CATALOGING_SCOPE, policy, agent)).thenReturn(Result.success(policy));
         when(definitionStore.findAll(QuerySpec.max())).thenReturn(Stream.of(ContractDefinition.Builder.newInstance().id("1").accessPolicyId("access").contractPolicyId("contract").selectorExpression(SELECT_ALL).build()));
 
         var definitions = definitionService.definitionsFor(agent, DEFAULT_RANGE);
@@ -129,13 +110,13 @@ class ContractDefinitionServiceImplTest {
         var contractDefinition = ContractDefinition.Builder.newInstance().id("1").accessPolicyId("access")
                 .contractPolicyId("contract").selectorExpression(SELECT_ALL).build();
         when(policyStore.findById(any())).thenReturn(definition);
-        when(policyEngine.evaluate(eq(NEGOTIATION_SCOPE), isA(Policy.class), isA(ParticipantAgent.class))).thenReturn(Result.success(definition.getPolicy()));
+        when(policyEngine.evaluate(eq(CATALOGING_SCOPE), isA(Policy.class), isA(ParticipantAgent.class))).thenReturn(Result.success(definition.getPolicy()));
         when(definitionStore.findById("1")).thenReturn(contractDefinition);
 
         var result = definitionService.definitionFor(agent, "1");
 
         assertThat(result).isNotNull();
-        verify(policyEngine, atLeastOnce()).evaluate(NEGOTIATION_SCOPE, definition.getPolicy(), agent);
+        verify(policyEngine, atLeastOnce()).evaluate(CATALOGING_SCOPE, definition.getPolicy(), agent);
     }
 
     @Test

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImplTest.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *       Daimler TSS GmbH - fixed contract dates to epoch seconds
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
+ *       Fraunhofer Institute for Software and Systems Engineering - add policy engine
  *
  */
 
@@ -25,8 +26,10 @@ import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractDefinitionService;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
+import org.eclipse.dataspaceconnector.spi.policy.PolicyEngine;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyDefinitionStore;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
@@ -48,6 +51,7 @@ import static java.time.Instant.MIN;
 import static java.time.ZoneOffset.UTC;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.spi.contract.validation.ContractValidationService.NEGOTIATION_SCOPE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -65,11 +69,12 @@ class ContractValidationServiceImplTest {
     private final AssetIndex assetIndex = mock(AssetIndex.class);
     private final PolicyDefinitionStore policyStore = mock(PolicyDefinitionStore.class);
     private final Clock clock = Clock.fixed(now, UTC);
+    private final PolicyEngine policyEngine = mock(PolicyEngine.class);
     private ContractValidationServiceImpl validationService;
 
     @BeforeEach
     void setUp() {
-        validationService = new ContractValidationServiceImpl(agentService, definitionService, assetIndex, policyStore, clock);
+        validationService = new ContractValidationServiceImpl(agentService, definitionService, assetIndex, policyStore, clock, policyEngine);
     }
 
     @Test
@@ -89,6 +94,7 @@ class ContractValidationServiceImplTest {
         when(policyStore.findById("access")).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
         when(policyStore.findById("contract")).thenReturn(PolicyDefinition.Builder.newInstance().policy(newPolicy).build());
         when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(Stream.of(asset));
+        when(policyEngine.evaluate(eq(NEGOTIATION_SCOPE), eq(newPolicy), isA(ParticipantAgent.class))).thenReturn(Result.success(newPolicy));
 
         var claimToken = ClaimToken.Builder.newInstance().build();
         var offer = ContractOffer.Builder.newInstance().id("1:2")
@@ -105,23 +111,19 @@ class ContractValidationServiceImplTest {
         verify(agentService).createFor(isA(ClaimToken.class));
         verify(definitionService).definitionFor(isA(ParticipantAgent.class), eq("1"));
         verify(assetIndex).queryAssets(isA(QuerySpec.class));
+        verify(policyEngine).evaluate(eq(NEGOTIATION_SCOPE), eq(newPolicy), isA(ParticipantAgent.class));
     }
 
     @Test
     void verifyContractAgreementValidation() {
         var newPolicy = Policy.Builder.newInstance().build();
-
-        var contractDefinition = ContractDefinition.Builder.newInstance()
-                .id("1")
-                .accessPolicyId("access")
-                .contractPolicyId("contract")
-                .selectorExpression(AssetSelectorExpression.SELECT_ALL)
-                .build();
+        var contractDefinition = getContractDefinition();
 
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
         when(definitionService.definitionFor(isA(ParticipantAgent.class), eq("1"))).thenReturn(contractDefinition);
         when(policyStore.findById("access")).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
         when(policyStore.findById("contract")).thenReturn(PolicyDefinition.Builder.newInstance().policy(newPolicy).build());
+        when(policyEngine.evaluate(eq(NEGOTIATION_SCOPE), eq(newPolicy), isA(ParticipantAgent.class))).thenReturn(Result.success(newPolicy));
 
         var claimToken = ClaimToken.Builder.newInstance().build();
         var agreement = ContractAgreement.Builder.newInstance().id("1")
@@ -137,6 +139,7 @@ class ContractValidationServiceImplTest {
         assertThat(validationService.validate(claimToken, agreement)).isTrue();
         verify(agentService).createFor(isA(ClaimToken.class));
         verify(definitionService).definitionFor(isA(ParticipantAgent.class), eq("1"));
+        verify(policyEngine).evaluate(eq(NEGOTIATION_SCOPE), eq(newPolicy), isA(ParticipantAgent.class));
     }
 
     @Test
@@ -159,12 +162,7 @@ class ContractValidationServiceImplTest {
     void verifyPolicyNotFound() {
         var originalPolicy = Policy.Builder.newInstance().build();
         var asset = Asset.Builder.newInstance().id("1").build();
-        var contractDefinition = ContractDefinition.Builder.newInstance()
-                .id("1")
-                .accessPolicyId("access")
-                .contractPolicyId("contract")
-                .selectorExpression(AssetSelectorExpression.SELECT_ALL)
-                .build();
+        var contractDefinition = getContractDefinition();
 
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
         when(definitionService.definitionFor(isA(ParticipantAgent.class), eq("1"))).thenReturn(contractDefinition);
@@ -186,6 +184,8 @@ class ContractValidationServiceImplTest {
 
     private boolean validateAgreementDate(long signingDate, long startDate, long endDate) {
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
+        when(definitionService.definitionFor(isA(ParticipantAgent.class), eq("1"))).thenReturn(getContractDefinition());
+        when(policyEngine.evaluate(eq(NEGOTIATION_SCOPE), isA(Policy.class), isA(ParticipantAgent.class))).thenReturn(Result.success(Policy.Builder.newInstance().build()));
 
         var claimToken = ClaimToken.Builder.newInstance().build();
         var agreement = ContractAgreement.Builder.newInstance().id("1")
@@ -199,5 +199,14 @@ class ContractValidationServiceImplTest {
                 .id("1:2").build();
 
         return validationService.validate(claimToken, agreement);
+    }
+    
+    private ContractDefinition getContractDefinition() {
+        return ContractDefinition.Builder.newInstance()
+                .id("1")
+                .accessPolicyId("access")
+                .contractPolicyId("contract")
+                .selectorExpression(AssetSelectorExpression.SELECT_ALL)
+                .build();
     }
 }

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
@@ -23,6 +23,7 @@ import org.eclipse.dataspaceconnector.spi.command.CommandHandlerRegistry;
 import org.eclipse.dataspaceconnector.spi.command.CommandRunner;
 import org.eclipse.dataspaceconnector.spi.event.EventRouter;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.dataspaceconnector.spi.policy.PolicyEngine;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyArchive;
 import org.eclipse.dataspaceconnector.spi.retry.ExponentialWaitStrategy;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
@@ -101,6 +102,9 @@ public class CoreTransferExtension implements ServiceExtension {
 
     @Inject
     private Clock clock;
+    
+    @Inject
+    private PolicyEngine policyEngine;
 
     private TransferProcessManagerImpl processManager;
 
@@ -122,7 +126,7 @@ public class CoreTransferExtension implements ServiceExtension {
         var dataFlowManager = new DataFlowManagerImpl();
         context.registerService(DataFlowManager.class, dataFlowManager);
 
-        var manifestGenerator = new ResourceManifestGeneratorImpl();
+        var manifestGenerator = new ResourceManifestGeneratorImpl(policyEngine);
         context.registerService(ResourceManifestGenerator.class, manifestGenerator);
 
         var statusCheckerRegistry = new StatusCheckerRegistryImpl();

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/provision/ResourceManifestGeneratorImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/provision/ResourceManifestGeneratorImpl.java
@@ -9,21 +9,27 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - policy evaluation
  *
  */
 
 package org.eclipse.dataspaceconnector.transfer.core.provision;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.policy.PolicyEngine;
+import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ConsumerResourceDefinitionGenerator;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ProviderResourceDefinitionGenerator;
+import org.eclipse.dataspaceconnector.spi.transfer.provision.ResourceManifestContext;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ResourceManifestGenerator;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceManifest;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -33,6 +39,11 @@ import java.util.stream.Collectors;
 public class ResourceManifestGeneratorImpl implements ResourceManifestGenerator {
     private final List<ConsumerResourceDefinitionGenerator> consumerGenerators = new ArrayList<>();
     private final List<ProviderResourceDefinitionGenerator> providerGenerators = new ArrayList<>();
+    private final PolicyEngine policyEngine;
+    
+    public ResourceManifestGeneratorImpl(PolicyEngine policyEngine) {
+        this.policyEngine = policyEngine;
+    }
 
     @Override
     public void registerGenerator(ConsumerResourceDefinitionGenerator generator) {
@@ -45,15 +56,35 @@ public class ResourceManifestGeneratorImpl implements ResourceManifestGenerator 
     }
 
     @Override
-    public ResourceManifest generateConsumerResourceManifest(DataRequest dataRequest, Policy policy) {
+    public Result<ResourceManifest> generateConsumerResourceManifest(DataRequest dataRequest, Policy policy) {
         if (!dataRequest.isManagedResources()) {
-            return ResourceManifest.Builder.newInstance().build();
+            return Result.success(ResourceManifest.Builder.newInstance().build());
         }
         var definitions = consumerGenerators.stream()
                 .map(generator -> generator.generate(dataRequest, policy))
                 .filter(Objects::nonNull).collect(Collectors.toList());
-
-        return ResourceManifest.Builder.newInstance().definitions(definitions).build();
+    
+        var manifest = ResourceManifest.Builder.newInstance().definitions(definitions).build();
+        
+        // Make all definitions available through manifest context
+        var manifestContext = new ResourceManifestContext();
+        manifest.getDefinitions().forEach(manifestContext::addDefinition);
+        
+        // Create additional context information for policy engine to make manifest context available
+        var contextInformation = new HashMap<Class, Object>();
+        contextInformation.put(ResourceManifestContext.class, manifestContext);
+    
+        var result = policyEngine.evaluate(MANIFEST_VERIFICATION_SCOPE, policy, null, contextInformation);
+        if (result.succeeded()) {
+            return Result.success(buildFromContextInformation(contextInformation));
+        } else {
+            return Result.failure(result.getFailureMessages());
+        }
+    }
+    
+    private ResourceManifest buildFromContextInformation(Map<Class, Object> contextInformation) {
+        var manifestContext = (ResourceManifestContext) contextInformation.get(ResourceManifestContext.class);
+        return ResourceManifest.Builder.newInstance().definitions(manifestContext.getDefinitions()).build();
     }
 
     @Override

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/provision/ResourceManifestGeneratorImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/provision/ResourceManifestGeneratorImpl.java
@@ -67,8 +67,7 @@ public class ResourceManifestGeneratorImpl implements ResourceManifestGenerator 
         var manifest = ResourceManifest.Builder.newInstance().definitions(definitions).build();
         
         // Make all definitions available through manifest context
-        var manifestContext = new ResourceManifestContext();
-        manifest.getDefinitions().forEach(manifestContext::addDefinition);
+        var manifestContext = new ResourceManifestContext(manifest);
         
         // Create additional context information for policy engine to make manifest context available
         var contextInformation = new HashMap<Class, Object>();

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/provision/ResourceManifestGeneratorImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/provision/ResourceManifestGeneratorImplTest.java
@@ -15,6 +15,8 @@
 package org.eclipse.dataspaceconnector.transfer.core.provision;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.policy.PolicyEngine;
+import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ConsumerResourceDefinitionGenerator;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ProviderResourceDefinitionGenerator;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
@@ -35,12 +37,15 @@ class ResourceManifestGeneratorImplTest {
 
     private final ConsumerResourceDefinitionGenerator consumerGenerator = mock(ConsumerResourceDefinitionGenerator.class);
     private final ProviderResourceDefinitionGenerator providerGenerator = mock(ProviderResourceDefinitionGenerator.class);
-    private final ResourceManifestGeneratorImpl generator = new ResourceManifestGeneratorImpl();
+    private ResourceManifestGeneratorImpl generator;
     private Policy policy;
     private DataAddress dataAddress;
+    private PolicyEngine policyEngine;
 
     @BeforeEach
     void setUp() {
+        policyEngine = mock(PolicyEngine.class);
+        generator = new ResourceManifestGeneratorImpl(policyEngine);
         generator.registerGenerator(consumerGenerator);
         generator.registerGenerator(providerGenerator);
         policy = Policy.Builder.newInstance().build();
@@ -52,22 +57,37 @@ class ResourceManifestGeneratorImplTest {
         var dataRequest = createDataRequest(true);
         var resourceDefinition = TestResourceDefinition.Builder.newInstance().id(UUID.randomUUID().toString()).build();
         when(consumerGenerator.generate(any(), any())).thenReturn(resourceDefinition);
-
-        var resourceManifest = generator.generateConsumerResourceManifest(dataRequest, policy);
-
-        assertThat(resourceManifest.getDefinitions()).hasSize(1).containsExactly(resourceDefinition);
+        when(policyEngine.evaluate(any(), any(), any(), any())).thenReturn(Result.success(policy));
+    
+        var result = generator.generateConsumerResourceManifest(dataRequest, policy);
+    
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent().getDefinitions()).hasSize(1).containsExactly(resourceDefinition);
         verifyNoInteractions(providerGenerator);
     }
 
     @Test
     void shouldGenerateEmptyResourceManifestForEmptyConsumerNotManagedTransferProcess() {
         var dataRequest = createDataRequest(false);
-
-        var resourceManifest = generator.generateConsumerResourceManifest(dataRequest, policy);
-
-        assertThat(resourceManifest.getDefinitions()).isEmpty();
+    
+        var result = generator.generateConsumerResourceManifest(dataRequest, policy);
+    
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent().getDefinitions()).isEmpty();
         verifyNoInteractions(consumerGenerator);
         verifyNoInteractions(providerGenerator);
+    }
+    
+    @Test
+    void shouldReturnFailedResultForConsumerWhenPolicyEvaluationFailed() {
+        var dataRequest = createDataRequest(true);
+        var resourceDefinition = TestResourceDefinition.Builder.newInstance().id(UUID.randomUUID().toString()).build();
+        when(consumerGenerator.generate(any(), any())).thenReturn(resourceDefinition);
+        when(policyEngine.evaluate(any(), any(), any(), any())).thenReturn(Result.failure("error"));
+        
+        var result = generator.generateConsumerResourceManifest(dataRequest, policy);
+        
+        assertThat(result.succeeded()).isFalse();
     }
 
     @Test

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplIntegrationTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplIntegrationTest.java
@@ -25,6 +25,7 @@ import org.eclipse.dataspaceconnector.spi.command.CommandRunner;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyArchive;
+import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.retry.ExponentialWaitStrategy;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowManager;
 import org.eclipse.dataspaceconnector.spi.transfer.observe.TransferProcessObservable;
@@ -76,7 +77,7 @@ class TransferProcessManagerImplIntegrationTest {
     @BeforeEach
     void setup() {
         var resourceManifest = ResourceManifest.Builder.newInstance().definitions(List.of(new TestResourceDefinition())).build();
-        when(manifestGenerator.generateConsumerResourceManifest(any(DataRequest.class), any(Policy.class))).thenReturn(resourceManifest);
+        when(manifestGenerator.generateConsumerResourceManifest(any(DataRequest.class), any(Policy.class))).thenReturn(Result.success(resourceManifest));
 
         var policyArchive = mock(PolicyArchive.class);
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());

--- a/docs/developer/policy-engine.md
+++ b/docs/developer/policy-engine.md
@@ -69,6 +69,9 @@ public class IdsPolicyExtension implements ServiceExtension {
 }
 ```
 
+In this example, the functions are registered for all policy scopes, meaning they will be used for every policy
+evaluation. Details on different policy scopes can be found [here](#policy-scopes).
+
 ### Step 3: Implement an `AtomicConstraintFunction`
 
 #### Absolute Spatial Position Constraint Function
@@ -114,3 +117,43 @@ public class PartnerLevelConstraintFunction implements AtomicConstraintFunction<
     }
 }
 ```
+
+### Policy scopes
+
+By binding a function to a specific scope instead of all scopes, the function will only be included in evaluations for
+that scope. Currently, the EDC core provides 3 different policy scopes, which are explained in the following.
+
+#### Cataloging scope: `contract.cataloging`
+
+This scope is used when contract offers are generated from contract definitions. Here, each contract definition's access
+policy is evaluated to decide which contract definitions may be used to generate offers for the requesting agent.
+
+#### Negotiation scope: `contract.negotiation`
+
+This scope is used during the contract negotiation. The policies from each contract offer and agreement exchanged during
+the negotiation are evaluated with this scope. This scope is also used to re-evaluate a contract agreement's policy
+before a data transfer is initiated.
+
+#### Manifest verification scope: `provision.manifest.verify`
+
+This scope is used during the provisioning phase to evaluate the resource definitions of a generated resource manifest.
+Functions registered in this scope may also modify resource definitions so that they comply with the policy.
+Therefore, a `ResourceManifestContext`, which provides access to a manifest's resource definitions, is available
+through the `PolicyContext` for functions registered in this scope. Using the `ResourceManifestContext`, resource
+definitions can be retrieved and updated by type.
+
+```java
+@Override
+public boolean evaluate(Operator operator, Object rightValue, Permission rule, PolicyContext context) {
+    var manifestContext = context.getContextData(ResourceManifestContext.class);
+
+    var bucketDefinitions = manifestContext.getDefinitions(S3BucketResourceDefinition.class);
+
+    // verify and/or modify definitions to comply with policy
+        
+     manifestContext.replaceDefinitions(S3BucketResourceDefinition.class, verifiedBucketDefinitions);
+     return true;
+}
+```
+
+If any of the resource definitions cannot be modified to comply with the policy, the function should return `false`.

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessEventDispatchTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessEventDispatchTest.java
@@ -126,7 +126,7 @@ public class TransferProcessEventDispatchTest {
                 .assetId("assetId")
                 .destinationType("any")
                 .protocol("test")
-                .managedResources(true)
+                .managedResources(false)
                 .build();
 
         service.initiateTransfer(dataRequest);

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/ContractDefinitionService.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/ContractDefinitionService.java
@@ -31,7 +31,7 @@ import java.util.stream.Stream;
 public interface ContractDefinitionService {
 
     @PolicyScope
-    String NEGOTIATION_SCOPE = "contract.negotiation";
+    String CATALOGING_SCOPE = "contract.cataloging";
 
     /**
      * Returns the definitions for the given participant agent.

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/validation/ContractValidationService.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/validation/ContractValidationService.java
@@ -9,12 +9,14 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - add policy scope
  *
  */
 
 package org.eclipse.dataspaceconnector.spi.contract.validation;
 
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
+import org.eclipse.dataspaceconnector.spi.policy.PolicyScope;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
@@ -24,6 +26,9 @@ import org.jetbrains.annotations.NotNull;
  * Validates {@link ContractOffer}s and {@link ContractAgreement}s.
  */
 public interface ContractValidationService {
+    
+    @PolicyScope
+    String NEGOTIATION_SCOPE = "contract.negotiation";
 
     /**
      * Validates and sanitizes the contract offer for the consumer represented by the given claims.

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/PolicyContext.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/PolicyContext.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - context data
  *
  */
 
@@ -44,5 +45,23 @@ public interface PolicyContext {
      * Returns the participant agent to evaluate the policy against.
      */
     ParticipantAgent getParticipantAgent();
-
+    
+    /**
+     * Gets additional data from the context by type.
+     *
+     * @param type the type class.
+     * @param <T> the type of data.
+     * @return the object associated with the type, or null.
+     */
+    <T> T getContextData(Class<T> type);
+    
+    /**
+     * Adds additional data to the context.
+     *
+     * @param type the type class.
+     * @param data the data.
+     * @param <T> the type of data.
+     */
+    <T> void putContextData(Class<T> type, T data);
+    
 }

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/PolicyEngine.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/policy/PolicyEngine.java
@@ -21,6 +21,7 @@ import org.eclipse.dataspaceconnector.policy.model.Rule;
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgent;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 
+import java.util.Map;
 import java.util.function.BiFunction;
 
 /**
@@ -56,6 +57,12 @@ public interface PolicyEngine {
      * Evaluates the given policy for an agent for the given scope.
      */
     Result<Policy> evaluate(String scope, Policy policy, ParticipantAgent agent);
+    
+    /**
+     * Evaluates the given policy for an agent for the given scope using additional context information.
+     * Values in the map need to be of the same type defined by the key.
+     */
+    Result<Policy> evaluate(String scope, Policy policy, ParticipantAgent agent, Map<Class, Object> contextInformation);
 
     /**
      * Registers a function that is invoked when a policy contains an atomic constraint whose left operator expression evaluates to the given key for the specified scope.

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ResourceManifestContext.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ResourceManifestContext.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2022 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.transfer.provision;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
+
+/**
+ * Provides access to a resource manifest's resource definitions by definition type.
+ */
+public class ResourceManifestContext {
+    
+    private Map<Class, List<ResourceDefinition>> resourceDefinitions = new HashMap<>();
+    
+    /**
+     * Adds a resource definition.
+     *
+     * @param definition the resource definition.
+     * @param <T> the type of resource definition.
+     */
+    public <T extends ResourceDefinition> void addDefinition(T definition) {
+        resourceDefinitions.computeIfAbsent(definition.getClass(), c -> new ArrayList<>()).add(definition);
+    }
+    
+    /**
+     * Replaces all definitions of a given type with the given definitions of the same type.
+     *
+     * @param type the type.
+     * @param definitions the list of resource definitions.
+     * @param <T> the type of resource definition.
+     */
+    public <T extends ResourceDefinition> void replaceDefinitions(Class<T> type, List<T> definitions) {
+        this.resourceDefinitions.put(type, (List<ResourceDefinition>) definitions);
+    }
+    
+    /**
+     * Returns all resource definitions for the given type.
+     *
+     * @param type the type.
+     * @param <T> the type of resource definition.
+     * @return a list of resource definitions.
+     */
+    public <T extends ResourceDefinition> List<T> getDefinitions(Class<T> type) {
+        return (List<T>) resourceDefinitions.get(type);
+    }
+    
+    /**
+     * Returns all resource definitions.
+     *
+     * @return a list of resource definitions.
+     */
+    public List<ResourceDefinition> getDefinitions() {
+        var list = new ArrayList<ResourceDefinition>();
+        resourceDefinitions.values().forEach(list::addAll);
+        return list;
+    }
+    
+}

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ResourceManifestContext.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ResourceManifestContext.java
@@ -14,12 +14,12 @@
 
 package org.eclipse.dataspaceconnector.spi.transfer.provision;
 
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
 
 /**
  * Provides access to a resource manifest's resource definitions by definition type.

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ResourceManifestContext.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ResourceManifestContext.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.spi.transfer.provision;
 
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefinition;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceManifest;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -27,6 +28,10 @@ import java.util.Map;
 public class ResourceManifestContext {
     
     private Map<Class, List<ResourceDefinition>> resourceDefinitions = new HashMap<>();
+    
+    public ResourceManifestContext(ResourceManifest resourceManifest) {
+        resourceManifest.getDefinitions().forEach(this::addDefinition);
+    }
     
     /**
      * Adds a resource definition.

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ResourceManifestGenerator.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/provision/ResourceManifestGenerator.java
@@ -9,12 +9,15 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - add policy scope
  *
  */
 
 package org.eclipse.dataspaceconnector.spi.transfer.provision;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.policy.PolicyScope;
+import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceManifest;
@@ -23,6 +26,9 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceManifest
  * Generates resource manifests for data transfer requests. Implementations are responsible for enforcing policy constraints associated with transfer requests.
  */
 public interface ResourceManifestGenerator {
+    
+    @PolicyScope
+    String MANIFEST_VERIFICATION_SCOPE = "provision.manifest.verify";
 
     /**
      * Registers a generator for consumer-side generation.
@@ -44,7 +50,7 @@ public interface ResourceManifestGenerator {
      * @param dataRequest the data request associated with transfer process
      * @param policy      the contract agreement usage policy for the asset being transferred
      */
-    ResourceManifest generateConsumerResourceManifest(DataRequest dataRequest, Policy policy);
+    Result<ResourceManifest> generateConsumerResourceManifest(DataRequest dataRequest, Policy policy);
 
     /**
      * Generates a resource manifest for a provider-side data request. Operations must be idempotent.


### PR DESCRIPTION
## What this PR changes/adds

It introduces two new policy scopes. The first one is `contract.cataloging`, which is used during the cataloging phase. The previously existing scope `contract.negotiation` is now used during the negotiation itself and to re-evaluate the policies before a new transfer process is created. The other new scope is `provision.manifest.verify`, which is used to evaluate a generated `ResourceManifest` to ensure that it fulfils the given policy.

## Why it does that

Currently, policy evaluation only takes place during the negotiation phase.

## Further notes

Introduces the possibility to pass additional context information to the `PolicyEngine`, which is available to evaluation functions via the `PolicyContext`. This is required to pass information about the `ResourceManifest` to the functions.

## Linked Issue(s)

Closes #1446
Closes #1331 

## Checklist

- [x] added appropriate tests?
- [ ] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
