### PR TITLE
test: e2e-transfer-test should use copied test resources

### DIFF
--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/dataspaceconnector/test/e2e/Participant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/dataspaceconnector/test/e2e/Participant.java
@@ -401,6 +401,6 @@ public class Participant {
 
     @NotNull
     private String resourceAbsolutePath(String filename) {
-        return System.getProperty("user.dir") + separator + "src" + separator + "test" + separator + "resources" + separator + filename;
+        return System.getProperty("user.dir") + separator + "build" + separator + "resources" + separator + "test" + separator + filename;
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Using test resources copied by processTestResources task of Gradle instead of files in the source tree.

## Why it does that

Tests should not update files under version control in order to avoid mysterious test failures and  unintentional change  checked in.

## Linked Issue(s)

Closes #1829

## Checklist

- [n/a] added appropriate tests?
- [x] performed checkstyle check locally?
- [n/a] added/updated copyright headers?
- [n/a] documented public classes/methods?
- [n/a] added/updated relevant documentation?
- [] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
