### PR TITLE
fix: Fix broken link in Policy javadoc

### DIFF
--- a/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Policy.java
+++ b/core/policy/policy-evaluator/src/main/java/org/eclipse/dataspaceconnector/policy/model/Policy.java
@@ -29,8 +29,7 @@ import java.util.stream.Collectors;
 /**
  * A collection of permissions, prohibitions, and obligations. Subtypes are defined by
  * {@link PolicyType}.
- * This is a value object. In order to have it identifiable and individually addressable, consider the use of
- * {@link PolicyDefinition}.
+ * This is a value object. In order to have it identifiable and individually addressable, consider the use of PolicyDefinition.
  */
 @JsonDeserialize(builder = Policy.Builder.class)
 public class Policy {


### PR DESCRIPTION
## What this PR changes/adds

Fix broken link in `Policy` javadoc.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
