### PR TITLE
docs: fix javadoc issue on ServiceResultHandler

### DIFF
--- a/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/ServiceResultHandler.java
+++ b/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/ServiceResultHandler.java
@@ -27,8 +27,9 @@ public class ServiceResultHandler {
      * Interprets a {@link ServiceResult} based on its {@link ServiceResult#reason()} property and returns the
      * appropriate exception:
      * <table>
-     *   <th>reason</th>
-     *   <th>exception</th>
+     *   <tr>
+     *     <th>reason</th> <th>exception</th>
+     *   </tr>
      *   <tr>
      *     <td>NOT_FOUND </td> <td>ObjectNotFoundException</td>
      *   </tr>
@@ -41,12 +42,14 @@ public class ServiceResultHandler {
      *   <tr>
      *     <td>other</td> <td>EdcException</td>
      *   </tr>
+     *   <caption>Mapping from failure reason to exception</caption>
      * </table>
      *
      * @param result The {@link ServiceResult}
      * @param clazz The type in whose context the failure occurred. Must not be null.
      * @param id The id of the entity which was involved in the failure. Can be null for
      *         {@link org.eclipse.dataspaceconnector.api.result.ServiceFailure.Reason#BAD_REQUEST}.
+     * @return Exception mapped from failure reason.
      */
     public static RuntimeException mapToException(@NotNull ServiceResult<?> result, @NotNull Class<?> clazz, @Nullable String id) {
         switch (result.reason()) {


### PR DESCRIPTION
## What this PR changes/adds

fixed Javadoc of ServiceResultHandler added by #1657.

## Why it does that

Invalid characters in the Javadoc cause a warning and build failure.

```
> Task :extensions:api:api-core:javadoc
/Users/iwasakims/srcs/DataSpaceConnector/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/ServiceResultHandler.java:30: error: tag not allowed here: <th>
     *   <th>reason</th>
         ^
/Users/iwasakims/srcs/DataSpaceConnector/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/ServiceResultHandler.java:31: error: tag not allowed here: <th>
     *   <th>exception</th>
         ^
/Users/iwasakims/srcs/DataSpaceConnector/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/ServiceResultHandler.java:44: error: no summary or caption for table
     * </table>
       ^
/Users/iwasakims/srcs/DataSpaceConnector/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/ServiceResultHandler.java:51: warning: no @return
    public static RuntimeException mapToException(@NotNull ServiceResult<?> result, @NotNull Class<?> clazz, @Nullable String id) {
                                   ^
3 errors
1 warning

> Task :extensions:api:api-core:javadoc FAILED

FAILURE: Build failed with an exception.
```
```
> Task :extensions:api:api-core:javadoc
/Users/iwasakims/srcs/DataSpaceConnector/extensions/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/ServiceResultHandler.java:53: warning: no @return
    public static RuntimeException mapToException(@NotNull ServiceResult<?> result, @NotNull Class<?> clazz, @Nullable String id) {
```

## Linked Issue(s)

related to #1654

## Checklist

- [n/a] added appropriate tests?
- [x] performed checkstyle check locally?
- [n/a] added/updated copyright headers?
- [n/a] documented public classes/methods?
- [n/a] added/updated relevant documentation?
- [n/a] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
