### PR TITLE
feat(Event Frame Work): add intermediate superclass for TransferProcess Events hierarchy

### DIFF
--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessCancelled.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessCancelled.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.spi.event.transferprocess;
 
 import org.eclipse.dataspaceconnector.spi.event.Event;
-import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
 import java.util.Objects;
 
@@ -48,11 +47,6 @@ public class TransferProcessCancelled extends Event<TransferProcessCancelled.Pay
         }
     }
 
-    public static class Payload extends EventPayload {
-        private String transferProcessId;
-
-        public String getTransferProcessId() {
-            return transferProcessId;
-        }
+    public static class Payload extends TransferProcessEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessCompleted.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessCompleted.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.spi.event.transferprocess;
 
 import org.eclipse.dataspaceconnector.spi.event.Event;
-import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
 import java.util.Objects;
 
@@ -48,11 +47,7 @@ public class TransferProcessCompleted extends Event<TransferProcessCompleted.Pay
         }
     }
 
-    public static class Payload extends EventPayload {
-        private String transferProcessId;
+    public static class Payload extends TransferProcessEventPayload {
 
-        public String getTransferProcessId() {
-            return transferProcessId;
-        }
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessDeprovisioned.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessDeprovisioned.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.spi.event.transferprocess;
 
 import org.eclipse.dataspaceconnector.spi.event.Event;
-import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
 import java.util.Objects;
 
@@ -48,11 +47,6 @@ public class TransferProcessDeprovisioned extends Event<TransferProcessDeprovisi
         }
     }
 
-    public static class Payload extends EventPayload {
-        private String transferProcessId;
-
-        public String getTransferProcessId() {
-            return transferProcessId;
-        }
+    public static class Payload extends TransferProcessEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessDeprovisioningRequested.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessDeprovisioningRequested.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.spi.event.transferprocess;
 
 import org.eclipse.dataspaceconnector.spi.event.Event;
-import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
 import java.util.Objects;
 
@@ -48,11 +47,6 @@ public class TransferProcessDeprovisioningRequested extends Event<TransferProces
         }
     }
 
-    public static class Payload extends EventPayload {
-        private String transferProcessId;
-
-        public String getTransferProcessId() {
-            return transferProcessId;
-        }
+    public static class Payload extends TransferProcessEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessEnded.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessEnded.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.spi.event.transferprocess;
 
 import org.eclipse.dataspaceconnector.spi.event.Event;
-import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
 import java.util.Objects;
 
@@ -48,11 +47,6 @@ public class TransferProcessEnded extends Event<TransferProcessEnded.Payload> {
         }
     }
 
-    public static class Payload extends EventPayload {
-        private String transferProcessId;
-
-        public String getTransferProcessId() {
-            return transferProcessId;
-        }
+    public static class Payload extends TransferProcessEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessEventPayload.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessEventPayload.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - expending Event classes
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.event.transferprocess;
+
+import org.eclipse.dataspaceconnector.spi.event.EventPayload;
+
+public class TransferProcessEventPayload extends EventPayload {
+    protected String transferProcessId;
+
+    public String getTransferProcessId() {
+        return transferProcessId;
+    }
+
+}

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessFailed.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessFailed.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.spi.event.transferprocess;
 
 import org.eclipse.dataspaceconnector.spi.event.Event;
-import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
 import java.util.Objects;
 
@@ -48,11 +47,6 @@ public class TransferProcessFailed extends Event<TransferProcessFailed.Payload> 
         }
     }
 
-    public static class Payload extends EventPayload {
-        private String transferProcessId;
-
-        public String getTransferProcessId() {
-            return transferProcessId;
-        }
+    public static class Payload extends TransferProcessEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessInitiated.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessInitiated.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.spi.event.transferprocess;
 
 import org.eclipse.dataspaceconnector.spi.event.Event;
-import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
 import java.util.Objects;
 
@@ -48,11 +47,6 @@ public class TransferProcessInitiated extends Event<TransferProcessInitiated.Pay
         }
     }
 
-    public static class Payload extends EventPayload {
-        private String transferProcessId;
-
-        public String getTransferProcessId() {
-            return transferProcessId;
-        }
+    public static class Payload extends TransferProcessEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessProvisioned.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessProvisioned.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.spi.event.transferprocess;
 
 import org.eclipse.dataspaceconnector.spi.event.Event;
-import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
 import java.util.Objects;
 
@@ -48,11 +47,6 @@ public class TransferProcessProvisioned extends Event<TransferProcessProvisioned
         }
     }
 
-    public static class Payload extends EventPayload {
-        private String transferProcessId;
-
-        public String getTransferProcessId() {
-            return transferProcessId;
-        }
+    public static class Payload extends TransferProcessEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessProvisioningRequested.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessProvisioningRequested.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.spi.event.transferprocess;
 
 import org.eclipse.dataspaceconnector.spi.event.Event;
-import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
 import java.util.Objects;
 
@@ -48,11 +47,7 @@ public class TransferProcessProvisioningRequested extends Event<TransferProcessP
         }
     }
 
-    public static class Payload extends EventPayload {
-        private String transferProcessId;
+    public static class Payload extends TransferProcessEventPayload {
 
-        public String getTransferProcessId() {
-            return transferProcessId;
-        }
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessRequested.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/transferprocess/TransferProcessRequested.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.spi.event.transferprocess;
 
 import org.eclipse.dataspaceconnector.spi.event.Event;
-import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
 import java.util.Objects;
 
@@ -48,11 +47,6 @@ public class TransferProcessRequested extends Event<TransferProcessRequested.Pay
         }
     }
 
-    public static class Payload extends EventPayload {
-        private String transferProcessId;
-
-        public String getTransferProcessId() {
-            return transferProcessId;
-        }
+    public static class Payload extends TransferProcessEventPayload {
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Add a 'intermediate' superclass for the Event Payload Classes of the TransferProcess classes.

## Why it does that

Improve the work with the Event Framework and give the possibility to filter Events on a bigger group of events.


## Linked Issue(s)

Closes #1873

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
