### PR TITLE
chore: update CHANGELOG for M5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,39 @@ This file will not cover changes about documentation, code clean-up, samples, or
 (respectively milestone), the core features are highlighted. Relevant changes to existing implementations can be found
 in the detailed section referring to by linking pull requests or issues.
 
-## [Unreleased]
+## [unreleased]
 
 ### Overview
 
 *
+
+### Detailed Changes
+
+*
+
+#### Added
+
+*
+
+#### Changed
+
+*
+
+#### Removed
+
+*
+
+#### Fixed
+
+*
+
+## [milestone-5] - 2022-07-21
+
+### Overview
+
+* Introduction of an event framework + cloud events
+* Full query capabilities for SQL persistence
+* Bugfixing and cleanup
 
 ### Detailed Changes
 


### PR DESCRIPTION
## What this PR changes/adds

Adds a pinned M5 section to the Changelog

## Why it does that

Preparation for M5

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
