### PR TITLE
feat: adds attribute to influence injection order DO NOT REVIEW

### DIFF
--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/injection/InjectorImpl.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/injection/InjectorImpl.java
@@ -18,8 +18,11 @@ import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.system.injection.EdcInjectionException;
 import org.eclipse.dataspaceconnector.spi.system.injection.InjectionContainer;
+import org.eclipse.dataspaceconnector.spi.system.injection.InjectionPoint;
 import org.eclipse.dataspaceconnector.spi.system.injection.Injector;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -47,7 +50,12 @@ public final class InjectorImpl implements Injector {
     public <T> T inject(InjectionContainer<T> container, ServiceExtensionContext context) {
         var monitor = context.getMonitor();
 
-        container.getInjectionPoints().forEach(ip -> {
+        var injectionPoints = container.getInjectionPoints();
+
+        var sortedList = new ArrayList<>(injectionPoints);
+        sortedList.sort(Comparator.comparingInt(InjectionPoint::getOrder));
+
+        sortedList.forEach(ip -> {
             try {
                 Object service = resolveService(context, ip.getType(), ip.isRequired());
                 if (service != null) { //can only be if not required

--- a/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtension.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtension.java
@@ -65,7 +65,7 @@ public class IdentityDidCoreExtension implements ServiceExtension {
     @Inject
     private DidResolverRegistry didResolverRegistry;
 
-    @Inject
+    @Inject(order = 10)
     private DidPublicKeyResolver publicKeyResolver;
 
     @Override
@@ -109,14 +109,15 @@ public class IdentityDidCoreExtension implements ServiceExtension {
         return new InMemoryDidDocumentStore(clock);
     }
 
-    @Provider(isDefault = true)
-    public DidResolverRegistry defaultDidResolverRegistry() {
-        return new DidResolverRegistryImpl();
-    }
 
     @Provider(isDefault = true)
     public DidPublicKeyResolver defaultDidPublicKeyResolver() {
         return new DidPublicKeyResolverImpl(didResolverRegistry);
+    }
+
+    @Provider(isDefault = true)
+    public DidResolverRegistry defaultDidResolverRegistry() {
+        return new DidResolverRegistryImpl();
     }
 
     private void registerParsers(PrivateKeyResolver resolver) {

--- a/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtension.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtension.java
@@ -44,6 +44,7 @@ import org.eclipse.dataspaceconnector.spi.system.health.HealthCheckResult;
 import org.eclipse.dataspaceconnector.spi.system.health.HealthCheckService;
 
 import java.time.Clock;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 
@@ -112,7 +113,7 @@ public class IdentityDidCoreExtension implements ServiceExtension {
 
     @Provider(isDefault = true)
     public DidPublicKeyResolver defaultDidPublicKeyResolver() {
-        return new DidPublicKeyResolverImpl(didResolverRegistry);
+        return new DidPublicKeyResolverImpl(Objects.requireNonNull(didResolverRegistry));
     }
 
     @Provider(isDefault = true)

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/Inject.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/Inject.java
@@ -30,4 +30,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Inject {
     boolean required() default true;
+
+    int order() default 0;
 }

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/injection/FieldInjectionPoint.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/injection/FieldInjectionPoint.java
@@ -31,17 +31,23 @@ public class FieldInjectionPoint<T> implements InjectionPoint<T> {
     private final Field injectedField;
     private final String featureString;
     private final boolean isRequired;
+    private final int order;
 
     public FieldInjectionPoint(T instance, Field injectedField, String featureString) {
         this(instance, injectedField, featureString, true);
     }
 
     public FieldInjectionPoint(T instance, Field injectedField, String featureString, boolean isRequired) {
+        this(instance, injectedField, featureString, isRequired, 0);
+    }
+
+    public FieldInjectionPoint(T instance, Field injectedField, String featureString, boolean isRequired, int order) {
         this.instance = instance;
         this.injectedField = injectedField;
         this.injectedField.setAccessible(true);
         this.featureString = featureString;
         this.isRequired = isRequired;
+        this.order = order;
     }
 
     @Override
@@ -64,6 +70,10 @@ public class FieldInjectionPoint<T> implements InjectionPoint<T> {
         return isRequired;
     }
 
+    public int getOrder() {
+        return order;
+    }
+
     @Override
     public void setTargetValue(Object service) throws IllegalAccessException {
         injectedField.set(instance, service);
@@ -71,6 +81,6 @@ public class FieldInjectionPoint<T> implements InjectionPoint<T> {
 
     @Override
     public String toString() {
-        return format("Field \"%s\" of type [%s] required by %s", injectedField.getName(), getType(), instance.getClass().getName());
+        return format("Field \"%s\" (order = %d) of type [%s] required by %s", injectedField.getName(), getOrder(), getType(), instance.getClass().getName());
     }
 }

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/injection/InjectionPoint.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/injection/InjectionPoint.java
@@ -28,5 +28,7 @@ public interface InjectionPoint<T> {
 
     boolean isRequired();
 
+    int getOrder();
+
     void setTargetValue(Object service) throws IllegalAccessException;
 }

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/injection/InjectionPointScanner.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/injection/InjectionPointScanner.java
@@ -33,7 +33,8 @@ public class InjectionPointScanner {
                 .filter(f -> f.getAnnotation(Inject.class) != null)
                 .map(f -> {
                     var isRequired = f.getAnnotation(Inject.class).required();
-                    return new FieldInjectionPoint<>(instance, f, f.getType().getName(), isRequired);
+                    var order = f.getAnnotation(Inject.class).order();
+                    return new FieldInjectionPoint<>(instance, f, f.getType().getName(), isRequired, order);
                 })
                 .collect(Collectors.toSet());
     }


### PR DESCRIPTION
## What this PR changes/adds

This PR introduces an attribute for the `@Inject` annotation, with which the order, in which the fields are injected, can be influenced.

Higher numbers mean it will be initialized later.

## Why it does that

This can be helpful if multiple fields injections are satisfied by `@Provider(isDefault=true)` methods which depend on each other.


## Further notes

- the default order is 0

## Linked Issue(s)
.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
