### PR TITLE
fix: avoid _contractOffer_ overwrite in `OfferedAssetToIdsResourceTransformer`

### DIFF
--- a/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/dataspaceconnector/ids/transform/OfferedAssetToIdsResourceTransformerTest.java
+++ b/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/dataspaceconnector/ids/transform/OfferedAssetToIdsResourceTransformerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021 Daimler TSS GmbH
+ *  Copyright (c) 2021 - 2022 Daimler TSS GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Daimler TSS GmbH - Initial Implementation
  *       Fraunhofer Institute for Software and Systems Engineering - refactoring
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
  *
  */
 
@@ -18,8 +19,6 @@ package org.eclipse.dataspaceconnector.ids.transform;
 import de.fraunhofer.iais.eis.ContractOfferBuilder;
 import de.fraunhofer.iais.eis.Representation;
 import de.fraunhofer.iais.eis.RepresentationBuilder;
-import org.eclipse.dataspaceconnector.ids.spi.types.IdsId;
-import org.eclipse.dataspaceconnector.ids.spi.types.IdsType;
 import org.eclipse.dataspaceconnector.ids.spi.types.container.OfferedAsset;
 import org.eclipse.dataspaceconnector.ids.transform.type.asset.OfferedAssetToIdsResourceTransformer;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
@@ -27,16 +26,18 @@ import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
-import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -45,61 +46,48 @@ class OfferedAssetToIdsResourceTransformerTest {
     private static final String RESOURCE_ID = "1";
     private static final URI RESOURCE_ID_URI = URI.create("urn:resource:1");
 
-    private OfferedAssetToIdsResourceTransformer transformer;
+    private final TransformerContext context = mock(TransformerContext.class);
 
-    private TransformerContext context;
+    private OfferedAssetToIdsResourceTransformer transformer;
 
     @BeforeEach
     void setUp() {
         transformer = new OfferedAssetToIdsResourceTransformer();
-        context = mock(TransformerContext.class);
     }
 
     @Test
-    void testThrowsNullPointerExceptionForAll() {
-        Assertions.assertThrows(NullPointerException.class, () -> {
-            transformer.transform(null, null);
-        });
-    }
-
-    @Test
-    void testThrowsNullPointerExceptionForContext() {
-        Assertions.assertThrows(NullPointerException.class, () -> {
-            transformer.transform(assetAndPolicy(), null);
-        });
-    }
-
-    @Test
-    void testReturnsNull() {
+    void transform_nullInputGivesNullResult() {
         var result = transformer.transform(null, context);
 
-        Assertions.assertNull(result);
+        assertThat(result).isNull();
     }
 
     @Test
-    void testSuccessfulSimple() {
+    void transform() {
         var representation = new RepresentationBuilder().build();
-        var id = IdsId.Builder.newInstance().value(RESOURCE_ID).type(IdsType.RESOURCE).build();
         when(context.transform(any(Asset.class), eq(Representation.class))).thenReturn(representation);
         when(context.transform(any(ContractOffer.class), eq(de.fraunhofer.iais.eis.ContractOffer.class))).thenReturn(new ContractOfferBuilder().build());
+        var offeredAsset = new OfferedAsset(
+                Asset.Builder.newInstance().id(RESOURCE_ID).build(),
+                List.of(createContractOffer(), createContractOffer())
+        );
 
-        var result = transformer.transform(assetAndPolicy(), context);
+        var result = transformer.transform(offeredAsset, context);
 
-        Assertions.assertNotNull(result);
-        Assertions.assertEquals(RESOURCE_ID_URI, result.getId());
-        Assertions.assertEquals(1, result.getRepresentation().size());
-        Assertions.assertEquals(representation, result.getRepresentation().get(0));
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(RESOURCE_ID_URI);
+        assertThat(result.getRepresentation()).hasSize(1).first().isEqualTo(representation);
+        assertThat(result.getContractOffer()).hasSize(2);
         verify(context).transform(any(Asset.class), eq(Representation.class));
-        verify(context).transform(any(ContractOffer.class), eq(de.fraunhofer.iais.eis.ContractOffer.class));
+        verify(context, times(2)).transform(any(ContractOffer.class), eq(de.fraunhofer.iais.eis.ContractOffer.class));
     }
 
     @NotNull
-    private OfferedAsset assetAndPolicy() {
-        var contractOffer = ContractOffer.Builder.newInstance()
-                .id("id")
+    private static ContractOffer createContractOffer() {
+        return ContractOffer.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
                 .policy(Policy.Builder.newInstance().build())
                 .build();
-        return new OfferedAsset(Asset.Builder.newInstance().id(RESOURCE_ID).build(), Collections.singletonList(contractOffer));
     }
 
 }


### PR DESCRIPTION
## What this PR changes/adds

Permits a `Catalog`'s `Resource` to have multiple `ContractOffer`s

## Why it does that

To fix an unexpected behavior

## Further notes

- Removed unnecessary null check on transform context and related tests

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
