### PR TITLE
refactor: remove deleted modules from settings.gradle

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,41 +28,34 @@ styleguide.md @paullatzelsperger
 /common/token-generation-lib/ @bscholtes1A
 /common/token-validation-lib/ @bscholtes1A
 
-/core/base/agent/ @jimmarino
-/core/base/policy/ @jimmarino
-/core/boot/ @jimmarino @paullatzelsperger
-/core/contract/ @jimmarino @juliapampus @ronjaquensel
-/core/defaults/ @paullatzelsperger
-/core/event/ @ndr-brt
-/core/health/ @paullatzelsperger
-/core/micrometer/ @algattik
-/core/policy/ @jimmarino
-/core/security/ @bscholtes1A
-/core/transfer/ @jimmarino @bscholtes1A @paullatzelsperger @ndr-brt
+/core/common/base/ @jimmarino @paullatzelsperger @ndr-brt
+/core/common/boot/ @jimmarino @paullatzelsperger
+core/common/policy-engine/ @jimmarino @ronjaquensel
+core/common/policy-evaluator/ @jimmarino @juliapampus @ronjaquensel
 
 /data-protocols/ids/ @ronjaquensel @juliapampus @DominikPinsel @denisneuling
 /data-protocols/ids/ids-jsonld-serdes-lib/ @juliapampus
 
 /docs/ @juliapampus
 
-/extensions/api/ @ndr-brt @paullatzelsperger
-/extensions/aws/ @paullatzelsperger
-/extensions/azure/ @paullatzelsperger
-/extensions/catalog/ @paullatzelsperger
+/extensions/common/api/ @ndr-brt @paullatzelsperger
+/extensions/common/aws/ @paullatzelsperger
+/extensions/common/azure/ @paullatzelsperger
+/extensions/common/configuration/ @jimmarino
+/extensions/common/events/ @ndr-brt
+/extensions/common/http/ @paullatzelsperger
+/extensions/common/iam/decentralized-identity/ @paullatzelsperger
+/extensions/common/iam/oauth2/ @bscholtes1A
+/extensions/common/junit/ @paullatzelsperger @algattik
+/extensions/common/micrometer/ @algattik
+/extensions/common/monitor/ @cpeeyush
+/extensions/common/sql/ @bcronin90 @denisneuling @paullatzelsperger
+/extensions/common/transaction/ @jimmarino
+/extensions/common/vault/ @paullatzelsperger
+/extensions/control-plane/ @paullatzelsperger
 /extensions/data-plane/ @bscholtes1A @jimmarino
 /extensions/data-plane-selector/ @paullatzelsperger
-/extensions/data-plane-transfer/ @bscholtes1A
-/extensions/events/ @ndr-brt
-/extensions/filesystem/ @jimmarino @paullatzelsperger
-/extensions/http/ @paullatzelsperger
-/extensions/http-provisioner/ @jimmarino @paullatzelsperger
-/extensions/http-receiver/ @bscholtes1A
-/extensions/iam/daps/ @bscholtes1A
-/extensions/iam/decentralized-identity/ @paullatzelsperger
-/extensions/iam/oauth2/ @bscholtes1A
-/extensions/jdk-logger-monitor/ @cpeeyush
-/extensions/sql/ @bcronin90 @denisneuling @paullatzelsperger
-/extensions/transaction/ @jimmarino
+/extensions/federated-catalog/ @paullatzelsperger
 
 /launchers/data-plane-server/ @bscholtes1A
 /launchers/dpf-selector/ @paullatzelsperger

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -47,7 +47,6 @@ include(":data-protocols:ids:ids-token-validation")
 include(":data-protocols:ids:ids-api-configuration")
 
 // modules for technology- or cloud-provider extensions
-include(":extensions:aws")
 include(":extensions:common:api:api-core")
 include(":extensions:common:auth:auth-basic")
 include(":extensions:common:auth:auth-tokenbased")
@@ -128,17 +127,11 @@ include(":extensions:control-plane:store:sql:policy-store-sql")
 include(":extensions:control-plane:store:sql:transfer-process-store-sql")
 // modules for launchers, i.e. runnable compositions of the app
 
-include(":launchers:test")
 include(":launchers:ids-connector")
 include(":launchers:dpf-selector")
 include(":launchers:data-plane-server")
 // modules for code samples
 
-include(":samples:other:copy-file-to-s3bucket")
-include(":samples:other:dataseed:dataseed-aws")
-include(":samples:other:dataseed:dataseed-azure")
-include(":samples:other:dataseed:dataseed-policy")
-include(":samples:other:run-from-junit")
 include(":samples:other:custom-runtime")
 // extension points for a connector
 


### PR DESCRIPTION
## What this PR changes/adds

When pulling the new project structure, I noticed that some deleted modules have not been removed from the `settings.gradle`. 

## Why it does that

clean up

## Further notes

--

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
