### PR TITLE
fix(DataPlane): Add system test for Client Data Pull with query parameters in the request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ in the detailed section referring to by linking pull requests or issues.
 
 #### Added
 
-*
+* System test for client data pull with query parameters (#1180)
 
 #### Changed
 

--- a/extensions/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityService.java
+++ b/extensions/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityService.java
@@ -22,11 +22,8 @@ import org.eclipse.dataspaceconnector.iam.did.crypto.key.KeyConverter;
 import org.eclipse.dataspaceconnector.iam.did.spi.credentials.CredentialsVerifier;
 import org.eclipse.dataspaceconnector.iam.did.spi.document.DidConstants;
 import org.eclipse.dataspaceconnector.iam.did.spi.document.DidDocument;
-import org.eclipse.dataspaceconnector.iam.did.spi.document.JwkPublicKey;
-import org.eclipse.dataspaceconnector.iam.did.spi.document.Service;
 import org.eclipse.dataspaceconnector.iam.did.spi.document.VerificationMethod;
 import org.eclipse.dataspaceconnector.iam.did.spi.key.PrivateKeyWrapper;
-import org.eclipse.dataspaceconnector.iam.did.spi.key.PublicKeyWrapper;
 import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidResolverRegistry;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
@@ -78,17 +75,17 @@ public class DecentralizedIdentityService implements IdentityService {
             monitor.debug("Extracting public key");
 
             // this will return the _first_ public key entry
-            Optional<VerificationMethod> publicKey = getPublicKey(didResult.getContent());
+            var publicKey = getPublicKey(didResult.getContent());
             if (publicKey.isEmpty()) {
                 return Result.failure("Public Key not found in DID Document!");
             }
 
             //convert the POJO into a usable PK-wrapper:
-            JwkPublicKey publicKeyJwk = publicKey.get().getPublicKeyJwk();
-            PublicKeyWrapper publicKeyWrapper = KeyConverter.toPublicKeyWrapper(publicKeyJwk, publicKey.get().getId());
+            var publicKeyJwk = publicKey.get().getPublicKeyJwk();
+            var publicKeyWrapper = KeyConverter.toPublicKeyWrapper(publicKeyJwk, publicKey.get().getId());
 
             monitor.debug("Verifying JWT with public key...");
-            Result<Void> verified = VerifiableCredentialFactory.verify(jwt, publicKeyWrapper, audience);
+            var verified = VerifiableCredentialFactory.verify(jwt, publicKeyWrapper, audience);
             if (verified.failed()) {
                 verified.getFailureMessages().forEach(m -> monitor.debug(() -> "Failure in token verification: " + m));
                 return Result.failure("Token could not be verified!");
@@ -106,10 +103,6 @@ public class DecentralizedIdentityService implements IdentityService {
             monitor.severe("Error parsing JWT", e);
             return Result.failure("Error parsing JWT");
         }
-    }
-
-    String getHubUrl(DidDocument did) {
-        return did.getService().stream().filter(service -> service.getType().equals(DidConstants.HUB_URL)).map(Service::getServiceEndpoint).findFirst().orElseThrow();
     }
 
     @NotNull

--- a/extensions/iam/decentralized-identity/identity-did-service/src/test/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityServiceTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-service/src/test/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityServiceTest.java
@@ -35,7 +35,6 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.time.Clock;
 import java.util.Map;
 
@@ -52,14 +51,8 @@ abstract class DecentralizedIdentityServiceTest {
     private static final Faker FAKER = new Faker();
     private static final String DID_DOCUMENT = getResourceFileContentAsString("dids.json");
 
-    String didUrl = FAKER.internet().url();
+    private final String didUrl = FAKER.internet().url();
     private DecentralizedIdentityService identityService;
-
-    @Test
-    void verifyResolveHubUrl() throws IOException {
-        var url = identityService.getHubUrl(new ObjectMapper().readValue(DID_DOCUMENT, DidDocument.class));
-        assertEquals("https://myhub.com", url);
-    }
 
     @Test
     void generateAndVerifyJwtToken_valid() {

--- a/system-tests/e2e-transfer-test/backend-service/src/main/java/org/eclipse/dataspaceconnector/test/e2e/BackendServiceTestExtension.java
+++ b/system-tests/e2e-transfer-test/backend-service/src/main/java/org/eclipse/dataspaceconnector/test/e2e/BackendServiceTestExtension.java
@@ -41,7 +41,7 @@ public class BackendServiceTestExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         var exposedHttpPort = context.getConfig().getInteger("web.http.port");
         webService.registerResource(new ProviderBackendApiController());
-        webService.registerResource(new ConsumerBackendServiceController(context.getMonitor(), okHttpClient));
+        webService.registerResource(new ConsumerBackendServiceController(context.getMonitor()));
         webService.registerResource(new BackendServiceHttpProvisionerController(context.getMonitor(), okHttpClient, typeManager, exposedHttpPort));
     }
 }

--- a/system-tests/e2e-transfer-test/backend-service/src/main/java/org/eclipse/dataspaceconnector/test/e2e/ProviderBackendApiController.java
+++ b/system-tests/e2e-transfer-test/backend-service/src/main/java/org/eclipse/dataspaceconnector/test/e2e/ProviderBackendApiController.java
@@ -14,20 +14,22 @@
 
 package org.eclipse.dataspaceconnector.test.e2e;
 
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
 import java.util.Map;
 
 @Path("/provider")
 public class ProviderBackendApiController {
-    
+
     @Path("/data")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public Map<String, String> getData() {
-        return Map.of("message", "some information");
+    public Map<String, String> getData(@DefaultValue("some information") @QueryParam("message") String message) {
+        return Map.of("message", message);
     }
 }

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/dataspaceconnector/test/e2e/AbstractEndToEndTransfer.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/dataspaceconnector/test/e2e/AbstractEndToEndTransfer.java
@@ -19,6 +19,8 @@ import org.eclipse.dataspaceconnector.spi.types.domain.HttpDataAddress;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,7 +39,7 @@ public abstract class AbstractEndToEndTransfer {
     void httpPullDataTransfer() {
         PROVIDER.registerDataPlane();
         CONSUMER.registerDataPlane();
-        String definitionId = "1";
+        var definitionId = "1";
         createAssetAndContractDefinitionOnProvider("asset-id", definitionId, "HttpData");
 
         var catalog = CONSUMER.getCatalog(PROVIDER.idsEndpoint());
@@ -50,29 +52,30 @@ public abstract class AbstractEndToEndTransfer {
 
         assertThat(contractAgreementId).isNotEmpty();
 
-        var transferProcessId = CONSUMER.dataRequest(contractAgreementId, assetId, PROVIDER, sync());
+        var dataRequestId = UUID.randomUUID().toString();
+        var transferProcessId = CONSUMER.dataRequest(dataRequestId, contractAgreementId, assetId, PROVIDER, sync());
 
         await().atMost(timeout).untilAsserted(() -> {
             var state = CONSUMER.getTransferProcessState(transferProcessId);
             assertThat(state).isEqualTo(COMPLETED.name());
         });
 
-        await().atMost(timeout).untilAsserted(() -> {
-            given()
-                    .baseUri(CONSUMER.backendService().toString())
-                    .when()
-                    .get("/api/consumer/data")
-                    .then()
-                    .statusCode(200)
-                    .body("message", equalTo("some information"));
-        });
+        // retrieve the data reference
+        var edr = CONSUMER.getDataReference(dataRequestId);
+
+        // pull the data without query parameter
+        await().atMost(timeout).untilAsserted(() -> CONSUMER.pullData(edr, Map.of(), equalTo("some information")));
+
+        // pull the data with additional query parameter
+        var msg = UUID.randomUUID().toString();
+        await().atMost(timeout).untilAsserted(() -> CONSUMER.pullData(edr, Map.of("message", msg), equalTo(msg)));
     }
 
     @Test
     void httpPullDataTransferProvisioner() {
         PROVIDER.registerDataPlane();
         CONSUMER.registerDataPlane();
-        String definitionId = "1";
+        var definitionId = "1";
         createAssetAndContractDefinitionOnProvider("asset-id", definitionId, "HttpProvision");
 
         await().atMost(timeout).untilAsserted(() -> {
@@ -88,22 +91,16 @@ public abstract class AbstractEndToEndTransfer {
 
         assertThat(contractAgreementId).isNotEmpty();
 
-        var transferProcessId = CONSUMER.dataRequest(contractAgreementId, assetId, PROVIDER, sync());
+        var dataRequestId = UUID.randomUUID().toString();
+        var transferProcessId = CONSUMER.dataRequest(dataRequestId, contractAgreementId, assetId, PROVIDER, sync());
 
         await().atMost(timeout).untilAsserted(() -> {
             var state = CONSUMER.getTransferProcessState(transferProcessId);
             assertThat(state).isEqualTo(COMPLETED.name());
         });
 
-        await().atMost(timeout).untilAsserted(() -> {
-            given()
-                    .baseUri(CONSUMER.backendService().toString())
-                    .when()
-                    .get("/api/consumer/data")
-                    .then()
-                    .statusCode(200)
-                    .body("message", equalTo("some information"));
-        });
+        var edr = CONSUMER.getDataReference(dataRequestId);
+        await().atMost(timeout).untilAsserted(() -> CONSUMER.pullData(edr, Map.of(), equalTo("some information")));
     }
 
     @Test
@@ -125,7 +122,7 @@ public abstract class AbstractEndToEndTransfer {
         var destination = HttpDataAddress.Builder.newInstance()
                 .baseUrl(CONSUMER.backendService() + "/api/consumer/store")
                 .build();
-        var transferProcessId = CONSUMER.dataRequest(contractAgreementId, assetId, PROVIDER, destination);
+        var transferProcessId = CONSUMER.dataRequest(UUID.randomUUID().toString(), contractAgreementId, assetId, PROVIDER, destination);
 
         await().atMost(timeout).untilAsserted(() -> {
             var state = CONSUMER.getTransferProcessState(transferProcessId);


### PR DESCRIPTION
## What this PR changes/adds

This PR adds a system test covering the use-case of a client data pull (see https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/585 for more details) with query parameters passed in input of the Data Plane public API.

## Why it does that

Ensure query parameters are properly conveyed all the way to the provider data source (if its allows it).

## Linked Issue(s)

Closes #1180 

## Checklist

- [x] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
