### PR TITLE
docs: fix link to JettyConfiguration in Tutorial 2

### DIFF
--- a/samples/02-health-endpoint/README.md
+++ b/samples/02-health-endpoint/README.md
@@ -61,10 +61,10 @@ java -jar samples/02-health-endpoint/build/libs/connector-health.jar
 we can issue a GET request to `http://localhost:8181/api/health` and receive the aforementioned string as a result.
 
 It is worth noting that by default the webserver listens on port `8181`, which is defined
-in [`JettyService.java`](../../extensions/http/jetty/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyService.java)
+in [`JettyConfiguration.java`](../../extensions/http/jetty/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyConfiguration.java)
 and can be configured using the `web.http.port` property (more on that in the next chapter). You will need to configure
 this whenever you have two connectors running on the same machine.
 
 Also, the default path is `/api/*`, which is defined
-in [`JerseyRestService.java`](../../extensions/http/jersey/src/main/java/org/eclipse/dataspaceconnector/extension/jersey/JerseyRestService.java)
+in [`JettyConfiguration.java`](../../extensions/http/jersey/src/main/java/org/eclipse/dataspaceconnector/extension/jersey/JettyConfiguration.java)
 .


### PR DESCRIPTION
## What this PR changes/adds

The tutorial 2 at https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/samples/02-health-endpoint/README.md mentions that port and api root can be changed in JettyService.java and JerseyService.java but they both happen at JettyConfiguration.java . Thus, this PR updates the readme to take this into account.

## Why it does that

The links and the associated text were wrong.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
