### PR TITLE
fix: remove Faker from DataPlane integration tests

### DIFF
--- a/extensions/data-plane/integration-tests/build.gradle.kts
+++ b/extensions/data-plane/integration-tests/build.gradle.kts
@@ -18,7 +18,6 @@ plugins {
 
 val assertj: String by project
 val awaitility: String by project
-val datafaker: String by project
 val jupiterVersion: String by project
 val httpMockServer: String by project
 val restAssured: String by project
@@ -31,7 +30,6 @@ dependencies {
     testImplementation("org.awaitility:awaitility:${awaitility}")
     testImplementation("org.mock-server:mockserver-netty:${httpMockServer}:shaded")
     testImplementation("org.mock-server:mockserver-client-java:${httpMockServer}:shaded")
-    testImplementation("net.datafaker:datafaker:${datafaker}")
 
     testImplementation(project(":extensions:junit"))
     testImplementation(testFixtures(project(":common:util")))


### PR DESCRIPTION
## What this PR changes/adds

Remove `Faker` from data plane integration tests, as it seems to make them flaky (see #1847)

## Why it does that

To strengthen tests

## Further notes

- the `DataPlaneHttpToHttpIntegrationTests` seems to be more of a `system-test` than an integration test, since it run a `launcher`: `data-plane-server`
- `DataPlaneHttpPullIntegrationTests` could stay in the `data-plane-http` module, since that's what it's testing

## Linked Issue(s)

Closes #1847

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
