### PR TITLE
docs: add decision record about create/update timestamps

### DIFF
--- a/docs/developer/decision-records/2022-08-01-entity-timestamp/README.md
+++ b/docs/developer/decision-records/2022-08-01-entity-timestamp/README.md
@@ -55,7 +55,7 @@ public abstract class StatefulEntity<T extends StatefulEntity<T>> extends Entity
     private long lastUpdatedAt;
 
     public long getLastUpdatedAt() {
-        return lastUpdateTimestamp;
+        return lastUpdatedAt;
     }
 
     public void setLastUpdatedAt(long epochMillis) {

--- a/docs/developer/decision-records/2022-08-01-entity-timestamp/README.md
+++ b/docs/developer/decision-records/2022-08-01-entity-timestamp/README.md
@@ -66,14 +66,14 @@ public abstract class StatefulEntity<T extends StatefulEntity<T>> extends Entity
 ```
 
 And similar to the `Entity`, the `StatefulEntity`'s Builder would also have a new method that sets the last update. By
-default, `updatedAt` would be initialized with `createAt`.
+default, `updatedAt` would be initialized with `createdAt`.
 
 _Note: the `StatefulEntity` class already has a `Clock` that can be moved up to the `Entity` and be re-used for this
 purpose._
 
 ### Mutating objects
 
-The `createAt` field would always be initialized during object creation. The `updatedAt` timestamp would be
+The `createdAt` field would always be initialized during object creation. The `updatedAt` timestamp would be
 updated by the _manipulating class_. That means, whichever class manipulates the `StatefulEntity` is also responsible
 for updating the `updatedAt` field. These are:
 
@@ -86,15 +86,15 @@ for updating the `updatedAt` field. These are:
 ### Persisting entities
 
 No action needs to be taken for the CosmosDB store as it is already document-based and persisting another field should
-be seamless. For the Postgres implementations the `createAt` and `updatedAt` fields should be of type `BIGINT`
+be seamless. For the Postgres implementations the `createdAt` and `updatedAt` fields should be of type `BIGINT`
 , for example (`TransferProcess`):
 
 ```postgresql
 
 CREATE TABLE IF NOT EXISTS edc_transfer_process
 (
-    created_time_stamp    BIGINT, -- already exists
-    updated_at            BIGINT  -- this is new
+    created_at    BIGINT, -- already exists (albeit with a different name)
+    updated_at    BIGINT  -- this is new
 
     -- other columns omitted
 );

--- a/docs/developer/decision-records/2022-08-01-entity-timestamp/README.md
+++ b/docs/developer/decision-records/2022-08-01-entity-timestamp/README.md
@@ -54,11 +54,11 @@ In addition, the `StatefulEntity` can be extended with a `updatedAt` field:
 public abstract class StatefulEntity<T extends StatefulEntity<T>> extends Entity implements TraceCarrier {
     private long updatedAt;
 
-    public long getLastUpdatedAt() {
+    public long getUpdatedAt() {
         return updatedAt;
     }
 
-    public void setLastUpdatedAt(long epochMillis) {
+    public void setUpdatedAt(long epochMillis) {
         updatedAt = epochMillis;
     }
     // ...
@@ -94,7 +94,7 @@ be seamless. For the Postgres implementations the `createAt` and `updatedAt` fie
 CREATE TABLE IF NOT EXISTS edc_transfer_process
 (
     created_time_stamp    BIGINT, -- already exists
-    last_update_timestamp BIGINT  -- this is new
+    updated_at            BIGINT  -- this is new
 
     -- other columns omitted
 );

--- a/docs/developer/decision-records/2022-08-01-entity-timestamp/README.md
+++ b/docs/developer/decision-records/2022-08-01-entity-timestamp/README.md
@@ -2,7 +2,7 @@
 
 ## Decision
 
-All objects in EDC, which can be persisted in a database, should have a `createdTimestamp` timestamp, all objects that
+All objects in EDC, which can be persisted in a database, should have a `createdAt` timestamp, all objects that
 are
 _mutable_ should also have a `lastUpdateTimestamp` timestamp. In this document they will be referred to as "business
 objects"

--- a/docs/developer/decision-records/2022-08-01-entity-timestamp/README.md
+++ b/docs/developer/decision-records/2022-08-01-entity-timestamp/README.md
@@ -45,20 +45,20 @@ both it and the `ContractAgreement` become _immutable_.
 ### Data model
 
 I propose extracting the `createdTimestamp` (plus the Builder infrastructure) into a new abstract classes `Entity`
-that is extended by _all_ entities, mutable and immutable. By default, the `createdTimestamp` is initialized with the
-current UTC epoch in milliseconds.
+(and renaming it to `createdAt`) that is extended by _all_ entities, mutable and immutable. By default, the `createAt`
+field is initialized with the current UTC epoch in milliseconds.
 
 In addition, the `StatefulEntity` can be extended with a `lastUpdateTimestamp` field:
 
 ```java
 public abstract class StatefulEntity<T extends StatefulEntity<T>> extends Entity implements TraceCarrier {
-    private long lastUpdateTimestamp;
+    private long lastUpdatedAt;
 
-    public long getLastUpdateTimestamp() {
+    public long getLastUpdatedAt() {
         return lastUpdateTimestamp;
     }
 
-    public void setLastUpdateTimestamp(long epochMillis) {
+    public void setLastUpdatedAt(long epochMillis) {
         lastUpdateTimestamp = epochMillis;
     }
     // ...
@@ -66,16 +66,16 @@ public abstract class StatefulEntity<T extends StatefulEntity<T>> extends Entity
 ```
 
 And similar to the `Entity`, the `StatefulEntity`'s Builder would also have a new method that sets the last update. By
-default, `lastUpdateTimestamp` would be initialized with `createdTimestamp`.
+default, `lastUpdateTimestamp` would be initialized with `createAt`.
 
 _Note: the `StatefulEntity` class already has a `Clock` that can be moved up to the `Entity` and be re-used for this
 purpose._
 
 ### Mutating objects
 
-The `createdTimestamp` field would always be initialized during object creation. The `lastUpdateTimestamp` timestamp
-would be updated by the _manipulating class_. That means, whichever class manipulates the `StatefulEntity` is also
-responsible for updating the `lastUpdateTimestamp` field. These are:
+The `createAt` field would always be initialized during object creation. The `lastUpdateTimestamp` timestamp would be
+updated by the _manipulating class_. That means, whichever class manipulates the `StatefulEntity` is also responsible
+for updating the `lastUpdateTimestamp` field. These are:
 
 - `TransferProcessManagerImpl`: right before `transferProcessStore.update()` is called
 - `SingleTransferProcessCommandHandler`: could be done in the `else` path of the `handle` method
@@ -86,8 +86,8 @@ responsible for updating the `lastUpdateTimestamp` field. These are:
 ### Persisting entities
 
 No action needs to be taken for the CosmosDB store as it is already document-based and persisting another field should
-be seamless. For the Postgres implementations the `createdTimestamp` and `lastUpdateTimestamp` fields should be of
-type `BIGINT`, for example (`TransferProcess`):
+be seamless. For the Postgres implementations the `createAt` and `lastUpdateTimestamp` fields should be of type `BIGINT`
+, for example (`TransferProcess`):
 
 ```postgresql
 

--- a/docs/developer/decision-records/2022-08-01-entity-timestamp/README.md
+++ b/docs/developer/decision-records/2022-08-01-entity-timestamp/README.md
@@ -45,7 +45,7 @@ both it and the `ContractAgreement` become _immutable_.
 ### Data model
 
 I propose extracting the `createdTimestamp` (plus the Builder infrastructure) into a new abstract classes `Entity`
-(and renaming it to `createdAt`) that is extended by _all_ entities, mutable and immutable. By default, the `createAt`
+(and renaming it to `createdAt`) that is extended by _all_ entities, mutable and immutable. By default, the `createdAt`
 field is initialized with the current UTC epoch in milliseconds.
 
 In addition, the `StatefulEntity` can be extended with a `lastUpdateTimestamp` field:

--- a/docs/developer/decision-records/2022-08-01-entity-timestamp/README.md
+++ b/docs/developer/decision-records/2022-08-01-entity-timestamp/README.md
@@ -1,0 +1,101 @@
+# Add creation and update timestamp
+
+## Decision
+
+All objects in EDC, which can be persisted in a database, should have a `createdTimestamp` timestamp, all objects that
+are
+_mutable_ should also have a `lastUpdateTimestamp` timestamp. In this document they will be referred to as "business
+objects"
+/"entities" and "mutable business objects"/"mutable entities" respectively
+
+## Rationale
+
+It should be possible to track the creation time and last-updated time for the aforementioned (mutable)
+entities, e.g. for auditing or for displaying purposes in a web frontend.
+
+The `createdTimestamp` timestamp must be immutable. It cannot be changed after the initial object construction. The
+`lastUpdateTimestamp` timestamp must be updated everytime the entity is put back into storage. This includes `save`
+operations that do not entail an actual change to the object.
+
+## Approach
+
+Both these timestamps are in Epoc milliseconds in Universal Coordinated Time (UTC), so obtaining the current time  
+would be done using `Clock.systemUTC().millis()`. This is in compliance with EDC usage of `java.time.Clock`.
+
+The following entities are considered _immutable_:
+
+- `Policy`/`PolicyDefinition`
+- `ContractDefinition`
+- `Asset`
+
+The following entities are considered _mutable_
+
+- `ContractNegotiation`
+- `TransferProcess`
+
+All entities that are effectively immutable, even though the might get re-persisted multiple times, are still
+considered _immutable_. They typically cannot exist on their own. For instance a `DataRequest` is always tied to the
+`TransferProcess` and cannot be changed once the transfer process has been created. By the same logic, a
+`ContractOffer` - once received by either party - is considered immutable and any counter-offer triggers the creation of
+a copy.
+
+Similarly, once a `ContractNegotiation` is in the `CONFIRMED` state, i.e. there is a `ContractAgreement` attached to it,
+both it and the `ContractAgreement` become _immutable_.
+
+### Data model
+
+I propose extracting the `createdTimestamp` (plus the Builder infrastructure) into a new abstract classes `Entity`
+that is extended by _all_ entities, mutable and immutable. By default, the `createdTimestamp` is initialized with the
+current UTC epoch in milliseconds.
+
+In addition, the `StatefulEntity` can be extended with a `lastUpdateTimestamp` field:
+
+```java
+public abstract class StatefulEntity<T extends StatefulEntity<T>> extends Entity implements TraceCarrier {
+    private long lastUpdateTimestamp;
+
+    public long getLastUpdateTimestamp() {
+        return lastUpdateTimestamp;
+    }
+
+    public void setLastUpdateTimestamp(long epochMillis) {
+        lastUpdateTimestamp = epochMillis;
+    }
+    // ...
+}
+```
+
+And similar to the `Entity`, the `StatefulEntity`'s Builder would also have a new method that sets the last update. By
+default, `lastUpdateTimestamp` would be initialized with `createdTimestamp`.
+
+_Note: the `StatefulEntity` class already has a `Clock` that can be moved up to the `Entity` and be re-used for this
+purpose._
+
+### Mutating objects
+
+The `createdTimestamp` field would always be initialized during object creation. The `lastUpdateTimestamp` timestamp
+would be updated by the _manipulating class_. That means, whichever class manipulates the `StatefulEntity` is also
+responsible for updating the `lastUpdateTimestamp` field. These are:
+
+- `TransferProcessManagerImpl`: right before `transferProcessStore.update()` is called
+- `SingleTransferProcessCommandHandler`: could be done in the `else` path of the `handle` method
+- `[Consumer|Provider]ContractNegotiationManagerImpl`: right before `negotiationStore.save()` is called. could be
+  extracted into the `AbstractContractNegotiationManager`
+- `SingleContractNegotiationCommandHandler`: could be done in the `else` path of the `handle` method
+
+### Persisting entities
+
+No action needs to be taken for the CosmosDB store as it is already document-based and persisting another field should
+be seamless. For the Postgres implementations the `createdTimestamp` and `lastUpdateTimestamp` fields should be of
+type `BIGINT`, for example (`TransferProcess`):
+
+```postgresql
+
+CREATE TABLE IF NOT EXISTS edc_transfer_process
+(
+    created_time_stamp    BIGINT, -- already exists
+    last_update_timestamp BIGINT  -- this is new
+
+    -- other columns omitted
+);
+```

--- a/docs/developer/decision-records/2022-08-01-entity-timestamp/README.md
+++ b/docs/developer/decision-records/2022-08-01-entity-timestamp/README.md
@@ -13,7 +13,7 @@ objects"
 It should be possible to track the creation time and last-updated time for the aforementioned (mutable)
 entities, e.g. for auditing or for displaying purposes in a web frontend.
 
-The `createdTimestamp` timestamp must be immutable. It cannot be changed after the initial object construction. The
+The `createdAt` timestamp must be immutable. It cannot be changed after the initial object construction. The
 `updatedAt` timestamp must be updated everytime the entity is put back into storage. This includes `save`
 operations that do not entail an actual change to the object.
 

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataRequest.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataRequest.java
@@ -70,19 +70,19 @@ public class DataRequest implements RemoteMessage, Polymorphic {
     }
 
     /**
-     * The protocol-specific address of the other connector.
-     */
-    @Override
-    public String getConnectorAddress() {
-        return connectorAddress;
-    }
-
-    /**
      * The protocol over which the data request is sent to the provider connector.
      */
     @Override
     public String getProtocol() {
         return protocol;
+    }
+
+    /**
+     * The protocol-specific address of the other connector.
+     */
+    @Override
+    public String getConnectorAddress() {
+        return connectorAddress;
     }
 
     /**
@@ -129,22 +129,6 @@ public class DataRequest implements RemoteMessage, Polymorphic {
 
     public boolean isManagedResources() {
         return managedResources;
-    }
-
-    public DataRequest copy(String newId) {
-        return Builder.newInstance()
-                .id(newId)
-                .processId(processId)
-                .connectorAddress(connectorAddress)
-                .protocol(protocol)
-                .connectorId(connectorId)
-                .assetId(assetId)
-                .contractId(contractId)
-                .dataAddress(dataDestination)
-                .transferType(transferType)
-                .managedResources(managedResources)
-                .properties(properties)
-                .build();
     }
 
     public void updateDestination(DataAddress dataAddress) {


### PR DESCRIPTION
## What this PR changes/adds

Adds a decision record about how all or EDC entities will get a `createTimestamp` and an `lastUpdateTimestamp`.


## Why it does that

Traceability, auditability.

## Further notes
removed an unused method in `DataRequest.java`

## Linked Issue(s)

Documents #1370 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [x] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
