### PR TITLE
feat: add prepare() lifecycle phase to extensions

### DIFF
--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoader.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoader.java
@@ -66,7 +66,8 @@ public class ExtensionLoader {
                 .map(ExtensionLifecycleManager::provide)
                 .collect(Collectors.toList());
 
-        lifeCycles.forEach(ExtensionLifecycleManager::start);
+        var preparedExtensions = lifeCycles.stream().map(ExtensionLifecycleManager::prepare).collect(Collectors.toList());
+        preparedExtensions.forEach(ExtensionLifecycleManager::start);
     }
 
     @NotNull

--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/injection/lifecycle/ExtensionLifecycleManager.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/injection/lifecycle/ExtensionLifecycleManager.java
@@ -65,9 +65,9 @@ public class ExtensionLifecycleManager {
      * Scans the {@linkplain ServiceExtension} for methods annotated with {@linkplain org.eclipse.dataspaceconnector.spi.system.Provider}
      * with the {@link Provider#isDefault()} flag set to {@code false}, invokes them and registers the bean into the {@link ServiceExtensionContext} if necessary.
      */
-    public static StartPhase provide(RegistrationPhase phase) {
+    public static PreparePhase provide(RegistrationPhase phase) {
         phase.invokeProviderMethods();
-        return new StartPhase(phase);
+        return new PreparePhase(phase);
     }
 
     /**
@@ -78,6 +78,14 @@ public class ExtensionLifecycleManager {
     }
 
     /**
+     * invokes the {@link ServiceExtension#prepare()}.
+     */
+    public static StartPhase prepare(PreparePhase preparePhase) {
+        preparePhase.prepare();
+        return new StartPhase(preparePhase);
+    }
+
+    /**
      * Injects all dependencies into a {@link ServiceExtension}: those dependencies must be class members annotated with @Inject.
      * Kicks off the multi-phase initialization.
      */
@@ -85,5 +93,4 @@ public class ExtensionLifecycleManager {
         injector.inject(container, context);
         return new InitializePhase(injector, container, context, monitor);
     }
-
 }

--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/injection/lifecycle/PreparePhase.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/injection/lifecycle/PreparePhase.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.boot.system.injection.lifecycle;
+
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
+
+/**
+ * Represents an {@link ServiceExtension}'s lifecycle phase where it's {@linkplain ServiceExtension#prepare()} method is
+ * invoked by the {@link ExtensionLifecycleManager}.
+ */
+public class PreparePhase extends Phase {
+    protected PreparePhase(Phase other) {
+        super(other);
+    }
+
+    public void prepare() {
+        var target = getTarget();
+        target.prepare();
+        monitor.info("Prepared " + target.name());
+    }
+}

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ServiceExtension.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ServiceExtension.java
@@ -38,4 +38,15 @@ public interface ServiceExtension extends SystemExtension {
     default void shutdown() {
     }
 
+    /**
+     * Hook method to perform some additional preparatory work before the extension is started.
+     * All dependencies are guaranteed to be resolved, and all other extensions are guaranteed to have completed initialization.
+     * <p>
+     * Typical use cases include wanting to wait until all registrations of a {@code *Registry} have completed, perform some additional
+     * checking whether a service exists or not, etc.
+     * <p>
+     * <strong>Do NOT perform any service registration in this method!</strong>
+     */
+    default void prepare() {
+    }
 }


### PR DESCRIPTION
## What this PR changes/adds

Adds an additional lifecycle method to `ServiceExtension` which is invoked after _all_ extensions have completed their initialization. The contract of this hook is:
- all service registrations are completed
- all extensions have finished executing the `initialize()` method
- the `prepare()` method of _all extensions_ will be invoked first
- the `start()` method of _all extensions_ will be invoked second

## Why it does that

Sometimes users may want to perform (potentially long-running) preparatory tasks, that rely on service registration and initialization being complete, such as querying a `*Registry`. 
Since the contract of the `start()` method is that it signals the ability of EDC to accept incoming requests, the `start()` method is unsuitable for these kinds of tasks.

## Further notes

.

## Linked Issue(s)

Closes #1765 

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
