### PR TITLE
feat: make rest api return error details on edc exceptions and validation error by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ in the detailed section referring to by linking pull requests or issues.
 
 #### Changed
 
-*
+* Return api validation error detail by default (#1492)
 
 #### Removed
 

--- a/extensions/http/jersey/README.md
+++ b/extensions/http/jersey/README.md
@@ -4,10 +4,9 @@ This extension provides a `Jersey` implementation for the `WebService` service.
 
 ## Configuration
 
-| Parameter name                        | Description                                                               | Default value                                 |
-|---------------------------------------|---------------------------------------------------------------------------|-----------------------------------------------|
-| `edc.web.rest.error.response.verbose` | If true, a detailed response body is sent to the client in case of errors | false                                         |
-| `edc.web.rest.cors.enabled`           | Enables or disables the CORS filter                                       | false                                         |
-| `edc.web.rest.cors.origins`           | Defines allowed origins for the CORS filter                               | "*"                                           |
-| `edc.web.rest.cors.headers`           | Defines allowed headers for the CORS filter                               | "origin, content-type, accept, authorization" |
-| `edc.web.rest.cors.methods`           | Defines allowed methods for the CORS filter                               | "GET, POST, DELETE, PUT, OPTIONS"             |
+| Parameter name                        | Description                                      | Default value                                 |
+|---------------------------------------|--------------------------------------------------|-----------------------------------------------|
+| `edc.web.rest.cors.enabled`           | Enables or disables the CORS filter              | false                                         |
+| `edc.web.rest.cors.origins`           | Defines allowed origins for the CORS filter      | "*"                                           |
+| `edc.web.rest.cors.headers`           | Defines allowed headers for the CORS filter      | "origin, content-type, accept, authorization" |
+| `edc.web.rest.cors.methods`           | Defines allowed methods for the CORS filter      | "GET, POST, DELETE, PUT, OPTIONS"             |

--- a/extensions/http/jersey/src/main/java/org/eclipse/dataspaceconnector/extension/jersey/JerseyConfiguration.java
+++ b/extensions/http/jersey/src/main/java/org/eclipse/dataspaceconnector/extension/jersey/JerseyConfiguration.java
@@ -22,8 +22,6 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
  */
 public class JerseyConfiguration {
     @EdcSetting
-    public static final String ERROR_RESPONSE_VERBOSE_SETTING = "edc.web.rest.error.response.verbose";
-    @EdcSetting
     public static final String CORS_CONFIG_ORIGINS_SETTING = "edc.web.rest.cors.origins";
     @EdcSetting
     public static final String CORS_CONFIG_ENABLED_SETTING = "edc.web.rest.cors.enabled";
@@ -35,7 +33,6 @@ public class JerseyConfiguration {
     private String allowedHeaders;
     private String allowedMethods;
     private boolean corsEnabled;
-    private boolean errorResponseVerbose;
 
     private JerseyConfiguration() {
     }
@@ -50,7 +47,6 @@ public class JerseyConfiguration {
         config.allowedOrigins = origins;
         config.allowedMethods = allowedMethods;
         config.corsEnabled = enabled;
-        config.errorResponseVerbose = context.getSetting(ERROR_RESPONSE_VERBOSE_SETTING, false);
 
         return config;
     }
@@ -75,7 +71,4 @@ public class JerseyConfiguration {
         return corsEnabled;
     }
 
-    public boolean isErrorResponseVerbose() {
-        return errorResponseVerbose;
-    }
 }

--- a/extensions/http/jersey/src/main/java/org/eclipse/dataspaceconnector/extension/jersey/JerseyRestService.java
+++ b/extensions/http/jersey/src/main/java/org/eclipse/dataspaceconnector/extension/jersey/JerseyRestService.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.stream.Collectors.toSet;
-import static org.glassfish.jersey.server.ServerProperties.BV_SEND_ERROR_IN_RESPONSE;
 import static org.glassfish.jersey.server.ServerProperties.WADL_FEATURE_DISABLE;
 
 public class JerseyRestService implements WebService {
@@ -79,17 +78,12 @@ public class JerseyRestService implements WebService {
         // Disable WADL as it is not used and emits a warning message about JAXB (which is also not used)
         resourceConfig.property(WADL_FEATURE_DISABLE, Boolean.TRUE);
 
-        if (configuration.isErrorResponseVerbose()) {
-            // enable returning jersey bean validation failure detail in body
-            resourceConfig.property(BV_SEND_ERROR_IN_RESPONSE, Boolean.TRUE);
-        }
-
         // Register controller (JAX-RS resources) with Jersey. Instances instead of classes are used so extensions may inject them with dependencies and manage their lifecycle.
         // In order to use instances with Jersey, the controller types must be registered along with an {@link AbstractBinder} that maps those types to the instances.
         resourceConfig.registerClasses(controllers.stream().map(Object::getClass).collect(toSet()));
         resourceConfig.registerInstances(new Binder());
         resourceConfig.registerInstances(new TypeManagerContextResolver(typeManager));
-        resourceConfig.registerInstances(new EdcApiExceptionMapper(configuration.isErrorResponseVerbose()));
+        resourceConfig.registerInstances(new EdcApiExceptionMapper());
         resourceConfig.registerInstances(new ValidationExceptionMapper());
 
         if (configuration.isCorsEnabled()) {

--- a/extensions/http/jersey/src/main/java/org/eclipse/dataspaceconnector/extension/jersey/mapper/EdcApiExceptionMapper.java
+++ b/extensions/http/jersey/src/main/java/org/eclipse/dataspaceconnector/extension/jersey/mapper/EdcApiExceptionMapper.java
@@ -39,10 +39,8 @@ import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
 
 public class EdcApiExceptionMapper implements ExceptionMapper<Throwable> {
     private final Map<Class<? extends Throwable>, Response.Status> exceptionMap;
-    private final boolean verboseResponse;
 
-    public EdcApiExceptionMapper(boolean verboseResponse) {
-        this.verboseResponse = verboseResponse;
+    public EdcApiExceptionMapper() {
         exceptionMap = Map.of(
                 IllegalArgumentException.class, BAD_REQUEST,
                 NullPointerException.class, BAD_REQUEST,
@@ -63,13 +61,17 @@ public class EdcApiExceptionMapper implements ExceptionMapper<Throwable> {
 
         var status = exceptionMap.getOrDefault(exception.getClass(), SERVICE_UNAVAILABLE);
 
-        if (exception instanceof EdcApiException && verboseResponse) {
+        if (exception instanceof EdcApiException) {
             var edcApiException = (EdcApiException) exception;
-            var apiError = ApiErrorDetail.Builder.newInstance()
+
+            var errorDetail = ApiErrorDetail.Builder.newInstance()
                     .message(edcApiException.getMessage())
                     .type(edcApiException.getType())
                     .build();
-            return Response.status(status).entity(List.of(apiError)).build();
+
+            return Response.status(status)
+                    .entity(List.of(errorDetail))
+                    .build();
         }
 
         return Response.status(status).build();

--- a/extensions/http/jersey/src/test/java/org/eclipse/dataspaceconnector/extension/jersey/mapper/ExceptionMappersIntegrationTest.java
+++ b/extensions/http/jersey/src/test/java/org/eclipse/dataspaceconnector/extension/jersey/mapper/ExceptionMappersIntegrationTest.java
@@ -57,8 +57,7 @@ public class ExceptionMappersIntegrationTest {
         extension.setConfiguration(Map.of(
                 "web.http.port", String.valueOf(getFreePort()),
                 "web.http.test.port", String.valueOf(port),
-                "web.http.test.path", "/",
-                "edc.web.rest.error.response.verbose", Boolean.TRUE.toString()
+                "web.http.test.path", "/"
         ));
         extension.registerSystemExtension(ServiceExtension.class, new MyServiceExtension());
     }


### PR DESCRIPTION
## What this PR changes/adds

Return the "api error detail" response payload by default

## Why it does that

The clients should be aware of the failure reason.

## Further notes

- having the possibility to include the stacktrace as it was hinted in the issue didn't seem a good idea, clients should only be aware of errors resolvable on their side, and the stacktrace won't help them at all, neither in a development environment
- Removed the "verbose" config settings as it has lost its value.

## Linked Issue(s)

Closes #1492 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
