### PR TITLE
fix(catalog): introduce a mark for out-of-date offers

### DIFF
--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/LoaderImpl.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/LoaderImpl.java
@@ -41,6 +41,7 @@ public class LoaderImpl implements Loader {
 
     @Override
     public void clear() {
-        store.deleteAll(); // delete all entries before re-populating
+        store.removedMarked(); // delete all still marked entries before re-populating
+        store.markAll(); // marks all entries for deletion, unless they get updated by the crawlers
     }
 }

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/management/PartitionManagerImpl.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/management/PartitionManagerImpl.java
@@ -43,13 +43,13 @@ public class PartitionManagerImpl implements PartitionManager {
     /**
      * Instantiates a new PartitionManagerImpl.
      *
-     * @param monitor A {@link Monitor}
-     * @param workQueue An implementation of a blocking {@link WorkItemQueue}
+     * @param monitor          A {@link Monitor}
+     * @param workQueue        An implementation of a blocking {@link WorkItemQueue}
      * @param crawlerGenerator A generator function that MUST create a new instance of a {@link Crawler}
-     * @param numCrawlers A number indicating how many {@code Crawler} instances should be generated. Note that
-     *         the PartitionManager may choose to generate more or less, e.g. because of constrained system resources.
-     * @param workloadSource A fixed list of {@link WorkItem} instances that need to be processed on every
-     *         execution run. This list is treated as immutable,
+     * @param numCrawlers      A number indicating how many {@code Crawler} instances should be generated. Note that
+     *                         the PartitionManager may choose to generate more or less, e.g. because of constrained system resources.
+     * @param workloadSource   A fixed list of {@link WorkItem} instances that need to be processed on every
+     *                         execution run. This list is treated as immutable,
      */
     public PartitionManagerImpl(Monitor monitor, WorkItemQueue workQueue, Function<WorkItemQueue, Crawler> crawlerGenerator, int numCrawlers, Supplier<List<WorkItem>> workloadSource) {
         this.monitor = monitor;
@@ -78,7 +78,6 @@ public class PartitionManagerImpl implements PartitionManager {
             }
 
             var currentList = workloadSource.get();
-
 
             monitor.debug("Partition manager: execute plan - waiting for queue lock");
             workQueue.lock();

--- a/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/store/InMemoryFederatedCacheStore.java
+++ b/extensions/catalog/federated-catalog-cache/src/main/java/org/eclipse/dataspaceconnector/catalog/store/InMemoryFederatedCacheStore.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
  */
 public class InMemoryFederatedCacheStore implements FederatedCacheStore {
 
-    private final Map<String, ContractOffer> cache = new ConcurrentHashMap<>();
+    private final Map<String, MarkableEntry<ContractOffer>> cache = new ConcurrentHashMap<>();
     private final CriterionConverter<Predicate<ContractOffer>> converter;
     private final LockManager lockManager;
 
@@ -43,21 +43,66 @@ public class InMemoryFederatedCacheStore implements FederatedCacheStore {
 
     @Override
     public void save(ContractOffer contractOffer) {
-        lockManager.writeLock(() -> cache.put(contractOffer.getAsset().getId(), contractOffer));
+        lockManager.writeLock(() -> {
+            var key = contractOffer.getAsset().getId();
+            if (cache.containsKey(key)) {
+                cache.get(key).updateEntry(contractOffer);
+            }
+            return cache.put(contractOffer.getAsset().getId(), new MarkableEntry<>(contractOffer));
+        });
     }
 
     @Override
     public Collection<ContractOffer> query(List<Criterion> query) {
         //AND all predicates
         var rootPredicate = query.stream().map(converter::convert).reduce(x -> true, Predicate::and);
-        return lockManager.readLock(() -> cache.values().stream().filter(rootPredicate).collect(Collectors.toList()));
+        return lockManager.readLock(() -> cache.values().stream().map(MarkableEntry::getEntry).filter(rootPredicate).collect(Collectors.toList()));
     }
 
     @Override
-    public void deleteAll() {
+    public void removedMarked() {
         lockManager.writeLock(() -> {
-            cache.clear();
+            var unmarkedItems = cache.entrySet().stream().filter(entry -> !entry.getValue().isMarked())
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.toList());
+
+            cache.keySet().retainAll(unmarkedItems);
             return null;
         });
+    }
+
+    @Override
+    public void markAll() {
+        cache.values().forEach(MarkableEntry::mark);
+    }
+
+    private static class MarkableEntry<T> {
+        private T entry;
+        private boolean mark;
+
+        MarkableEntry(T t) {
+            entry = t;
+        }
+
+        public void mark() {
+            mark = true;
+        }
+
+        public boolean isMarked() {
+            return mark;
+        }
+
+        public void unmark() {
+            mark = false;
+        }
+
+        public T getEntry() {
+            return entry;
+        }
+
+        public void updateEntry(T t) {
+            entry = t;
+            unmark();
+        }
     }
 }

--- a/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/FederatedCacheStore.java
+++ b/extensions/catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/FederatedCacheStore.java
@@ -41,6 +41,10 @@ public interface FederatedCacheStore {
     /**
      * Deletes all entries from the cache
      */
-    void deleteAll();
+    void removedMarked();
 
+    /**
+     * Marks all entries for deletion
+     */
+    void markAll();
 }


### PR DESCRIPTION
## What this PR changes/adds

This PR solves the problem, where a catalog gets emptied at the beginning of a crawl run and items only trickling in as crawlers finish. This can lead to inconsistent UX for example in web frontends.

In order to alleviate that, I introduce the concept of a "mark" (or "dirty flag") which indicates that an item should be deleted.

At the beginning of every crawl run, the loader removes all marked items from the cache, and then proceeds to mark the remaining items. 
The mark is reset when the item is updated through the crawler. This way, only items that _didn't get updated_ retain the mark, and are thus deleted on the next crawl run.

## Why it does that

This counters inconsistencies with the cache.

## Linked Issue(s)

Closes #1703 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
