### PR TITLE
fix: validate offer policy equality with definition policy on negotiation

### DIFF
--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
@@ -25,6 +25,7 @@ import org.eclipse.dataspaceconnector.contract.observe.ContractNegotiationObserv
 import org.eclipse.dataspaceconnector.contract.offer.ContractDefinitionServiceImpl;
 import org.eclipse.dataspaceconnector.contract.offer.ContractOfferServiceImpl;
 import org.eclipse.dataspaceconnector.contract.policy.PolicyArchiveImpl;
+import org.eclipse.dataspaceconnector.contract.policy.PolicyEquality;
 import org.eclipse.dataspaceconnector.contract.validation.ContractValidationServiceImpl;
 import org.eclipse.dataspaceconnector.spi.EdcSetting;
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgentService;
@@ -156,7 +157,8 @@ public class ContractServiceExtension implements ServiceExtension {
         var contractOfferService = new ContractOfferServiceImpl(agentService, definitionService, assetIndex, policyStore);
         context.registerService(ContractOfferService.class, contractOfferService);
 
-        var validationService = new ContractValidationServiceImpl(agentService, definitionService, assetIndex, policyStore, clock, policyEngine);
+        var policyEquality = new PolicyEquality(context.getTypeManager());
+        var validationService = new ContractValidationServiceImpl(agentService, definitionService, assetIndex, policyStore, clock, policyEngine, policyEquality);
         context.registerService(ContractValidationService.class, validationService);
 
         var waitStrategy = context.hasService(NegotiationWaitStrategy.class) ? context.getService(NegotiationWaitStrategy.class) : new ExponentialWaitStrategy(DEFAULT_ITERATION_WAIT);

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/policy/PolicyEquality.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/policy/PolicyEquality.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.contract.policy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
+
+import java.util.function.BiPredicate;
+
+public class PolicyEquality implements BiPredicate<Policy, Policy> {
+
+    private final ObjectMapper mapper;
+
+    public PolicyEquality(TypeManager typeManager) {
+        this.mapper = typeManager.getMapper();
+    }
+
+    @Override
+    public boolean test(Policy one, Policy two) {
+        var oneTree = mapper.<ObjectNode>valueToTree(one);
+        var twoTree = mapper.<ObjectNode>valueToTree(two);
+        // TODO: target is excluded from the equality as it's not possible to map it to the current IDS implementation: https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/1791
+        oneTree.remove("target");
+        twoTree.remove("target");
+        return oneTree.equals(twoTree);
+    }
+}

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/policy/PolicyEqualityTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/policy/PolicyEqualityTest.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.contract.policy;
+
+import org.eclipse.dataspaceconnector.policy.model.Permission;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PolicyEqualityTest {
+
+    private final PolicyEquality comparator = new PolicyEquality(new TypeManager());
+
+    @Test
+    void emptyPoliciesAreEqual() {
+        var one = Policy.Builder.newInstance().build();
+        var two = Policy.Builder.newInstance().build();
+
+        var result = comparator.test(one, two);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void ifDifferentRulesPoliciesAreNotEqual() {
+        var one = Policy.Builder.newInstance().permission(Permission.Builder.newInstance().build()).build();
+        var two = Policy.Builder.newInstance().build();
+
+        var result = comparator.test(one, two);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void targetIsExcludedFromTheComparison() {
+        var one = Policy.Builder.newInstance().target("a").build();
+        var two = Policy.Builder.newInstance().target("b").build();
+
+        var result = comparator.test(one, two);
+
+        assertThat(result).isTrue();
+    }
+}

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImplTest.java
@@ -18,6 +18,9 @@
 package org.eclipse.dataspaceconnector.contract.validation;
 
 import net.datafaker.Faker;
+import org.eclipse.dataspaceconnector.contract.policy.PolicyEquality;
+import org.eclipse.dataspaceconnector.policy.model.AtomicConstraint;
+import org.eclipse.dataspaceconnector.policy.model.Permission;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgent;
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgentService;
@@ -28,7 +31,6 @@ import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.policy.PolicyDefinition;
 import org.eclipse.dataspaceconnector.spi.policy.PolicyEngine;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyDefinitionStore;
-import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
@@ -43,7 +45,6 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.UUID;
-import java.util.stream.Stream;
 
 import static java.time.Instant.EPOCH;
 import static java.time.Instant.MAX;
@@ -70,17 +71,18 @@ class ContractValidationServiceImplTest {
     private final PolicyDefinitionStore policyStore = mock(PolicyDefinitionStore.class);
     private final Clock clock = Clock.fixed(now, UTC);
     private final PolicyEngine policyEngine = mock(PolicyEngine.class);
+    private final PolicyEquality policyEquality = mock(PolicyEquality.class);
     private ContractValidationServiceImpl validationService;
 
     @BeforeEach
     void setUp() {
-        validationService = new ContractValidationServiceImpl(agentService, definitionService, assetIndex, policyStore, clock, policyEngine);
+        validationService = new ContractValidationServiceImpl(agentService, definitionService, assetIndex, policyStore, clock, policyEngine, policyEquality);
     }
 
     @Test
     void verifyContractOfferValidation() {
-        var originalPolicy = Policy.Builder.newInstance().build();
-        var newPolicy = Policy.Builder.newInstance().build();
+        var originalPolicy = Policy.Builder.newInstance().target("a").build();
+        var newPolicy = Policy.Builder.newInstance().target("b").build();
         var asset = Asset.Builder.newInstance().id("1").build();
         var contractDefinition = ContractDefinition.Builder.newInstance()
                 .id("1")
@@ -93,8 +95,9 @@ class ContractValidationServiceImplTest {
         when(definitionService.definitionFor(isA(ParticipantAgent.class), eq("1"))).thenReturn(contractDefinition);
         when(policyStore.findById("access")).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
         when(policyStore.findById("contract")).thenReturn(PolicyDefinition.Builder.newInstance().policy(newPolicy).build());
-        when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(Stream.of(asset));
+        when(assetIndex.findById("1")).thenReturn(asset);
         when(policyEngine.evaluate(eq(NEGOTIATION_SCOPE), eq(newPolicy), isA(ParticipantAgent.class))).thenReturn(Result.success(newPolicy));
+        when(policyEquality.test(any(), any())).thenReturn(true);
 
         var claimToken = ClaimToken.Builder.newInstance().build();
         var offer = ContractOffer.Builder.newInstance().id("1:2")
@@ -106,12 +109,64 @@ class ContractValidationServiceImplTest {
 
         var result = validationService.validate(claimToken, offer);
 
-        assertThat(result.getContent()).isNotNull();
+        assertThat(result.succeeded()).isTrue();
         assertThat(result.getContent().getPolicy()).isNotSameAs(originalPolicy); // verify the returned policy is the sanitized one
         verify(agentService).createFor(isA(ClaimToken.class));
         verify(definitionService).definitionFor(isA(ParticipantAgent.class), eq("1"));
-        verify(assetIndex).queryAssets(isA(QuerySpec.class));
+        verify(assetIndex).findById("1");
         verify(policyEngine).evaluate(eq(NEGOTIATION_SCOPE), eq(newPolicy), isA(ParticipantAgent.class));
+    }
+
+    @Test
+    void validate_failsIfPolicyNotFound() {
+        var originalPolicy = Policy.Builder.newInstance().build();
+        var asset = Asset.Builder.newInstance().id("1").build();
+        var contractDefinition = getContractDefinition();
+
+        when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
+        when(definitionService.definitionFor(isA(ParticipantAgent.class), eq("1"))).thenReturn(contractDefinition);
+        when(policyStore.findById(any())).thenReturn(null);
+        when(assetIndex.findById("1")).thenReturn(asset);
+
+        var claimToken = ClaimToken.Builder.newInstance().build();
+        var offer = ContractOffer.Builder.newInstance().id("1:2")
+                .asset(asset)
+                .policy(originalPolicy)
+                .provider(URI.create("provider"))
+                .consumer(URI.create("consumer"))
+                .build();
+
+        var result = validationService.validate(claimToken, offer);
+
+        assertThat(result.failed()).isTrue();
+    }
+
+    @Test
+    void validate_failsIfOfferedPolicyIsNotTheEqualToTheStoredOne() {
+        var offeredPolicy = Policy.Builder.newInstance().permission(Permission.Builder.newInstance().build()).build();
+        var storedPolicy = Policy.Builder.newInstance().permission(Permission.Builder.newInstance()
+                .constraint(AtomicConstraint.Builder.newInstance().build()).build())
+                .build();
+        var asset = Asset.Builder.newInstance().id("1").build();
+        var contractDefinition = getContractDefinition();
+
+        when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
+        when(definitionService.definitionFor(isA(ParticipantAgent.class), eq("1"))).thenReturn(contractDefinition);
+        when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(storedPolicy).build());
+        when(assetIndex.findById("1")).thenReturn(asset);
+        when(policyEquality.test(any(), any())).thenReturn(false);
+
+        var claimToken = ClaimToken.Builder.newInstance().build();
+        var offer = ContractOffer.Builder.newInstance().id("1:2")
+                .asset(asset)
+                .policy(offeredPolicy)
+                .provider(URI.create("provider"))
+                .consumer(URI.create("consumer"))
+                .build();
+
+        var result = validationService.validate(claimToken, offer);
+
+        assertThat(result.failed()).isTrue();
     }
 
     @Test
@@ -136,7 +191,9 @@ class ContractValidationServiceImplTest {
                 .contractSigningDate(now.getEpochSecond())
                 .id("1:2").build();
 
-        assertThat(validationService.validate(claimToken, agreement)).isTrue();
+        boolean isValid = validationService.validate(claimToken, agreement);
+
+        assertThat(isValid).isTrue();
         verify(agentService).createFor(isA(ClaimToken.class));
         verify(definitionService).definitionFor(isA(ParticipantAgent.class), eq("1"));
         verify(policyEngine).evaluate(eq(NEGOTIATION_SCOPE), eq(newPolicy), isA(ParticipantAgent.class));
@@ -156,30 +213,6 @@ class ContractValidationServiceImplTest {
         var isValid = validateAgreementDate(MIN.getEpochSecond(), MAX.getEpochSecond(), MAX.getEpochSecond());
 
         assertThat(isValid).isFalse();
-    }
-
-    @Test
-    void verifyPolicyNotFound() {
-        var originalPolicy = Policy.Builder.newInstance().build();
-        var asset = Asset.Builder.newInstance().id("1").build();
-        var contractDefinition = getContractDefinition();
-
-        when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
-        when(definitionService.definitionFor(isA(ParticipantAgent.class), eq("1"))).thenReturn(contractDefinition);
-        when(policyStore.findById(any())).thenReturn(null);
-        when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(Stream.of(asset));
-
-        var claimToken = ClaimToken.Builder.newInstance().build();
-        var offer = ContractOffer.Builder.newInstance().id("1:2")
-                .asset(asset)
-                .policy(originalPolicy)
-                .provider(URI.create("provider"))
-                .consumer(URI.create("consumer"))
-                .build();
-
-        var result = validationService.validate(claimToken, offer);
-
-        assertThat(result.failed()).isTrue();
     }
 
     private boolean validateAgreementDate(long signingDate, long startDate, long endDate) {

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/dataspaceconnector/test/e2e/Participant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/dataspaceconnector/test/e2e/Participant.java
@@ -304,8 +304,10 @@ public class Participant {
                 put("edc.transfer.proxy.token.signer.privatekey.alias", "1");
                 put("edc.transfer.proxy.token.verifier.publickey.alias", "public-key");
                 put("edc.transfer.proxy.endpoint", dataPlanePublic.toString());
-                put("edc.negotiation.consumer.send.retry.limit", "100");
-                put("edc.negotiation.provider.send.retry.limit", "100");
+                put("edc.negotiation.consumer.send.retry.limit", "1");
+                put("edc.negotiation.provider.send.retry.limit", "1");
+                put("edc.negotiation.consumer.send.retry.base-delay.ms", "100");
+                put("edc.negotiation.provider.send.retry.base-delay.ms", "100");
 
                 put("provisioner.http.entries.default.provisioner.type", "provider");
                 put("provisioner.http.entries.default.endpoint", backendService + "/api/provision");

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/dataspaceconnector/test/e2e/Participant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/dataspaceconnector/test/e2e/Participant.java
@@ -15,12 +15,10 @@
 package org.eclipse.dataspaceconnector.test.e2e;
 
 import org.eclipse.dataspaceconnector.common.util.postgres.PostgresqlLocalInstance;
-import org.eclipse.dataspaceconnector.policy.model.Action;
-import org.eclipse.dataspaceconnector.policy.model.Permission;
-import org.eclipse.dataspaceconnector.policy.model.Policy;
-import org.eclipse.dataspaceconnector.policy.model.PolicyType;
+import org.eclipse.dataspaceconnector.policy.model.PolicyRegistrationTypes;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 import org.eclipse.dataspaceconnector.spi.policy.PolicyDefinition;
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
@@ -40,9 +38,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.io.File.separator;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.dataspaceconnector.junit.testfixtures.TestUtils.getFreePort;
-import static org.hamcrest.CoreMatchers.notNullValue;
 
 public class Participant {
 
@@ -59,9 +57,11 @@ public class Participant {
     private final URI backendService = URI.create("http://localhost:" + getFreePort());
     private final URI idsEndpoint = URI.create("http://localhost:" + getFreePort());
     private final String name;
+    private final TypeManager typeManager = new TypeManager();
 
     public Participant(String name) {
         this.name = name;
+        PolicyRegistrationTypes.TYPES.forEach(typeManager::registerTypes);
     }
 
     public void createAsset(String assetId, String addressType) {
@@ -92,33 +92,22 @@ public class Participant {
                 .then();
     }
 
-    public String createPolicy(String assetId) {
-        var policy = PolicyDefinition.Builder.newInstance()
-                .policy(Policy.Builder.newInstance()
-                        .permission(Permission.Builder.newInstance()
-                                .target(assetId)
-                                .action(Action.Builder.newInstance().type("USE").build())
-                                .build())
-                        .type(PolicyType.SET)
-                        .build())
-                .build();
-
+    public void createPolicy(PolicyDefinition policyDefinition) {
         given()
                 .baseUri(controlPlane.toString())
                 .contentType(JSON)
-                .body(policy)
+                .body(policyDefinition)
                 .when()
                 .post("/api/policydefinitions")
-                .then();
-
-        return policy.getUid();
+                .then()
+                .statusCode(204);
     }
 
-    public void createContractDefinition(String policyId, String assetId, String definitionId) {
+    public void createContractDefinition(String assetId, String definitionId, String accessPolicyId, String contractPolicyId) {
         var contractDefinition = Map.of(
                 "id", definitionId,
-                "accessPolicyId", policyId,
-                "contractPolicyId", policyId,
+                "accessPolicyId", accessPolicyId,
+                "contractPolicyId", contractPolicyId,
                 "criteria", AssetSelectorExpression.Builder.newInstance().constraint("asset:prop:id", "=", assetId).build().getCriteria()
         );
 
@@ -146,7 +135,7 @@ public class Participant {
         return given()
                 .baseUri(controlPlane.toString())
                 .contentType(JSON)
-                .body(request)
+                .body(typeManager.writeValueAsString(request))
                 .when()
                 .post("/api/contractnegotiations")
                 .then()
@@ -158,20 +147,29 @@ public class Participant {
         var contractAgreementId = new AtomicReference<String>();
 
         await().atMost(timeout).untilAsserted(() -> {
-            var result = given()
-                    .baseUri(controlPlane.toString())
-                    .contentType(JSON)
-                    .when()
-                    .get("/api/contractnegotiations/{id}", negotiationId)
-                    .then()
-                    .statusCode(200)
-                    .body("contractAgreementId", notNullValue())
-                    .extract().body().jsonPath().getString("contractAgreementId");
+            var agreementId = getContractNegotiationField(negotiationId, "contractAgreementId");
+            assertThat(agreementId).isNotNull().isInstanceOf(String.class);
 
-            contractAgreementId.set(result);
+            contractAgreementId.set(agreementId);
         });
 
         return contractAgreementId.get();
+    }
+
+    public String getContractNegotiationState(String negotiationId) {
+        return getContractNegotiationField(negotiationId, "state");
+    }
+
+    private String getContractNegotiationField(String negotiationId, String fieldName) {
+        return given()
+                .baseUri(controlPlane.toString())
+                .contentType(JSON)
+                .when()
+                .get("/api/contractnegotiations/{id}", negotiationId)
+                .then()
+                .statusCode(200)
+                .extract().body().jsonPath()
+                .getString(fieldName);
     }
 
     public String dataRequest(String id, String contractAgreementId, String assetId, Participant provider, DataAddress dataAddress) {
@@ -268,7 +266,7 @@ public class Participant {
     }
 
     public Catalog getCatalog(URI provider) {
-        return given()
+        String response = given()
                 .baseUri(controlPlane.toString())
                 .contentType(JSON)
                 .when()
@@ -276,7 +274,9 @@ public class Participant {
                 .get("/api/catalog")
                 .then()
                 .statusCode(200)
-                .extract().body().as(Catalog.class);
+                .extract().body().asString();
+
+        return typeManager.readValue(response, Catalog.class);
     }
 
     public URI idsEndpoint() {
@@ -304,6 +304,8 @@ public class Participant {
                 put("edc.transfer.proxy.token.signer.privatekey.alias", "1");
                 put("edc.transfer.proxy.token.verifier.publickey.alias", "public-key");
                 put("edc.transfer.proxy.endpoint", dataPlanePublic.toString());
+                put("edc.negotiation.consumer.send.retry.limit", "100");
+                put("edc.negotiation.provider.send.retry.limit", "100");
 
                 put("provisioner.http.entries.default.provisioner.type", "provider");
                 put("provisioner.http.entries.default.endpoint", backendService + "/api/provision");
@@ -343,7 +345,6 @@ public class Participant {
 
         return baseConfiguration;
     }
-
 
     public Map<String, String> controlPlaneCosmosDbConfiguration() {
         var baseConfiguration = controlPlaneConfiguration();


### PR DESCRIPTION
## What this PR changes/adds

Add an equality check between contract offer policy and contract negotiation policy in `ContractValidationService`

## Why it does that

To avoid injection of malicious policies.

## Further notes

- this check is needed since currently the negotiation is automatically, and no counter offers are supported
- the equality check is done using the `ObjectMapper`'s `ObjectNode` as it is way less disruptive than overriding the `equals` method on every policy model class 
- the `target` has been excluded from the check for reasons explained in the issue: #1791 
- in `ContractValidationServiceImpl` the way the target asset is retrieved has been simplified, since the `id` must always be present, it can be used as the only criteria to get the `Asset`
- I'm not a supporter of "unhappy path e2e tests" but I needed this to light the way to the solution, I would keep it as it is a critical case, but it could be deleted in the future.
- **question**: is the `assetId` in the `ContractOffer` still useful? seems like isn't used by anoyone. I left it as it is, but in my opinion it could be removed.

## Linked Issue(s)

Closes #1791 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
