### PR TITLE
chore(IdsMultipartSender): use default object mapper for data reference serialization

### DIFF
--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/IdsMultipartDispatcherServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/IdsMultipartDispatcherServiceExtension.java
@@ -78,6 +78,7 @@ public class IdsMultipartDispatcherServiceExtension implements ServiceExtension 
         var idsWebhookAddress = idsApiConfiguration.getIdsWebhookAddress();
 
         var objectMapper = context.getTypeManager().getMapper("ids");
+        var typeManager = context.getTypeManager();
 
         var dispatcher = new IdsMultipartRemoteMessageDispatcher();
         dispatcher.register(new MultipartArtifactRequestSender(connectorId, httpClient, objectMapper, monitor, vault, identityService, transformerRegistry, idsWebhookAddress));
@@ -86,7 +87,7 @@ public class IdsMultipartDispatcherServiceExtension implements ServiceExtension 
         dispatcher.register(new MultipartContractAgreementSender(connectorId, httpClient, objectMapper, monitor, identityService, transformerRegistry, idsWebhookAddress));
         dispatcher.register(new MultipartContractRejectionSender(connectorId, httpClient, objectMapper, monitor, identityService, transformerRegistry));
         dispatcher.register(new MultipartCatalogDescriptionRequestSender(connectorId, httpClient, objectMapper, monitor, identityService, transformerRegistry));
-        dispatcher.register(new MultipartEndpointDataReferenceRequestSender(connectorId, httpClient, objectMapper, monitor, identityService, transformerRegistry));
+        dispatcher.register(new MultipartEndpointDataReferenceRequestSender(connectorId, httpClient, objectMapper, monitor, identityService, transformerRegistry, typeManager));
 
         dispatcherRegistry.register(dispatcher);
     }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/IdsMultipartSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/IdsMultipartSender.java
@@ -326,7 +326,7 @@ abstract class IdsMultipartSender<M extends RemoteMessage, R> implements IdsMess
     private void checkResponseType(@NotNull MultipartResponse<?> response) {
         var type = getAllowedResponseTypes();
         if (!type.contains(response.getHeader().getClass())) {
-            throw new EdcException("Received unexpected response type.");
+            throw new EdcException(String.format("Received %s but expected %s.", response.getHeader().getClass(), type));
         }
     }
 

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartEndpointDataReferenceRequestSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartEndpointDataReferenceRequestSender.java
@@ -27,6 +27,7 @@ import org.eclipse.dataspaceconnector.ids.spi.domain.IdsConstants;
 import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTransformerRegistry;
 import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.edr.EndpointDataReferenceMessage;
 import org.jetbrains.annotations.NotNull;
 
@@ -41,14 +42,18 @@ import static org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender
  * expects an IDS MessageProcessedMessage as the response.
  */
 public class MultipartEndpointDataReferenceRequestSender extends IdsMultipartSender<EndpointDataReferenceMessage, String> {
+    private final TypeManager typeManager;
 
     public MultipartEndpointDataReferenceRequestSender(@NotNull String connectorId,
                                                        @NotNull OkHttpClient httpClient,
                                                        @NotNull ObjectMapper objectMapper,
                                                        @NotNull Monitor monitor,
                                                        @NotNull IdentityService identityService,
-                                                       @NotNull IdsTransformerRegistry transformerRegistry) {
+                                                       @NotNull IdsTransformerRegistry transformerRegistry,
+                                                       @NotNull TypeManager typeManager) {
         super(connectorId, httpClient, objectMapper, monitor, identityService, transformerRegistry);
+
+        this.typeManager = typeManager;
     }
 
     @Override
@@ -88,7 +93,8 @@ public class MultipartEndpointDataReferenceRequestSender extends IdsMultipartSen
      */
     @Override
     protected String buildMessagePayload(EndpointDataReferenceMessage request) throws Exception {
-        return getObjectMapper().writeValueAsString(request.getEndpointDataReference());
+        // Note: EndpointDataReference is not an IDS object, so there is no need to serialize is with the IDS object mapper
+        return typeManager.writeValueAsString(request.getEndpointDataReference());
     }
 
     /**

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartEndpointDataReferenceRequestSenderTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartEndpointDataReferenceRequestSenderTest.java
@@ -55,9 +55,10 @@ class MultipartEndpointDataReferenceRequestSenderTest {
         var transformerRegistry = mock(IdsTransformerRegistry.class);
         var identityService = mock(IdentityService.class);
 
-        mapper = IdsTypeManagerUtil.getIdsObjectMapper(new TypeManager());
+        var typeManager = new TypeManager();
+        mapper = IdsTypeManagerUtil.getIdsObjectMapper(typeManager);
 
-        sender = new MultipartEndpointDataReferenceRequestSender(connectorId, httpClient, mapper, monitor, identityService, transformerRegistry);
+        sender = new MultipartEndpointDataReferenceRequestSender(connectorId, httpClient, mapper, monitor, identityService, transformerRegistry, typeManager);
     }
 
     @Test

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/EndpointDataReferenceHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/EndpointDataReferenceHandler.java
@@ -70,7 +70,7 @@ public class EndpointDataReferenceHandler implements Handler {
      */
     @Override
     public @NotNull MultipartResponse handleRequest(@NotNull MultipartRequest multipartRequest) {
-        // Read and transform the endpoint data reference from the request payload
+        // Read and transform the endpoint data reference from the request payload (using the default object mapper)
         var edr = typeManager.readValue(multipartRequest.getPayload(), EndpointDataReference.class);
         var transformationResult = transformerRegistry.transform(edr);
         if (transformationResult.failed()) {


### PR DESCRIPTION
## What this PR changes/adds

Resets the used `ObjectMapper` for serializing the `MultipartEndpointDataReferenceRequestSender` payload to the default one, since `EndpointDataReference` is not an IDS object and `EndpointDataReferenceHandler` uses the same for reading this value.

Details the edc exception message in `IdsMultipartSender::checkResponseType`.

## Why it does that

The IDS object mapper should only be used for de/serializing ids objects, not edc objects.

## Further notes

--

## Linked Issue(s)

Relates #1781 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
