### PR TITLE
feat: do not overwrite registered mocks in tests

### DIFF
--- a/extensions/junit/src/main/java/org/eclipse/dataspaceconnector/junit/extensions/EdcExtension.java
+++ b/extensions/junit/src/main/java/org/eclipse/dataspaceconnector/junit/extensions/EdcExtension.java
@@ -61,7 +61,8 @@ public class EdcExtension extends BaseRuntime implements BeforeTestExecutionCall
     }
 
     /**
-     * Registers a mock service with the runtime.
+     * Registers a mock service with the runtime. Note that the mock will overwrite any service already registered with the context.
+     * This is intentional. A warning will be logged to STDOUT if the mock actually replaces an existing service.
      *
      * @param mock the service mock
      */
@@ -120,7 +121,6 @@ public class EdcExtension extends BaseRuntime implements BeforeTestExecutionCall
 
     @Override
     protected void initializeContext(ServiceExtensionContext context) {
-        serviceMocks.forEach((key, value) -> context.registerService(cast(key), value));
         super.initializeContext(context);
     }
 
@@ -131,7 +131,7 @@ public class EdcExtension extends BaseRuntime implements BeforeTestExecutionCall
 
     @Override
     protected @NotNull ServiceExtensionContext createContext(TypeManager typeManager, Monitor monitor, Telemetry telemetry) {
-        context = new DefaultServiceExtensionContext(typeManager, monitor, telemetry, loadConfigurationExtensions());
+        context = new TestServiceExtensionContext(typeManager, monitor, telemetry, loadConfigurationExtensions(), serviceMocks);
         return context;
     }
 

--- a/extensions/junit/src/main/java/org/eclipse/dataspaceconnector/junit/extensions/TestServiceExtensionContext.java
+++ b/extensions/junit/src/main/java/org/eclipse/dataspaceconnector/junit/extensions/TestServiceExtensionContext.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.junit.extensions;
+
+import org.eclipse.dataspaceconnector.boot.system.DefaultServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.system.ConfigurationExtension;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.telemetry.Telemetry;
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import static java.util.Optional.ofNullable;
+
+/**
+ * This variant of the {@link DefaultServiceExtensionContext} maintains a list of service mocks, so that they will be used for dependency resolution
+ * during the extension loading phase.
+ * If a mock exists for any particular service, the following behavioural changes occur:
+ * <ul>
+ *     <li>{@link ServiceExtensionContext#registerService(Class, Object)} will only register the service, if no mock exists for the same type</li>
+ *     <li>{@link ServiceExtensionContext#getService(Class)} will always return the service mock, if one exists </li>
+ *     <li>{@link ServiceExtensionContext#hasService(Class)} will check first if a mock exists for any service, and then forward the call to the superclass</li>
+ * </ul>
+ *
+ * <strong>This is only to be used in test situations!</strong>
+ */
+public class TestServiceExtensionContext extends DefaultServiceExtensionContext {
+    private final LinkedHashMap<Class<?>, Object> serviceMocks;
+
+    public TestServiceExtensionContext(TypeManager typeManager, Monitor monitor, Telemetry telemetry, List<ConfigurationExtension> configurationExtensions, LinkedHashMap<Class<?>, Object> serviceMocks) {
+        super(typeManager, monitor, telemetry, configurationExtensions);
+        this.serviceMocks = serviceMocks;
+    }
+
+
+    @Override
+    public <T> boolean hasService(Class<T> type) {
+        return (serviceMocks != null && serviceMocks.containsKey(type)) || super.hasService(type);
+    }
+
+    @Override
+    public <T> T getService(Class<T> type) {
+        return (T) ofNullable(serviceMocks.get(type)).orElseGet(() -> super.getService(type));
+    }
+
+    @Override
+    public <T> void registerService(Class<T> type, T service) {
+        if (serviceMocks != null && serviceMocks.containsKey(type)) {
+            getMonitor().warning("TestServiceExtensionContext: A service mock was registered for type " + type.getCanonicalName() + " - will NOT register a " + service.getClass().getCanonicalName());
+        } else {
+            super.registerService(type, service);
+        }
+    }
+}

--- a/extensions/junit/src/test/java/org/eclipse/dataspaceconnector/junit/extensions/EdcExtensionTest.java
+++ b/extensions/junit/src/test/java/org/eclipse/dataspaceconnector/junit/extensions/EdcExtensionTest.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.junit.extensions;
+
+import okhttp3.OkHttpClient;
+import org.eclipse.dataspaceconnector.spi.system.MonitorExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(EdcExtension.class)
+class EdcExtensionTest {
+
+    private OkHttpClient testClient;
+
+    @BeforeEach
+    void setUp(EdcExtension extension) {
+        testClient = mock(OkHttpClient.class);
+        // registers a mock(Monitor.class)
+        var mockMonitorExtension = new MockMonitorExtension();
+        extension.registerSystemExtension(MonitorExtension.class, mockMonitorExtension);
+        extension.registerServiceMock(OkHttpClient.class, testClient);
+    }
+
+    @Test
+    void registerServiceMock_serviceAlreadyExists(EdcExtension extension) {
+        var mockedMonitor = extension.getContext().getMonitor();
+        assertThat(extension.getContext().getService(OkHttpClient.class)).isEqualTo(testClient);
+        verify(mockedMonitor, atLeastOnce()).warning(startsWith("TestServiceExtensionContext: A service mock was registered for type okhttp3.OkHttpClient"));
+    }
+}

--- a/extensions/junit/src/test/java/org/eclipse/dataspaceconnector/junit/extensions/MockMonitorExtension.java
+++ b/extensions/junit/src/test/java/org/eclipse/dataspaceconnector/junit/extensions/MockMonitorExtension.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.junit.extensions;
+
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.system.MonitorExtension;
+
+import static org.mockito.Mockito.mock;
+
+public class MockMonitorExtension implements MonitorExtension {
+    private final Monitor monitorMock;
+
+    public MockMonitorExtension() {
+        monitorMock = mock(Monitor.class);
+    }
+
+    @Override
+    public Monitor getMonitor() {
+        return monitorMock;
+    }
+}

--- a/extensions/junit/src/test/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.MonitorExtension
+++ b/extensions/junit/src/test/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.MonitorExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2022 Microsoft Corporation
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Microsoft Corporation - initial API and implementation
+#
+#
+
+org.eclipse.dataspaceconnector.junit.extensions.MockMonitorExtension


### PR DESCRIPTION
## What this PR changes/adds

This PR introduces a subclass of `DefaultServiceExtensionContext` that maintains a list of service mocks (in addition to the normal services).

Then, when services are to be registered or resolved, that list of mocks is queried first to make sure, that mocks are always used first.

## Why it does that

When service mocks are registered, we need to make sure they do not get overwritten by the normal extension loading.

## Further notes

.

## Linked Issue(s)

Closes #1819 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
