### PR TITLE
fix: remove logging of api key from TokenBasedAuthenticationExtension

### DIFF
--- a/extensions/api/auth-tokenbased/src/main/java/org/eclipse/dataspaceconnector/api/auth/TokenBasedAuthenticationExtension.java
+++ b/extensions/api/auth-tokenbased/src/main/java/org/eclipse/dataspaceconnector/api/auth/TokenBasedAuthenticationExtension.java
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
  *       Mercedes-Benz Tech Innovation GmbH - add README.md; authentication key can be retrieved from vault
+ *       Fraunhofer Institute for Software and Systems Engineering - update monitor info
  *
  */
 
@@ -23,8 +24,6 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
 import java.util.UUID;
-
-import static java.lang.String.format;
 
 /**
  * Extension that registers an AuthenticationService that uses API Keys
@@ -42,12 +41,15 @@ public class TokenBasedAuthenticationExtension implements ServiceExtension {
     private Vault vault;
 
     @Override
-    public void initialize(ServiceExtensionContext context) {
+    public String name() {
+        return "Static token API Authentication";
+    }
 
+    @Override
+    public void initialize(ServiceExtensionContext context) {
         String apiKey = null;
 
         var apiKeyAlias = context.getSetting(AUTH_SETTING_APIKEY_ALIAS, null);
-
         if (apiKeyAlias != null) {
             apiKey = vault.resolveSecret(apiKeyAlias);
         }
@@ -56,9 +58,6 @@ public class TokenBasedAuthenticationExtension implements ServiceExtension {
             apiKey = context.getSetting(AUTH_SETTING_APIKEY, UUID.randomUUID().toString());
         }
 
-        context.getMonitor().info(format("API Authentication: using static API Key '%s'", apiKey));
-
-        var authService = new TokenBasedAuthenticationService(apiKey);
-        context.registerService(AuthenticationService.class, authService);
+        context.registerService(AuthenticationService.class, new TokenBasedAuthenticationService(apiKey));
     }
 }

--- a/extensions/api/data-management/api-configuration/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/configuration/DataManagementApiConfigurationExtension.java
+++ b/extensions/api/data-management/api-configuration/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/configuration/DataManagementApiConfigurationExtension.java
@@ -54,7 +54,7 @@ public class DataManagementApiConfigurationExtension implements ServiceExtension
         var path = "/api";
         var config = context.getConfig(WEB_DATA_CONFIG);
         if (config.getEntries().isEmpty()) {
-            monitor.warning("No [web.http.data.port] or [web.http.data.path] configuration has been provided, therefor the default will be used. " +
+            monitor.warning("No [web.http.data.port] or [web.http.data.path] configuration has been provided, therefore the default will be used. " +
                     "This means that the AuthenticationRequestFilter and the EdcApiExceptionMapper " + "will also be registered for the default context and fire for EVERY request on that context!");
         } else {
             contextAlias = "data";


### PR DESCRIPTION
## What this PR changes/adds

Removes plain key from log line.

## Why it does that

Password shouldn't be part of the log file

## Further notes

--

## Linked Issue(s)

Closes #1780

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
