### PR TITLE
feat: enable s3 multipart upload

### DIFF
--- a/extensions/data-plane/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataSink.java
+++ b/extensions/data-plane/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataSink.java
@@ -20,9 +20,15 @@ import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
 import org.eclipse.dataspaceconnector.spi.response.StatusResult;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
+import software.amazon.awssdk.services.s3.model.CompletedPart;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.List;
 
 class S3DataSink extends ParallelSink {
@@ -30,18 +36,49 @@ class S3DataSink extends ParallelSink {
     private S3Client client;
     private String bucketName;
     private String keyName;
+    private int chunkSize;
 
-    private S3DataSink() { }
+    private S3DataSink() {}
 
     @Override
     protected StatusResult<Void> transferParts(List<DataSource.Part> parts) {
         for (DataSource.Part part : parts) {
             try (var input = part.openStream()) {
-                PutObjectRequest request = PutObjectRequest.builder()
+
+                int partNumber = 1;
+                List<CompletedPart> completedParts = new ArrayList<>();
+
+                String uploadId = client.createMultipartUpload(CreateMultipartUploadRequest.builder()
                         .bucket(bucketName)
                         .key(keyName)
-                        .build();
-                client.putObject(request, RequestBody.fromBytes(input.readAllBytes()));
+                        .build()).uploadId();
+
+                while (true) {
+                    byte[] bytesChunk = input.readNBytes(chunkSize);
+
+                    if (bytesChunk.length < 1) {
+                        break;
+                    }
+
+                    completedParts.add(CompletedPart.builder().partNumber(partNumber)
+                            .eTag(client.uploadPart(UploadPartRequest.builder()
+                                .bucket(bucketName)
+                                .key(keyName)
+                                .uploadId(uploadId)
+                                .partNumber(partNumber)
+                                .build(), RequestBody.fromByteBuffer(ByteBuffer.wrap(bytesChunk))).eTag()).build());
+                    partNumber++;
+                }
+
+                client.completeMultipartUpload(CompleteMultipartUploadRequest.builder()
+                        .bucket(bucketName)
+                        .key(keyName)
+                        .uploadId(uploadId)
+                        .multipartUpload(CompletedMultipartUpload.builder()
+                            .parts(completedParts)
+                            .build())
+                        .build());
+
             } catch (IOException e) {
                 monitor.severe("Cannot open the input part");
                 return StatusResult.failure(ResponseStatus.FATAL_ERROR, "An error");
@@ -50,6 +87,7 @@ class S3DataSink extends ParallelSink {
                 return StatusResult.failure(ResponseStatus.FATAL_ERROR, "An error");
             }
         }
+
         return StatusResult.success();
     }
 
@@ -78,9 +116,12 @@ class S3DataSink extends ParallelSink {
             return this;
         }
 
-        @Override
-        protected void validate() {
-
+        public Builder chunkSizeBytes(int chunkSize) {
+            sink.chunkSize = chunkSize;
+            return this;
         }
+
+        @Override
+        protected void validate() {}
     }
 }

--- a/extensions/data-plane/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataSink.java
+++ b/extensions/data-plane/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataSink.java
@@ -42,19 +42,19 @@ class S3DataSink extends ParallelSink {
 
     @Override
     protected StatusResult<Void> transferParts(List<DataSource.Part> parts) {
-        for (DataSource.Part part : parts) {
+        for (var part : parts) {
             try (var input = part.openStream()) {
 
-                int partNumber = 1;
+                var partNumber = 1;
                 List<CompletedPart> completedParts = new ArrayList<>();
 
-                String uploadId = client.createMultipartUpload(CreateMultipartUploadRequest.builder()
+                var uploadId = client.createMultipartUpload(CreateMultipartUploadRequest.builder()
                         .bucket(bucketName)
                         .key(keyName)
                         .build()).uploadId();
 
                 while (true) {
-                    byte[] bytesChunk = input.readNBytes(chunkSize);
+                    var bytesChunk = input.readNBytes(chunkSize);
 
                     if (bytesChunk.length < 1) {
                         break;

--- a/extensions/data-plane/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataSinkFactory.java
+++ b/extensions/data-plane/data-plane-s3/src/main/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataSinkFactory.java
@@ -42,6 +42,8 @@ import static org.eclipse.dataspaceconnector.aws.s3.core.S3BucketSchema.SECRET_A
 
 public class S3DataSinkFactory implements DataSinkFactory {
 
+    private static final int CHUNK_SIZE_IN_BYTES = 1024 * 1024 * 500; // 500MB chunk size
+
     private final ValidationRule<DataAddress> validation = new S3DataAddressValidationRule();
     private final ValidationRule<DataAddress> credentialsValidation = new S3DataAddressCredentialsValidationRule();
     private final AwsClientProvider clientProvider;
@@ -92,13 +94,14 @@ public class S3DataSinkFactory implements DataSinkFactory {
         }
 
         return S3DataSink.Builder.newInstance()
-                .bucketName(destination.getProperty(BUCKET_NAME))
-                .keyName(destination.getKeyName())
-                .requestId(request.getId())
-                .executorService(executorService)
-                .monitor(monitor)
-                .client(client)
-                .build();
+            .bucketName(destination.getProperty(BUCKET_NAME))
+            .keyName(destination.getKeyName())
+            .requestId(request.getId())
+            .executorService(executorService)
+            .monitor(monitor)
+            .client(client)
+            .chunkSizeBytes(CHUNK_SIZE_IN_BYTES)
+            .build();
     }
 
 }

--- a/extensions/data-plane/data-plane-s3/src/test/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataSinkTest.java
+++ b/extensions/data-plane/data-plane-s3/src/test/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataSinkTest.java
@@ -1,0 +1,107 @@
+/*
+ *  Copyright (c) 2022 ZF Friedrichshafen AG
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.aws.dataplane.s3;
+
+import org.eclipse.dataspaceconnector.aws.s3.core.S3BucketSchema;
+import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.InputStreamDataSource;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
+
+import java.io.ByteArrayInputStream;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.aws.dataplane.s3.TestFunctions.createRequest;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class S3DataSinkTest {
+
+    private static final String BUCKET_NAME = "bucketName";
+    private static final String KEY_NAME = "keyName";
+    private static final String ETAG = "eTag";
+    private static final int CHUNK_SIZE_BYTES = 50;
+
+    private final Monitor monitor = mock(Monitor.class);
+    private final S3Client s3ClientMock = mock(S3Client.class);
+    private final DataFlowRequest.Builder request = createRequest(S3BucketSchema.TYPE);
+    private final ExecutorService executor = Executors.newFixedThreadPool(2);
+
+    private final ArgumentCaptor<CompleteMultipartUploadRequest> completeMultipartUploadRequestCaptor =
+            ArgumentCaptor.forClass(CompleteMultipartUploadRequest.class);
+
+    private final S3DataSink dataSink = S3DataSink.Builder.newInstance()
+            .bucketName(BUCKET_NAME)
+            .keyName(KEY_NAME)
+            .client(s3ClientMock)
+            .requestId(request.build().getId())
+            .executorService(executor)
+            .monitor(monitor)
+            .chunkSizeBytes(CHUNK_SIZE_BYTES)
+            .build();
+
+    @BeforeEach
+    void setup() {
+        when(s3ClientMock.createMultipartUpload(any(CreateMultipartUploadRequest.class)))
+                .thenReturn(CreateMultipartUploadResponse.builder().uploadId("uploadId").build());
+        when(s3ClientMock.uploadPart(any(UploadPartRequest.class), any(RequestBody.class)))
+                .thenReturn(UploadPartResponse.builder().eTag(ETAG).build());
+    }
+
+    @Test
+    void transferParts_singlePart_succeeds() {
+        var result = dataSink.transferParts(
+                List.of(new InputStreamDataSource(KEY_NAME, new ByteArrayInputStream("content smaller than a chunk size".getBytes(UTF_8)))));
+        assertThat(result.succeeded()).isTrue();
+        verify(s3ClientMock).completeMultipartUpload(completeMultipartUploadRequestCaptor.capture());
+
+        CompleteMultipartUploadRequest completeMultipartUploadRequest = completeMultipartUploadRequestCaptor.getValue();
+        assertThat(completeMultipartUploadRequest.bucket()).isEqualTo(BUCKET_NAME);
+        assertThat(completeMultipartUploadRequest.key()).isEqualTo(KEY_NAME);
+        assertThat(completeMultipartUploadRequest.multipartUpload().parts()).hasSize(1);
+    }
+
+    @Test
+    void transferParts_multiPart_succeeds() {
+        var result = dataSink.transferParts(
+                List.of(new InputStreamDataSource(KEY_NAME,
+                        new ByteArrayInputStream("content bigger than 50 bytes chunk size so that it gets chunked and uploaded as a multipart upload"
+                            .getBytes(UTF_8)))));
+        assertThat(result.succeeded()).isTrue();
+        verify(s3ClientMock).completeMultipartUpload(completeMultipartUploadRequestCaptor.capture());
+
+        CompleteMultipartUploadRequest completeMultipartUploadRequest = completeMultipartUploadRequestCaptor.getValue();
+        assertThat(completeMultipartUploadRequest.bucket()).isEqualTo(BUCKET_NAME);
+        assertThat(completeMultipartUploadRequest.key()).isEqualTo(KEY_NAME);
+
+        assertThat(completeMultipartUploadRequest.multipartUpload().parts()).hasSize(2);
+    }
+
+}

--- a/extensions/data-plane/data-plane-s3/src/test/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/TestFunctions.java
+++ b/extensions/data-plane/data-plane-s3/src/test/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/TestFunctions.java
@@ -16,6 +16,9 @@ package org.eclipse.dataspaceconnector.aws.dataplane.s3;
 
 import org.eclipse.dataspaceconnector.aws.s3.core.S3BucketSchema;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
+
+import java.util.UUID;
 
 public class TestFunctions {
 
@@ -26,13 +29,13 @@ public class TestFunctions {
 
     public static DataAddress s3DataAddressWithCredentials() {
         return DataAddress.Builder.newInstance()
-                .type(S3BucketSchema.TYPE)
-                .keyName("aKey")
-                .property(S3BucketSchema.BUCKET_NAME, VALID_BUCKET_NAME)
-                .property(S3BucketSchema.REGION, VALID_REGION)
-                .property(S3BucketSchema.ACCESS_KEY_ID, VALID_ACCESS_KEY_ID)
-                .property(S3BucketSchema.SECRET_ACCESS_KEY, VALID_SECRET_ACCESS_KEY)
-                .build();
+            .type(S3BucketSchema.TYPE)
+            .keyName("aKey")
+            .property(S3BucketSchema.BUCKET_NAME, VALID_BUCKET_NAME)
+            .property(S3BucketSchema.REGION, VALID_REGION)
+            .property(S3BucketSchema.ACCESS_KEY_ID, VALID_ACCESS_KEY_ID)
+            .property(S3BucketSchema.SECRET_ACCESS_KEY, VALID_SECRET_ACCESS_KEY)
+            .build();
     }
 
     public static DataAddress s3DataAddressWithoutCredentials() {
@@ -43,4 +46,17 @@ public class TestFunctions {
                 .property(S3BucketSchema.REGION, VALID_REGION)
                 .build();
     }
+
+    public static DataFlowRequest.Builder createRequest(String type) {
+        return DataFlowRequest.Builder.newInstance()
+            .id(UUID.randomUUID().toString())
+            .processId(UUID.randomUUID().toString())
+            .sourceDataAddress(createDataAddress(type).build())
+            .destinationDataAddress(createDataAddress(type).build());
+    }
+
+    public static DataAddress.Builder createDataAddress(String type) {
+        return DataAddress.Builder.newInstance().type(type);
+    }
+
 }


### PR DESCRIPTION
## What this PR changes/adds

Enables multipart upload via S3 Extension

## Why it does that

Current implementation relies on loading all content of the file into InputStream thus making it impossible to use files larger than InputStream's MAX_BUFFER_SIZE

## Further notes

## Linked Issue(s)

Closes #1875 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
