### PR TITLE
feat: fluent use of `Result`

### DIFF
--- a/spi/common/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/result/ResultTest.java
+++ b/spi/common/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/result/ResultTest.java
@@ -16,7 +16,18 @@ package org.eclipse.dataspaceconnector.spi.result;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 class ResultTest {
 
@@ -57,8 +68,7 @@ class ResultTest {
 
         var result = r1.merge(r2);
         assertThat(result.failed()).isTrue();
-        assertThat(result.getFailureMessages()).hasSize(2)
-                .containsExactly("reason 1", "reason 2");
+        assertThat(result.getFailureMessages()).hasSize(2).containsExactly("reason 1", "reason 2");
     }
 
     @Test
@@ -69,9 +79,7 @@ class ResultTest {
 
         var result = r1.merge(r2);
         assertThat(result.failed()).isTrue();
-        assertThat(result.getFailureMessages())
-                .hasSize(1)
-                .containsExactly("reason 1");
+        assertThat(result.getFailureMessages()).hasSize(1).containsExactly("reason 1");
 
     }
 
@@ -83,4 +91,141 @@ class ResultTest {
         var result = r1.merge(r2);
         assertThat(result.succeeded()).isTrue();
     }
+
+    @Test
+    void onSuccess_whenSucceeded() {
+        var result = Result.success("foo");
+        Consumer<String> consumer = mock(Consumer.class);
+
+        assertThat(result.onSuccess(consumer)).isEqualTo(result);
+        verify(consumer).accept(eq("foo"));
+    }
+
+    @Test
+    void onSuccess_whenFailed() {
+        Consumer<String> consumer = mock(Consumer.class);
+
+        Result<String> result = Result.failure("bar");
+        assertThat(result.onSuccess(consumer)).isEqualTo(result);
+        verifyNoInteractions(consumer);
+    }
+
+    @Test
+    void onFailure_whenSucceeded() {
+        var result = Result.success("foo");
+        Consumer<Failure> consumer = mock(Consumer.class);
+
+        assertThat(result.onFailure(consumer)).isEqualTo(result);
+        verifyNoInteractions(consumer);
+    }
+
+    @Test
+    void onFailure_whenFailed() {
+        Consumer<Failure> consumer = mock(Consumer.class);
+
+        Result<String> result = Result.failure("bar");
+        assertThat(result.onFailure(consumer)).isEqualTo(result);
+        verify(consumer).accept(argThat(f -> f.getMessages().contains("bar")));
+    }
+
+    @Test
+    void mapTo_succeeded() {
+        var res = Result.success("foobar");
+        Result<Void> mapped = res.mapTo();
+        assertThat(mapped.succeeded()).isTrue();
+        assertThat(mapped.getContent()).isNull();
+    }
+
+    @Test
+    void mapTo_failed() {
+        var res = Result.failure("foobar");
+        Result<String> mapped = res.mapTo();
+        assertThat(mapped.failed()).isTrue();
+        assertThat(mapped.getFailureDetail()).isEqualTo("foobar");
+    }
+
+    @Test
+    void mapTo_explicitType_succeeded() {
+        var res = Result.success("foobar");
+        var mapped = res.mapTo(Object.class);
+        assertThat(mapped.succeeded()).isTrue();
+        assertThat(mapped.getContent()).isNull();
+    }
+
+    @Test
+    void mapTo_explicitType_failed() {
+        var res = Result.failure("foobar");
+        var mapped = res.mapTo(String.class);
+        assertThat(mapped.failed()).isTrue();
+        assertThat(mapped.getFailureDetail()).isEqualTo("foobar");
+    }
+
+
+    @Test
+    void whenSuccess_chainsSuccesses() {
+        var result1 = Result.success("res1");
+        var finalResult = result1.flatMap(r -> Result.success("res2")).flatMap(r -> Result.success("res3"));
+
+        assertThat(finalResult.succeeded()).isTrue();
+        assertThat(finalResult.getContent()).isEqualTo("res3");
+    }
+
+    @Test
+    void whenSuccess_middleOneFails() {
+        var result1 = Result.success("res1");
+        var finalResult = result1
+                .flatMap(r -> Result.success("res2"))
+                .flatMap(r -> Result.failure("some failure"))
+                .flatMap(Result::mapTo);
+
+        assertThat(finalResult.failed()).isTrue();
+        assertThat(finalResult.getFailureDetail()).isEqualTo("some failure");
+    }
+
+    @Test
+    void whenSuccess_firstOneFails() {
+        Result<String> result1 = Result.failure("fail1");
+        var finalResult = result1
+                .flatMap(r -> Result.failure("fail2"))
+                .flatMap(r -> Result.failure("fail3"));
+
+        assertThat(finalResult.failed()).isTrue();
+        assertThat(finalResult.getFailureDetail()).isEqualTo("fail3");
+    }
+
+    @Test
+    void asOptional() {
+        assertThat(Result.success("some value").asOptional()).hasValue("some value");
+        assertThat(Result.success().asOptional()).isEmpty();
+        assertThat(Result.failure("foobar").asOptional()).isEmpty();
+    }
+
+    @Test
+    void from() {
+        var res = Result.from(Optional.of("some val"));
+        assertThat(res.succeeded()).isTrue();
+        assertThat(res.getContent()).isEqualTo("some val");
+
+        var failedRes = Result.from(Optional.empty());
+        assertThat(failedRes.failed()).isTrue();
+        assertThat(failedRes.getFailureDetail()).isNotNull();
+    }
+
+    @Test
+    void orElseThrow() {
+        assertThat(Result.success("foobar").orElseThrow(RuntimeException::new))
+                .extracting(AbstractResult::getContent)
+                .isEqualTo("foobar");
+
+        assertThatThrownBy(() -> Result.failure("barbaz").orElseThrow(RuntimeException::new))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    private <U> Function<Result<U>, Result<String>> failWhenCalled() {
+        return r -> {
+            fail("should not be called!");
+            return Result.success("next result");
+        };
+    }
+
 }

--- a/spi/common/transport-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transformer/TransformerContextImpl.java
+++ b/spi/common/transport-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transformer/TransformerContextImpl.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.spi.transformer;
 
 import org.jetbrains.annotations.Nullable;


### PR DESCRIPTION
## What this PR changes/adds

adds some syntactic sugar to the `Result` and `AbstractResult` class to make them usable in fluent statements.

## Why it does that

Enable code fluency and more descriptive and succinct code pieces.

## Further notes

- I tried to add the methods to the base class wherever possible to make them available to all subclasses.

## Linked Issue(s)

Closes #1823 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
