### PR TITLE
fix: avoid cyclic dependency

### DIFF
--- a/core/base/build.gradle.kts
+++ b/core/base/build.gradle.kts
@@ -32,8 +32,8 @@ dependencies {
     implementation(project(":core:policy:policy-engine"))
     implementation(project(":extensions:dataloading"))
 
-    implementation("com.squareup.okhttp3:okhttp:${okHttpVersion}")
-    implementation("dev.failsafe:failsafe:${failsafeVersion}")
+    api("com.squareup.okhttp3:okhttp:${okHttpVersion}")
+    api("dev.failsafe:failsafe:${failsafeVersion}")
     implementation("org.bouncycastle:bcpkix-jdk15on:${bouncycastleVersion}")
 
     testImplementation(project(":extensions:junit"))

--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/defaults/DefaultServicesExtension.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/defaults/DefaultServicesExtension.java
@@ -14,7 +14,11 @@
 
 package org.eclipse.dataspaceconnector.core.defaults;
 
+import dev.failsafe.RetryPolicy;
+import okhttp3.EventListener;
+import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.common.concurrency.LockManager;
+import org.eclipse.dataspaceconnector.core.base.OkHttpClientFactory;
 import org.eclipse.dataspaceconnector.core.defaults.assetindex.InMemoryAssetIndex;
 import org.eclipse.dataspaceconnector.core.defaults.contractdefinition.InMemoryContractDefinitionStore;
 import org.eclipse.dataspaceconnector.core.defaults.negotiationstore.InMemoryContractNegotiationStore;
@@ -22,11 +26,13 @@ import org.eclipse.dataspaceconnector.core.defaults.policystore.InMemoryPolicyDe
 import org.eclipse.dataspaceconnector.core.defaults.transferprocessstore.InMemoryTransferProcessStore;
 import org.eclipse.dataspaceconnector.dataloading.AssetLoader;
 import org.eclipse.dataspaceconnector.dataloading.ContractDefinitionLoader;
+import org.eclipse.dataspaceconnector.spi.EdcSetting;
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyDefinitionStore;
+import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.Provider;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
@@ -34,6 +40,7 @@ import org.eclipse.dataspaceconnector.spi.transaction.NoopTransactionContext;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 
+import java.time.temporal.ChronoUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
@@ -41,11 +48,35 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * Provider methods are only invoked if no other implementation was found on the classpath.
  */
 public class DefaultServicesExtension implements ServiceExtension {
+    @EdcSetting(value = "Maximum retries for the retry policy before a failure is propagated")
+    public static final String MAX_RETRIES = "edc.core.retry.retries.max";
+    @EdcSetting(value = "Minimum number of milliseconds for exponential backoff")
+    public static final String BACKOFF_MIN_MILLIS = "edc.core.retry.backoff.min";
+    @EdcSetting(value = "Maximum number of milliseconds for exponential backoff. ")
+    public static final String BACKOFF_MAX_MILLIS = "edc.core.retry.backoff.max";
 
     private InMemoryAssetIndex assetIndex;
     private InMemoryContractDefinitionStore contractDefinitionStore;
+    /**
+     * An optional OkHttp {@link EventListener} that can be used to instrument OkHttp client for collecting metrics.
+     * Used by the optional {@code micrometer} module.
+     */
+    @Inject(required = false)
+    private EventListener okHttpEventListener;
 
     public DefaultServicesExtension() {
+    }
+
+    @Provider
+    public RetryPolicy<?> retryPolicy(ServiceExtensionContext context) {
+        var maxRetries = context.getSetting(MAX_RETRIES, 5);
+        var minBackoff = context.getSetting(BACKOFF_MIN_MILLIS, 500);
+        var maxBackoff = context.getSetting(BACKOFF_MAX_MILLIS, 10_000);
+
+        return RetryPolicy.builder()
+                .withMaxRetries(maxRetries)
+                .withBackoff(minBackoff, maxBackoff, ChronoUnit.MILLIS)
+                .build();
     }
 
     @Provider(isDefault = true)
@@ -92,6 +123,12 @@ public class DefaultServicesExtension implements ServiceExtension {
     public TransactionContext defaultTransactionContext(ServiceExtensionContext context) {
         context.getMonitor().warning("No TransactionContext registered, a no-op implementation will be used, not suitable for production environments");
         return new NoopTransactionContext();
+    }
+
+
+    @Provider
+    public OkHttpClient okHttpClient(ServiceExtensionContext context) {
+        return OkHttpClientFactory.create(context, okHttpEventListener);
     }
 
     private ContractDefinitionStore getContractDefinitionStore() {


### PR DESCRIPTION
## What this PR changes/adds

This PR moves the factory methods for `RetryPolicy` and `OkHttpClient` from the `CoreServicesExtension` --> `DefaultServicesExtension`.

## Why it does that

This is to avoid cyclic dependencies when attempting to `@Inject` either of these two into an extension, onto which the `CoreServicesExtension` in turn has a dependency, e.g. a `Vault` extension (it surfaced during #1534).

## Further notes

~~The two new `@Provider` methods were attributed as default providers (`isDefault=true`) to allow any other extension to override them.~~
[edit] removed the `isDefault` again, this caused problems with system tests


## Linked Issue(s)

Closes #1775 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
