### PR TITLE
fix: explicitly set default ports in tests

### DIFF
--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiControllerIntegrationTest.java
@@ -52,6 +52,8 @@ public class AssetApiControllerIntegrationTest {
     @BeforeEach
     void setUp(EdcExtension extension) {
         extension.setConfiguration(Map.of(
+                "web.http.port", String.valueOf(getFreePort()),
+                "web.http.path", "/api",
                 "web.http.data.port", String.valueOf(port),
                 "web.http.data.path", "/api/v1/data",
                 "edc.api.auth.key", authKey

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetEventDispatchTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/service/AssetEventDispatchTest.java
@@ -22,13 +22,16 @@ import org.eclipse.dataspaceconnector.spi.event.asset.AssetCreated;
 import org.eclipse.dataspaceconnector.spi.event.asset.AssetDeleted;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.junit.testfixtures.TestUtils.getFreePort;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -38,6 +41,14 @@ import static org.mockito.Mockito.verify;
 public class AssetEventDispatchTest {
 
     private final EventSubscriber eventSubscriber = mock(EventSubscriber.class);
+
+    @BeforeEach
+    void setUp(EdcExtension extension) {
+        extension.setConfiguration(Map.of(
+                "web.http.port", String.valueOf(getFreePort()),
+                "web.http.path", "/api"
+        ));
+    }
 
     @Test
     void shouldDispatchEventsOnAssetCreationAndDeletion(AssetService service, EventRouter eventRouter) throws InterruptedException {

--- a/extensions/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerIntegrationTest.java
@@ -59,6 +59,8 @@ public class CatalogApiControllerIntegrationTest {
 
         extension.registerSystemExtension(ServiceExtension.class, new TestExtension());
         extension.setConfiguration(Map.of(
+                "web.http.port", String.valueOf(getFreePort()),
+                "web.http.path", "/api",
                 "web.http.data.port", String.valueOf(port),
                 "web.http.data.path", "/api/v1/data",
                 "edc.api.auth.key", authKey

--- a/extensions/api/data-management/contractagreement/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/contractagreement/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApiControllerIntegrationTest.java
@@ -43,6 +43,8 @@ public class ContractAgreementApiControllerIntegrationTest {
     @BeforeEach
     void setUp(EdcExtension extension) {
         extension.setConfiguration(Map.of(
+                "web.http.port", String.valueOf(getFreePort()),
+                "web.http.path", "/api",
                 "web.http.data.port", String.valueOf(port),
                 "web.http.data.path", "/api/v1/data",
                 "edc.api.auth.key", authKey

--- a/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiControllerIntegrationTest.java
@@ -45,6 +45,8 @@ public class ContractDefinitionApiControllerIntegrationTest {
     @BeforeEach
     void setUp(EdcExtension extension) {
         extension.setConfiguration(Map.of(
+                "web.http.port", String.valueOf(getFreePort()),
+                "web.http.path", "/api",
                 "web.http.data.port", String.valueOf(port),
                 "web.http.data.path", "/api/v1/data",
                 "edc.api.auth.key", authKey

--- a/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/service/ContractDefinitionEventDispatchTest.java
+++ b/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/service/ContractDefinitionEventDispatchTest.java
@@ -21,12 +21,15 @@ import org.eclipse.dataspaceconnector.spi.event.EventSubscriber;
 import org.eclipse.dataspaceconnector.spi.event.contractdefinition.ContractDefinitionCreated;
 import org.eclipse.dataspaceconnector.spi.event.contractdefinition.ContractDefinitionDeleted;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.Map;
 import java.util.UUID;
 
 import static org.awaitility.Awaitility.await;
+import static org.eclipse.dataspaceconnector.junit.testfixtures.TestUtils.getFreePort;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -35,6 +38,14 @@ import static org.mockito.Mockito.verify;
 public class ContractDefinitionEventDispatchTest {
 
     private final EventSubscriber eventSubscriber = mock(EventSubscriber.class);
+
+    @BeforeEach
+    void setUp(EdcExtension extension) {
+        extension.setConfiguration(Map.of(
+                "web.http.port", String.valueOf(getFreePort()),
+                "web.http.path", "/api"
+        ));
+    }
 
     @Test
     void shouldDispatchEventOnContractDefinitionCreationAndDeletion(ContractDefinitionService service, EventRouter eventRouter) {

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
@@ -51,6 +51,8 @@ class ContractNegotiationApiControllerIntegrationTest {
     @BeforeEach
     void setUp(EdcExtension extension) {
         extension.setConfiguration(Map.of(
+                "web.http.port", String.valueOf(getFreePort()),
+                "web.http.path", "/api",
                 "web.http.data.port", String.valueOf(port),
                 "web.http.data.path", "/api/v1/data",
                 "edc.api.auth.key", authKey

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/service/ContractNegotiationEventDispatchTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/service/ContractNegotiationEventDispatchTest.java
@@ -53,6 +53,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static org.awaitility.Awaitility.await;
+import static org.eclipse.dataspaceconnector.junit.testfixtures.TestUtils.getFreePort;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
@@ -68,6 +69,8 @@ public class ContractNegotiationEventDispatchTest {
     @BeforeEach
     void setUp(EdcExtension extension) {
         extension.setConfiguration(Map.of(
+                "web.http.port", String.valueOf(getFreePort()),
+                "web.http.path", "/api",
                 "edc.negotiation.consumer.send.retry.limit", "0",
                 "edc.negotiation.provider.send.retry.limit", "0"
         ));

--- a/extensions/api/data-management/policydefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyDefinitionApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/policydefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyDefinitionApiControllerIntegrationTest.java
@@ -43,6 +43,8 @@ public class PolicyDefinitionApiControllerIntegrationTest {
     @BeforeEach
     void setUp(EdcExtension extension) {
         extension.setConfiguration(Map.of(
+                "web.http.port", String.valueOf(getFreePort()),
+                "web.http.path", "/api",
                 "web.http.data.port", String.valueOf(port),
                 "web.http.data.path", "/api/v1/data",
                 "edc.api.auth.key", authKey

--- a/extensions/api/data-management/policydefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/service/PolicyDefinitionEventDispatchTest.java
+++ b/extensions/api/data-management/policydefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/service/PolicyDefinitionEventDispatchTest.java
@@ -22,13 +22,16 @@ import org.eclipse.dataspaceconnector.spi.event.EventRouter;
 import org.eclipse.dataspaceconnector.spi.event.EventSubscriber;
 import org.eclipse.dataspaceconnector.spi.event.policydefinition.PolicyDefinitionCreated;
 import org.eclipse.dataspaceconnector.spi.event.policydefinition.PolicyDefinitionDeleted;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.junit.testfixtures.TestUtils.getFreePort;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -38,6 +41,14 @@ import static org.mockito.Mockito.verify;
 public class PolicyDefinitionEventDispatchTest {
 
     private final EventSubscriber eventSubscriber = mock(EventSubscriber.class);
+
+    @BeforeEach
+    void setUp(EdcExtension extension) {
+        extension.setConfiguration(Map.of(
+                "web.http.port", String.valueOf(getFreePort()),
+                "web.http.path", "/api"
+        ));
+    }
 
     @Test
     void shouldDispatchEventOnPolicyDefinitionCreationAndDeletion(PolicyDefinitionService service, EventRouter eventRouter) throws InterruptedException {

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerIntegrationTest.java
@@ -47,6 +47,8 @@ class TransferProcessApiControllerIntegrationTest {
     @BeforeEach
     void setUp(EdcExtension extension) {
         extension.setConfiguration(Map.of(
+                "web.http.port", String.valueOf(getFreePort()),
+                "web.http.path", "/api",
                 "web.http.data.port", String.valueOf(port),
                 "web.http.data.path", "/api/v1/data",
                 "edc.api.auth.key", authKey

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessEventDispatchTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessEventDispatchTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 
 import static org.awaitility.Awaitility.await;
+import static org.eclipse.dataspaceconnector.junit.testfixtures.TestUtils.getFreePort;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
@@ -54,10 +55,12 @@ public class TransferProcessEventDispatchTest {
     @BeforeEach
     void setUp(EdcExtension extension) {
         extension.setConfiguration(Map.of("edc.transfer.send.retry.limit", "0",
-                                          "edc.transfer.send.retry.base-delay.ms", "0"));
+                "edc.transfer.send.retry.base-delay.ms", "0",
+                "web.http.port", String.valueOf(getFreePort()),
+                "web.http.path", "/api"));
         extension.registerServiceMock(TransferWaitStrategy.class, () -> 1);
         extension.registerServiceMock(EventExecutorServiceContainer.class,
-                                      new EventExecutorServiceContainer(Executors.newSingleThreadExecutor()));
+                new EventExecutorServiceContainer(Executors.newSingleThreadExecutor()));
     }
 
     @Test

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
@@ -101,6 +101,8 @@ public class HttpProvisionerExtensionEndToEndTest {
     @BeforeEach
     void setup(EdcExtension extension) {
         extension.setConfiguration(Map.of(
+                "web.http.port", String.valueOf(getFreePort()),
+                "web.http.path", "/api",
                 "web.http.data.port", String.valueOf(dataPort),
                 "web.http.data.path", "/api/v1/data"
         ));

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/webhook/HttpProvisionerWebhookApiControllerIntegrationTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/webhook/HttpProvisionerWebhookApiControllerIntegrationTest.java
@@ -49,6 +49,8 @@ class HttpProvisionerWebhookApiControllerIntegrationTest {
     @BeforeEach
     void setUp(EdcExtension extension) {
         extension.setConfiguration(Map.of(
+                "web.http.port", String.valueOf(getFreePort()),
+                "web.http.path", "/api",
                 "web.http.provisioner.port", String.valueOf(port),
                 "web.http.provisioner.path", PROVISIONER_BASE_PATH,
                 "edc.api.auth.key", authKey

--- a/extensions/http/jersey/src/test/java/org/eclipse/dataspaceconnector/extension/jersey/mapper/ExceptionMappersIntegrationTest.java
+++ b/extensions/http/jersey/src/test/java/org/eclipse/dataspaceconnector/extension/jersey/mapper/ExceptionMappersIntegrationTest.java
@@ -56,6 +56,7 @@ public class ExceptionMappersIntegrationTest {
     void setUp(EdcExtension extension) {
         extension.setConfiguration(Map.of(
                 "web.http.port", String.valueOf(getFreePort()),
+                "web.http.path", "/api",
                 "web.http.test.port", String.valueOf(port),
                 "web.http.test.path", "/"
         ));
@@ -115,6 +116,16 @@ public class ExceptionMappersIntegrationTest {
                 .statusCode(500);
     }
 
+    private static class RequestPayload {
+        @NotBlank
+        @JsonProperty
+        private String data;
+
+        @Positive
+        @JsonProperty
+        private long number;
+    }
+
     @Path("/test")
     public class TestController {
 
@@ -130,16 +141,6 @@ public class ExceptionMappersIntegrationTest {
         public void doAction(@Valid RequestPayload payload) {
         }
 
-    }
-
-    private static class RequestPayload {
-        @NotBlank
-        @JsonProperty
-        private String data;
-
-        @Positive
-        @JsonProperty
-        private long number;
     }
 
     private class MyServiceExtension implements ServiceExtension {

--- a/extensions/junit/src/main/java/org/eclipse/dataspaceconnector/junit/testfixtures/TestUtils.java
+++ b/extensions/junit/src/main/java/org/eclipse/dataspaceconnector/junit/testfixtures/TestUtils.java
@@ -33,9 +33,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class TestUtils {
     public static final int MAX_TCP_PORT = 65_535;
     public static final String GRADLE_WRAPPER;
-    private static File buildRoot = null;
     private static final String GRADLE_WRAPPER_UNIX = "gradlew";
     private static final String GRADLE_WRAPPER_WINDOWS = "gradlew.bat";
+    private static final Random RANDOM = new Random();
+    private static File buildRoot = null;
 
     static {
         GRADLE_WRAPPER = (System.getProperty("os.name").toLowerCase().contains("win")) ? GRADLE_WRAPPER_WINDOWS : GRADLE_WRAPPER_UNIX;
@@ -65,7 +66,7 @@ public class TestUtils {
      * @throws IllegalArgumentException if no free port is available
      */
     public static int getFreePort() {
-        var rnd = 1024 + new Random().nextInt(MAX_TCP_PORT - 1024);
+        var rnd = 1024 + RANDOM.nextInt(MAX_TCP_PORT - 1024);
         return getFreePort(rnd);
     }
 
@@ -152,7 +153,9 @@ public class TestUtils {
      */
     public static File findBuildRoot() {
         // Use cached value if already existing.
-        if (buildRoot != null) return buildRoot;
+        if (buildRoot != null) {
+            return buildRoot;
+        }
 
         File canonicalFile;
         try {


### PR DESCRIPTION
## What this PR changes/adds

this PR explicitly adds configuration values for default port and context path to tests that spin up an EDC runtime.

## Why it does that

When running `./gradlew test` with parallelism, parallel tests potentially attempt to spin up an EDC runtime, each of which binding against port 8181 (which is the default) which of course fails.
This supposedly only surfaced on local builds on machines with parallelism on, because it can never happen when running tests sequentially.

## Further notes

What made this a bit tricky to debug is the fact, that by default the gradle runner does not print STDOUT. Supplying the `-PverboseTest` argument does cause it to be printed, but then slows down test execution significantly, which made the bug not occur again.

## Linked Issue(s)

Closes #1743

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
