### PR TITLE
DID: Fix extension provider

### DIFF
--- a/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtension.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtension.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021 Microsoft Corporation
+ *  Copyright (c) 2021 - 2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at

--- a/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtension.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtension.java
@@ -47,7 +47,7 @@ import java.time.Clock;
 import java.util.function.Supplier;
 
 
-@Provides({ IdentityHub.class, IdentityHubClient.class, DidResolverRegistry.class, DidPublicKeyResolver.class })
+@Provides({ IdentityHub.class, IdentityHubClient.class })
 public class IdentityDidCoreExtension implements ServiceExtension {
 
     @Inject

--- a/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtension.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtension.java
@@ -62,6 +62,7 @@ public class IdentityDidCoreExtension implements ServiceExtension {
     @Inject
     private Clock clock;
 
+    @Inject
     private DidResolverRegistry didResolverRegistry;
 
     @Inject

--- a/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtension.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtension.java
@@ -62,6 +62,11 @@ public class IdentityDidCoreExtension implements ServiceExtension {
     @Inject
     private Clock clock;
 
+    private DidResolverRegistry didResolverRegistry;
+
+    @Inject
+    private DidPublicKeyResolver publicKeyResolver;
+
     @Override
     public String name() {
         return "Identity Did Core";
@@ -70,12 +75,6 @@ public class IdentityDidCoreExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var objectMapper = context.getTypeManager().getMapper();
-
-        var resolverRegistry = new DidResolverRegistryImpl();
-        context.registerService(DidResolverRegistry.class, resolverRegistry);
-
-        var publicKeyResolver = new DidPublicKeyResolverImpl(resolverRegistry);
-        context.registerService(DidPublicKeyResolver.class, publicKeyResolver);
 
         registerParsers(privateKeyResolver);
 
@@ -107,6 +106,16 @@ public class IdentityDidCoreExtension implements ServiceExtension {
     @Provider(isDefault = true)
     public DidStore defaultDidDocumentStore() {
         return new InMemoryDidDocumentStore(clock);
+    }
+
+    @Provider(isDefault = true)
+    public DidResolverRegistry defaultDidResolverRegistry() {
+        return new DidResolverRegistryImpl();
+    }
+
+    @Provider(isDefault = true)
+    public DidPublicKeyResolver defaultDidPublicKeyResolver() {
+        return new DidPublicKeyResolverImpl(didResolverRegistry);
     }
 
     private void registerParsers(PrivateKeyResolver resolver) {

--- a/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtensionTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtensionTest.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Daimler TSS GmbH - Initial implementation
+ *       Microsoft Corporation - adapted to extension changes
  *
  */
 
@@ -18,7 +19,6 @@ import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.iam.did.hub.IdentityHubApiController;
 import org.eclipse.dataspaceconnector.iam.did.hub.IdentityHubClientImpl;
 import org.eclipse.dataspaceconnector.iam.did.hub.IdentityHubImpl;
-import org.eclipse.dataspaceconnector.iam.did.resolution.DidPublicKeyResolverImpl;
 import org.eclipse.dataspaceconnector.iam.did.spi.hub.IdentityHub;
 import org.eclipse.dataspaceconnector.iam.did.spi.hub.IdentityHubClient;
 import org.eclipse.dataspaceconnector.iam.did.spi.hub.IdentityHubStore;

--- a/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtensionTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtensionTest.java
@@ -53,6 +53,8 @@ class IdentityDidCoreExtensionTest {
         webserviceMock = mock(WebService.class);
         context.registerService(WebService.class, webserviceMock);
         context.registerService(PrivateKeyResolver.class, mock(PrivateKeyResolver.class));
+        context.registerService(DidPublicKeyResolver.class, mock(DidPublicKeyResolver.class));
+        context.registerService(DidResolverRegistry.class, mock(DidResolverRegistry.class));
         extension = factory.constructInstance(IdentityDidCoreExtension.class);
     }
 
@@ -64,8 +66,6 @@ class IdentityDidCoreExtensionTest {
 
         extension.initialize(context);
 
-        assertThat(context.getService(DidResolverRegistry.class)).isInstanceOf(DidResolverRegistry.class);
-        assertThat(context.getService(DidPublicKeyResolver.class)).isInstanceOf(DidPublicKeyResolverImpl.class);
         assertThat(context.getService(IdentityHub.class)).isInstanceOf(IdentityHubImpl.class);
         assertThat(context.getService(IdentityHubClient.class)).isInstanceOf(IdentityHubClientImpl.class);
         verify(webserviceMock).registerResource(isA(IdentityHubApiController.class));


### PR DESCRIPTION
## What this PR changes/adds

Inject DID services with `isDefault = true`

## Why it does that

Allow Identity Hub integration tests to mock DidPublicKeyResolver. `EdcExtension.registerServiceMock()` only works with services that are created with `isDefault = true`, otherwise the mock is overwritten.

## Further notes

## Linked Issue(s)

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
