### PR TITLE
chore(build): change bugfix header to 'Bugfixes'

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -7,7 +7,7 @@ changelog:
     authors:
       - dependabot[bot]
   categories:
-    - title: Bugs
+    - title: Bugfixes
       labels:
         - bug
     - title: New Features & Improvements


### PR DESCRIPTION
## What this PR changes/adds

Fixes the header in the GH release note configuration.

## Why it does that

We're not introducing bugs, but bug fixes.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #1718 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
