### PR TITLE
docs: add decision record about using maven artifacts

### DIFF
--- a/docs/developer/decision-records/2022-08-11-versioning_and_artifacts/README.md
+++ b/docs/developer/decision-records/2022-08-11-versioning_and_artifacts/README.md
@@ -1,0 +1,26 @@
+# Versioning concept for MVD
+
+## Decision
+We want to get rid of checking out other repositories during CI, building them locally and publishing them into the local Maven cache (`publishToMavenLocal`).
+
+## Rationale
+When building and/or running projects that use EDC (such as MVD) it is quite cumbersome and error prone having to check out a particular git ref in different projects and to build and publish them locally.
+
+We will therefore move toward a system where we use distributed Maven artifacts rather than local ones. This is less flexible than git refs, but at the same improves coherence and setup speed.
+
+## General rules
+- All projects must use Maven artifacts from MavenCentral or OSSRH Snapshots
+- EDC (and other projects) produce a new rolling `-SNAPSHOT` version based on their respective `main` branch every 30 minutes if there are changes. _This is already in place._
+- EDC (and other projects) produce a nightly snapshot build containing the date in the metadata, in the format `X.Y.Z-YYYYMMDD-SNAPSHOT`. _This is already in place._
+
+## Specific rules for "our" dependent projects 
+_for the sake of brevity, "our" refers to all implementation projects inside the `eclipse-dataspaceconnector` org in Github_
+
+- publishing a new release in EDC should also trigger a release in all "our" other projects with the same version string
+- all our dependent projects **must** maintain version consistency: for example when RS and IH both reference EDC `0.0.1-some-fix-SNAPSHOT`, then MVD **must** reference that same version
+- version bumps must happen across all "our" repos: when RS upgrades to EDC `0.0.1-milestone-69`, then all other projects **must** follow suit.
+
+## During development of "our" dependent projects
+- the `main` branches of dependent projects must always reference releases or "named" snapshots of EDC
+- in case a dependent project requires a change in EDC, they can temporarily use the rolling snapshot or nightly version of EDC including that fix, but EDC should release a "named" snapshot, e.g. `0.0.1-something-SNAPSHOT` in a timely manner. From time forward, that project will use `0.0.1-something-SNAPSHOT` on its `main` branch.
+- before merging the PR in the dependent project, there **must** be a named snapshot or release of EDC, which the dependent project references henceforth.

--- a/docs/developer/decision-records/2022-08-11-versioning_and_artifacts/README.md
+++ b/docs/developer/decision-records/2022-08-11-versioning_and_artifacts/README.md
@@ -1,26 +1,46 @@
 # Versioning concept for MVD
 
 ## Decision
-We want to get rid of checking out other repositories during CI, building them locally and publishing them into the local Maven cache (`publishToMavenLocal`).
+
+We want to get rid of checking out other repositories during CI, building them locally and publishing them into the
+local Maven cache (`publishToMavenLocal`).
 
 ## Rationale
-When building and/or running projects that use EDC (such as MVD) it is quite cumbersome and error prone having to check out a particular git ref in different projects and to build and publish them locally.
 
-We will therefore move toward a system where we use distributed Maven artifacts rather than local ones. This is less flexible than git refs, but at the same improves coherence and setup speed.
+When building and/or running projects that use EDC (such as MVD) it is quite cumbersome and error-prone to check out a
+particular git ref in different projects and to build and publish them locally.
+
+We will therefore move toward a system where we use distributed Maven artifacts rather than local ones. This is less
+flexible than git refs, but at the same time improves coherence and setup speed.
 
 ## General rules
-- All projects must use Maven artifacts from MavenCentral or OSSRH Snapshots
-- EDC (and other projects) produce a new rolling `-SNAPSHOT` version based on their respective `main` branch every 30 minutes if there are changes. _This is already in place._
-- EDC (and other projects) produce a nightly snapshot build containing the date in the metadata, in the format `X.Y.Z-YYYYMMDD-SNAPSHOT`. _This is already in place._
 
-## Specific rules for "our" dependent projects 
-_for the sake of brevity, "our" refers to all implementation projects inside the `eclipse-dataspaceconnector` org in Github_
+_for the sake of brevity, the term "our" refers to all original implementation projects inside the
+`eclipse-dataspaceconnector` org in Github. At the time of this writing that includes `DataSpaceConnector`,
+`RegistrationService`, `IdentityHub`, `MinimumViableDataspace` and `FederatedCatalog` (not yet populated)._
 
-- publishing a new release in EDC should also trigger a release in all "our" other projects with the same version string
-- all our dependent projects **must** maintain version consistency: for example when RS and IH both reference EDC `0.0.1-some-fix-SNAPSHOT`, then MVD **must** reference that same version
-- version bumps must happen across all "our" repos: when RS upgrades to EDC `0.0.1-milestone-69`, then all other projects **must** follow suit.
+All "our" projects must
+
+- use Maven artifacts from MavenCentral or OSSRH Snapshots, both for local and CI builds
+- produce a new rolling `-SNAPSHOT` version based on their respective `main` branch every 30 minutes if there are
+  changes. _This is already in place._
+- produce a nightly snapshot build containing the date in the metadata, in the format `X.Y.Z-YYYYMMDD-SNAPSHOT`. _This
+  is already in place._
+
+## Specific rules for "our" dependent projects
+
+- publishing a new release in a dependency should also trigger a release in dependent projects with the same version
+  string. E.g. building EDC -> triggers RS and IH.
+- all "our" dependent projects **must** maintain version consistency: for example when RS and IH both reference
+  EDC `0.0.1-some-fix-SNAPSHOT`, then MVD **must** reference that same version
+- version bumps must happen across all "our" repos: when RS upgrades to EDC `0.0.1-milestone-69`, then all other
+  projects **must** follow suit.
 
 ## During development of "our" dependent projects
-- the `main` branches of dependent projects must always reference releases or "named" snapshots of EDC
-- in case a dependent project requires a change in EDC, they can temporarily use the rolling snapshot or nightly version of EDC including that fix, but EDC should release a "named" snapshot, e.g. `0.0.1-something-SNAPSHOT` in a timely manner. From time forward, that project will use `0.0.1-something-SNAPSHOT` on its `main` branch.
-- before merging the PR in the dependent project, there **must** be a named snapshot or release of EDC, which the dependent project references henceforth.
+
+- the `main` branches of "our" dependent projects must always reference releases or "named" snapshots of EDC
+- in case a dependent project requires a change in EDC, they can temporarily use the rolling snapshot or nightly version
+  of EDC including that fix, but EDC should release a "named" snapshot, e.g. `0.0.1-something-SNAPSHOT` in a timely
+  manner. From that time forward, that project will use `0.0.1-something-SNAPSHOT` on its `main` branch.
+- before merging the PR in the dependent project, there **must** be a named snapshot or release of EDC, which the
+  dependent project references henceforth.

--- a/docs/developer/decision-records/2022-08-11-versioning_and_artifacts/README.md
+++ b/docs/developer/decision-records/2022-08-11-versioning_and_artifacts/README.md
@@ -15,9 +15,14 @@ flexible than git refs, but at the same time improves coherence and setup speed.
 
 ## General rules
 
-_for the sake of brevity, the term "our" refers to all original implementation projects inside the
-`eclipse-dataspaceconnector` org in Github. At the time of this writing that includes `DataSpaceConnector`,
-`RegistrationService`, `IdentityHub`, `MinimumViableDataspace` and `FederatedCatalog` (not yet populated)._
+> for the sake of brevity, the term "our" refers to all original implementation projects inside the
+`eclipse-dataspaceconnector` org in [Github](https://github.com/eclipse-dataspaceconnector/). At the time of this
+> writing that includes `DataSpaceConnector` (a.k.a. "EDC"),
+`RegistrationService` (a.k.a. "RS", [see Github](https://github.com/eclipse-dataspaceconnector/RegistrationService)),
+`IdentityHub` (a.k.a. "IH", [see Github](https://github.com/eclipse-dataspaceconnector/IdentityHub),
+`MinimumViableDataspace` (a.k.a. "MVD"
+> , [see Github](https://github.com/eclipse-dataspaceconnector/MinimumViableDataspace))) and `FederatedCatalog` (a.k.a.
+"FC", [see Github](https://github.com/eclipse-dataspaceconnector/FederatedCatalog), not yet populated).
 
 All "our" projects must
 


### PR DESCRIPTION
## What this PR changes/adds

Adds a D-R about using only Maven artifacts (instead of local checkouts) and how the versioning is supposed to work.

## Why it does that

While local checkouts have their upsides, I find them cumbersome and quirky to work with.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. .

## Linked Issue(s)
.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
