### PR TITLE
chore: remove `no-changelog` label from dependabot PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/adoption_request.md
+++ b/.github/ISSUE_TEMPLATE/adoption_request.md
@@ -9,12 +9,9 @@ assignees: ''
 
 # Adoption Request
 
-_Thank you for wanting to contribute to the project! We are very happy to see the functionalities of the
-EDC being extended. Providing this open-source is a great opportunity for others with similar requirements
-and to avoid additional work._
+_Thank you for wanting to contribute to the project! We are very happy to see the functionalities of the EDC being extended. Providing this open-source is a great opportunity for others with similar requirements and to avoid additional work._
 
-_For any details about the guidelines for submitting features, please take a look at the
-[contribution categories](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/contribution_categories.md)._
+_For any details about the guidelines for submitting features, please take a look at the [contribution categories](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/contribution_categories.md)._
 
 
 ## General information
@@ -22,8 +19,7 @@ _For any details about the guidelines for submitting features, please take a loo
 Please provide some information about your project or code contribution. 
 
 _If you choose to be referenced as a "friend", these will be added to the [known friends list](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/known_friends.md)._
-_If you choose to add your feature as a core EDC component, links to your current code and correlated issues,
-discussions, and pull requests are of great importance._
+_If you choose to add your feature as a core EDC component, links to your current code and correlated issues, discussions, and pull requests are of great importance._
 
 | Title | Description | Contact | Links
 | :--- | :--- | :--- | :---
@@ -37,7 +33,7 @@ Next, please tell us what level of adoption you intend to provide. _(pick only o
 - [ ] Reference a feature as "friend"
 - [ ] Incorporate a feature as core EDC component
 
----
+
 
 ## Adoption in EDC core
 
@@ -47,26 +43,16 @@ _If you chose to add your feature as a core EDC component, please answer the fol
 _Please argue why this feature must be hosted upstream and be maintained by the EDC core team._
 
 ### Could it be achieved with existing functionality? If not, why?
-_If there is any existing code that can achieve the same thing with little modification, that is usually
-the preferable way for the EDC core team. We aim to keep the code succinct and want to avoid similar/duplicate
-code. Make sure you understand the EDC code base well!_
+_If there is any existing code that can achieve the same thing with little modification, that is usually the preferable way for the EDC core team. We aim to keep the code succinct and want to avoid similar/duplicate code. Make sure you understand the EDC code base well!_
 
 ### Are there multiple use cases or applications who will benefit from the contribution?
-_Basically, we want you to motivate who will use that feature and why, thereby arguing the fact that it
-is well-suited to be adopted in the core code base. One-off features are better suited to be maintained
-externally._
+_Basically, we want you to motivate who will use that feature and why, thereby arguing the fact that it is well-suited to be adopted in the core code base. One-off features are better suited to be maintained externally._
 
 ### Can it be achieved without introducing third-party dependencies? If not, which ones?
-_EDC is a platform rather than an application, therefore we are extremely careful when it comes to introducing
-third party libraries. The reasons are diverse: security, license issues and over all JAR weight, just to
-mention a few important ones._
+_EDC is a platform rather than an application, therefore we are extremely careful when it comes to introducing third party libraries. The reasons are diverse: security, license issues and over all JAR weight, just to mention a few important ones._
 
 ### Would this feature limit platform independence in any way? If so, how and why?
-_Features that do not work well in clustered environments are difficult to adopt, since EDC is designed
-from the ground up to be stateless and clusterable. Similarly, features, that have dependencies onto certain
-operating systems are difficult to argue._
+_Features that do not work well in clustered environments are difficult to adopt, since EDC is designed from the ground up to be stateless and clusterable. Similarly, features, that have dependencies onto certain operating systems are difficult to argue._
 
 ### Is it going to be a self-contained feature, or would it cut across the entire code base?
-_Features that have a large impact on the code base are very complex to thoroughly test, they have a
-high chance to destabilize the code and require careful inspection. Self-contained features on the other
-hand are easier to isolate and test._
+_Features that have a large impact on the code base are very complex to thoroughly test, they have a high chance to destabilize the code and require careful inspection. Self-contained features on the other hand are easier to isolate and test._

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,8 +9,7 @@ assignees: ''
 
 # Feature Request
 
-_If you are missing a feature or have an idea how to improve this project that should first be 
-discussed, please feel free to open up a [discussion](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/discussions/categories/ideas)._
+_If you are missing a feature or have an idea how to improve this project that should first be discussed, please feel free to open up a [discussion](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/discussions/categories/ideas)._
 
 ## Which Areas Would Be Affected?
 _e.g., DPF, CI, build, transfer, etc._

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,8 +8,7 @@ _Briefly state why the change was necessary._
 
 ## Further notes
 
-_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
-signature changes, package declarations, bugs that were encountered and were fixed inline, etc._
+_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._
 
 ## Linked Issue(s)
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
     labels:
       - "dependencies"
       - "github_actions"
-      - "no-changelog"
 
   # maintain dependencies for Gradle
   - package-ecosystem: "gradle" # checks build.gradle(.kts) and settings.gradle(.kts)
@@ -20,4 +19,3 @@ updates:
     labels:
       - "dependencies"
       - "java"
-      - "no-changelog"

--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -15,7 +15,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           issue-message: 'Thanks for your contribution :fire: We will take a look asap :rocket:'
           pr-message: >-
-            'We are always happy to welcome new contributors :heart: To make things easier for everyone, please
-            - make sure to follow our [contribution guidelines](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md),
-            - check if you have already signed the [ECA](http://www.eclipse.org/legal/ecafaq.php), and
-            - relate this pull request to an existing issue or discussion.'
+            We are always happy to welcome new contributors :heart: To make things easier for everyone, please
+            make sure to follow our [contribution guidelines](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md),
+            check if you have already signed the [ECA](http://www.eclipse.org/legal/ecafaq.php), and
+            relate this pull request to an existing issue or discussion.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,12 +3,13 @@
 # Please note that this file does not represent all contributions to the code. What persons and organizations
 # actually contributed to each file can be seen on GitHub and is documented in the license headers.
 
+# Linked persons with write permissions are automatically added as reviewers when a pull request is opened.
+
 # Each line is a file pattern followed by one or more contact persons. The last matching pattern has the most precedence.
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
-# The linked persons are automatically added as reviewers when a pull request is opened.
-
 CONTRIBUTING.md @MoritzKeppler @juliapampus @alexandrudanciu @mspiekermann
+contribution_categories.md @paullatzelsperger @mspiekermann
 LICENSE @MoritzKeppler @juliapampus @alexandrudanciu @mspiekermann
 NOTICE.md @alexandrudanciu @mspiekermann
 onboarding.md @paullatzelsperger
@@ -29,12 +30,14 @@ styleguide.md @paullatzelsperger
 
 /core/base/agent/ @jimmarino
 /core/base/policy/ @jimmarino
-/core/base/health/ @paullatzelsperger
 /core/boot/ @jimmarino @paullatzelsperger
 /core/contract/ @jimmarino @juliapampus @ronjaquensel
 /core/defaults/ @paullatzelsperger
+/core/event/ @ndr-brt
+/core/health/ @paullatzelsperger
 /core/micrometer/ @algattik
 /core/policy/ @jimmarino
+/core/security/ @bscholtes1A
 /core/transfer/ @jimmarino @bscholtes1A @paullatzelsperger @ndr-brt
 
 /data-protocols/ids/ @ronjaquensel @juliapampus @DominikPinsel @denisneuling
@@ -50,29 +53,24 @@ styleguide.md @paullatzelsperger
 /extensions/data-plane-selector/ @paullatzelsperger
 /extensions/data-plane-transfer/ @bscholtes1A
 /extensions/dataloading/ @paullatzelsperger
+/extensions/events/ @ndr-brt
 /extensions/filesystem/ @jimmarino @paullatzelsperger
 /extensions/http/ @paullatzelsperger
 /extensions/http-provisioner/ @jimmarino @paullatzelsperger
 /extensions/http-receiver/ @bscholtes1A
 /extensions/iam/daps/ @bscholtes1A
 /extensions/iam/decentralized-identity/ @paullatzelsperger
-/extensions/iam/iam-mock/ @jimmarino
-/extensions/iam/oauth2/ @bscholtes1A @jimmarino
+/extensions/iam/oauth2/ @bscholtes1A
 /extensions/jdk-logger-monitor/ @cpeeyush
-/extensions/policy/ @ndr-brt
 /extensions/sql/ @bcronin90 @denisneuling @paullatzelsperger
 /extensions/transaction/ @jimmarino
-/extensions/transfer-functions/ @jimmarino
 
 /launchers/data-loader-cli/ @paullatzelsperger @ronjaquensel
 /launchers/data-plane-server/ @bscholtes1A
 /launchers/dpf-selector/ @paullatzelsperger
 /launchers/ids-connector/ @ronjaquensel
-/launchers/junit/ @jimmarino @paullatzelsperger @algattik @ndr-brt
-/launchers/registration-service-app/ @paullatzelsperger
 
-/resources/charts/ @algattik
-/resources/openapi/ @paullatzelsperger
+/resources/ @paullatzelsperger
 
 /samples/01-basic-connector/ @paullatzelsperger
 /samples/02-health-endpoint/ @paullatzelsperger
@@ -90,3 +88,5 @@ styleguide.md @paullatzelsperger
 /system-tests/minikube/ @algattik
 /system-tests/runtimes/ @algattik
 /system-tests/tests/ @algattik
+
+/tooling/ @jimmarino

--- a/docs/developer/decision-records/README.md
+++ b/docs/developer/decision-records/README.md
@@ -27,3 +27,4 @@
 - [2022-07-22 Simplify FCC](2022-07-22-simplify-fcc/README.md)
 - [2022-07-27 Custom DTO validation](2022-07-27-custom-dto-validation/README.md)
 - [2022-07-28 "Provisioning Requested" TransferProcess new state](2022-07-28-transfer-process-new-state/README.md)
+- [2022-08-01 Entity Timestamp](2022-08-01-entity-timestamp/README.md)


### PR DESCRIPTION
## What this PR changes/adds

Removes `no-changelog` label from dependabot PRs.

## Why it does that

Exclusion from the changelog should not be decided by the action itself. (it may be interesting to have this information included in the release notes)

## Further notes

Little housekeeping of `CODEOWNERS`, docs and templates

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
