### PR TITLE
feat(Event Framework): add intermediate superclass for Asset Events

### DIFF
--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/asset/AssetCreated.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/asset/AssetCreated.java
@@ -9,13 +9,13 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - expending Event classes
  *
  */
 
 package org.eclipse.dataspaceconnector.spi.event.asset;
 
 import org.eclipse.dataspaceconnector.spi.event.Event;
-import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
 import java.util.Objects;
 
@@ -38,22 +38,18 @@ public class AssetCreated extends Event<AssetCreated.Payload> {
         }
 
         public Builder assetId(String assetId) {
-            event.payload.assetId = assetId;
+            event.payload.setAssetId(assetId);
             return this;
         }
 
         @Override
         protected void validate() {
-            Objects.requireNonNull(event.payload.assetId);
+            Objects.requireNonNull(event.payload.getAssetId());
         }
     }
 
-    public static class Payload extends EventPayload {
-        private String assetId;
+    public static class Payload extends AssetEventPayload {
 
-        public String getAssetId() {
-            return assetId;
-        }
     }
 
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/asset/AssetCreated.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/asset/AssetCreated.java
@@ -38,7 +38,7 @@ public class AssetCreated extends Event<AssetCreated.Payload> {
         }
 
         public Builder assetId(String assetId) {
-            event.payload.setAssetId(assetId);
+            event.payload.assetId = assetId;
             return this;
         }
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/asset/AssetDeleted.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/asset/AssetDeleted.java
@@ -38,7 +38,7 @@ public class AssetDeleted extends Event<AssetDeleted.Payload> {
         }
 
         public Builder assetId(String assetId) {
-            event.payload.setAssetId(assetId);
+            event.payload.assetId = assetId;
             return this;
         }
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/asset/AssetDeleted.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/asset/AssetDeleted.java
@@ -9,13 +9,13 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - expending Event classes
  *
  */
 
 package org.eclipse.dataspaceconnector.spi.event.asset;
 
 import org.eclipse.dataspaceconnector.spi.event.Event;
-import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
 import java.util.Objects;
 
@@ -38,21 +38,17 @@ public class AssetDeleted extends Event<AssetDeleted.Payload> {
         }
 
         public Builder assetId(String assetId) {
-            event.payload.assetId = assetId;
+            event.payload.setAssetId(assetId);
             return this;
         }
 
         @Override
         protected void validate() {
-            Objects.requireNonNull(event.payload.assetId);
+            Objects.requireNonNull(event.payload.getAssetId());
         }
     }
 
-    public static class Payload extends EventPayload {
-        private String assetId;
+    public static class Payload extends AssetEventPayload {
 
-        public String getAssetId() {
-            return assetId;
-        }
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/asset/AssetEventPayload.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/asset/AssetEventPayload.java
@@ -23,8 +23,4 @@ public class AssetEventPayload extends EventPayload {
     public String getAssetId() {
         return assetId;
     }
-
-    public void setAssetId(String assetId) {
-        this.assetId = assetId;
-    }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/asset/AssetEventPayload.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/asset/AssetEventPayload.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - expending Event classes
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.event.asset;
+
+import org.eclipse.dataspaceconnector.spi.event.EventPayload;
+
+public class AssetEventPayload extends EventPayload {
+    protected String assetId;
+
+    public String getAssetId() {
+        return assetId;
+    }
+
+    public void setAssetId(String assetId) {
+        this.assetId = assetId;
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

Add a 'intermediate' superclass for the Event Classes `AssetCreated` and `AssetDeleted`. 

## Why it does that

Improve the work with the Event Framework and give the possibility to filter Events on a bigger group of events

## Linked Issue(s)

Closes #1813

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly?
