### PR TITLE
chore: increase allowed pr title length

### DIFF
--- a/.github/workflows/scan-pull-request.yaml
+++ b/.github/workflows/scan-pull-request.yaml
@@ -29,7 +29,7 @@ jobs:
           # - Add cool feature
           # - Feature/some cool improvement
           # - fix: resolve minor issue.
-          regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(\w+((,|\/|\\)?\s?\w+)+\))?!?: [\S ]{1,49}[^\.]$'
+          regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(\w+((,|\/|\\)?\s?\w+)+\))?!?: [\S ]{1,80}[^\.]$'
           allowed_prefixes: 'build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test'
           prefix_case_sensitive: true
 


### PR DESCRIPTION
## What this PR changes/adds

Increase PR title length from 49 to 80 characters. 

## Why it does that

Based on feedback.

## Further notes

Remove empty leftover `CHANGELOG.md`.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
