### PR TITLE
chore(observability): Add context information to jetty metrics

### DIFF
--- a/extensions/http/jetty-micrometer/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyMicrometerConfiguration.java
+++ b/extensions/http/jetty-micrometer/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyMicrometerConfiguration.java
@@ -16,6 +16,7 @@
 package org.eclipse.dataspaceconnector.extension.jetty;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.jetty.JettyConnectionMetrics;
 import org.eclipse.jetty.server.ServerConnector;
@@ -34,17 +35,10 @@ public class JettyMicrometerConfiguration implements Consumer<ServerConnector> {
 
     @Override
     public void accept(ServerConnector connector) {
-        var tags = Tags.empty();
-
-        if (connector.getPort() != 0) {
-            tags = tags.and("jetty_port", String.valueOf(connector.getPort()));
-        } else {
-            tags = tags.and("jetty_port", String.valueOf(connector.getLocalPort()));
-        }
-
-        if (connector.getName() != null) {
-            tags = tags.and("jetty_context", connector.getName());
-        }
+        var tags = Tags.of(
+                Tag.of("jetty_port", String.valueOf(connector.getPort())),
+                Tag.of("jetty_context", connector.getName())
+        );
 
         connector.addBean(new JettyConnectionMetrics(registry, connector, tags));
     }

--- a/extensions/http/jetty-micrometer/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyMicrometerConfiguration.java
+++ b/extensions/http/jetty-micrometer/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyMicrometerConfiguration.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       ZF Friedrichshafen AG - Add tags with context informations
  *
  */
 
@@ -33,6 +34,18 @@ public class JettyMicrometerConfiguration implements Consumer<ServerConnector> {
 
     @Override
     public void accept(ServerConnector connector) {
-        connector.addBean(new JettyConnectionMetrics(registry, connector, Tags.empty()));
+        var tags = Tags.empty();
+
+        if (connector.getPort() != 0) {
+            tags = tags.and("jetty_port", String.valueOf(connector.getPort()));
+        } else {
+            tags = tags.and("jetty_port", String.valueOf(connector.getLocalPort()));
+        }
+
+        if (connector.getName() != null) {
+            tags = tags.and("jetty_context", connector.getName());
+        }
+
+        connector.addBean(new JettyConnectionMetrics(registry, connector, tags));
     }
 }

--- a/extensions/http/jetty/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyService.java
+++ b/extensions/http/jetty/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyService.java
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
  *       Fraunhofer Institute for Software and Systems Engineering - added method
+ *       ZF Friedrichshafen AG - Set connector name
  *
  */
 
@@ -82,10 +83,10 @@ public class JettyService implements WebServer {
                     throw new IllegalArgumentException("A binding for port " + mapping.getPort() + " already exists");
                 }
                 if (keyStore != null) {
-                    connector = httpsServerConnector(mapping.getPort());
+                    connector = httpsServerConnector(mapping.getName(), mapping.getPort());
                     monitor.info("HTTPS context '" + mapping.getName() + "' listening on port " + mapping.getPort());
                 } else {
-                    connector = httpServerConnector(mapping.getPort());
+                    connector = httpServerConnector(mapping.getName(), mapping.getPort());
                     monitor.info("HTTP context '" + mapping.getName() + "' listening on port " + mapping.getPort());
                 }
                 connector.setName(mapping.getName());
@@ -159,7 +160,7 @@ public class JettyService implements WebServer {
     }
 
     @NotNull
-    private ServerConnector httpsServerConnector(int port) {
+    private ServerConnector httpsServerConnector(String name, int port) {
         var storePassword = configuration.getKeystorePassword();
         var managerPassword = configuration.getKeymanagerPassword();
 
@@ -178,14 +179,16 @@ public class JettyService implements WebServer {
         var httpConnectionFactory = new HttpConnectionFactory(httpsConfiguration);
         var sslConnectionFactory = new SslConnectionFactory(contextFactory, HttpVersion.HTTP_1_1.asString());
         var sslConnector = new ServerConnector(server, sslConnectionFactory, httpConnectionFactory);
+        sslConnector.setName(name);
         sslConnector.setPort(port);
         configure(sslConnector);
         return sslConnector;
     }
 
     @NotNull
-    private ServerConnector httpServerConnector(int port) {
+    private ServerConnector httpServerConnector(String name, int port) {
         ServerConnector connector = new ServerConnector(server, httpConnectionFactory());
+        connector.setName(name);
         connector.setPort(port);
         configure(connector);
         return connector;

--- a/extensions/http/jetty/src/test/java/org/eclipse/dataspaceconnector/extension/jetty/JettyServiceTest.java
+++ b/extensions/http/jetty/src/test/java/org/eclipse/dataspaceconnector/extension/jetty/JettyServiceTest.java
@@ -70,7 +70,7 @@ class JettyServiceTest {
     }
 
     @Test
-    @DisplayName("Verifies the a custom port mapping")
+    @DisplayName("Verifies a custom port mapping")
     void verifyCustomPortMapping() {
         var config = ConfigFactory.fromMap(Map.of(
                 "web.http.another.port", "9191",


### PR DESCRIPTION
## What this PR changes/adds


The PR adds the Tags `jetty_context` and `jetty_port` to the jetty connection metrics (e.g. `jetty_connections_max`)

PR will result in this:
![](https://user-images.githubusercontent.com/97295414/180776532-ca1b61e6-550f-40e0-aec9-ba2dc822279f.png)

## Why it does that

To support specific alerts for each context

## Linked Issue(s)

Closes #1738 

## Checklist

- [x] ~added appropriate tests?~ (Not necessary in my opinion)
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] ~documented public classes/methods?~
- [x] ~added/updated relevant documentation?~
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
