### PR TITLE
test: S3DataPlaneIntegrationTest should be annotated with AwsS3IntegrationTest

### DIFF
--- a/extensions/data-plane/data-plane-s3/src/test/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataPlaneIntegrationTest.java
+++ b/extensions/data-plane/data-plane-s3/src/test/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataPlaneIntegrationTest.java
@@ -16,7 +16,7 @@ package org.eclipse.dataspaceconnector.aws.dataplane.s3;
 
 import org.eclipse.dataspaceconnector.aws.s3.core.S3BucketSchema;
 import org.eclipse.dataspaceconnector.aws.testfixtures.AbstractS3Test;
-import org.eclipse.dataspaceconnector.common.util.junit.annotations.IntegrationTest;
+import org.eclipse.dataspaceconnector.aws.testfixtures.annotations.AwsS3IntegrationTest;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
@@ -41,7 +41,7 @@ import static org.eclipse.dataspaceconnector.aws.s3.core.S3BucketSchema.BUCKET_N
 import static org.eclipse.dataspaceconnector.aws.s3.core.S3BucketSchema.SECRET_ACCESS_KEY;
 import static org.mockito.Mockito.mock;
 
-@IntegrationTest
+@AwsS3IntegrationTest
 public class S3DataPlaneIntegrationTest extends AbstractS3Test {
 
     private final String sourceBucketName = "source-" + UUID.randomUUID();


### PR DESCRIPTION
## What this PR changes/adds

Updated the annotation of org.eclipse.dataspaceconnector.aws.dataplane.s3.S3DataPlaneIntegrationTest.

## Why it does that

In order to make the test executed by specifying `-DincludeTags='AwsS3IntegrationTest'`.

## Linked Issue(s)

Closes #1896 

## Checklist

- [n/a] added appropriate tests?
- [x] performed checkstyle check locally?
- [n/a] added/updated copyright headers?
- [n/a] documented public classes/methods?
- [n/a] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
