### PR TITLE
fix: avoid CodeQL run for dependabot pushes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,8 @@ name: "CodeQL"
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
     branches: [ main ]
     paths-ignore:


### PR DESCRIPTION
## What this PR changes/adds

Avoid execution of CodeQL scanning on `push` event on `dependabot/**` branches

## Why it does that

Because it causes failures, e.g.: https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/runs/7742411601?check_suite_focus=true

The error suggested to do it:
> Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, **please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches**. See https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push for more information on how to configure these events.

## Further notes

-

## Linked Issue(s)

-

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
