### PR TITLE
fix(sql): map contractnegotiation type

### DIFF
--- a/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -336,6 +336,8 @@ public class SqlContractNegotiationStore implements ContractNegotiationStore {
                 .errorDetail(resultSet.getString(statements.getErrorDetailColumn()))
                 .traceContext(fromJson(resultSet.getString(statements.getTraceContextColumn()), new TypeReference<>() {
                 }))
+                // will throw an exception if the value is outside the Type.values() range
+                .type(ContractNegotiation.Type.values()[resultSet.getInt(statements.getTypeColumn())])
                 .build();
     }
 

--- a/extensions/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStoreTest.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStoreTest.java
@@ -54,6 +54,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.dataspaceconnector.sql.contractnegotiation.TestFunctions.createContract;
 import static org.eclipse.dataspaceconnector.sql.contractnegotiation.TestFunctions.createContractBuilder;
 import static org.eclipse.dataspaceconnector.sql.contractnegotiation.TestFunctions.createNegotiation;
+import static org.eclipse.dataspaceconnector.sql.contractnegotiation.TestFunctions.createNegotiationBuilder;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -179,7 +180,9 @@ class SqlContractNegotiationStoreTest {
     @Test
     @DisplayName("Verify that entity is stored")
     void save() {
-        var negotiation = createNegotiation("test-id1");
+        var negotiation = createNegotiationBuilder("test-id1")
+                .type(ContractNegotiation.Type.PROVIDER)
+                .build();
         store.save(negotiation);
 
         assertThat(store.find(negotiation.getId()))


### PR DESCRIPTION
## What this PR changes/adds

Correctly maps the `ContractNegotiation#type` field when reading from SQL storage

## Why it does that

it did not get mapped before.

## Further notes

- the `Type.values()[VALUE]` is used. An `ArrayIndexOutOfBoundException` is thrown when the DB value is out-of-range.

## Linked Issue(s)

Closes #1766 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
