### PR TITLE
feat: introduce sync subscribers on EventRouter

### DIFF
--- a/docs/developer/events.md
+++ b/docs/developer/events.md
@@ -6,6 +6,16 @@ emitted from the core of the EDC and also emit custom events.
 ## Subscribe to events
 The entry point for event listening is the `EventRouter` component, on which an `EventSubscriber` can be registered.
 
+Actually, there are two ways to register an `EventSubscriber`:
+- **async**: every event will be sent to the subscriber in an asynchronous way. Features:
+  - fast, as the main thread won't be blocked during dispatchment. 
+  - not-reliable, as an eventual subscriber dispatch failure won't get handled.
+  - to be used for notifications and for send-and-forget event dispatchment.
+- **sync**: every event will be sent to the subscriber in a synchronous way. Features:
+  - slow, as the subscriber will block the main thread until the event is dispatched
+  - reliable, an eventual exception will be thrown to the caller, and it could make a transactional context fail
+  - to be used for event persistence and to satisfy the "at-least-one" rule.
+
 Extension example:
 ```java
 public class ExampleEventSubscriptionExtension implements ServiceExtension {
@@ -14,7 +24,8 @@ public class ExampleEventSubscriptionExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        eventRouter.register(new ExampleEventSubscriber());
+        eventRouter.register(new ExampleEventSubscriber()); // asynchronous dispatch
+        eventRouter.registerSync(new ExampleEventSubscriber()); // synchronous dispatch
     }
 }
 ```

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/EventRouter.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/EventRouter.java
@@ -21,7 +21,16 @@ package org.eclipse.dataspaceconnector.spi.event;
 public interface EventRouter {
 
     /**
-     * Register a new subscriber to the events
+     * Register a new synchronous subscriber.
+     * The synchronous subscribers are supposed to being notified before the standard subscribers in a synchronous way.
+     * If a synchronous subscriber thrown an exception, this will stop the publish operation.
+     *
+     * @param subscriber that will receive every published event
+     */
+    void registerSync(EventSubscriber subscriber);
+
+    /**
+     * Register a new asynchronous subscriber to the events
      *
      * @param subscriber that will receive every published event
      */


### PR DESCRIPTION
## What this PR changes/adds

Introduce sync subscribers on `EventRouter`

## Why it does that

To permit reliable event dispatch

## Further notes

-

## Linked Issue(s)

Closes #1774

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
