### PR TITLE
fix: added update stmt for DataRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,8 @@ in the detailed section referring to by linking pull requests or issues.
 * Old RegistrationService (was used for a PoC) (#164)
 * Deprecate `InlineDataFlowController` (replaced by the Data Plane) (#1464)
 * Unused classes and interfaces at `ids.spi.policy` (#1471)
-* Remove modules `:extensions:transfer-functions:transfer-functions-spi` and `:extensions:transfer-functions:transfer-functions-core` (#1482)
+* Remove modules `:extensions:transfer-functions:transfer-functions-spi`
+  and `:extensions:transfer-functions:transfer-functions-core` (#1482)
 * Remove `ConnectorVersionProvider`, provide version as static string (#1470)
 * Remove `samples/other/run-from-junit` (#1456)
 
@@ -67,6 +68,7 @@ in the detailed section referring to by linking pull requests or issues.
 * Adapt logs to the logging guide (#1425)
 * Fix incompatibility `DecentralizedIdentityServiceExtension` and `FsPrivateKeyResolver` (#1696)
 * Add support for domain port domain in Web Did resolver (#1652)
+* Fixed persistence update bug with `DataRequest` (#1707)
 
 ## [milestone-4] - 2022-06-07
 
@@ -106,7 +108,8 @@ in the detailed section referring to by linking pull requests or issues.
 
 * Restructure sql extension folder tree (#1154)
 * Extract single `PolicyArchive` implementation (#1158)
-* Replace `accessPolicy` and `contractPolicy` with `accessPolicyId` and `contractPolicyId` on `ContractDefinition` (#1144)
+* Replace `accessPolicy` and `contractPolicy` with `accessPolicyId` and `contractPolicyId` on `ContractDefinition` (
+  #1144)
 * Replace `policy` with `policyId` on `ContractAgreement` (#1220)
 * All DMgmt Api methods now produce and consume `APPLICATION_JSON` (#1175)
 * Make data-plane public api controller asynchronous (#1228)

--- a/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStore.java
+++ b/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStore.java
@@ -179,8 +179,8 @@ public class SqlTransferProcessStore implements TransferProcessStore {
     }
 
     private void update(Connection conn, String transferProcessId, TransferProcess process) {
-        var stmt = statements.getUpdateTransferProcessTemplate();
-        executeQuery(conn, stmt, process.getState(),
+        var updateStmt = statements.getUpdateTransferProcessTemplate();
+        executeQuery(conn, updateStmt, process.getState(),
                 process.getStateCount(),
                 process.getStateTimestamp(),
                 toJson(process.getTraceContext()),
@@ -190,6 +190,22 @@ public class SqlTransferProcessStore implements TransferProcessStore {
                 toJson(process.getContentDataAddress()),
                 toJson(process.getDeprovisionedResources()),
                 transferProcessId);
+
+        var dr = process.getDataRequest();
+        var updateDrStmt = statements.getUpdateDataRequestTemplate();
+
+        executeQuery(conn, updateDrStmt,
+                dr.getProcessId(),
+                dr.getConnectorAddress(),
+                dr.getProtocol(),
+                dr.getConnectorId(),
+                dr.getAssetId(),
+                dr.getContractId(),
+                toJson(dr.getDataDestination()),
+                dr.isManagedResources(),
+                toJson(dr.getProperties()),
+                toJson(dr.getTransferType()),
+                dr.getId());
     }
 
     /**

--- a/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStore.java
+++ b/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStore.java
@@ -111,8 +111,17 @@ public class SqlTransferProcessStore implements TransferProcessStore {
         });
     }
 
+    /**
+     * Creates a new {@link TransferProcess}, or updates if one already exists.
+     *
+     * @param process The new TransferProcess.
+     * @throws IllegalArgumentException if the TransferProcess does not have a {@link DataRequest}.
+     */
     @Override
     public void create(TransferProcess process) {
+        if (process.getDataRequest() == null) {
+            throw new IllegalArgumentException("Cannot store TransferProcess without a DataRequest");
+        }
         transactionContext.execute(() -> {
             if (find(process.getId()) != null) {
                 update(process);
@@ -123,6 +132,12 @@ public class SqlTransferProcessStore implements TransferProcessStore {
 
     }
 
+    /**
+     * Updates a TransferProcess overwriting all properties. The {@link DataRequest} that is associated with the {@link TransferProcess}
+     * will get updated including its ID (primary key).
+     *
+     * @param process The new TransferProcess
+     */
     @Override
     public void update(TransferProcess process) {
         transactionContext.execute(() -> {
@@ -133,9 +148,8 @@ public class SqlTransferProcessStore implements TransferProcessStore {
                 insert(process);
             } else {
                 try (var conn = getConnection()) {
-
                     leaseContext.by(leaseHolderName).withConnection(conn).breakLease(id);
-                    update(conn, id, process);
+                    update(conn, process, existing.getDataRequest().getId());
                 } catch (SQLException e) {
                     throw new EdcPersistenceException(e);
                 }
@@ -171,14 +185,30 @@ public class SqlTransferProcessStore implements TransferProcessStore {
         return transactionContext.execute(() -> {
             try (var conn = getConnection()) {
                 var statement = statements.createQuery(querySpec);
-                return executeQuery(conn, this::mapTransferProcess, statement.getQueryAsString(), statement.getParameters()).stream();
+                return executeQuery(conn, this::mapTransferProcess, statement.getQueryAsString(), statement.getParameters()).stream().distinct();
             } catch (SQLException e) {
                 throw new EdcPersistenceException(e);
             }
         });
     }
 
-    private void update(Connection conn, String transferProcessId, TransferProcess process) {
+    public DataRequest mapDataRequest(ResultSet resultSet) throws SQLException {
+        return DataRequest.Builder.newInstance()
+                .id(resultSet.getString("edc_data_request_id"))
+                .assetId(resultSet.getString(statements.getAssetIdColumn()))
+                .protocol(resultSet.getString(statements.getProtocolColumn()))
+                .dataDestination(fromJson(resultSet.getString(statements.getDataDestinationColumn()), DataAddress.class))
+                .connectorId(resultSet.getString(statements.getConnectorIdColumn()))
+                .connectorAddress(resultSet.getString(statements.getConnectorAddressColumn()))
+                .contractId(resultSet.getString(statements.getContractIdColumn()))
+                .managedResources(resultSet.getBoolean(statements.getManagedResourcesColumn()))
+                .transferType(fromJson(resultSet.getString(statements.getTransferTypeColumn()), TransferType.class))
+                .processId(resultSet.getString(statements.getProcessIdColumn()))
+                .properties(fromJson(resultSet.getString(statements.getPropertiesColumn()), getTypeRef()))
+                .build();
+    }
+
+    private void update(Connection conn, TransferProcess process, String existingDataRequestId) {
         var updateStmt = statements.getUpdateTransferProcessTemplate();
         executeQuery(conn, updateStmt, process.getState(),
                 process.getStateCount(),
@@ -189,23 +219,28 @@ public class SqlTransferProcessStore implements TransferProcessStore {
                 toJson(process.getProvisionedResourceSet()),
                 toJson(process.getContentDataAddress()),
                 toJson(process.getDeprovisionedResources()),
-                transferProcessId);
+                process.getId());
 
-        var dr = process.getDataRequest();
+        var newDr = process.getDataRequest();
+        updateDataRequest(conn, newDr, existingDataRequestId);
+    }
+
+    private void updateDataRequest(Connection conn, DataRequest dataRequest, String existingDataRequestId) {
         var updateDrStmt = statements.getUpdateDataRequestTemplate();
 
         executeQuery(conn, updateDrStmt,
-                dr.getProcessId(),
-                dr.getConnectorAddress(),
-                dr.getProtocol(),
-                dr.getConnectorId(),
-                dr.getAssetId(),
-                dr.getContractId(),
-                toJson(dr.getDataDestination()),
-                dr.isManagedResources(),
-                toJson(dr.getProperties()),
-                toJson(dr.getTransferType()),
-                dr.getId());
+                dataRequest.getId(),
+                dataRequest.getProcessId(),
+                dataRequest.getConnectorAddress(),
+                dataRequest.getProtocol(),
+                dataRequest.getConnectorId(),
+                dataRequest.getAssetId(),
+                dataRequest.getContractId(),
+                toJson(dataRequest.getDataDestination()),
+                dataRequest.isManagedResources(),
+                toJson(dataRequest.getProperties()),
+                toJson(dataRequest.getTransferType()),
+                existingDataRequestId);
     }
 
     /**
@@ -245,24 +280,30 @@ public class SqlTransferProcessStore implements TransferProcessStore {
 
                 //insert DataRequest
                 var dr = process.getDataRequest();
-                var insertDrStmt = statements.getInsertDataRequestTemplate();
-                executeQuery(conn, insertDrStmt,
-                        dr.getId(),
-                        dr.getProcessId(),
-                        dr.getConnectorAddress(),
-                        dr.getConnectorId(),
-                        dr.getAssetId(),
-                        dr.getContractId(),
-                        toJson(dr.getDataDestination()),
-                        toJson(dr.getProperties()),
-                        toJson(dr.getTransferType()),
-                        process.getId(),
-                        dr.getProtocol(),
-                        dr.isManagedResources());
+                if (dr != null) {
+                    insertDataRequest(process.getId(), dr, conn);
+                }
             } catch (SQLException e) {
                 throw new EdcPersistenceException(e);
             }
         });
+    }
+
+    private void insertDataRequest(String processId, DataRequest dr, Connection conn) {
+        var insertDrStmt = statements.getInsertDataRequestTemplate();
+        executeQuery(conn, insertDrStmt,
+                dr.getId(),
+                dr.getProcessId(),
+                dr.getConnectorAddress(),
+                dr.getConnectorId(),
+                dr.getAssetId(),
+                dr.getContractId(),
+                toJson(dr.getDataDestination()),
+                toJson(dr.getProperties()),
+                toJson(dr.getTransferType()),
+                processId,
+                dr.getProtocol(),
+                dr.isManagedResources());
     }
 
     private TransferProcess mapTransferProcess(ResultSet resultSet) throws SQLException {
@@ -281,24 +322,6 @@ public class SqlTransferProcessStore implements TransferProcessStore {
                 .contentDataAddress(fromJson(resultSet.getString(statements.getContentDataAddressColumn()), DataAddress.class))
                 .deprovisionedResources(fromJson(resultSet.getString(statements.getDeprovisionedResourcesColumn()), new TypeReference<>() {
                 }))
-                .build();
-    }
-
-
-    private DataRequest mapDataRequest(ResultSet resultSet) throws SQLException {
-        return DataRequest.Builder.newInstance()
-                .id(resultSet.getString("edc_data_request_id"))
-                .assetId(resultSet.getString(statements.getAssetIdColumn()))
-                .protocol(resultSet.getString(statements.getProtocolColumn()))
-                .dataDestination(fromJson(resultSet.getString(statements.getDataDestinationColumn()), DataAddress.class))
-                .connectorId(resultSet.getString(statements.getConnectorIdColumn()))
-                .connectorAddress(resultSet.getString(statements.getConnectorAddressColumn()))
-                .contractId(resultSet.getString(statements.getContractIdColumn()))
-                .managedResources(resultSet.getBoolean(statements.getManagedResourcesColumn()))
-                .transferType(fromJson(resultSet.getString(statements.getTransferTypeColumn()), TransferType.class))
-                .processId(resultSet.getString(statements.getProcessIdColumn()))
-                .properties(fromJson(resultSet.getString(statements.getPropertiesColumn()), getTypeRef()))
-
                 .build();
     }
 

--- a/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/schema/BaseSqlDialectStatements.java
@@ -111,6 +111,15 @@ public abstract class BaseSqlDialectStatements implements TransferProcessStoreSt
     }
 
     @Override
+    public String getUpdateDataRequestTemplate() {
+        return format("UPDATE %s SET %s=?, %s=?, %s=?, %s=?, %s=?, %s=?, %s=?%s, %s=?, %s=?%s, %s=?%s WHERE %s=?",
+                getDataRequestTable(),
+                getProcessIdColumn(), getConnectorAddressColumn(), getProtocolColumn(), getConnectorIdColumn(), getAssetIdColumn(), getContractIdColumn(),
+                getDataDestinationColumn(), getFormatAsJsonOperator(), getManagedResourcesColumn(), getPropertiesColumn(), getFormatAsJsonOperator(), getTransferTypeColumn(), getFormatAsJsonOperator(),
+                getDataRequestIdColumn());
+    }
+
+    @Override
     public SqlQueryStatement createQuery(QuerySpec querySpec) {
         return new SqlQueryStatement(getSelectTemplate(), querySpec, new TransferProcessMapping(this));
     }

--- a/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/schema/BaseSqlDialectStatements.java
@@ -112,9 +112,9 @@ public abstract class BaseSqlDialectStatements implements TransferProcessStoreSt
 
     @Override
     public String getUpdateDataRequestTemplate() {
-        return format("UPDATE %s SET %s=?, %s=?, %s=?, %s=?, %s=?, %s=?, %s=?%s, %s=?, %s=?%s, %s=?%s WHERE %s=?",
+        return format("UPDATE %s SET %s=?, %s=?, %s=?, %s=?, %s=?, %s=?, %s=?, %s=?%s, %s=?, %s=?%s, %s=?%s WHERE %s=?",
                 getDataRequestTable(),
-                getProcessIdColumn(), getConnectorAddressColumn(), getProtocolColumn(), getConnectorIdColumn(), getAssetIdColumn(), getContractIdColumn(),
+                getDataRequestIdColumn(), getProcessIdColumn(), getConnectorAddressColumn(), getProtocolColumn(), getConnectorIdColumn(), getAssetIdColumn(), getContractIdColumn(),
                 getDataDestinationColumn(), getFormatAsJsonOperator(), getManagedResourcesColumn(), getPropertiesColumn(), getFormatAsJsonOperator(), getTransferTypeColumn(), getFormatAsJsonOperator(),
                 getDataRequestIdColumn());
     }

--- a/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/schema/TransferProcessStoreStatements.java
+++ b/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/schema/TransferProcessStoreStatements.java
@@ -38,6 +38,7 @@ public interface TransferProcessStoreStatements extends LeaseStatements {
 
     String getSelectTemplate();
 
+    String getUpdateDataRequestTemplate();
 
     default String getIdColumn() {
         return "transferprocess_id";

--- a/extensions/sql/transfer-process-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStoreTest.java
+++ b/extensions/sql/transfer-process-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStoreTest.java
@@ -276,6 +276,23 @@ public class SqlTransferProcessStoreTest {
     }
 
     @Test
+    void update_shouldPersistDataRequest() {
+        var t1 = createTransferProcess("id1", TransferProcessStates.IN_PROGRESS);
+        store.create(t1);
+
+        t1.getDataRequest().getProperties().put("newKey", "newValue");
+        store.update(t1);
+
+        var all = store.findAll(QuerySpec.none()).collect(Collectors.toList());
+        assertThat(all)
+                .hasSize(1)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(t1);
+
+        assertThat(all.get(0).getDataRequest().getProperties()).containsEntry("newKey", "newValue");
+    }
+
+    @Test
     void update_exists_shouldUpdate() {
         var t1 = createTransferProcess("id1", TransferProcessStates.IN_PROGRESS);
         store.create(t1);

--- a/extensions/sql/transfer-process-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStoreTest.java
+++ b/extensions/sql/transfer-process-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStoreTest.java
@@ -42,11 +42,14 @@ import java.util.stream.IntStream;
 import javax.sql.DataSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.dataspaceconnector.sql.SqlQueryExecutor.executeQuery;
 import static org.eclipse.dataspaceconnector.sql.transferprocess.store.TestFunctions.createDataRequest;
+import static org.eclipse.dataspaceconnector.sql.transferprocess.store.TestFunctions.createDataRequestBuilder;
 import static org.eclipse.dataspaceconnector.sql.transferprocess.store.TestFunctions.createTransferProcess;
+import static org.eclipse.dataspaceconnector.sql.transferprocess.store.TestFunctions.createTransferProcessBuilder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
@@ -292,6 +295,7 @@ public class SqlTransferProcessStoreTest {
         assertThat(all.get(0).getDataRequest().getProperties()).containsEntry("newKey", "newValue");
     }
 
+
     @Test
     void update_exists_shouldUpdate() {
         var t1 = createTransferProcess("id1", TransferProcessStates.IN_PROGRESS);
@@ -356,7 +360,7 @@ public class SqlTransferProcessStoreTest {
         store.create(t1);
 
         store.delete("id1");
-        assertThat(count()).isEqualTo(0);
+        assertThat(countTransferProcesses()).isEqualTo(0);
         assertThat(store.findAll(QuerySpec.none())).isEmpty();
     }
 
@@ -436,6 +440,43 @@ public class SqlTransferProcessStoreTest {
 
     }
 
+    @Test
+    void create_withoutDataRequest_throwsException() {
+        var t1 = createTransferProcessBuilder("id1")
+                .dataRequest(null)
+                .build();
+        assertThatIllegalArgumentException().isThrownBy(() -> store.create(t1));
+    }
+
+    @Test
+    void update_dataRequestWithNewId_replacesOld() {
+        var t1 = createTransferProcess("id1", TransferProcessStates.IN_PROGRESS);
+        store.create(t1);
+
+        var t2 = createTransferProcessBuilder("id1")
+                .dataRequest(createDataRequestBuilder()
+                        .id("new-dr-id")
+                        .assetId("new-asset")
+                        .contractId("new-contract")
+                        .protocol("test-protocol")
+                        .connectorId("new-connector")
+                        .build())
+                .build();
+        store.update(t2);
+
+        var all = store.findAll(QuerySpec.none()).collect(Collectors.toList());
+        assertThat(all)
+                .hasSize(1)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(t2);
+
+
+        var drs = all.stream().map(TransferProcess::getDataRequest).collect(Collectors.toList());
+        assertThat(drs).hasSize(1)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsOnly(t2.getDataRequest());
+    }
+
     private Connection getConnection() {
         try {
             return dataSourceRegistry.resolve(DATASOURCE_NAME).getConnection();
@@ -444,13 +485,14 @@ public class SqlTransferProcessStoreTest {
         }
     }
 
-    private int count() {
+    private int countTransferProcesses() {
         try (var conn = dataSourceRegistry.resolve(DATASOURCE_NAME).getConnection()) {
             return executeQuery(conn, "SELECT COUNT(*) FROM edc_transfer_process");
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
     }
+
 
     private static class H2DialectStatements extends BaseSqlDialectStatements {
     }


### PR DESCRIPTION
## What this PR changes/adds

This PR fixes a bug in the SQL impl where a `DataRequest` was not persisted when updating TransferProcesses.

## Further notes
.

## Linked Issue(s)

Closes #1707 

## Checklist

- [x] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
