### PR TITLE
chore: removed data-faker from all test code

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,6 @@ dependencies {
     "swaggerUI"("org.webjars:swagger-ui:4.11.1")
 }
 
-val datafaker: String by project
 val jetBrainsAnnotationsVersion: String by project
 val jacksonVersion: String by project
 val javaVersion: String by project
@@ -175,7 +174,6 @@ allprojects {
             testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")
             testImplementation("org.mockito:mockito-core:${mockitoVersion}")
             testImplementation("org.assertj:assertj-core:${assertj}")
-            testImplementation("net.datafaker:datafaker:${datafaker}")
         }
 
         if (!project.hasProperty("skip.signing")) {
@@ -331,7 +329,6 @@ if (project.hasProperty("dependency.analysis")) {
                 onUnusedDependencies {
                     exclude(
                         // dependencies declared at the root level for all modules
-                        "net.datafaker:datafaker",
                         "org.assertj:assertj-core",
                         "org.junit.jupiter:junit-jupiter-api",
                         "org.junit.jupiter:junit-jupiter-params",

--- a/common/state-machine-lib/src/test/java/org/eclipse/dataspaceconnector/common/statemachine/retry/EntitySendRetryManagerTest.java
+++ b/common/state-machine-lib/src/test/java/org/eclipse/dataspaceconnector/common/statemachine/retry/EntitySendRetryManagerTest.java
@@ -16,7 +16,6 @@ package org.eclipse.dataspaceconnector.common.statemachine.retry;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.spi.entity.StatefulEntity;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.retry.WaitStrategy;
@@ -28,6 +27,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Clock;
+import java.util.Random;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -39,11 +39,10 @@ import static org.mockito.Mockito.when;
 
 class EntitySendRetryManagerTest {
 
-    private final Faker faker = new Faker();
-
+    private static final Random RANDOM = new Random();
     private final Monitor monitor = mock(Monitor.class);
     private final WaitStrategy delayStrategy = mock(WaitStrategy.class);
-    private final int sendRetryLimit = faker.number().numberBetween(5, 10);
+    private final int sendRetryLimit = 5 + RANDOM.nextInt(11);
 
     private final Clock clock = mock(Clock.class);
     private final Supplier<WaitStrategy> waitStrategy = () -> delayStrategy;
@@ -76,7 +75,7 @@ class EntitySendRetryManagerTest {
     @ValueSource(ints = { -2, -1, 0, 1, 2 })
     void retriesExhausted(int retriesLeft) {
         var stateCount = sendRetryLimit - retriesLeft;
-        var stateTimestamp = faker.number().randomNumber();
+        var stateTimestamp = RANDOM.nextInt();
         var process = TestEntity.Builder.newInstance()
                 .id("any")
                 .stateCount(stateCount)

--- a/core/common/base/src/test/java/org/eclipse/dataspaceconnector/core/security/DefaultPrivateKeyParseFunctionTest.java
+++ b/core/common/base/src/test/java/org/eclipse/dataspaceconnector/core/security/DefaultPrivateKeyParseFunctionTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.core.security;
 
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,38 +22,15 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class DefaultPrivateKeyParseFunctionTest {
 
-    private static final Faker FAKER = new Faker();
 
     private DefaultPrivateKeyParseFunction parseFunction;
-
-    @BeforeEach
-    public void setUp() {
-        parseFunction = new DefaultPrivateKeyParseFunction();
-    }
-
-    @Test
-    void verifyParseInvalidPemThrowsException() {
-        assertThatExceptionOfType(EdcException.class)
-                .isThrownBy(() -> parseFunction.apply(FAKER.internet().uuid()))
-                .withMessageContaining("Object cannot be null");
-    }
-
-    @ParameterizedTest(name = "{index} {1}")
-    @CsvSource({"rsa-privatekey.pem, RSA", "ec-privatekey.pem, EC"})
-    void verifyParseSuccess(String keyFileName, String expectedAlgo) throws IOException {
-        var pem = loadResourceFile(keyFileName);
-
-        var key = parseFunction.apply(pem);
-
-        assertThat(key).isNotNull();
-        assertThat(key.getAlgorithm()).isEqualTo(expectedAlgo);
-    }
 
     /**
      * Load content from a resource file.
@@ -65,5 +41,28 @@ class DefaultPrivateKeyParseFunctionTest {
                                 DefaultPrivateKeyParseFunctionTest.class.getClassLoader().getResourceAsStream(file)
                         )
                         .readAllBytes());
+    }
+
+    @BeforeEach
+    public void setUp() {
+        parseFunction = new DefaultPrivateKeyParseFunction();
+    }
+
+    @Test
+    void verifyParseInvalidPemThrowsException() {
+        assertThatExceptionOfType(EdcException.class)
+                .isThrownBy(() -> parseFunction.apply(UUID.randomUUID().toString()))
+                .withMessageContaining("Object cannot be null");
+    }
+
+    @ParameterizedTest(name = "{index} {1}")
+    @CsvSource({ "rsa-privatekey.pem, RSA", "ec-privatekey.pem, EC" })
+    void verifyParseSuccess(String keyFileName, String expectedAlgo) throws IOException {
+        var pem = loadResourceFile(keyFileName);
+
+        var key = parseFunction.apply(pem);
+
+        assertThat(key).isNotNull();
+        assertThat(key.getAlgorithm()).isEqualTo(expectedAlgo);
     }
 }

--- a/core/common/base/src/test/java/org/eclipse/dataspaceconnector/core/security/DefaultPrivateKeyParseFunctionTest.java
+++ b/core/common/base/src/test/java/org/eclipse/dataspaceconnector/core/security/DefaultPrivateKeyParseFunctionTest.java
@@ -32,17 +32,6 @@ class DefaultPrivateKeyParseFunctionTest {
 
     private DefaultPrivateKeyParseFunction parseFunction;
 
-    /**
-     * Load content from a resource file.
-     */
-    private static String loadResourceFile(String file) throws IOException {
-        return new String(
-                Objects.requireNonNull(
-                                DefaultPrivateKeyParseFunctionTest.class.getClassLoader().getResourceAsStream(file)
-                        )
-                        .readAllBytes());
-    }
-
     @BeforeEach
     public void setUp() {
         parseFunction = new DefaultPrivateKeyParseFunction();
@@ -64,5 +53,16 @@ class DefaultPrivateKeyParseFunctionTest {
 
         assertThat(key).isNotNull();
         assertThat(key.getAlgorithm()).isEqualTo(expectedAlgo);
+    }
+
+    /**
+     * Load content from a resource file.
+     */
+    private String loadResourceFile(String file) throws IOException {
+        return new String(
+                Objects.requireNonNull(
+                                DefaultPrivateKeyParseFunctionTest.class.getClassLoader().getResourceAsStream(file)
+                        )
+                        .readAllBytes());
     }
 }

--- a/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImplTest.java
+++ b/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImplTest.java
@@ -17,7 +17,6 @@
 
 package org.eclipse.dataspaceconnector.contract.validation;
 
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.contract.policy.PolicyEquality;
 import org.eclipse.dataspaceconnector.policy.model.AtomicConstraint;
 import org.eclipse.dataspaceconnector.policy.model.Permission;
@@ -40,13 +39,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
-import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
-import static java.time.Instant.EPOCH;
 import static java.time.Instant.MAX;
 import static java.time.Instant.MIN;
 import static java.time.ZoneOffset.UTC;
@@ -62,7 +59,6 @@ import static org.mockito.Mockito.when;
 
 class ContractValidationServiceImplTest {
 
-    private static final Faker FAKER = new Faker();
     private final Instant now = Instant.now();
 
     private final ParticipantAgentService agentService = mock(ParticipantAgentService.class);
@@ -145,7 +141,7 @@ class ContractValidationServiceImplTest {
     void validate_failsIfOfferedPolicyIsNotTheEqualToTheStoredOne() {
         var offeredPolicy = Policy.Builder.newInstance().permission(Permission.Builder.newInstance().build()).build();
         var storedPolicy = Policy.Builder.newInstance().permission(Permission.Builder.newInstance()
-                .constraint(AtomicConstraint.Builder.newInstance().build()).build())
+                        .constraint(AtomicConstraint.Builder.newInstance().build()).build())
                 .build();
         var asset = Asset.Builder.newInstance().id("1").build();
         var contractDefinition = getContractDefinition();
@@ -201,7 +197,7 @@ class ContractValidationServiceImplTest {
 
     @Test
     void verifyContractAgreementExpired() {
-        var past = FAKER.date().between(Timestamp.from(EPOCH), Timestamp.from(now)).toInstant().getEpochSecond();
+        var past = Instant.now().getEpochSecond() - 5000;
         var isValid =
                 validateAgreementDate(MIN.getEpochSecond(), MIN.getEpochSecond(), past);
 

--- a/core/control-plane/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/edr/EndpointDataReferenceFixtures.java
+++ b/core/control-plane/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/edr/EndpointDataReferenceFixtures.java
@@ -14,22 +14,21 @@
 
 package org.eclipse.dataspaceconnector.transfer.core.edr;
 
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.spi.types.domain.edr.EndpointDataReference;
 
 import java.util.Map;
+import java.util.UUID;
 
 public class EndpointDataReferenceFixtures {
 
-    private static final Faker FAKER = new Faker();
 
     public static EndpointDataReference createEndpointDataReference() {
         return EndpointDataReference.Builder.newInstance()
-                .endpoint(FAKER.internet().url())
-                .authKey(FAKER.lorem().word())
-                .authCode(FAKER.internet().uuid())
-                .id(FAKER.internet().uuid())
-                .properties(Map.of(FAKER.lorem().word(), FAKER.internet().uuid()))
+                .endpoint("test.endpoint.url")
+                .authKey("test-authkey")
+                .authCode(UUID.randomUUID().toString())
+                .id(UUID.randomUUID().toString())
+                .properties(Map.of("test-key", UUID.randomUUID().toString()))
                 .build();
     }
 }

--- a/core/control-plane/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/edr/EndpointDataReferenceReceiverRegistryImplTest.java
+++ b/core/control-plane/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/edr/EndpointDataReferenceReceiverRegistryImplTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.transfer.core.edr;
 
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.transfer.edr.EndpointDataReferenceReceiver;
 import org.eclipse.dataspaceconnector.spi.transfer.edr.EndpointDataReferenceReceiverRegistry;
@@ -34,7 +33,6 @@ import static org.mockito.Mockito.when;
 
 class EndpointDataReferenceReceiverRegistryImplTest {
 
-    private static final Faker FAKER = new Faker();
 
     private EndpointDataReferenceReceiver receiver1;
     private EndpointDataReferenceReceiver receiver2;
@@ -67,7 +65,7 @@ class EndpointDataReferenceReceiverRegistryImplTest {
     @Test
     void receiveAll_failsBecauseReceiverReturnsFailedResult_shouldReturnFailedResult() {
         var edr = createEndpointDataReference();
-        var errorMsg = FAKER.lorem().sentence();
+        var errorMsg = "Test error message";
 
         when(receiver1.send(any())).thenReturn(CompletableFuture.completedFuture(Result.success()));
         when(receiver2.send(any())).thenReturn(CompletableFuture.completedFuture(Result.failure(errorMsg)));
@@ -86,7 +84,7 @@ class EndpointDataReferenceReceiverRegistryImplTest {
     @Test
     void receiveAll_failsBecauseReceiverThrows_shouldReturnFailedResult() {
         var edr = createEndpointDataReference();
-        var errorMsg = FAKER.lorem().sentence();
+        var errorMsg = "Test error message";
 
         when(receiver1.send(any())).thenReturn(CompletableFuture.completedFuture(Result.success()));
         when(receiver2.send(any())).thenReturn(CompletableFuture.failedFuture(new RuntimeException(errorMsg)));

--- a/core/control-plane/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/edr/EndpointDataReferenceTransformerRegistryImplTest.java
+++ b/core/control-plane/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/edr/EndpointDataReferenceTransformerRegistryImplTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.transfer.core.edr;
 
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.transfer.edr.EndpointDataReferenceTransformer;
 import org.eclipse.dataspaceconnector.spi.transfer.edr.EndpointDataReferenceTransformerRegistry;
@@ -30,8 +29,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class EndpointDataReferenceTransformerRegistryImplTest {
-
-    private static final Faker FAKER = new Faker();
 
     private EndpointDataReferenceTransformer transformer1;
     private EndpointDataReferenceTransformer transformer2;
@@ -94,7 +91,7 @@ class EndpointDataReferenceTransformerRegistryImplTest {
 
     @Test
     void transform_transformerFailed_shouldReturnFailedResult() {
-        var errorMsg = FAKER.lorem().sentence();
+        var errorMsg = "Test error message";
         var inputEdr = createEndpointDataReference();
 
         when(transformer1.canHandle(inputEdr)).thenReturn(true);

--- a/core/control-plane/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/flow/DataFlowManagerImplTest.java
+++ b/core/control-plane/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/flow/DataFlowManagerImplTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.transfer.core.flow;
 
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.response.StatusResult;
@@ -31,15 +30,14 @@ import static org.mockito.Mockito.when;
 
 class DataFlowManagerImplTest {
 
-    private static final Faker FAKER = new Faker();
 
     @Test
     void should_initiate_flow_on_correct_controller() {
         var manager = new DataFlowManagerImpl();
         var controller = mock(DataFlowController.class);
-        var dataRequest = DataRequest.Builder.newInstance().destinationType(FAKER.lorem().word()).build();
+        var dataRequest = DataRequest.Builder.newInstance().destinationType("test-dest-type").build();
         var policy = Policy.Builder.newInstance().build();
-        var dataAddress = DataAddress.Builder.newInstance().type(FAKER.lorem().word()).build();
+        var dataAddress = DataAddress.Builder.newInstance().type("test-type").build();
 
         when(controller.canHandle(any(), any())).thenReturn(true);
         when(controller.initiateFlow(any(), any(), any())).thenReturn(StatusResult.success());
@@ -54,8 +52,8 @@ class DataFlowManagerImplTest {
     void should_return_fatal_error_if_no_controller_can_handle_the_request() {
         var manager = new DataFlowManagerImpl();
         var controller = mock(DataFlowController.class);
-        var dataRequest = DataRequest.Builder.newInstance().destinationType(FAKER.lorem().word()).build();
-        var dataAddress = DataAddress.Builder.newInstance().type(FAKER.lorem().word()).build();
+        var dataRequest = DataRequest.Builder.newInstance().destinationType("test-dest-type").build();
+        var dataAddress = DataAddress.Builder.newInstance().type("test-type").build();
         var policy = Policy.Builder.newInstance().build();
 
         when(controller.canHandle(any(), any())).thenReturn(false);
@@ -71,11 +69,11 @@ class DataFlowManagerImplTest {
     void should_catch_exceptions_and_return_fatal_error() {
         var manager = new DataFlowManagerImpl();
         var controller = mock(DataFlowController.class);
-        var dataRequest = DataRequest.Builder.newInstance().destinationType(FAKER.lorem().word()).build();
-        var dataAddress = DataAddress.Builder.newInstance().type(FAKER.lorem().word()).build();
+        var dataRequest = DataRequest.Builder.newInstance().destinationType("test-dest-type").build();
+        var dataAddress = DataAddress.Builder.newInstance().type("test-type").build();
         var policy = Policy.Builder.newInstance().build();
 
-        var errorMsg = FAKER.lorem().sentence();
+        var errorMsg = "Test Error Message";
         when(controller.canHandle(any(), any())).thenReturn(true);
         when(controller.initiateFlow(any(), any(), any())).thenThrow(new EdcException(errorMsg));
         manager.register(controller);

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/IdsMultipartSenderTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/IdsMultipartSenderTest.java
@@ -18,7 +18,6 @@ package org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.fraunhofer.iais.eis.DynamicAttributeToken;
 import de.fraunhofer.iais.eis.Message;
-import net.datafaker.Faker;
 import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.response.IdsMultipartParts;
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.response.MultipartResponse;
@@ -40,9 +39,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class IdsMultipartSenderTest {
-    private static final Faker FAKER = new Faker();
     private final IdentityService identityService = mock(IdentityService.class);
-    private final String remoteAddress = FAKER.internet().url();
 
     @Test
     void should_fail_if_token_retrieval_fails() {
@@ -55,6 +52,19 @@ class IdsMultipartSenderTest {
         var result = sender.send(new TestRemoteMessage(), () -> "any");
 
         assertThat(result).failsWithin(1, TimeUnit.SECONDS);
+    }
+
+    private static class TestRemoteMessage implements RemoteMessage {
+
+        @Override
+        public String getProtocol() {
+            return null;
+        }
+
+        @Override
+        public String getConnectorAddress() {
+            return null;
+        }
     }
 
     private class TestIdsMultipartSender extends IdsMultipartSender<TestRemoteMessage, MultipartResponse> {
@@ -71,7 +81,7 @@ class IdsMultipartSenderTest {
 
         @Override
         protected String retrieveRemoteConnectorAddress(TestRemoteMessage request) {
-            return remoteAddress;
+            return "some.remote.url";
         }
 
         @Override
@@ -86,19 +96,6 @@ class IdsMultipartSenderTest {
 
         @Override
         protected List<Class<? extends Message>> getAllowedResponseTypes() {
-            return null;
-        }
-    }
-
-    private static class TestRemoteMessage implements RemoteMessage {
-
-        @Override
-        public String getProtocol() {
-            return null;
-        }
-
-        @Override
-        public String getConnectorAddress() {
             return null;
         }
     }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/EndpointDataReferenceHandlerTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/EndpointDataReferenceHandlerTest.java
@@ -20,7 +20,6 @@ import de.fraunhofer.iais.eis.MessageProcessedNotificationMessage;
 import de.fraunhofer.iais.eis.ParticipantCertificateRevokedMessageBuilder;
 import de.fraunhofer.iais.eis.ParticipantUpdateMessageBuilder;
 import de.fraunhofer.iais.eis.RejectionMessage;
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.ids.api.multipart.message.MultipartRequest;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
@@ -34,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,17 +45,38 @@ import static org.mockito.Mockito.when;
 
 class EndpointDataReferenceHandlerTest {
 
-    private static final Faker FAKER = new Faker();
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private EndpointDataReferenceHandler handler;
     private EndpointDataReferenceReceiverRegistry receiverRegistry;
     private EndpointDataReferenceTransformerRegistry transformerRegistry;
 
+    private static EndpointDataReference createEndpointDataReference() {
+        return EndpointDataReference.Builder.newInstance()
+                .endpoint("some.endpoint.url")
+                .authKey("test-authkey")
+                .authCode(UUID.randomUUID().toString())
+                .id(UUID.randomUUID().toString())
+                .properties(Map.of("key1", UUID.randomUUID().toString()))
+                .build();
+    }
+
+    private static MultipartRequest createMultipartRequest(EndpointDataReference payload) throws JsonProcessingException {
+        return MultipartRequest.Builder.newInstance()
+                .header(new ParticipantUpdateMessageBuilder().build())
+                .payload(MAPPER.writeValueAsString(payload))
+                .claimToken(createClaimToken())
+                .build();
+    }
+
+    private static ClaimToken createClaimToken() {
+        return ClaimToken.Builder.newInstance().build();
+    }
+
     @BeforeEach
     public void setUp() {
         var monitor = mock(Monitor.class);
-        var connectorId = FAKER.lorem().word();
+        var connectorId = "test-connector-id";
         receiverRegistry = mock(EndpointDataReferenceReceiverRegistry.class);
         transformerRegistry = mock(EndpointDataReferenceTransformerRegistry.class);
         var typeManager = new TypeManager();
@@ -110,7 +131,7 @@ class EndpointDataReferenceHandlerTest {
         var edr = createEndpointDataReference();
         var request = createMultipartRequest(edr);
 
-        when(transformerRegistry.transform(any())).thenReturn(Result.failure(FAKER.lorem().sentence()));
+        when(transformerRegistry.transform(any())).thenReturn(Result.failure("Test failure"));
 
         var response = handler.handleRequest(request);
 
@@ -125,34 +146,12 @@ class EndpointDataReferenceHandlerTest {
         var request = createMultipartRequest(edr);
 
         when(transformerRegistry.transform(any())).thenReturn(Result.success(edr));
-        when(receiverRegistry.receiveAll(edr)).thenReturn(CompletableFuture.completedFuture(Result.failure(FAKER.lorem().sentence())));
+        when(receiverRegistry.receiveAll(edr)).thenReturn(CompletableFuture.completedFuture(Result.failure("Test failure")));
 
         var response = handler.handleRequest(request);
 
         assertThat(response)
                 .isNotNull()
                 .satisfies(r -> assertThat(r.getHeader()).isInstanceOf(RejectionMessage.class));
-    }
-
-    private static EndpointDataReference createEndpointDataReference() {
-        return EndpointDataReference.Builder.newInstance()
-                .endpoint(FAKER.internet().url())
-                .authKey(FAKER.lorem().word())
-                .authCode(FAKER.internet().uuid())
-                .id(FAKER.internet().uuid())
-                .properties(Map.of(FAKER.lorem().word(), FAKER.internet().uuid()))
-                .build();
-    }
-
-    private static MultipartRequest createMultipartRequest(EndpointDataReference payload) throws JsonProcessingException {
-        return MultipartRequest.Builder.newInstance()
-                .header(new ParticipantUpdateMessageBuilder().build())
-                .payload(MAPPER.writeValueAsString(payload))
-                .claimToken(createClaimToken())
-                .build();
-    }
-
-    private static ClaimToken createClaimToken() {
-        return ClaimToken.Builder.newInstance().build();
     }
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/EndpointDataReferenceHandlerTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/EndpointDataReferenceHandlerTest.java
@@ -51,28 +51,6 @@ class EndpointDataReferenceHandlerTest {
     private EndpointDataReferenceReceiverRegistry receiverRegistry;
     private EndpointDataReferenceTransformerRegistry transformerRegistry;
 
-    private static EndpointDataReference createEndpointDataReference() {
-        return EndpointDataReference.Builder.newInstance()
-                .endpoint("some.endpoint.url")
-                .authKey("test-authkey")
-                .authCode(UUID.randomUUID().toString())
-                .id(UUID.randomUUID().toString())
-                .properties(Map.of("key1", UUID.randomUUID().toString()))
-                .build();
-    }
-
-    private static MultipartRequest createMultipartRequest(EndpointDataReference payload) throws JsonProcessingException {
-        return MultipartRequest.Builder.newInstance()
-                .header(new ParticipantUpdateMessageBuilder().build())
-                .payload(MAPPER.writeValueAsString(payload))
-                .claimToken(createClaimToken())
-                .build();
-    }
-
-    private static ClaimToken createClaimToken() {
-        return ClaimToken.Builder.newInstance().build();
-    }
-
     @BeforeEach
     public void setUp() {
         var monitor = mock(Monitor.class);
@@ -153,5 +131,27 @@ class EndpointDataReferenceHandlerTest {
         assertThat(response)
                 .isNotNull()
                 .satisfies(r -> assertThat(r.getHeader()).isInstanceOf(RejectionMessage.class));
+    }
+
+    private EndpointDataReference createEndpointDataReference() {
+        return EndpointDataReference.Builder.newInstance()
+                .endpoint("some.endpoint.url")
+                .authKey("test-authkey")
+                .authCode(UUID.randomUUID().toString())
+                .id(UUID.randomUUID().toString())
+                .properties(Map.of("key1", UUID.randomUUID().toString()))
+                .build();
+    }
+
+    private MultipartRequest createMultipartRequest(EndpointDataReference payload) throws JsonProcessingException {
+        return MultipartRequest.Builder.newInstance()
+                .header(new ParticipantUpdateMessageBuilder().build())
+                .payload(MAPPER.writeValueAsString(payload))
+                .claimToken(createClaimToken())
+                .build();
+    }
+
+    private ClaimToken createClaimToken() {
+        return ClaimToken.Builder.newInstance().build();
     }
 }

--- a/extensions/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerIntegrationTest.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.api.datamanagement.catalog;
 
 import io.restassured.specification.RequestSpecification;
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.junit.extensions.EdcExtension;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
@@ -48,7 +47,6 @@ import static org.mockito.Mockito.when;
 @ExtendWith(EdcExtension.class)
 public class CatalogApiControllerIntegrationTest {
 
-    private static final Faker FAKER = Faker.instance();
     private final int port = getFreePort();
     private final String authKey = "123456";
     private final RemoteMessageDispatcher dispatcher = mock(RemoteMessageDispatcher.class);
@@ -81,7 +79,7 @@ public class CatalogApiControllerIntegrationTest {
                 .thenReturn(completedFuture(emptyCatalog));
 
         baseRequest()
-                .queryParam("providerUrl", FAKER.internet().url())
+                .queryParam("providerUrl", "some.provider.url")
                 .get("/catalog")
                 .then()
                 .statusCode(200)

--- a/extensions/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerTest.java
+++ b/extensions/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerTest.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.api.datamanagement.catalog;
 
 import jakarta.ws.rs.container.AsyncResponse;
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.api.datamanagement.catalog.service.CatalogService;
 import org.eclipse.dataspaceconnector.api.query.QuerySpecDto;
 import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
@@ -44,7 +43,6 @@ import static org.mockito.Mockito.when;
 
 class CatalogApiControllerTest {
 
-    private static final Faker FAKER = Faker.instance();
     private final CatalogService service = mock(CatalogService.class);
     private final Monitor monitor = mock(Monitor.class);
     private DtoTransformerRegistry transformerRegistry;
@@ -66,7 +64,7 @@ class CatalogApiControllerTest {
                 .assetId(UUID.randomUUID().toString())
                 .build();
         var catalog = Catalog.Builder.newInstance().id("any").contractOffers(List.of(offer)).build();
-        var url = FAKER.internet().url();
+        var url = "test.url";
         when(service.getByProviderUrl(eq(url), any())).thenReturn(completedFuture(catalog));
 
         controller.getCatalog(url, new QuerySpecDto(), response);
@@ -78,7 +76,7 @@ class CatalogApiControllerTest {
     void shouldResumeWithExceptionIfGetCatalogFails() {
         var controller = new CatalogApiController(service, transformerRegistry, monitor);
         var response = mock(AsyncResponse.class);
-        var url = FAKER.internet().url();
+        var url = "test.url";
         when(service.getByProviderUrl(eq(url), any())).thenReturn(failedFuture(new EdcException("error")));
 
         controller.getCatalog(url, new QuerySpecDto(), response);

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess;
 
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferProcessDto;
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferRequestDto;
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.service.TransferProcessService;
@@ -42,6 +41,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,7 +55,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class TransferProcessApiControllerTest {
-    private static final Faker FAKER = new Faker();
     private final TransferProcessService service = mock(TransferProcessService.class);
     private final DtoTransformerRegistry transformerRegistry = mock(DtoTransformerRegistry.class);
     private TransferProcessApiController controller;
@@ -276,7 +275,7 @@ class TransferProcessApiControllerTest {
     }
 
     private TransferProcess transferProcess() {
-        return transferProcess(FAKER.lorem().word());
+        return transferProcess(UUID.randomUUID().toString());
     }
 
     private TransferProcess transferProcess(String id) {

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiExtensionTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiExtensionTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess;
 
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.api.datamanagement.configuration.DataManagementApiConfiguration;
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferProcessDto;
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform.TransferProcessTransformerTestData;
@@ -38,9 +37,8 @@ import static org.mockito.Mockito.verify;
 
 @ExtendWith(DependencyInjectionExtension.class)
 class TransferProcessApiExtensionTest {
-    static Faker faker = new Faker();
-    TransferProcessTransformerTestData data = new TransferProcessTransformerTestData();
-    String contextAlias = faker.lorem().word();
+    private final TransferProcessTransformerTestData data = new TransferProcessTransformerTestData();
+    private final String contextAlias = "test-alias";
 
     @Test
     void initialize(ServiceExtensionContext context, ObjectFactory factory) {

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImplTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImplTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.service;
 
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.response.StatusResult;
 import org.eclipse.dataspaceconnector.spi.transaction.NoopTransactionContext;
@@ -34,6 +33,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,19 +47,18 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class TransferProcessServiceImplTest {
-    static Faker faker = new Faker();
 
-    String id = faker.lorem().word();
-    TransferProcess process1 = transferProcess();
-    TransferProcess process2 = transferProcess();
-    QuerySpec query = QuerySpec.Builder.newInstance().limit(5).offset(2).build();
-    ArgumentCaptor<SingleTransferProcessCommand> commandCaptor = ArgumentCaptor.forClass(SingleTransferProcessCommand.class);
+    private final String id = UUID.randomUUID().toString();
+    private final TransferProcess process1 = transferProcess();
+    private final TransferProcess process2 = transferProcess();
+    private final QuerySpec query = QuerySpec.Builder.newInstance().limit(5).offset(2).build();
+    private final ArgumentCaptor<SingleTransferProcessCommand> commandCaptor = ArgumentCaptor.forClass(SingleTransferProcessCommand.class);
 
-    TransferProcessStore store = mock(TransferProcessStore.class);
-    TransferProcessManager manager = mock(TransferProcessManager.class);
-    TransactionContext transactionContext = spy(new NoopTransactionContext());
+    private final TransferProcessStore store = mock(TransferProcessStore.class);
+    private final TransferProcessManager manager = mock(TransferProcessManager.class);
+    private final TransactionContext transactionContext = spy(new NoopTransactionContext());
 
-    TransferProcessService service = new TransferProcessServiceImpl(store, manager, transactionContext);
+    private final TransferProcessService service = new TransferProcessServiceImpl(store, manager, transactionContext);
 
     @Test
     void findById_whenFound() {
@@ -210,7 +209,8 @@ class TransferProcessServiceImplTest {
     }
 
     private TransferProcess transferProcess() {
-        return transferProcess(faker.options().option(TransferProcessStates.class), UUID.randomUUID().toString());
+        var state = TransferProcessStates.values()[ThreadLocalRandom.current().nextInt(TransferProcessStates.values().length)];
+        return transferProcess(state, UUID.randomUUID().toString());
     }
 
     private TransferProcess transferProcess(TransferProcessStates state, String id) {

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/DataRequestTransformerTestData.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/DataRequestTransformerTestData.java
@@ -14,27 +14,27 @@
 
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform;
 
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.DataRequestDto;
 import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 
+import java.util.UUID;
+
 import static org.mockito.Mockito.mock;
 
 class DataRequestTransformerTestData {
-    static Faker faker = new Faker();
 
     TransformerContext context = mock(TransformerContext.class);
-    String assetId = faker.lorem().word();
-    String contractId = faker.lorem().word();
-    String connectorId = faker.lorem().word();
+    String assetId = UUID.randomUUID().toString();
+    String contractId = UUID.randomUUID().toString();
+    String connectorId = UUID.randomUUID().toString();
 
     DataRequest entity = DataRequest.Builder.newInstance()
             .assetId(assetId)
             .contractId(contractId)
             .connectorId(connectorId)
-            .dataDestination(DataAddress.Builder.newInstance().type(faker.lorem().word()).build())
+            .dataDestination(DataAddress.Builder.newInstance().type("test-type").build())
             .build();
 
     DataRequestDto dto = DataRequestDto.Builder.newInstance()

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessTransformerTestData.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessTransformerTestData.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform;
 
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.DataAddressInformationDto;
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.DataRequestDto;
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferProcessDto;
@@ -28,23 +27,24 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessS
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static org.mockito.Mockito.mock;
 
 public class TransferProcessTransformerTestData {
-    static Faker faker = new Faker();
 
     DtoTransformerRegistry registry = mock(DtoTransformerRegistry.class);
     TransformerContext context = new TransformerContextImpl(registry);
-    String id = faker.lorem().word();
-    TransferProcess.Type type = faker.options().option(TransferProcess.Type.class);
-    TransferProcessStates state = faker.options().option(TransferProcessStates.class);
-    long stateTimestamp = faker.random().nextLong();
-    long createdTimestamp = faker.random().nextLong();
-    String errorDetail = faker.lorem().word();
+    String id = UUID.randomUUID().toString();
+    TransferProcess.Type type = TransferProcess.Type.CONSUMER;
+    TransferProcessStates state = TransferProcessStates.values()[ThreadLocalRandom.current().nextInt(TransferProcessStates.values().length)];
+    long stateTimestamp = ThreadLocalRandom.current().nextLong();
+    long createdTimestamp = ThreadLocalRandom.current().nextLong();
+    String errorDetail = "test error detail";
 
-    Map<String, String> dataDestinationProperties = Map.of(faker.lorem().word(), faker.lorem().word());
-    String dataDestinationType = faker.lorem().word();
+    Map<String, String> dataDestinationProperties = Map.of("key1", "value1");
+    String dataDestinationType = "test-destination-type";
     DataAddress.Builder dataDestination = DataAddress.Builder.newInstance().type(dataDestinationType).properties(dataDestinationProperties);
     DataRequest dataRequest = DataRequest.Builder.newInstance()
             .dataDestination(dataDestination.build())

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferRequestDtoToDataRequestTransformerTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferRequestDtoToDataRequestTransformerTest.java
@@ -15,7 +15,6 @@
 
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform;
 
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferRequestDto;
 import org.eclipse.dataspaceconnector.api.transformer.DtoTransformer;
 import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
@@ -25,14 +24,14 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 class TransferRequestDtoToDataRequestTransformerTest {
 
-    private static Faker faker = new Faker();
-    private DtoTransformer<TransferRequestDto, DataRequest> transformer = new TransferRequestDtoToDataRequestTransformer();
+    private final DtoTransformer<TransferRequestDto, DataRequest> transformer = new TransferRequestDtoToDataRequestTransformer();
 
     @Test
     void getInputType() {
@@ -48,7 +47,7 @@ class TransferRequestDtoToDataRequestTransformerTest {
     void transform() {
         var context = mock(TransformerContext.class);
         var transferReq = transferRequestDto()
-                .id(faker.lorem().word())
+                .id(UUID.randomUUID().toString())
                 .build();
         var dataRequest = transformer.transform(transferReq, context);
         assertThat(dataRequest.getId()).isEqualTo(transferReq.getId());
@@ -76,13 +75,13 @@ class TransferRequestDtoToDataRequestTransformerTest {
     @NotNull
     private TransferRequestDto.Builder transferRequestDto() {
         return TransferRequestDto.Builder.newInstance()
-                .connectorAddress(faker.internet().url())
-                .assetId(faker.lorem().word())
-                .contractId(faker.lorem().word())
-                .protocol(faker.lorem().word())
-                .dataDestination(DataAddress.Builder.newInstance().type(faker.lorem().word()).build())
-                .connectorId(faker.lorem().word())
-                .properties(Map.of(faker.lorem().word(), faker.lorem().word()));
+                .connectorAddress("http://some.connector.address")
+                .assetId(UUID.randomUUID().toString())
+                .contractId(UUID.randomUUID().toString())
+                .protocol("test-protocol")
+                .dataDestination(DataAddress.Builder.newInstance().type("test-type").build())
+                .connectorId(UUID.randomUUID().toString())
+                .properties(Map.of("key1", "value1"));
     }
 
 }

--- a/extensions/aws/data-plane-s3/src/test/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataPlaneIntegrationTest.java
+++ b/extensions/aws/data-plane-s3/src/test/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataPlaneIntegrationTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.aws.dataplane.s3;
 
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.aws.s3.core.S3BucketSchema;
 import org.eclipse.dataspaceconnector.aws.testfixtures.AbstractS3Test;
 import org.eclipse.dataspaceconnector.aws.testfixtures.TestS3ClientProvider;
@@ -42,7 +41,6 @@ import static org.mockito.Mockito.mock;
 @IntegrationTest
 public class S3DataPlaneIntegrationTest extends AbstractS3Test {
 
-    static Faker faker = new Faker();
 
     private final String sourceBucketName = "source-" + UUID.randomUUID();
     private final String destinationBucketName = "destination-" + UUID.randomUUID();
@@ -61,7 +59,7 @@ public class S3DataPlaneIntegrationTest extends AbstractS3Test {
 
     @Test
     void shouldCopyFromSourceToSink() {
-        putStringOnBucket(sourceBucketName, "key", faker.lorem().sentence());
+        putStringOnBucket(sourceBucketName, "key", UUID.randomUUID().toString());
 
         var s3ClientProvider = new TestS3ClientProvider(getCredentials(), S3_ENDPOINT);
 

--- a/extensions/azure/blobstorage/blob-core/build.gradle.kts
+++ b/extensions/azure/blobstorage/blob-core/build.gradle.kts
@@ -17,7 +17,6 @@ plugins {
     `java-test-fixtures`
 }
 
-val datafaker: String by project
 val storageBlobVersion: String by project
 val failsafeVersion: String by project
 val jupiterVersion: String by project
@@ -33,7 +32,6 @@ dependencies {
 
     testFixturesImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
     testFixturesRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")
-    testFixturesImplementation("net.datafaker:datafaker:${datafaker}")
 }
 
 publishing {

--- a/extensions/azure/blobstorage/blob-core/src/test/java/org/eclipse/dataspaceconnector/azure/blob/core/validator/AzureStorageValidatorTest.java
+++ b/extensions/azure/blobstorage/blob-core/src/test/java/org/eclipse/dataspaceconnector/azure/blob/core/validator/AzureStorageValidatorTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.azure.blob.core.validator;
 
-import net.datafaker.Faker;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -27,58 +26,6 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class AzureStorageValidatorTest {
 
-    static Faker faker = new Faker();
-
-    @ParameterizedTest
-    @ValueSource(strings = {"abc", "abcdefghijabcdefghijbcde", "1er", "451", "ge45"})
-    void validateAccountName_success(String input) {
-        AzureStorageValidator.validateAccountName(input);
-    }
-
-    @ParameterizedTest
-    @NullAndEmptySource
-    @ValueSource(strings = {"  ", "$log", "r", "re", "a a", " b", "ag_c", "re-r", "bdjfkCJdfd", "efer:a",
-            "abcdefghijabcdefghijbcdef"})
-    void validateAccountName_fail(String input) {
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> AzureStorageValidator.validateAccountName(input));
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {
-            "$root", "$logs", "$web",
-            "re-r", "z0r-a-q",
-            "abc", "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz01234567890", "1er", "451", "ge45"})
-    void validateContainerName_success(String input) {
-        AzureStorageValidator.validateContainerName(input);
-    }
-
-    @ParameterizedTest
-    @NullAndEmptySource
-    @ValueSource(strings = {"$log", "  ", "r", "re", "a a", "-ree", "era-", "z0rr--", " b", "ag_c",
-            "bdjfkCJdfd", "efer:a", "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz012345678901"})
-    void validateContainerName_fail(String input) {
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> AzureStorageValidator.validateContainerName(input));
-    }
-
-    @ParameterizedTest
-    @NullAndEmptySource
-    void validateKeyName_fail(String input) {
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> AzureStorageValidator.validateKeyName(input));
-    }
-
-    @Test
-    void validateKeyName_success() {
-        AzureStorageValidator.validateKeyName(faker.lorem().word());
-    }
-
-    @ParameterizedTest
-    @MethodSource("validBlobNames")
-    void validateBlobName_success(String input) {
-        AzureStorageValidator.validateBlobName(input);
-    }
 
     private static Stream<String> validBlobNames() {
         return Stream.of(
@@ -100,6 +47,56 @@ class AzureStorageValidatorTest {
                 "a/b".repeat(254));
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = { "abc", "abcdefghijabcdefghijbcde", "1er", "451", "ge45" })
+    void validateAccountName_success(String input) {
+        AzureStorageValidator.validateAccountName(input);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = { "  ", "$log", "r", "re", "a a", " b", "ag_c", "re-r", "bdjfkCJdfd", "efer:a",
+            "abcdefghijabcdefghijbcdef" })
+    void validateAccountName_fail(String input) {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> AzureStorageValidator.validateAccountName(input));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "$root", "$logs", "$web",
+            "re-r", "z0r-a-q",
+            "abc", "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz01234567890", "1er", "451", "ge45" })
+    void validateContainerName_success(String input) {
+        AzureStorageValidator.validateContainerName(input);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = { "$log", "  ", "r", "re", "a a", "-ree", "era-", "z0rr--", " b", "ag_c",
+            "bdjfkCJdfd", "efer:a", "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz012345678901" })
+    void validateContainerName_fail(String input) {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> AzureStorageValidator.validateContainerName(input));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void validateKeyName_fail(String input) {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> AzureStorageValidator.validateKeyName(input));
+    }
+
+    @Test
+    void validateKeyName_success() {
+        AzureStorageValidator.validateKeyName("test random key name");
+    }
+
+    @ParameterizedTest
+    @MethodSource("validBlobNames")
+    void validateBlobName_success(String input) {
+        AzureStorageValidator.validateBlobName(input);
+    }
 
     @ParameterizedTest
     @MethodSource("invalidBlobNames")

--- a/extensions/azure/blobstorage/blob-core/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/blob/core/AzureStorageTestFixtures.java
+++ b/extensions/azure/blobstorage/blob-core/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/blob/core/AzureStorageTestFixtures.java
@@ -14,18 +14,22 @@
 
 package org.eclipse.dataspaceconnector.azure.blob.core;
 
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
 
+import java.time.Instant;
+import java.util.UUID;
+
 public class AzureStorageTestFixtures {
 
-    private static final Faker FAKER = new Faker();
+
+    private AzureStorageTestFixtures() {
+    }
 
     public static DataFlowRequest.Builder createRequest(String type) {
         return DataFlowRequest.Builder.newInstance()
-                .id(FAKER.internet().uuid())
-                .processId(FAKER.internet().uuid())
+                .id(UUID.randomUUID().toString())
+                .processId(UUID.randomUUID().toString())
                 .sourceDataAddress(createDataAddress(type).build())
                 .destinationDataAddress(createDataAddress(type).build());
     }
@@ -35,26 +39,23 @@ public class AzureStorageTestFixtures {
     }
 
     public static String createAccountName() {
-        return FAKER.lorem().characters(3, 24, false, false);
+        return ("acct" + Instant.now().getEpochSecond()); // UUID would be too long
     }
 
     public static String createContainerName() {
-        return FAKER.lorem().characters(3, 40, false, false);
+        return ("cont-" + UUID.randomUUID()).toLowerCase();
     }
 
     public static String createBlobName() {
-        return FAKER.lorem().characters(3, 40, false, false);
+        return "blob-" + UUID.randomUUID();
     }
 
     public static String createSharedKey() {
-        return FAKER.lorem().characters();
+        return "SK-" + UUID.randomUUID();
     }
 
     public static String createSharedAccessSignature() {
-        return FAKER.lorem().characters();
-    }
-
-    private AzureStorageTestFixtures() {
+        return "SAS-" + UUID.randomUUID();
     }
 
 }

--- a/extensions/azure/data-plane/data-factory/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azuredatafactory/AzureDataFactoryCopyIntegrationTest.java
+++ b/extensions/azure/data-plane/data-factory/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azuredatafactory/AzureDataFactoryCopyIntegrationTest.java
@@ -22,7 +22,6 @@ import com.azure.storage.blob.BlobServiceClientBuilder;
 import com.azure.storage.blob.sas.BlobContainerSasPermission;
 import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
 import com.azure.storage.common.StorageSharedKeyCredential;
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.azure.blob.core.AzureSasToken;
 import org.eclipse.dataspaceconnector.azure.testfixtures.annotations.AzureDataFactoryIntegrationTest;
 import org.eclipse.dataspaceconnector.dataplane.spi.manager.DataPlaneManager;
@@ -178,19 +177,17 @@ class AzureDataFactoryCopyIntegrationTest {
         SECRET_CLEANUP.add(() -> vault.secretClient().purgeDeletedSecret(secretName).block(Duration.ofMinutes(1)));
     }
 
-    static class Account {
+    private static class Account {
 
-        static final Faker FAKER = new Faker();
-        final String name;
-        final String key;
-        final BlobServiceClient client;
-        final String containerName = FAKER.lorem().characters(35, 40, false, false);
+        private final String name;
+        private final BlobServiceClient client;
+        private final String containerName = "test-container-" + UUID.randomUUID();
 
         Account(AzureResourceManager azure, EdcExtension edc, String setting) {
             String accountId = Objects.requireNonNull(edc.getContext().getConfig().getString(setting), setting);
             var account = azure.storageAccounts().getById(accountId);
             name = account.name();
-            key = account.getKeys().stream().findFirst().orElseThrow().value();
+            String key = account.getKeys().stream().findFirst().orElseThrow().value();
             client = new BlobServiceClientBuilder()
                     .credential(new StorageSharedKeyCredential(account.name(), key))
                     .endpoint(account.endPoints().primary().blob())

--- a/extensions/azure/data-plane/data-factory/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azuredatafactory/AzureDataFactoryTransferManagerTest.java
+++ b/extensions/azure/data-plane/data-factory/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azuredatafactory/AzureDataFactoryTransferManagerTest.java
@@ -19,7 +19,6 @@ import com.azure.resourcemanager.datafactory.models.CreateRunResponse;
 import com.azure.resourcemanager.datafactory.models.PipelineResource;
 import com.azure.resourcemanager.datafactory.models.PipelineRun;
 import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
-import net.datafaker.Faker;
 import org.assertj.core.api.ObjectAssert;
 import org.bouncycastle.util.test.UncloseableOutputStream;
 import org.eclipse.dataspaceconnector.azure.blob.core.AzureSasToken;
@@ -41,9 +40,12 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Random;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.azure.dataplane.azuredatafactory.TestFunctions.createFlowRequest;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -51,21 +53,26 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class AzureDataFactoryTransferManagerTest {
-    static final Faker FAKER = new Faker();
 
-    Monitor monitor = mock(Monitor.class);
-    Clock clock = mock(Clock.class);
-    Instant fixedInstant = Instant.EPOCH;
-    DataFactoryClient client = mock(DataFactoryClient.class);
-    DataFactoryPipelineFactory pipelineFactory = mock(DataFactoryPipelineFactory.class);
-    BlobStoreApi blobStoreApi = mock(BlobStoreApi.class);
-    TypeManager typeManager = new TypeManager();
-    KeyVaultClient keyVaultClient = mock(KeyVaultClient.class);
-    KeyVaultSecret keyVaultSecret = mock(KeyVaultSecret.class);
-    AzureSasToken sasToken = new AzureSasToken(FAKER.lorem().word(), FAKER.number().randomNumber());
-    BlobAdapter blobAdapter = mock(BlobAdapter.class);
-    Duration maxDuration = Duration.ofMillis(FAKER.number().numberBetween(1, 10));
-    AzureDataFactoryTransferManager transferManager = new AzureDataFactoryTransferManager(
+    private final Monitor monitor = mock(Monitor.class);
+    private final Clock clock = mock(Clock.class);
+    private final Instant fixedInstant = Instant.EPOCH;
+    private final DataFactoryClient client = mock(DataFactoryClient.class);
+    private final DataFactoryPipelineFactory pipelineFactory = mock(DataFactoryPipelineFactory.class);
+    private final BlobStoreApi blobStoreApi = mock(BlobStoreApi.class);
+    private final TypeManager typeManager = new TypeManager();
+    private final KeyVaultClient keyVaultClient = mock(KeyVaultClient.class);
+    private final KeyVaultSecret keyVaultSecret = mock(KeyVaultSecret.class);
+    private final BlobAdapter blobAdapter = mock(BlobAdapter.class);
+    private final DataFlowRequest request = createFlowRequest();
+    private final PipelineResource pipeline = mock(PipelineResource.class);
+    private final CreateRunResponse runResponse = mock(CreateRunResponse.class);
+    private final String runId = UUID.randomUUID().toString();
+    private final PipelineRun run = mock(PipelineRun.class);
+    private final Random random = new Random();
+    private final AzureSasToken sasToken = new AzureSasToken("test-wo-sas", random.nextLong());
+    private final Duration maxDuration = Duration.ofMillis(1 + random.nextInt(11));
+    private final AzureDataFactoryTransferManager transferManager = new AzureDataFactoryTransferManager(
             monitor,
             client,
             pipelineFactory,
@@ -76,12 +83,22 @@ class AzureDataFactoryTransferManagerTest {
             keyVaultClient,
             Duration.ofMillis(0));
 
-    DataFlowRequest request = AzureDataFactoryTransferRequestValidatorTest.requestWithProperties;
+    static Stream<Arguments> successStates() {
+        return Stream.of(
+                arguments(List.of("Succeeded")),
+                arguments(List.of("Queued", "InProgress", "Succeeded"))
+        );
+    }
 
-    PipelineResource pipeline = mock(PipelineResource.class);
-    CreateRunResponse runResponse = mock(CreateRunResponse.class);
-    String runId = FAKER.lorem().characters();
-    PipelineRun run = mock(PipelineRun.class);
+    static Stream<Arguments> failureStates() {
+        return Stream.of(
+                arguments(List.of("Failed")),
+                arguments(List.of("Queued", "InProgress", "Failed")),
+                arguments(List.of("Queued", "InProgress", "Canceling", "Cancelled")),
+                arguments(List.of("Cancelled")),
+                arguments(List.of("Queued", "InProgress", UUID.randomUUID().toString()))
+        );
+    }
 
     @BeforeEach
     void setUp() {
@@ -115,13 +132,6 @@ class AzureDataFactoryTransferManagerTest {
                 .matches(StatusResult::succeeded, "is succeeded");
     }
 
-    static Stream<Arguments> successStates() {
-        return Stream.of(
-                arguments(List.of("Succeeded")),
-                arguments(List.of("Queued", "InProgress", "Succeeded"))
-        );
-    }
-
     @ParameterizedTest
     @MethodSource("failureStates")
     void transfer_failure(List<String> states) {
@@ -144,17 +154,6 @@ class AzureDataFactoryTransferManagerTest {
                 .matches(StatusResult::failed);
         assertThatTransferResult()
                 .satisfies(r -> assertThat(r.getFailure().status()).isEqualTo(ResponseStatus.ERROR_RETRY));
-    }
-
-
-    static Stream<Arguments> failureStates() {
-        return Stream.of(
-                arguments(List.of("Failed")),
-                arguments(List.of("Queued", "InProgress", "Failed")),
-                arguments(List.of("Queued", "InProgress", "Canceling", "Cancelled")),
-                arguments(List.of("Cancelled")),
-                arguments(List.of("Queued", "InProgress", FAKER.lorem().word()))
-        );
     }
 
     @Test

--- a/extensions/azure/data-plane/data-factory/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azuredatafactory/AzureDataFactoryTransferServiceTest.java
+++ b/extensions/azure/data-plane/data-factory/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azuredatafactory/AzureDataFactoryTransferServiceTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.azure.dataplane.azuredatafactory;
 
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.azure.blob.core.AzureBlobStoreSchema;
 import org.eclipse.dataspaceconnector.spi.response.StatusResult;
 import org.eclipse.dataspaceconnector.spi.result.Result;
@@ -31,22 +30,21 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class AzureDataFactoryTransferServiceTest {
-    static final Faker FAKER = new Faker();
 
-    AzureDataFactoryTransferRequestValidator validator = mock(AzureDataFactoryTransferRequestValidator.class);
-    AzureDataFactoryTransferManager transferManager = mock(AzureDataFactoryTransferManager.class);
-    AzureDataFactoryTransferService transferService = new AzureDataFactoryTransferService(
+    private final AzureDataFactoryTransferRequestValidator validator = mock(AzureDataFactoryTransferRequestValidator.class);
+    private final AzureDataFactoryTransferManager transferManager = mock(AzureDataFactoryTransferManager.class);
+    private final AzureDataFactoryTransferService transferService = new AzureDataFactoryTransferService(
             validator,
             transferManager);
 
-    DataFlowRequest.Builder request = createRequest(AzureBlobStoreSchema.TYPE);
-    Result<Boolean> failure = Result.failure(FAKER.lorem().sentence());
-    Result<Boolean> success = Result.success(true);
+    private final DataFlowRequest.Builder request = createRequest(AzureBlobStoreSchema.TYPE);
+    private final Result<Boolean> failure = Result.failure("Test Failure");
+    private final Result<Boolean> success = Result.success(true);
     @SuppressWarnings("unchecked")
-    CompletableFuture<StatusResult<Void>> result = mock(CompletableFuture.class);
+    private final CompletableFuture<StatusResult<Void>> result = mock(CompletableFuture.class);
 
     @ParameterizedTest
-    @ValueSource(booleans = {true, false})
+    @ValueSource(booleans = { true, false })
     void canHandle_onResult(boolean expected) {
         // Arrange
         when(validator.canHandle(request.build())).thenReturn(expected);

--- a/extensions/azure/data-plane/data-factory/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azuredatafactory/DataFactoryPipelineFactoryTest.java
+++ b/extensions/azure/data-plane/data-factory/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azuredatafactory/DataFactoryPipelineFactoryTest.java
@@ -15,12 +15,14 @@
 package org.eclipse.dataspaceconnector.azure.dataplane.azuredatafactory;
 
 import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.azure.blob.core.AzureSasToken;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
 import org.junit.jupiter.api.Test;
 
+import java.util.Random;
+
+import static org.eclipse.dataspaceconnector.azure.dataplane.azuredatafactory.TestFunctions.createFlowRequest;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -31,19 +33,18 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 class DataFactoryPipelineFactoryTest {
-    static final Faker FAKER = new Faker();
 
-    DataFactoryClient client = mock(DataFactoryClient.class, RETURNS_DEEP_STUBS);
-    TypeManager typeManager = new TypeManager();
-    KeyVaultClient keyVaultClient = mock(KeyVaultClient.class);
-    AzureSasToken azureSasToken = new AzureSasToken(FAKER.lorem().word(), FAKER.number().randomNumber());
-    KeyVaultSecret writeOnlySasSecret = new KeyVaultSecret(FAKER.lorem().word(), typeManager.writeValueAsString(azureSasToken));
-    KeyVaultSecret destinationSecret = new KeyVaultSecret(FAKER.lorem().word(), FAKER.lorem().word());
+    private final DataFactoryClient client = mock(DataFactoryClient.class, RETURNS_DEEP_STUBS);
+    private final TypeManager typeManager = new TypeManager();
+    private final KeyVaultClient keyVaultClient = mock(KeyVaultClient.class);
+    private final AzureSasToken azureSasToken = new AzureSasToken("test-wo-sas", new Random().nextLong());
+    private final KeyVaultSecret writeOnlySasSecret = new KeyVaultSecret("wo-sas-name", typeManager.writeValueAsString(azureSasToken));
+    private final KeyVaultSecret destinationSecret = new KeyVaultSecret("test-secret-name", "test-dest-secret");
 
-    DataFlowRequest request = AzureDataFactoryTransferRequestValidatorTest.requestWithProperties;
+    private final DataFlowRequest request = createFlowRequest();
 
-    String keyVaultLinkedService = FAKER.lorem().word();
-    DataFactoryPipelineFactory factory = new DataFactoryPipelineFactory(keyVaultLinkedService, keyVaultClient, client, typeManager);
+    private final String keyVaultLinkedService = "test-linked-service";
+    private final DataFactoryPipelineFactory factory = new DataFactoryPipelineFactory(keyVaultLinkedService, keyVaultClient, client, typeManager);
 
     @Test
     void createPipeline() {

--- a/extensions/azure/data-plane/data-factory/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azuredatafactory/TestFunctions.java
+++ b/extensions/azure/data-plane/data-factory/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azuredatafactory/TestFunctions.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.azure.dataplane.azuredatafactory;
+
+import org.eclipse.dataspaceconnector.azure.blob.core.AzureBlobStoreSchema;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
+
+import java.util.Map;
+
+import static org.eclipse.dataspaceconnector.azure.blob.core.AzureStorageTestFixtures.createAccountName;
+import static org.eclipse.dataspaceconnector.azure.blob.core.AzureStorageTestFixtures.createBlobName;
+import static org.eclipse.dataspaceconnector.azure.blob.core.AzureStorageTestFixtures.createContainerName;
+import static org.eclipse.dataspaceconnector.azure.blob.core.AzureStorageTestFixtures.createDataAddress;
+import static org.eclipse.dataspaceconnector.azure.blob.core.AzureStorageTestFixtures.createRequest;
+
+public class TestFunctions {
+
+    public static Map<String, String> sourceProperties() {
+        var srcStorageAccount = createAccountName();
+        return Map.of(
+                AzureBlobStoreSchema.ACCOUNT_NAME, srcStorageAccount,
+                AzureBlobStoreSchema.CONTAINER_NAME, createContainerName(),
+                AzureBlobStoreSchema.BLOB_NAME, createBlobName(),
+                DataAddress.KEY_NAME, srcStorageAccount + "-key1");
+    }
+
+    public static Map<String, String> destinationProperties() {
+        var destStorageAccount = createAccountName();
+
+        return Map.of(
+                AzureBlobStoreSchema.ACCOUNT_NAME, destStorageAccount,
+                AzureBlobStoreSchema.CONTAINER_NAME, createContainerName(),
+                DataAddress.KEY_NAME, destStorageAccount + "-key1");
+    }
+
+    public static DataFlowRequest createFlowRequest() {
+        return createRequest(AzureBlobStoreSchema.TYPE)
+                .sourceDataAddress(createDataAddress(AzureBlobStoreSchema.TYPE).properties(sourceProperties()).build())
+                .destinationDataAddress(createDataAddress(AzureBlobStoreSchema.TYPE).properties(destinationProperties()).build())
+                .build();
+    }
+}

--- a/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/AzureDataPlaneCopyIntegrationTest.java
+++ b/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/AzureDataPlaneCopyIntegrationTest.java
@@ -16,7 +16,6 @@ package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage;
 
 import com.azure.core.util.BinaryData;
 import dev.failsafe.RetryPolicy;
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.azure.blob.core.AzureSasToken;
 import org.eclipse.dataspaceconnector.azure.blob.core.api.BlobStoreApi;
 import org.eclipse.dataspaceconnector.azure.blob.core.api.BlobStoreApiImpl;
@@ -52,21 +51,17 @@ import static org.mockito.Mockito.when;
 @AzureStorageIntegrationTest
 class AzureDataPlaneCopyIntegrationTest extends AbstractAzureBlobTest {
 
-    static Faker faker = new Faker();
     private final TypeManager typeManager = new TypeManager();
 
-    String account1KeyName = faker.lorem().word() + "1";
-    String account2KeyName = faker.lorem().word() + "2";
-    RetryPolicy<Object> policy = RetryPolicy.builder().withMaxRetries(1).build();
-    String sinkContainerName = createContainerName();
-    String blobName = createBlobName();
-    String content = faker.lorem().sentence();
-    ExecutorService executor = Executors.newFixedThreadPool(2);
-    Monitor monitor = mock(Monitor.class);
-    Vault vault = mock(Vault.class);
+    private final RetryPolicy<Object> policy = RetryPolicy.builder().withMaxRetries(1).build();
+    private final String sinkContainerName = createContainerName();
+    private final String blobName = createBlobName();
+    private final ExecutorService executor = Executors.newFixedThreadPool(2);
+    private final Monitor monitor = mock(Monitor.class);
+    private final Vault vault = mock(Vault.class);
 
-    BlobStoreApi account1Api = new BlobStoreApiImpl(vault, TestFunctions.getBlobServiceTestEndpoint(account1Name));
-    BlobStoreApi account2Api = new BlobStoreApiImpl(vault, TestFunctions.getBlobServiceTestEndpoint(account2Name));
+    private final BlobStoreApi account1Api = new BlobStoreApiImpl(vault, TestFunctions.getBlobServiceTestEndpoint(account1Name));
+    private final BlobStoreApi account2Api = new BlobStoreApiImpl(vault, TestFunctions.getBlobServiceTestEndpoint(account2Name));
 
     @BeforeEach
     void setUp() {
@@ -75,10 +70,12 @@ class AzureDataPlaneCopyIntegrationTest extends AbstractAzureBlobTest {
 
     @Test
     void transfer_success() {
+        String content = "test-content";
         blobServiceClient1.getBlobContainerClient(account1ContainerName)
                 .getBlobClient(blobName)
                 .upload(BinaryData.fromString(content));
 
+        String account1KeyName = "test-account-key-name1";
         var source = DataAddress.Builder.newInstance()
                 .type(TYPE)
                 .property(ACCOUNT_NAME, account1Name)
@@ -88,6 +85,7 @@ class AzureDataPlaneCopyIntegrationTest extends AbstractAzureBlobTest {
                 .build();
         when(vault.resolveSecret(account1KeyName)).thenReturn(account1Key);
 
+        String account2KeyName = "test-account-key-name2";
         var destination = DataAddress.Builder.newInstance()
                 .type(TYPE)
                 .property(ACCOUNT_NAME, account2Name)

--- a/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureDataSourceToDataSinkTest.java
+++ b/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureDataSourceToDataSinkTest.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline;
 
 import dev.failsafe.RetryPolicy;
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.azure.blob.core.AzureStorageTestFixtures;
 import org.eclipse.dataspaceconnector.azure.blob.core.adapter.BlobAdapter;
 import org.eclipse.dataspaceconnector.azure.blob.core.api.BlobStoreApi;
@@ -26,6 +25,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -42,20 +42,18 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class AzureDataSourceToDataSinkTest {
-    static Faker faker = new Faker();
-    ExecutorService executor = Executors.newFixedThreadPool(2);
-    Monitor monitor = mock(Monitor.class);
-    FakeBlobAdapter fakeSource = new FakeBlobAdapter();
-    FakeBlobAdapter fakeSink = new FakeBlobAdapter();
-    FakeBlobAdapter fakeCompletionMarker = new FakeBlobAdapter();
-    String sourceAccountName = AzureStorageTestFixtures.createAccountName();
-    String sourceContainerName = AzureStorageTestFixtures.createContainerName();
-    String sourceSharedKey = AzureStorageTestFixtures.createSharedKey();
-    String sinkAccountName = AzureStorageTestFixtures.createAccountName();
-    String sinkContainerName = AzureStorageTestFixtures.createContainerName();
-    String sinkSharedAccessSignature = AzureStorageTestFixtures.createSharedAccessSignature();
-    String requestId = UUID.randomUUID().toString();
-    String errorMessage = faker.lorem().sentence();
+    private final ExecutorService executor = Executors.newFixedThreadPool(2);
+    private final Monitor monitor = mock(Monitor.class);
+    private final FakeBlobAdapter fakeSource = new FakeBlobAdapter();
+    private final FakeBlobAdapter fakeSink = new FakeBlobAdapter();
+    private final FakeBlobAdapter fakeCompletionMarker = new FakeBlobAdapter();
+    private final String sourceAccountName = AzureStorageTestFixtures.createAccountName();
+    private final String sourceContainerName = AzureStorageTestFixtures.createContainerName();
+    private final String sourceSharedKey = AzureStorageTestFixtures.createSharedKey();
+    private final String sinkAccountName = AzureStorageTestFixtures.createAccountName();
+    private final String sinkContainerName = AzureStorageTestFixtures.createContainerName();
+    private final String sinkSharedAccessSignature = AzureStorageTestFixtures.createSharedAccessSignature();
+    private final String requestId = UUID.randomUUID().toString();
 
     /**
      * Verifies a sink is able to pull data from the source without exceptions if both endpoints are functioning.
@@ -120,6 +118,7 @@ class AzureDataSourceToDataSinkTest {
         // simulate source error
         var blobAdapter = mock(BlobAdapter.class);
         when(blobAdapter.getBlobName()).thenReturn(fakeSource.name);
+        String errorMessage = "Test error message";
         when(blobAdapter.openInputStream()).thenThrow(new RuntimeException(errorMessage));
         var fakeSourceFactory = mock(BlobStoreApi.class);
         when(fakeSourceFactory.getBlobAdapter(
@@ -209,11 +208,11 @@ class AzureDataSourceToDataSinkTest {
         assertThat(dataSink.transfer(dataSource).get().failed()).isTrue();
     }
 
-    static class FakeBlobAdapter implements BlobAdapter {
-        final String name = faker.lorem().characters();
-        final String content = faker.lorem().sentence();
-        final long length = faker.random().nextLong(1_000_000_000_000_000L);
-        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    private static class FakeBlobAdapter implements BlobAdapter {
+        private final String name = "test-name";
+        private final String content = "test-content";
+        private final long length = new Random().nextLong();
+        private final ByteArrayOutputStream out = new ByteArrayOutputStream();
 
         @Override
         public OutputStream getOutputStream() {

--- a/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSinkFactoryTest.java
+++ b/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSinkFactoryTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline;
 
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.azure.blob.core.AzureBlobStoreSchema;
 import org.eclipse.dataspaceconnector.azure.blob.core.AzureSasToken;
 import org.eclipse.dataspaceconnector.azure.blob.core.api.BlobStoreApi;
@@ -26,6 +25,7 @@ import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
 import org.junit.jupiter.api.Test;
 
+import java.util.Random;
 import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,19 +37,18 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class AzureStorageDataSinkFactoryTest {
-    static Faker faker = new Faker();
-    BlobStoreApi blobStoreApi = mock(BlobStoreApi.class);
-    Vault vault = mock(Vault.class);
-    TypeManager typeManager = new TypeManager();
-    AzureStorageDataSinkFactory factory = new AzureStorageDataSinkFactory(blobStoreApi, Executors.newFixedThreadPool(1), 5, mock(Monitor.class), vault, typeManager);
-    DataFlowRequest.Builder request = createRequest(AzureBlobStoreSchema.TYPE);
-    DataFlowRequest.Builder invalidRequest = createRequest(faker.lorem().word());
-    DataAddress.Builder dataAddress = DataAddress.Builder.newInstance().type(AzureBlobStoreSchema.TYPE);
+    private final BlobStoreApi blobStoreApi = mock(BlobStoreApi.class);
+    private final Vault vault = mock(Vault.class);
+    private final TypeManager typeManager = new TypeManager();
+    private final AzureStorageDataSinkFactory factory = new AzureStorageDataSinkFactory(blobStoreApi, Executors.newFixedThreadPool(1), 5, mock(Monitor.class), vault, typeManager);
+    private final DataFlowRequest.Builder request = createRequest(AzureBlobStoreSchema.TYPE);
+    private final DataFlowRequest.Builder invalidRequest = createRequest("test-type");
+    private final DataAddress.Builder dataAddress = DataAddress.Builder.newInstance().type(AzureBlobStoreSchema.TYPE);
 
-    String accountName = createAccountName();
-    String containerName = createContainerName();
-    String keyName = faker.lorem().word();
-    AzureSasToken token = new AzureSasToken(faker.lorem().word(), faker.random().nextLong());
+    private final String accountName = createAccountName();
+    private final String containerName = createContainerName();
+    private final String keyName = "test-keyname";
+    private final AzureSasToken token = new AzureSasToken("test-writeonly-sas", new Random().nextLong());
 
     @Test
     void canHandle_whenBlobRequest_returnsTrue() {

--- a/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSinkTest.java
+++ b/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSinkTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline;
 
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.azure.blob.core.AzureBlobStoreSchema;
 import org.eclipse.dataspaceconnector.azure.blob.core.adapter.BlobAdapter;
 import org.eclipse.dataspaceconnector.azure.blob.core.api.BlobStoreApi;
@@ -51,22 +50,17 @@ import static org.mockito.Mockito.when;
 
 class AzureStorageDataSinkTest {
 
-    static Faker faker = new Faker();
-    Monitor monitor = mock(Monitor.class);
-    ExecutorService executor = Executors.newFixedThreadPool(2);
-    BlobStoreApi blobStoreApi = mock(BlobStoreApi.class);
-    DataFlowRequest.Builder request = createRequest(AzureBlobStoreSchema.TYPE);
-
-    String accountName = createAccountName();
-    String containerName = createContainerName();
-    String sharedAccessSignature = createSharedAccessSignature();
-
-    String blobName = createBlobName();
-    String content = faker.lorem().sentence();
-
-    Exception exception = new TestCustomException(faker.lorem().sentence());
-
-    AzureStorageDataSink dataSink = AzureStorageDataSink.Builder.newInstance()
+    private final Monitor monitor = mock(Monitor.class);
+    private final ExecutorService executor = Executors.newFixedThreadPool(2);
+    private final BlobStoreApi blobStoreApi = mock(BlobStoreApi.class);
+    private final DataFlowRequest.Builder request = createRequest(AzureBlobStoreSchema.TYPE);
+    private final String accountName = createAccountName();
+    private final String containerName = createContainerName();
+    private final String sharedAccessSignature = createSharedAccessSignature();
+    private final String blobName = createBlobName();
+    private final String content = "Test Content";
+    private final Exception exception = new TestCustomException("Test custom exception message");
+    private final AzureStorageDataSink dataSink = AzureStorageDataSink.Builder.newInstance()
             .accountName(accountName)
             .containerName(containerName)
             .sharedAccessSignature(sharedAccessSignature)
@@ -75,11 +69,11 @@ class AzureStorageDataSinkTest {
             .executorService(executor)
             .monitor(monitor)
             .build();
-    BlobAdapter destination = mock(BlobAdapter.class);
-    BlobAdapter completionMarker = mock(BlobAdapter.class);
+    private final BlobAdapter destination = mock(BlobAdapter.class);
+    private final BlobAdapter completionMarker = mock(BlobAdapter.class);
+    private final ByteArrayOutputStream output = new ByteArrayOutputStream();
+    private final OutputStream completionMarkerOutput = mock(OutputStream.class);
     InputStreamDataSource part = new InputStreamDataSource(blobName, new ByteArrayInputStream(content.getBytes(UTF_8)));
-    ByteArrayOutputStream output = new ByteArrayOutputStream();
-    OutputStream completionMarkerOutput = mock(OutputStream.class);
 
     @BeforeEach
     void setUp() {

--- a/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSourceFactoryTest.java
+++ b/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSourceFactoryTest.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline;
 
 import dev.failsafe.RetryPolicy;
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.azure.blob.core.AzureBlobStoreSchema;
 import org.eclipse.dataspaceconnector.azure.blob.core.api.BlobStoreApi;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
@@ -34,19 +33,17 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class AzureStorageDataSourceFactoryTest {
-    static Faker faker = new Faker();
-    BlobStoreApi blobStoreApi = mock(BlobStoreApi.class);
-    Vault vault = mock(Vault.class);
-    AzureStorageDataSourceFactory factory = new AzureStorageDataSourceFactory(blobStoreApi, RetryPolicy.ofDefaults(), mock(Monitor.class), vault);
-    DataFlowRequest.Builder request = createRequest(AzureBlobStoreSchema.TYPE);
-    DataFlowRequest.Builder invalidRequest = createRequest(faker.lorem().word());
-    DataAddress.Builder dataAddress = DataAddress.Builder.newInstance().type(AzureBlobStoreSchema.TYPE);
+    private final BlobStoreApi blobStoreApi = mock(BlobStoreApi.class);
+    private final Vault vault = mock(Vault.class);
+    private final AzureStorageDataSourceFactory factory = new AzureStorageDataSourceFactory(blobStoreApi, RetryPolicy.ofDefaults(), mock(Monitor.class), vault);
+    private final DataFlowRequest.Builder request = createRequest(AzureBlobStoreSchema.TYPE);
+    private final DataFlowRequest.Builder invalidRequest = createRequest("test-type");
+    private final DataAddress.Builder dataAddress = DataAddress.Builder.newInstance().type(AzureBlobStoreSchema.TYPE);
 
-    String accountName = createAccountName();
-    String containerName = createContainerName();
-    String blobName = createBlobName();
-    String sharedKey = createSharedKey();
-    String keyName = faker.lorem().word();
+    private final String accountName = createAccountName();
+    private final String containerName = createContainerName();
+    private final String blobName = createBlobName();
+    private final String sharedKey = createSharedKey();
 
     @Test
     void canHandle_whenBlobRequest_returnsTrue() {
@@ -102,6 +99,7 @@ class AzureStorageDataSourceFactoryTest {
 
     @Test
     void createSource_whenValidRequest_succeeds() {
+        String keyName = "test-key-name";
         when(vault.resolveSecret(keyName)).thenReturn(sharedKey);
         var validRequest = request.sourceDataAddress(dataAddress
                 .property(AzureBlobStoreSchema.ACCOUNT_NAME, accountName)

--- a/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSourceTest.java
+++ b/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSourceTest.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline;
 
 import dev.failsafe.RetryPolicy;
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.azure.blob.core.AzureBlobStoreSchema;
 import org.eclipse.dataspaceconnector.azure.blob.core.adapter.BlobAdapter;
 import org.eclipse.dataspaceconnector.azure.blob.core.api.BlobStoreApi;
@@ -42,7 +41,6 @@ import static org.mockito.Mockito.when;
 
 class AzureStorageDataSourceTest {
 
-    static Faker faker = new Faker();
     Monitor monitor = mock(Monitor.class);
     BlobStoreApi blobStoreApi = mock(BlobStoreApi.class);
     DataFlowRequest.Builder request = createRequest(AzureBlobStoreSchema.TYPE);
@@ -51,9 +49,9 @@ class AzureStorageDataSourceTest {
     String containerName = createContainerName();
     String sharedKey = createSharedKey();
     String blobName = createBlobName();
-    String content = faker.lorem().sentence();
+    String content = "Test Content";
 
-    Exception exception = new TestCustomException(faker.lorem().sentence());
+    Exception exception = new TestCustomException("Test exception message");
 
     AzureStorageDataSource dataSource = AzureStorageDataSource.Builder.newInstance()
             .accountName(accountName)

--- a/extensions/data-plane-transfer/data-plane-transfer-client/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/client/EmbeddedDataPlaneTransferClientTest.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-client/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/client/EmbeddedDataPlaneTransferClientTest.java
@@ -14,12 +14,13 @@
 
 package org.eclipse.dataspaceconnector.transfer.dataplane.client;
 
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.dataplane.spi.manager.DataPlaneManager;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.transfer.dataplane.spi.client.DataPlaneTransferClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.transfer.dataplane.TestFixtures.createDataFlowRequest;
@@ -32,8 +33,6 @@ import static org.mockito.Mockito.when;
 
 class EmbeddedDataPlaneTransferClientTest {
 
-    private static final Faker FAKER = new Faker();
-
     private DataPlaneManager dataPlaneManagerMock;
     private DataPlaneTransferClient client;
 
@@ -45,7 +44,7 @@ class EmbeddedDataPlaneTransferClientTest {
 
     @Test
     void validationFailure_shouldReturnFailedResult() {
-        var errorMsg = FAKER.internet().uuid();
+        var errorMsg = UUID.randomUUID().toString();
         var request = createDataFlowRequest();
         when(dataPlaneManagerMock.validate(any())).thenReturn(Result.failure(errorMsg));
         doNothing().when(dataPlaneManagerMock).initiateTransfer(any());

--- a/extensions/data-plane-transfer/data-plane-transfer-client/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/client/RemoteDataPlaneTransferClientTest.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-client/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/client/RemoteDataPlaneTransferClientTest.java
@@ -17,7 +17,6 @@ package org.eclipse.dataspaceconnector.transfer.dataplane.client;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.failsafe.RetryPolicy;
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.dataplane.selector.client.DataPlaneSelectorClient;
 import org.eclipse.dataspaceconnector.dataplane.selector.instance.DataPlaneInstance;
 import org.eclipse.dataspaceconnector.dataplane.spi.response.TransferErrorResponse;
@@ -38,6 +37,7 @@ import org.mockserver.verify.VerificationTimes;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
+import java.util.UUID;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -53,8 +53,6 @@ import static org.mockserver.model.HttpResponse.response;
 import static org.mockserver.stop.Stop.stopQuietly;
 
 class RemoteDataPlaneTransferClientTest {
-
-    private static final Faker FAKER = new Faker();
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -91,7 +89,7 @@ class RemoteDataPlaneTransferClientTest {
     public void init() {
         var okHttpClient = testOkHttpClient();
         selectorClientMock = mock(DataPlaneSelectorClient.class);
-        var selectionStrategy = FAKER.internet().uuid();
+        var selectionStrategy = UUID.randomUUID().toString();
         transferClient = new RemoteDataPlaneTransferClient(okHttpClient, selectorClientMock, selectionStrategy, RetryPolicy.ofDefaults(), MAPPER);
     }
 
@@ -144,7 +142,7 @@ class RemoteDataPlaneTransferClientTest {
 
         // config data plane mock server
         var httpRequest = new HttpRequest().withPath(DATA_PLANE_PATH).withBody(MAPPER.writeValueAsString(flowRequest));
-        var errorMsg = FAKER.internet().uuid();
+        var errorMsg = UUID.randomUUID().toString();
         dataPlaneClientAndServer.when(httpRequest, once()).respond(withResponse(errorMsg));
 
         var result = transferClient.transfer(flowRequest);

--- a/extensions/data-plane-transfer/data-plane-transfer-client/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/flow/DataPlaneTransferFlowControllerTest.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-client/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/flow/DataPlaneTransferFlowControllerTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.transfer.dataplane.flow;
 
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
 import org.eclipse.dataspaceconnector.spi.response.StatusResult;
@@ -26,6 +25,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.transfer.dataplane.spi.DataPlaneTransferConstants.HTTP_PROXY;
 import static org.mockito.ArgumentMatchers.any;
@@ -36,11 +37,33 @@ import static org.mockito.Mockito.when;
 
 class DataPlaneTransferFlowControllerTest {
 
-    private static final Faker FAKER = new Faker();
 
     private DataPlaneTransferClient transferClientMock;
 
     private DataPlaneTransferFlowController flowController;
+
+    private static DataAddress testDataAddress() {
+        return DataAddress.Builder.newInstance().type(UUID.randomUUID().toString()).build();
+    }
+
+    public static DataRequest createDataRequest() {
+        return createDataRequest(UUID.randomUUID().toString());
+    }
+
+    /**
+     * Create a {@link DataRequest} object with provided destination type.
+     */
+    public static DataRequest createDataRequest(String destinationType) {
+        return DataRequest.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .protocol(UUID.randomUUID().toString())
+                .contractId(UUID.randomUUID().toString())
+                .assetId(UUID.randomUUID().toString())
+                .connectorAddress("test.connector.address")
+                .processId(UUID.randomUUID().toString())
+                .destinationType(destinationType)
+                .build();
+    }
 
     @BeforeEach
     public void setUp() {
@@ -57,7 +80,7 @@ class DataPlaneTransferFlowControllerTest {
 
     @Test
     void transferFailure_shouldReturnFailedTransferResult() {
-        var errorMsg = FAKER.internet().uuid();
+        var errorMsg = UUID.randomUUID().toString();
         var request = createDataRequest();
 
         when(transferClientMock.transfer(any())).thenReturn(StatusResult.failure(ResponseStatus.FATAL_ERROR, errorMsg));
@@ -93,28 +116,5 @@ class DataPlaneTransferFlowControllerTest {
         assertThat(dataFlowRequest.getSourceDataAddress().getType()).isEqualTo(source.getType());
         assertThat(dataFlowRequest.getDestinationDataAddress().getType()).isEqualTo(request.getDestinationType());
         assertThat(dataFlowRequest.getProperties()).isEmpty();
-    }
-
-    private static DataAddress testDataAddress() {
-        return DataAddress.Builder.newInstance().type(FAKER.internet().uuid()).build();
-    }
-
-    public static DataRequest createDataRequest() {
-        return createDataRequest(FAKER.internet().uuid());
-    }
-
-    /**
-     * Create a {@link DataRequest} object with provided destination type.
-     */
-    public static DataRequest createDataRequest(String destinationType) {
-        return DataRequest.Builder.newInstance()
-                .id(FAKER.internet().uuid())
-                .protocol(FAKER.internet().uuid())
-                .contractId(FAKER.internet().uuid())
-                .assetId(FAKER.internet().uuid())
-                .connectorAddress(FAKER.internet().url())
-                .processId(FAKER.internet().uuid())
-                .destinationType(destinationType)
-                .build();
     }
 }

--- a/extensions/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/api/DataPlaneTokenValidationApiControllerTest.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/api/DataPlaneTokenValidationApiControllerTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.transfer.dataplane.sync.api;
 
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.common.token.TokenValidationService;
 import org.eclipse.dataspaceconnector.spi.exception.NotAuthorizedException;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
@@ -26,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -37,8 +37,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class DataPlaneTokenValidationApiControllerTest {
-
-    private static final Faker FAKER = new Faker();
 
     private static final TypeManager TYPE_MANAGER = new TypeManager();
 
@@ -54,12 +52,12 @@ class DataPlaneTokenValidationApiControllerTest {
 
     @Test
     void verifyValidateSuccess() {
-        var token = FAKER.internet().uuid();
-        var encryptedDataAddress = FAKER.internet().uuid();
-        var decryptedDataAddress = DataAddress.Builder.newInstance().type(FAKER.internet().uuid()).build();
+        var token = UUID.randomUUID().toString();
+        var encryptedDataAddress = UUID.randomUUID().toString();
+        var decryptedDataAddress = DataAddress.Builder.newInstance().type(UUID.randomUUID().toString()).build();
         var claims = ClaimToken.Builder.newInstance()
                 .claims(Map.of(
-                                FAKER.lorem().word(), FAKER.lorem().word(),
+                                "key1", "value1",
                                 DATA_ADDRESS, encryptedDataAddress
                         )
                 )
@@ -77,8 +75,8 @@ class DataPlaneTokenValidationApiControllerTest {
 
     @Test
     void verifyTokenValidationFailureThrowsException() {
-        var token = FAKER.internet().uuid();
-        var errorMsg = FAKER.internet().uuid();
+        var token = UUID.randomUUID().toString();
+        var errorMsg = UUID.randomUUID().toString();
 
         when(tokenValidationServiceMock.validate(token)).thenReturn(Result.failure(errorMsg));
 
@@ -89,12 +87,9 @@ class DataPlaneTokenValidationApiControllerTest {
 
     @Test
     void verifyMissingAddressThrowsException() {
-        var token = FAKER.internet().uuid();
+        var token = UUID.randomUUID().toString();
         var claims = ClaimToken.Builder.newInstance()
-                .claims(Map.of(
-                                FAKER.lorem().word(), FAKER.lorem().word()
-                        )
-                )
+                .claims(Map.of("key1", "value1"))
                 .build();
 
         when(tokenValidationServiceMock.validate(token)).thenReturn(Result.success(claims));

--- a/extensions/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/proxy/DataPlaneProxyTokenDecoratorTest.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/proxy/DataPlaneProxyTokenDecoratorTest.java
@@ -15,20 +15,20 @@
 package org.eclipse.dataspaceconnector.transfer.dataplane.sync.proxy;
 
 import com.nimbusds.jwt.JWTClaimsSet;
-import net.datafaker.Faker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.text.ParseException;
 import java.time.Instant;
 import java.util.Date;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.transfer.dataplane.spi.DataPlaneTransferConstants.CONTRACT_ID;
 import static org.eclipse.dataspaceconnector.transfer.dataplane.spi.DataPlaneTransferConstants.DATA_ADDRESS;
 
 class DataPlaneProxyTokenDecoratorTest {
-    private static final Faker FAKER = new Faker();
 
     private Date expiration;
     private String contractId;
@@ -38,9 +38,9 @@ class DataPlaneProxyTokenDecoratorTest {
 
     @BeforeEach
     public void setUp() {
-        expiration = Date.from(Instant.now().plusSeconds(FAKER.random().nextInt(1, 10)));
-        contractId = FAKER.internet().uuid();
-        encryptedDataAddress = FAKER.internet().uuid();
+        expiration = Date.from(Instant.now().plusSeconds(ThreadLocalRandom.current().nextInt(1, 10)));
+        contractId = UUID.randomUUID().toString();
+        encryptedDataAddress = UUID.randomUUID().toString();
         decorator = new DataPlaneProxyTokenDecorator(expiration, contractId, encryptedDataAddress);
     }
 

--- a/extensions/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/proxy/DataPlaneTransferProxyResolverImplTest.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/proxy/DataPlaneTransferProxyResolverImplTest.java
@@ -14,13 +14,14 @@
 
 package org.eclipse.dataspaceconnector.transfer.dataplane.sync.proxy;
 
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.dataplane.selector.client.DataPlaneSelectorClient;
 import org.eclipse.dataspaceconnector.dataplane.selector.instance.DataPlaneInstanceImpl;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -30,7 +31,6 @@ import static org.mockito.Mockito.when;
 
 class DataPlaneTransferProxyResolverImplTest {
 
-    private static final Faker FAKER = new Faker();
 
     private DataPlaneSelectorClient selectorClient;
     private DataPlaneTransferProxyResolver resolver;
@@ -38,16 +38,16 @@ class DataPlaneTransferProxyResolverImplTest {
     @BeforeEach
     public void setUp() {
         selectorClient = mock(DataPlaneSelectorClient.class);
-        resolver = new DataPlaneTransferProxyResolverImpl(selectorClient, FAKER.internet().uuid());
+        resolver = new DataPlaneTransferProxyResolverImpl(selectorClient, UUID.randomUUID().toString());
     }
 
     @Test
     void verifyResolveSuccess() {
-        var address = DataAddress.Builder.newInstance().type(FAKER.internet().uuid()).build();
-        var proxyUrl = FAKER.internet().url();
+        var address = DataAddress.Builder.newInstance().type(UUID.randomUUID().toString()).build();
+        var proxyUrl = "test.proxy.url";
         var instance = DataPlaneInstanceImpl.Builder.newInstance()
-                .id(FAKER.internet().uuid())
-                .url("http://" + FAKER.internet().url())
+                .id(UUID.randomUUID().toString())
+                .url("http://some.test.url")
                 .property("publicApiUrl", proxyUrl)
                 .build();
 
@@ -69,7 +69,7 @@ class DataPlaneTransferProxyResolverImplTest {
 
     @Test
     void verifyFailedResultReturnedIfDataPlaneResolutionFails() {
-        var address = DataAddress.Builder.newInstance().type(FAKER.internet().uuid()).build();
+        var address = DataAddress.Builder.newInstance().type(UUID.randomUUID().toString()).build();
 
         when(selectorClient.find(any(), any(), any())).thenReturn(null);
 
@@ -83,10 +83,10 @@ class DataPlaneTransferProxyResolverImplTest {
 
     @Test
     void verifyFailedResultReturnedIfDataPlaneInstanceDoesNotContainPublicApiUrl() {
-        var address = DataAddress.Builder.newInstance().type(FAKER.internet().uuid()).build();
+        var address = DataAddress.Builder.newInstance().type(UUID.randomUUID().toString()).build();
         var instance = DataPlaneInstanceImpl.Builder.newInstance()
-                .id(FAKER.internet().uuid())
-                .url("http://" + FAKER.internet().url())
+                .id(UUID.randomUUID().toString())
+                .url("http://some.test.url")
                 .build();
 
         when(selectorClient.find(any(), any(), any())).thenReturn(instance);

--- a/extensions/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/validation/ContractValidationRuleTest.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/validation/ContractValidationRuleTest.java
@@ -18,7 +18,6 @@ import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
@@ -41,7 +40,6 @@ import static org.mockito.Mockito.when;
 
 class ContractValidationRuleTest {
 
-    private static final Faker FAKER = new Faker();
     private final Instant now = Instant.now();
     private final Clock clock = Clock.fixed(now, UTC);
 
@@ -56,7 +54,7 @@ class ContractValidationRuleTest {
 
     @Test
     void shouldSucceedIfContractIsStillValid() {
-        var contractId = FAKER.internet().uuid();
+        var contractId = UUID.randomUUID().toString();
         var contractAgreement = createContractAgreement(contractId, now.plus(1, HOURS));
         when(contractNegotiationStoreMock.findContractAgreement(contractId)).thenReturn(contractAgreement);
         var claims = new JWTClaimsSet.Builder()
@@ -70,7 +68,7 @@ class ContractValidationRuleTest {
 
     @Test
     void shouldFailIfContractIsExpired() {
-        var contractId = FAKER.internet().uuid();
+        var contractId = UUID.randomUUID().toString();
         var contractAgreement = createContractAgreement(contractId, now.minus(1, SECONDS));
         when(contractNegotiationStoreMock.findContractAgreement(contractId)).thenReturn(contractAgreement);
         var claims = new JWTClaimsSet.Builder()
@@ -115,8 +113,8 @@ class ContractValidationRuleTest {
                 .assetId(UUID.randomUUID().toString())
                 .policy(Policy.Builder.newInstance().build())
                 .contractEndDate(endDate.getEpochSecond())
-                .consumerAgentId(FAKER.lorem().word())
-                .providerAgentId(FAKER.lorem().word())
+                .consumerAgentId("consumer-agent-id")
+                .providerAgentId("provider-agent-id")
                 .build();
     }
 }

--- a/extensions/data-plane/data-plane-api/src/test/java/org/eclipse/dataspaceconnector/dataplane/api/controller/DataFlowRequestSupplierTest.java
+++ b/extensions/data-plane/data-plane-api/src/test/java/org/eclipse/dataspaceconnector/dataplane/api/controller/DataFlowRequestSupplierTest.java
@@ -16,7 +16,6 @@ package org.eclipse.dataspaceconnector.dataplane.api.controller;
 
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.core.MediaType;
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.OutputStreamDataSinkFactory;
 import org.eclipse.dataspaceconnector.dataplane.spi.schema.DataFlowRequestSchema;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
@@ -30,9 +29,12 @@ import static org.mockito.Mockito.when;
 
 class DataFlowRequestSupplierTest {
 
-    private static final Faker FAKER = new Faker();
 
     private final DataFlowRequestSupplier supplier = new DataFlowRequestSupplier();
+
+    private static DataAddress createDataAddress() {
+        return DataAddress.Builder.newInstance().type("test-type").build();
+    }
 
     @Test
     void verifyMapping_noInputBody() {
@@ -40,8 +42,8 @@ class DataFlowRequestSupplierTest {
         var address = createDataAddress();
 
         var method = HttpMethod.GET;
-        var queryParams = FAKER.lorem().word();
-        var path = FAKER.lorem().word();
+        var queryParams = "test-query-param";
+        var path = "test-path";
 
         when(contextApi.method()).thenReturn(method);
         when(contextApi.queryParams()).thenReturn(queryParams);
@@ -62,14 +64,14 @@ class DataFlowRequestSupplierTest {
     }
 
     @Test
-    void veirfyMapping_withInputBody() {
+    void verifyMapping_withInputBody() {
         var contextApi = mock(ContainerRequestContextApi.class);
         var address = createDataAddress();
 
         var method = HttpMethod.GET;
-        var queryParams = FAKER.lorem().word();
-        var path = FAKER.lorem().word();
-        var body = FAKER.lorem().sentence();
+        var queryParams = "test-query-param";
+        var path = "test-path";
+        var body = "Test request body";
 
         when(contextApi.method()).thenReturn(method);
         when(contextApi.queryParams()).thenReturn(queryParams);
@@ -90,9 +92,5 @@ class DataFlowRequestSupplierTest {
                 DataFlowRequestSchema.BODY, body,
                 DataFlowRequestSchema.MEDIA_TYPE, MediaType.TEXT_PLAIN
         ));
-    }
-
-    private static DataAddress createDataAddress() {
-        return DataAddress.Builder.newInstance().type(FAKER.lorem().word()).build();
     }
 }

--- a/extensions/data-plane/data-plane-api/src/test/java/org/eclipse/dataspaceconnector/dataplane/api/controller/DataPlaneApiIntegrationTest.java
+++ b/extensions/data-plane/data-plane-api/src/test/java/org/eclipse/dataspaceconnector/dataplane/api/controller/DataPlaneApiIntegrationTest.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.http.ContentType;
 import jakarta.ws.rs.core.Response;
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.dataplane.spi.manager.DataPlaneManager;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSink;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.OutputStreamDataSinkFactory;
@@ -48,6 +47,7 @@ import org.mockserver.verify.VerificationTimes;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
@@ -68,7 +68,6 @@ import static org.mockserver.stop.Stop.stopQuietly;
 @ExtendWith(EdcExtension.class)
 class DataPlaneApiIntegrationTest {
 
-    private static final Faker FAKER = new Faker();
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private static final int PUBLIC_API_PORT = getFreePort();
@@ -110,8 +109,8 @@ class DataPlaneApiIntegrationTest {
     @Test
     void controlApi_should_callDataPlaneManager_if_requestIsValid() {
         var flowRequest = DataFlowRequest.Builder.newInstance()
-                .id(FAKER.internet().uuid())
-                .processId(FAKER.internet().uuid())
+                .id(UUID.randomUUID().toString())
+                .processId(UUID.randomUUID().toString())
                 .sourceDataAddress(testDestAddress())
                 .destinationDataAddress(testDestAddress())
                 .build();
@@ -131,10 +130,10 @@ class DataPlaneApiIntegrationTest {
 
     @Test
     void controlApi_should_returnBadRequest_if_requestIsInValid() {
-        var errorMsg = FAKER.lorem().word();
+        var errorMsg = "test error message";
         var flowRequest = DataFlowRequest.Builder.newInstance()
-                .id(FAKER.internet().uuid())
-                .processId(FAKER.internet().uuid())
+                .id(UUID.randomUUID().toString())
+                .processId(UUID.randomUUID().toString())
                 .sourceDataAddress(testDestAddress())
                 .destinationDataAddress(testDestAddress())
                 .build();
@@ -165,7 +164,7 @@ class DataPlaneApiIntegrationTest {
 
     @Test
     void publicApi_should_returnForbidden_if_tokenValidationFails() {
-        var token = FAKER.internet().uuid();
+        var token = UUID.randomUUID().toString();
 
         var validationServerRequest = new HttpRequest().withHeader(AUTHORIZATION, token);
         tokenValidationServer.when(validationServerRequest, once()).respond(new HttpResponse().withStatusCode(400));
@@ -183,8 +182,8 @@ class DataPlaneApiIntegrationTest {
 
     @Test
     void publicApi_should_returnBadRequest_if_requestValidationFails() throws JsonProcessingException {
-        var token = FAKER.internet().uuid();
-        var errorMsg = FAKER.internet().uuid();
+        var token = UUID.randomUUID().toString();
+        var errorMsg = UUID.randomUUID().toString();
         tokenValidationServer.when(new HttpRequest().withHeader(AUTHORIZATION, token), once())
                 .respond(new HttpResponse()
                         .withStatusCode(200)
@@ -205,8 +204,8 @@ class DataPlaneApiIntegrationTest {
 
     @Test
     void publicApi_should_returnInternalServerError_if_transferFails() throws JsonProcessingException {
-        var token = FAKER.internet().uuid();
-        var errorMsg = FAKER.internet().uuid();
+        var token = UUID.randomUUID().toString();
+        var errorMsg = UUID.randomUUID().toString();
         tokenValidationServer.when(new HttpRequest().withHeader(AUTHORIZATION, token), once())
                 .respond(new HttpResponse()
                         .withStatusCode(200)
@@ -229,8 +228,8 @@ class DataPlaneApiIntegrationTest {
 
     @Test
     void publicApi_should_returnInternalServerError_if_transferThrows() throws JsonProcessingException {
-        var token = FAKER.internet().uuid();
-        var errorMsg = FAKER.internet().uuid();
+        var token = UUID.randomUUID().toString();
+        var errorMsg = UUID.randomUUID().toString();
         tokenValidationServer.when(new HttpRequest().withHeader(AUTHORIZATION, token), once())
                 .respond(new HttpResponse()
                         .withStatusCode(200)
@@ -253,7 +252,7 @@ class DataPlaneApiIntegrationTest {
 
     @Test
     void publicApi_should_returnDataFromSource_if_transferSuccessful() throws JsonProcessingException {
-        var token = FAKER.internet().uuid();
+        var token = UUID.randomUUID().toString();
         var address = testDestAddress();
         var requestCaptor = ArgumentCaptor.forClass(DataFlowRequest.class);
 

--- a/extensions/data-plane/data-plane-api/src/test/java/org/eclipse/dataspaceconnector/dataplane/api/response/ResponseFunctionsTest.java
+++ b/extensions/data-plane/data-plane-api/src/test/java/org/eclipse/dataspaceconnector/dataplane/api/response/ResponseFunctionsTest.java
@@ -15,11 +15,11 @@
 
 package org.eclipse.dataspaceconnector.dataplane.api.response;
 
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.dataplane.spi.response.TransferErrorResponse;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.UUID;
 
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 import static jakarta.ws.rs.core.Response.Status.OK;
@@ -30,11 +30,10 @@ import static org.eclipse.dataspaceconnector.dataplane.api.response.ResponseFunc
 
 class ResponseFunctionsTest {
 
-    private static final Faker FAKER = new Faker();
 
     @Test
     void verifyValidationErrors() {
-        var errorMessages = List.of(FAKER.internet().uuid(), FAKER.internet().uuid());
+        var errorMessages = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
         var response = validationErrors(errorMessages);
         assertThat(response.getStatusInfo()).isEqualTo(BAD_REQUEST);
 
@@ -46,7 +45,7 @@ class ResponseFunctionsTest {
 
     @Test
     void verifySuccess() {
-        var data = FAKER.internet().uuid();
+        var data = UUID.randomUUID().toString();
         var response = success(data);
         assertThat(response.getStatusInfo()).isEqualTo(OK);
         assertThat(response.getEntity()).asInstanceOf(STRING).isEqualTo(data);

--- a/extensions/data-plane/data-plane-api/src/test/java/org/eclipse/dataspaceconnector/dataplane/api/validation/TokenValidationClientImplTest.java
+++ b/extensions/data-plane/data-plane-api/src/test/java/org/eclipse/dataspaceconnector/dataplane/api/validation/TokenValidationClientImplTest.java
@@ -17,7 +17,6 @@ package org.eclipse.dataspaceconnector.dataplane.api.validation;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.ws.rs.core.HttpHeaders;
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.junit.jupiter.api.AfterAll;
@@ -30,6 +29,8 @@ import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 import org.mockserver.model.MediaType;
 
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.junit.testfixtures.TestUtils.getFreePort;
 import static org.eclipse.dataspaceconnector.junit.testfixtures.TestUtils.testOkHttpClient;
@@ -40,7 +41,6 @@ import static org.mockserver.stop.Stop.stopQuietly;
 
 class TokenValidationClientImplTest {
 
-    private static final Faker FAKER = new Faker();
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final int PORT = getFreePort();
     private static final String TOKEN_VALIDATION_SERVER_URL = "http://localhost:" + PORT;
@@ -71,9 +71,9 @@ class TokenValidationClientImplTest {
 
     @Test
     void verifySuccessTokenValidation() throws JsonProcessingException {
-        var token = FAKER.internet().uuid();
+        var token = UUID.randomUUID().toString();
         var address = DataAddress.Builder.newInstance()
-                .type(FAKER.lorem().word())
+                .type("test-type")
                 .build();
 
         validationClientAndServer.when(new HttpRequest().withHeader(HttpHeaders.AUTHORIZATION, token), once())
@@ -90,9 +90,9 @@ class TokenValidationClientImplTest {
 
     @Test
     void verifyFailedResultReturnedIfServerResponseIsUnsuccessful() throws JsonProcessingException {
-        var token = FAKER.internet().uuid();
+        var token = UUID.randomUUID().toString();
         var address = DataAddress.Builder.newInstance()
-                .type(FAKER.lorem().word())
+                .type("test-type")
                 .build();
 
         validationClientAndServer.when(new HttpRequest().withHeader(HttpHeaders.AUTHORIZATION, token), once())

--- a/extensions/data-plane/data-plane-http/build.gradle.kts
+++ b/extensions/data-plane/data-plane-http/build.gradle.kts
@@ -12,7 +12,6 @@
  *
  */
 
-val datafaker: String by project
 val failsafeVersion: String by project
 val httpMockServer: String by project
 val okHttpVersion: String by project
@@ -35,7 +34,6 @@ dependencies {
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
     testImplementation("org.mock-server:mockserver-netty:${httpMockServer}:shaded")
     testFixturesImplementation("com.squareup.okhttp3:okhttp:${okHttpVersion}")
-    testFixturesImplementation("net.datafaker:datafaker:${datafaker}")
 }
 
 publishing {

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/ChunkedTransferRequestBodyTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/ChunkedTransferRequestBodyTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.dataplane.http.pipeline;
 
-import net.datafaker.Faker;
 import okio.BufferedSink;
 import org.eclipse.dataspaceconnector.spi.types.domain.HttpDataAddress;
 import org.junit.jupiter.api.Test;
@@ -28,11 +27,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class ChunkedTransferRequestBodyTest {
-    private static final Faker FAKER = new Faker();
 
     @Test
     void verifyStreamingTransfer() throws IOException {
-        var content = FAKER.lorem().word();
+        var content = "Test content";
         var sink = mock(BufferedSink.class);
         var outputStream = new ByteArrayOutputStream();
 

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpDataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpDataSinkFactoryTest.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.dataplane.http.pipeline;
 
 import io.netty.handler.codec.http.HttpMethod;
-import net.datafaker.Faker;
 import okhttp3.Call;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -35,6 +34,7 @@ import org.mockito.ArgumentMatchers;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -48,7 +48,6 @@ import static org.mockito.Mockito.when;
 
 class HttpDataSinkFactoryTest {
 
-    private static final Faker FAKER = new Faker();
     private static final OkHttpClient HTTP_CLIENT = mock(OkHttpClient.class);
     private static final Monitor MONITOR = mock(Monitor.class);
     private static final ExecutorService EXECUTOR_SERVICE = mock(ExecutorService.class);
@@ -56,6 +55,15 @@ class HttpDataSinkFactoryTest {
     private final HttpRequestParamsSupplier supplierMock = mock(HttpRequestParamsSupplier.class);
 
     private HttpDataSinkFactory factory;
+
+    private static DataFlowRequest createRequest(DataAddress destination) {
+        return DataFlowRequest.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .processId(UUID.randomUUID().toString())
+                .sourceDataAddress(DataAddress.Builder.newInstance().type("test-type").build())
+                .destinationDataAddress(destination)
+                .build();
+    }
 
     @BeforeEach
     void setUp() {
@@ -74,7 +82,7 @@ class HttpDataSinkFactoryTest {
 
     @Test
     void verifyValidationFailsIfSupplierThrows() {
-        var errorMsg = FAKER.lorem().sentence();
+        var errorMsg = "Test error message";
         var address = HttpDataAddress.Builder.newInstance().build();
         var request = createRequest(address);
 
@@ -91,7 +99,7 @@ class HttpDataSinkFactoryTest {
         var address = HttpDataAddress.Builder.newInstance().build();
         var request = createRequest(address);
         var params = HttpRequestParams.Builder.newInstance()
-                .baseUrl("http://" + FAKER.internet().url())
+                .baseUrl("http://some.base.url")
                 .method(HttpMethod.POST.name())
                 .contentType("application/json")
                 .build();
@@ -127,7 +135,7 @@ class HttpDataSinkFactoryTest {
         var address = HttpDataAddress.Builder.newInstance().build();
         var request = createRequest(address);
         var params = HttpRequestParams.Builder.newInstance()
-                .baseUrl("http://" + FAKER.internet().url())
+                .baseUrl("http://some.base.url")
                 .method(method)
                 .contentType("application/json")
                 .build();
@@ -149,14 +157,5 @@ class HttpDataSinkFactoryTest {
         assertThat(result.succeeded()).isTrue();
 
         verify(call).execute();
-    }
-
-    private static DataFlowRequest createRequest(DataAddress destination) {
-        return DataFlowRequest.Builder.newInstance()
-                .id(FAKER.internet().uuid())
-                .processId(FAKER.internet().uuid())
-                .sourceDataAddress(DataAddress.Builder.newInstance().type(FAKER.lorem().word()).build())
-                .destinationDataAddress(destination)
-                .build();
     }
 }

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpDataSourceFactoryTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpDataSourceFactoryTest.java
@@ -18,7 +18,6 @@
 package org.eclipse.dataspaceconnector.dataplane.http.pipeline;
 
 import dev.failsafe.RetryPolicy;
-import net.datafaker.Faker;
 import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.dataplane.http.HttpTestFixtures;
 import org.eclipse.dataspaceconnector.spi.EdcException;
@@ -29,6 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.spi.types.domain.HttpDataAddress.DATA_TYPE;
@@ -37,13 +37,21 @@ import static org.mockito.Mockito.when;
 
 class HttpDataSourceFactoryTest {
 
-    private static final Faker FAKER = new Faker();
     private static final OkHttpClient HTTP_CLIENT = mock(OkHttpClient.class);
     private static final RetryPolicy<Object> RETRY_POLICY = RetryPolicy.ofDefaults();
 
     private final HttpRequestParamsSupplier supplierMock = mock(HttpRequestParamsSupplier.class);
 
     private HttpDataSourceFactory factory;
+
+    private static DataFlowRequest createRequest(DataAddress source) {
+        return DataFlowRequest.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .processId(UUID.randomUUID().toString())
+                .sourceDataAddress(source)
+                .destinationDataAddress(DataAddress.Builder.newInstance().type("Test type").build())
+                .build();
+    }
 
     @BeforeEach
     void setUp() {
@@ -62,8 +70,8 @@ class HttpDataSourceFactoryTest {
 
     @Test
     void verifyValidationFailsIfSupplierThrows() {
-        var errorMsg = FAKER.lorem().sentence();
-        var request = createRequest(DataAddress.Builder.newInstance().type(FAKER.lorem().word()).build());
+        var errorMsg = "Test error message";
+        var request = createRequest(DataAddress.Builder.newInstance().type("Test type").build());
 
         when(supplierMock.apply(request)).thenThrow(new EdcException(errorMsg));
 
@@ -76,7 +84,7 @@ class HttpDataSourceFactoryTest {
     @Test
     void verifySuccessSourceCreation() {
         var address = HttpDataAddress.Builder.newInstance()
-                .name(FAKER.lorem().word())
+                .name("test address name")
                 .build();
         var request = createRequest(address);
         var params = mock(HttpRequestParams.class);
@@ -104,14 +112,5 @@ class HttpDataSourceFactoryTest {
                 throw new AssertionError("Comparison failed for field: " + f.getName());
             }
         });
-    }
-
-    private static DataFlowRequest createRequest(DataAddress source) {
-        return DataFlowRequest.Builder.newInstance()
-                .id(FAKER.internet().uuid())
-                .processId(FAKER.internet().uuid())
-                .sourceDataAddress(source)
-                .destinationDataAddress(DataAddress.Builder.newInstance().type(FAKER.lorem().word()).build())
-                .build();
     }
 }

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpRequestParamsSupplierTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpRequestParamsSupplierTest.java
@@ -16,7 +16,6 @@
 package org.eclipse.dataspaceconnector.dataplane.http.pipeline;
 
 import io.netty.handler.codec.http.HttpMethod;
-import net.datafaker.Faker;
 import okhttp3.MediaType;
 import org.eclipse.dataspaceconnector.dataplane.http.HttpTestFixtures;
 import org.eclipse.dataspaceconnector.spi.EdcException;
@@ -33,6 +32,7 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Random;
+import java.util.UUID;
 
 import static io.netty.handler.codec.http.HttpHeaders.Values.APPLICATION_JSON;
 import static io.netty.handler.codec.http.HttpHeaders.Values.APPLICATION_X_WWW_FORM_URLENCODED;
@@ -44,10 +44,16 @@ import static org.mockito.Mockito.when;
 
 class HttpRequestParamsSupplierTest {
 
-    private static final Faker FAKER = new Faker();
-
     private final Vault vaultMock = Mockito.mock(Vault.class);
     private TestHttpRequestParamsSupplier supplier;
+
+    private static DataFlowRequest createRequest(DataAddress source) {
+        return DataFlowRequest.Builder.newInstance()
+                .destinationDataAddress(DataAddress.Builder.newInstance().type("test-type").build())
+                .sourceDataAddress(source)
+                .processId(UUID.randomUUID().toString())
+                .build();
+    }
 
     @BeforeEach
     public void setUp() {
@@ -65,9 +71,9 @@ class HttpRequestParamsSupplierTest {
     @Test
     void verifySecretFromAddressIsUsed() {
         var dataAddress = HttpDataAddress.Builder.newInstance()
-                .authKey(FAKER.lorem().word())
-                .authCode(FAKER.lorem().word())
-                .baseUrl("http://" + FAKER.internet().url())
+                .authKey("test-auth-key")
+                .authCode("test-auth-code")
+                .baseUrl("http://some.base.url")
                 .build();
         var request = createRequest(dataAddress);
 
@@ -84,12 +90,12 @@ class HttpRequestParamsSupplierTest {
 
     @Test
     void verifySecretIsRetrievedFromVault() {
-        var secretName = FAKER.lorem().word();
-        var secret = FAKER.lorem().word();
+        var secretName = "test-secret-name";
+        var secret = "test-secret";
         var dataAddress = HttpDataAddress.Builder.newInstance()
-                .authKey(FAKER.lorem().word())
+                .authKey("test-auth-key")
                 .secretName(secretName)
-                .baseUrl("http://" + FAKER.internet().url())
+                .baseUrl("http://test.base.url")
                 .build();
         var request = createRequest(dataAddress);
 
@@ -110,9 +116,9 @@ class HttpRequestParamsSupplierTest {
 
     @Test
     void verifyAdditionalHeadersAreRetrievedFromAddress() {
-        var additionalHeaders = Map.of(FAKER.lorem().word(), FAKER.lorem().word());
+        var additionalHeaders = Map.of("key1", "value1");
         var builder = HttpDataAddress.Builder.newInstance()
-                .baseUrl("http://" + FAKER.internet().url());
+                .baseUrl("http://some.base.url");
         additionalHeaders.forEach(builder::addAdditionalHeader);
         var request = createRequest(builder.build());
 
@@ -128,7 +134,7 @@ class HttpRequestParamsSupplierTest {
     @Test
     void verifyAbstractMethodsInvokation() throws IOException {
         var dataAddress = HttpDataAddress.Builder.newInstance()
-                .baseUrl("http://" + FAKER.internet().url())
+                .baseUrl("http://some.base.url")
                 .build();
         var request = createRequest(dataAddress);
 
@@ -146,7 +152,7 @@ class HttpRequestParamsSupplierTest {
     @Test
     void verifyChunkedCall() throws IOException {
         var dataAddress = HttpDataAddress.Builder.newInstance()
-                .baseUrl("http://" + FAKER.internet().url())
+                .baseUrl("http://some.base.url")
                 .build();
         var request = createRequest(dataAddress);
 
@@ -162,14 +168,6 @@ class HttpRequestParamsSupplierTest {
         assertThat(httpRequest.body().contentLength()).isEqualTo(supplier.body.getBytes().length);
     }
 
-    private static DataFlowRequest createRequest(DataAddress source) {
-        return DataFlowRequest.Builder.newInstance()
-                .destinationDataAddress(DataAddress.Builder.newInstance().type(FAKER.lorem().word()).build())
-                .sourceDataAddress(source)
-                .processId(FAKER.internet().uuid())
-                .build();
-    }
-
     public static final class TestHttpRequestParamsSupplier extends HttpRequestParamsSupplier {
 
         private final String method;
@@ -183,20 +181,20 @@ class HttpRequestParamsSupplierTest {
             super(vault);
             this.method = new Random().nextBoolean() ? HttpMethod.PUT.name() : HttpMethod.POST.name();
             this.isOneGo = false;
-            this.path = FAKER.lorem().word();
-            this.queryParams = FAKER.lorem().word();
+            this.path = "somepath";
+            this.queryParams = "testqueryparam";
             this.contentType = new Random().nextBoolean() ? APPLICATION_JSON : APPLICATION_X_WWW_FORM_URLENCODED;
-            this.body = FAKER.lorem().word();
+            this.body = "Test-Body";
         }
 
         private TestHttpRequestParamsSupplier(Vault vault, boolean isOneGo) {
             super(vault);
             this.method = new Random().nextBoolean() ? HttpMethod.PUT.name() : HttpMethod.POST.name();
             this.isOneGo = isOneGo;
-            this.path = FAKER.lorem().word();
-            this.queryParams = FAKER.lorem().word();
+            this.path = "somepath";
+            this.queryParams = "testqueryparam";
             this.contentType = new Random().nextBoolean() ? APPLICATION_JSON : APPLICATION_X_WWW_FORM_URLENCODED;
-            this.body = FAKER.lorem().word();
+            this.body = "Test-Body";
         }
 
         @Override

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpRequestParamsTests.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpRequestParamsTests.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.dataplane.http.pipeline;
 
 import io.netty.handler.codec.http.HttpMethod;
-import net.datafaker.Faker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -30,13 +29,11 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.eclipse.dataspaceconnector.dataplane.http.HttpTestFixtures.formatRequestBodyAsString;
 
 class HttpRequestParamsTests {
-    private static final Faker FAKER = new Faker();
-
     private String baseUrl;
 
     @BeforeEach
     public void setUp() {
-        baseUrl = "http://" + FAKER.internet().url();
+        baseUrl = "http://some.base.url";
     }
 
     @ParameterizedTest
@@ -65,7 +62,7 @@ class HttpRequestParamsTests {
 
     @Test
     void verifyHeaders() {
-        var headers = Map.of(FAKER.lorem().word(), FAKER.lorem().word());
+        var headers = Map.of("key1", "value1");
         var params = HttpRequestParams.Builder.newInstance()
                 .baseUrl(baseUrl)
                 .method(HttpMethod.GET.name())
@@ -79,8 +76,8 @@ class HttpRequestParamsTests {
 
     @Test
     void verifyComplexUrl() {
-        var path = FAKER.lorem().word();
-        var queryParams = FAKER.lorem().word();
+        var path = "testpath";
+        var queryParams = "test-queryparams";
         var params = HttpRequestParams.Builder.newInstance()
                 .baseUrl(baseUrl)
                 .method(HttpMethod.GET.name())
@@ -96,7 +93,7 @@ class HttpRequestParamsTests {
 
     @Test
     void verifyDefaultContentTypeIsOctetStream() {
-        var body = FAKER.lorem().word();
+        var body = "Test body";
         var contentType = "application/octet-stream";
         var params = HttpRequestParams.Builder.newInstance()
                 .baseUrl(baseUrl)
@@ -113,7 +110,7 @@ class HttpRequestParamsTests {
 
     @Test
     void verifyBodyFromParams() throws IOException {
-        var body = FAKER.lorem().word();
+        var body = "Test body";
         var contentType = "text/plain";
         var params = HttpRequestParams.Builder.newInstance()
                 .baseUrl(baseUrl)
@@ -133,7 +130,7 @@ class HttpRequestParamsTests {
 
     @Test
     void verifyBodyFromMethodCall() throws IOException {
-        var body = FAKER.lorem().word();
+        var body = "Test body";
         var contentType = "application/json";
         var params = HttpRequestParams.Builder.newInstance()
                 .baseUrl(baseUrl)
@@ -151,7 +148,7 @@ class HttpRequestParamsTests {
 
     @Test
     void verifyRequestBodyIsNullIfNoContentProvided() {
-        var contentType = FAKER.lorem().word();
+        var contentType = "test/content-type";
         var params = HttpRequestParams.Builder.newInstance()
                 .baseUrl(baseUrl)
                 .method(HttpMethod.GET.name())
@@ -173,7 +170,7 @@ class HttpRequestParamsTests {
 
     @Test
     void verifyExceptionThrownIfMethodMissing() {
-        var builder = HttpRequestParams.Builder.newInstance().baseUrl(FAKER.internet().url());
+        var builder = HttpRequestParams.Builder.newInstance().baseUrl("http://some.base.url");
 
         assertThatExceptionOfType(NullPointerException.class).isThrownBy(builder::build);
     }
@@ -181,10 +178,10 @@ class HttpRequestParamsTests {
     @Test
     void verifyExceptionIsRaisedIfContentTypeIsNull() {
         var builder = HttpRequestParams.Builder.newInstance()
-                .baseUrl(FAKER.internet().url())
+                .baseUrl("http://some.base.url")
                 .method(HttpMethod.POST.name())
                 .contentType(null)
-                .body(FAKER.lorem().word());
+                .body("Test Body");
 
         assertThatExceptionOfType(NullPointerException.class).isThrownBy(builder::build);
     }

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpSinkRequestParamsSupplierTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpSinkRequestParamsSupplierTest.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.dataplane.http.pipeline;
 
 import io.netty.handler.codec.http.HttpMethod;
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.HttpDataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
@@ -23,13 +22,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Random;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 class HttpSinkRequestParamsSupplierTest {
 
-    private static final Faker FAKER = new Faker();
 
     private HttpSinkRequestParamsSupplier supplier;
 
@@ -43,7 +42,7 @@ class HttpSinkRequestParamsSupplierTest {
         var source = mock(DataAddress.class);
         var destination = mock(DataAddress.class);
         var request = DataFlowRequest.Builder.newInstance()
-                .processId(FAKER.internet().uuid())
+                .processId(UUID.randomUUID().toString())
                 .sourceDataAddress(source)
                 .destinationDataAddress(destination)
                 .build();
@@ -55,7 +54,7 @@ class HttpSinkRequestParamsSupplierTest {
 
     @Test
     void extractMethod() {
-        var method = FAKER.lorem().word();
+        var method = "test-method";
         var address = HttpDataAddress.Builder.newInstance()
                 .method(method)
                 .build();
@@ -77,7 +76,7 @@ class HttpSinkRequestParamsSupplierTest {
 
     @Test
     void extractPath() {
-        var path = FAKER.lorem().word();
+        var path = "test-path";
         var address = HttpDataAddress.Builder.newInstance()
                 .path(path)
                 .build();
@@ -94,7 +93,7 @@ class HttpSinkRequestParamsSupplierTest {
 
     @Test
     void extractContentType() {
-        var contentType = FAKER.lorem().word();
+        var contentType = "test/content-type";
         var address = HttpDataAddress.Builder.newInstance()
                 .contentType(contentType)
                 .build();

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpSourceRequestParamsSupplierTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/HttpSourceRequestParamsSupplierTest.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.dataplane.http.pipeline;
 
 import io.netty.handler.codec.http.HttpMethod;
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.dataplane.spi.schema.DataFlowRequestSchema;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
@@ -26,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.Random;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -33,9 +33,20 @@ import static org.mockito.Mockito.mock;
 
 class HttpSourceRequestParamsSupplierTest {
 
-    private static final Faker FAKER = new Faker();
-
     private HttpSourceRequestParamsSupplier supplier;
+
+    private static DataFlowRequest createRequest(DataAddress source) {
+        return createRequest(source, Map.of());
+    }
+
+    private static DataFlowRequest createRequest(DataAddress source, Map<String, String> props) {
+        return DataFlowRequest.Builder.newInstance()
+                .processId(UUID.randomUUID().toString())
+                .sourceDataAddress(source)
+                .destinationDataAddress(mock(DataAddress.class))
+                .properties(props)
+                .build();
+    }
 
     @BeforeEach
     public void setUp() {
@@ -54,7 +65,7 @@ class HttpSourceRequestParamsSupplierTest {
 
     @Test
     void extractMethod() {
-        var method = FAKER.lorem().word();
+        var method = "test-method";
         var address = HttpDataAddress.Builder.newInstance()
                 .proxyMethod(Boolean.TRUE.toString())
                 .build();
@@ -77,7 +88,7 @@ class HttpSourceRequestParamsSupplierTest {
 
     @Test
     void extractMethodDefault() {
-        var method = FAKER.lorem().word();
+        var method = "test-method";
         var address = HttpDataAddress.Builder.newInstance().build();
         var request = createRequest(address, Map.of(DataFlowRequestSchema.METHOD, method));
 
@@ -88,7 +99,7 @@ class HttpSourceRequestParamsSupplierTest {
 
     @Test
     void extractPath() {
-        var path = FAKER.lorem().word();
+        var path = "test-path";
         var address = HttpDataAddress.Builder.newInstance()
                 .proxyPath(Boolean.TRUE.toString())
                 .build();
@@ -113,7 +124,7 @@ class HttpSourceRequestParamsSupplierTest {
 
     @Test
     void extractPathFilteredByProxy() {
-        var path = FAKER.lorem().word();
+        var path = "test-path";
         var address = HttpDataAddress.Builder.newInstance().build();
         var request = createRequest(address, Map.of(DataFlowRequestSchema.PATH, path));
 
@@ -124,7 +135,7 @@ class HttpSourceRequestParamsSupplierTest {
 
     @Test
     void extractQueryParams() {
-        var queryParams = FAKER.lorem().word();
+        var queryParams = "test-queryparams";
         var address = HttpDataAddress.Builder.newInstance()
                 .proxyQueryParams(Boolean.TRUE.toString())
                 .build();
@@ -149,7 +160,7 @@ class HttpSourceRequestParamsSupplierTest {
 
     @Test
     void extractQueryParamsFilteredByProxy() {
-        var queryParams = FAKER.lorem().word();
+        var queryParams = "test-queryparams";
         var address = HttpDataAddress.Builder.newInstance().build();
         var request = createRequest(address, Map.of(DataFlowRequestSchema.QUERY_PARAMS, queryParams));
 
@@ -160,7 +171,7 @@ class HttpSourceRequestParamsSupplierTest {
 
     @Test
     void extractContentType() {
-        var contentType = FAKER.lorem().word();
+        var contentType = "test/content-type";
         var address = HttpDataAddress.Builder.newInstance()
                 .proxyBody(Boolean.TRUE.toString())
                 .build();
@@ -185,7 +196,7 @@ class HttpSourceRequestParamsSupplierTest {
 
     @Test
     void extractContentFilteredByProxy() {
-        var contentType = FAKER.lorem().word();
+        var contentType = "test-contenttype";
         var address = HttpDataAddress.Builder.newInstance().build();
         var request = createRequest(address, Map.of(DataFlowRequestSchema.MEDIA_TYPE, contentType));
 
@@ -196,7 +207,7 @@ class HttpSourceRequestParamsSupplierTest {
 
     @Test
     void extractBody() {
-        var body = FAKER.lorem().word();
+        var body = "Test Body";
         var address = HttpDataAddress.Builder.newInstance()
                 .proxyBody(Boolean.TRUE.toString())
                 .build();
@@ -209,7 +220,6 @@ class HttpSourceRequestParamsSupplierTest {
 
     @Test
     void extractBodyEmpty() {
-        var body = FAKER.lorem().word();
         var address = HttpDataAddress.Builder.newInstance()
                 .proxyBody(Boolean.TRUE.toString())
                 .build();
@@ -222,7 +232,7 @@ class HttpSourceRequestParamsSupplierTest {
 
     @Test
     void extractBodyFilteredByProxy() {
-        var body = FAKER.lorem().word();
+        var body = "Test Body";
         var address = HttpDataAddress.Builder.newInstance().build();
         var request = createRequest(address, Map.of(DataFlowRequestSchema.BODY, body));
 
@@ -241,18 +251,5 @@ class HttpSourceRequestParamsSupplierTest {
         var result = supplier.extractNonChunkedTransfer(address);
 
         assertThat(result).isFalse();
-    }
-
-    private static DataFlowRequest createRequest(DataAddress source) {
-        return createRequest(source, Map.of());
-    }
-
-    private static DataFlowRequest createRequest(DataAddress source, Map<String, String> props) {
-        return DataFlowRequest.Builder.newInstance()
-                .processId(FAKER.internet().uuid())
-                .sourceDataAddress(source)
-                .destinationDataAddress(mock(DataAddress.class))
-                .properties(props)
-                .build();
     }
 }

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/NonChunkedTransferRequestBodyTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/NonChunkedTransferRequestBodyTest.java
@@ -15,7 +15,6 @@
 
 package org.eclipse.dataspaceconnector.dataplane.http.pipeline;
 
-import net.datafaker.Faker;
 import okio.BufferedSink;
 import org.eclipse.dataspaceconnector.spi.types.domain.HttpDataAddress;
 import org.junit.jupiter.api.Test;
@@ -30,11 +29,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class NonChunkedTransferRequestBodyTest {
-    private static final Faker FAKER = new Faker();
 
     @Test
     void verifyTransferWhenDataAvailable() throws IOException {
-        var content = FAKER.lorem().word();
+        var content = "Test Content";
         var sink = mock(BufferedSink.class);
         var outputStream = new ByteArrayOutputStream();
 

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/StringRequestBodySupplierTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/dataspaceconnector/dataplane/http/pipeline/StringRequestBodySupplierTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.dataplane.http.pipeline;
 
-import net.datafaker.Faker;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -24,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class StringRequestBodySupplierTest {
 
-    private static final Faker FAKER = new Faker();
 
     @Test
     void verifyExceptionThrownIfNullBody() {
@@ -33,7 +31,7 @@ class StringRequestBodySupplierTest {
 
     @Test
     void verifySuccessSupply() throws IOException {
-        var body = FAKER.lorem().word();
+        var body = "Test body";
         var supplier = new StringRequestBodySupplier(body);
 
         try (var is = supplier.get()) {

--- a/extensions/data-plane/data-plane-http/src/testFixtures/java/org/eclipse/dataspaceconnector/dataplane/http/HttpTestFixtures.java
+++ b/extensions/data-plane/data-plane-http/src/testFixtures/java/org/eclipse/dataspaceconnector/dataplane/http/HttpTestFixtures.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.dataplane.http;
 
-import net.datafaker.Faker;
 import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -29,12 +28,15 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.UUID;
 
 import static okhttp3.Protocol.HTTP_2;
 
 public class HttpTestFixtures {
 
-    private static final Faker FAKER = new Faker();
+
+    private HttpTestFixtures() {
+    }
 
     public static DataFlowRequest.Builder createRequest(String type) {
         return createRequest(
@@ -46,8 +48,8 @@ public class HttpTestFixtures {
 
     public static DataFlowRequest.Builder createRequest(Map<String, String> properties, DataAddress source, DataAddress destination) {
         return DataFlowRequest.Builder.newInstance()
-                .id(FAKER.internet().uuid())
-                .processId(FAKER.internet().uuid())
+                .id(UUID.randomUUID().toString())
+                .processId(UUID.randomUUID().toString())
                 .properties(properties)
                 .sourceDataAddress(source)
                 .destinationDataAddress(destination)
@@ -80,8 +82,5 @@ public class HttpTestFixtures {
             requestBody.writeTo(bufferedSink);
             return os.toString();
         }
-    }
-
-    private HttpTestFixtures() {
     }
 }

--- a/extensions/iam/decentralized-identity/identity-did-crypto/src/test/java/org/eclipse/dataspaceconnector/iam/did/crypto/JwtUtilsTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-crypto/src/test/java/org/eclipse/dataspaceconnector/iam/did/crypto/JwtUtilsTest.java
@@ -19,7 +19,6 @@ import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.iam.did.crypto.key.EcPrivateKeyWrapper;
 import org.eclipse.dataspaceconnector.iam.did.crypto.key.EcPublicKeyWrapper;
 import org.jetbrains.annotations.NotNull;
@@ -53,7 +52,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class JwtUtilsTest {
-    private static final Faker FAKER = new Faker();
 
     private final Instant now = Instant.now();
     private final Clock clock = Clock.fixed(now, UTC);
@@ -108,7 +106,7 @@ class JwtUtilsTest {
     @Test
     void verifyJwt_OnVerificationFailure_fails() throws Exception {
         var jwt = mock(SignedJWT.class);
-        var message = FAKER.lorem().sentence();
+        var message = "Test Message";
         when(jwt.verify(any())).thenThrow(new JOSEException(message));
         assertThat(verify(jwt, publicKey, "test-audience").getFailureMessages())
                 .containsExactly("Unable to verify JWT token. " + message);
@@ -118,7 +116,7 @@ class JwtUtilsTest {
     @Test
     void verifyJwt_OnInvalidClaims_fails() throws Exception {
         var jwt = mock(SignedJWT.class);
-        var message = FAKER.lorem().sentence();
+        var message = "Test Message";
         when(jwt.verify(any())).thenReturn(true);
         when(jwt.getJWTClaimsSet()).thenThrow(new ParseException(message, 0));
         assertThat(verify(jwt, publicKey, "test-audience").getFailureMessages())

--- a/extensions/iam/decentralized-identity/identity-did-service/src/test/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityServiceTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-service/src/test/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityServiceTest.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.JWK;
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.iam.did.crypto.key.EcPrivateKeyWrapper;
 import org.eclipse.dataspaceconnector.iam.did.crypto.key.KeyPairFactory;
 import org.eclipse.dataspaceconnector.iam.did.spi.credentials.CredentialsVerifier;
@@ -43,15 +42,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Test the {@link DecentralizedIdentityService} with a key algorithm.
- * See {@link WithP256Test} for concrete impl.
+ * Test the {@link DecentralizedIdentityService} with a key algorithm. See {@link WithP256Test} for concrete impl.
  */
 
 abstract class DecentralizedIdentityServiceTest {
-    private static final Faker FAKER = new Faker();
     private static final String DID_DOCUMENT = getResourceFileContentAsString("dids.json");
 
-    private final String didUrl = FAKER.internet().url();
     private DecentralizedIdentityService identityService;
 
     @Test
@@ -85,6 +81,7 @@ abstract class DecentralizedIdentityServiceTest {
 
         var didResolver = new TestResolverRegistry(DID_DOCUMENT, keyPair);
         CredentialsVerifier verifier = document -> Result.success(Map.of("region", "eu"));
+        String didUrl = "random.did.url";
         identityService = new DecentralizedIdentityService(didResolver, verifier, new ConsoleMonitor(), privateKey, didUrl, Clock.systemUTC());
     }
 

--- a/extensions/iam/oauth2/oauth2-core/src/test/java/org/eclipse/dataspaceconnector/iam/oauth2/core/identity/IdentityProviderKeyResolverTest.java
+++ b/extensions/iam/oauth2/oauth2-core/src/test/java/org/eclipse/dataspaceconnector/iam/oauth2/core/identity/IdentityProviderKeyResolverTest.java
@@ -16,7 +16,6 @@
 package org.eclipse.dataspaceconnector.iam.oauth2.core.identity;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import net.datafaker.Faker;
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -45,8 +44,7 @@ import static org.mockito.Mockito.when;
 
 class IdentityProviderKeyResolverTest {
 
-    private static final Faker FAKER = Faker.instance();
-    private static final String JWKS_URL = "https://" + FAKER.internet().url();
+    private static final String JWKS_URL = "https://test.jwks.url";
     private static final String JWKS_FILE = "jwks_response.json";
     private final Interceptor interceptor = mock(Interceptor.class);
     private final TypeManager typeManager = new TypeManager();
@@ -114,9 +112,9 @@ class IdentityProviderKeyResolverTest {
         return new Response.Builder()
                 .code(code)
                 .body(ResponseBody.create(typeManager.writeValueAsString(body), MediaType.get("application/json")))
-                .message(FAKER.twinPeaks().quote())
+                .message("Test message")
                 .protocol(Protocol.HTTP_1_1)
-                .request(new Request.Builder().url("http://" + FAKER.internet().url()).build())
+                .request(new Request.Builder().url("http://test.some.url").build())
                 .build();
     }
 }

--- a/extensions/jdk-logger-monitor/src/test/java/org/eclipse/dataspaceconnector/logger/LoggerMonitorTest.java
+++ b/extensions/jdk-logger-monitor/src/test/java/org/eclipse/dataspaceconnector/logger/LoggerMonitorTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.logger;
 
-import net.datafaker.Faker;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,11 +36,9 @@ import static org.assertj.core.api.Assertions.tuple;
 
 public class LoggerMonitorTest {
 
-    static Faker faker = new Faker();
-    final String message = faker.lorem().sentence();
-    final String extraParams = faker.lorem().sentence();
-    TestLogHandler handler = new TestLogHandler();
-    LoggerMonitor sut = new LoggerMonitor();
+    private final String message = "test message";
+    private final TestLogHandler handler = new TestLogHandler();
+    private final LoggerMonitor sut = new LoggerMonitor();
 
     @BeforeEach
     public void setUp() {
@@ -87,12 +84,13 @@ public class LoggerMonitorTest {
 
     @Test
     public void loggedOnSevereLevel_WithParams() {
+        String extraParams = "test-extraparams";
         Map<String, Object> errors = Map.of(message, extraParams);
         sut.severe(errors);
 
         assertThat(handler.getRecords())
                 .extracting(LogRecord::getMessage, LogRecord::getLevel, LogRecord::getThrown, LogRecord::getParameters)
-                .containsExactly(tuple(message, Level.SEVERE, null, new Object[]{extraParams}));
+                .containsExactly(tuple(message, Level.SEVERE, null, new Object[]{ extraParams }));
     }
 
     @Test
@@ -157,8 +155,8 @@ public class LoggerMonitorTest {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
             return Stream.of(
-                    Arguments.of(faker.lorem().sentence(), new Throwable[]{new RuntimeException()}),
-                    Arguments.of(faker.lorem().sentence(), new Throwable[]{new RuntimeException(), new Exception()})
+                    Arguments.of("test-message-1", new Throwable[]{ new RuntimeException() }),
+                    Arguments.of("test-message-2", new Throwable[]{ new RuntimeException(), new Exception() })
             );
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,12 @@
 groupId=org.eclipse.dataspaceconnector
 defaultVersion=0.0.1-SNAPSHOT
 javaVersion=11
-
 edcDeveloperId=mspiekermann
 edcDeveloperName=Markus Spiekermann
 edcDeveloperEmail=markus.spiekermann@isst.fraunhofer.de
 edcScmConnection=scm:git:git@github.com:eclipse-dataspaceconnector/DataSpaceConnector.git
 edcWebsiteUrl=https://github.com/eclipse-dataspaceconnector/DataSpaceConnector.git
 edcScmUrl=https://github.com/eclipse-dataspaceconnector/DataSpaceConnector.git
-
 apacheCommonsPool2Version=2.11.1
 assertj=3.22.0
 atomikosVersion=5.0.8
@@ -21,7 +19,6 @@ azureResourceManagerVersion=2.12.0
 bouncycastleVersion=1.70
 cloudEvents=2.3.0
 cosmosSdkVersion=4.26.0
-datafaker=1.4.0
 eventGridSdkVersion=4.4.0
 gatlingVersion=3.7.5
 h2Version=2.1.210

--- a/spi/data-plane/data-plane-spi/src/test/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSinkTest.java
+++ b/spi/data-plane/data-plane-spi/src/test/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSinkTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.dataplane.spi.pipeline;
 
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
 import org.eclipse.dataspaceconnector.spi.response.StatusResult;
@@ -36,16 +35,14 @@ import static org.mockito.Mockito.when;
 
 class ParallelSinkTest {
 
-    Faker faker = new Faker();
-    Monitor monitor = mock(Monitor.class);
-    ExecutorService executor = Executors.newFixedThreadPool(2);
-    String dataSourceName = faker.lorem().word();
-    String dataSourceContent = faker.lorem().characters();
-    String errorMessage = faker.lorem().sentence();
-    InputStreamDataSource dataSource = new InputStreamDataSource(
+    private final Monitor monitor = mock(Monitor.class);
+    private final ExecutorService executor = Executors.newFixedThreadPool(2);
+    private final String dataSourceName = "test-datasource-name";
+    private final String dataSourceContent = "test-content";
+    private final String errorMessage = "test-errormessage";
+    private final InputStreamDataSource dataSource = new InputStreamDataSource(
             dataSourceName,
             new ByteArrayInputStream(dataSourceContent.getBytes()));
-
     FakeParallelSink fakeSink;
 
     @BeforeEach

--- a/system-tests/azure-tests/build.gradle.kts
+++ b/system-tests/azure-tests/build.gradle.kts
@@ -20,7 +20,6 @@ plugins {
 }
 
 val assertj: String by project
-val datafaker: String by project
 val gatlingVersion: String by project
 val restAssured: String by project
 val storageBlobVersion: String by project
@@ -46,7 +45,6 @@ dependencies {
     testFixturesImplementation(testFixtures(project(":system-tests:tests")))
     testFixturesImplementation(testFixtures(project(":extensions:azure:azure-test")))
     testFixturesImplementation("org.assertj:assertj-core:${assertj}")
-    testFixturesImplementation("net.datafaker:datafaker:${datafaker}")
     testImplementation("com.azure:azure-storage-blob:${storageBlobVersion}")
     testFixturesImplementation("io.rest-assured:rest-assured:${restAssured}")
 

--- a/system-tests/azure-tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/local/BlobTransferSimulationConfiguration.java
+++ b/system-tests/azure-tests/src/testFixtures/java/org/eclipse/dataspaceconnector/system/tests/local/BlobTransferSimulationConfiguration.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.system.tests.local;
 
 import com.azure.storage.blob.BlobServiceClient;
-import net.datafaker.Faker;
 import org.eclipse.dataspaceconnector.azure.blob.core.AzureBlobStoreSchema;
 import org.eclipse.dataspaceconnector.azure.testfixtures.TestFunctions;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
@@ -37,9 +36,9 @@ import static org.eclipse.dataspaceconnector.system.tests.utils.TransferSimulati
  */
 public class BlobTransferSimulationConfiguration implements TransferSimulationConfiguration {
 
+    static final String BLOB_CONTENT = "Test blob content";
     private final BlobServiceClient blobServiceClient;
     private final int maxSeconds;
-    static final String BLOB_CONTENT = Faker.instance().lorem().sentence();
 
     public BlobTransferSimulationConfiguration(String accountName, String accountKey, String accountEndpoint, int maxSeconds) {
         this.blobServiceClient = TestFunctions.getBlobServiceClient(accountName, accountKey, accountEndpoint);


### PR DESCRIPTION
## What this PR changes/adds

Removes the `data-faker` library from the code base, replacing all occurrences with either `UUID.randomUuid().toString()` or other test strings and random numbers.


## Why it does that

The data faker has caused problems with test stability, and in addition, it offers little value, all the while increasing the library footprint.

## Further notes

.

## Linked Issue(s)

Closes #1851 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
