### PR TITLE
fix: jwt-core module produces jwt-core named jar artifact

### DIFF
--- a/core/common/jwt-core/build.gradle.kts
+++ b/core/common/jwt-core/build.gradle.kts
@@ -27,8 +27,8 @@ dependencies {
 
 publishing {
     publications {
-        create<MavenPublication>("jwt-spi") {
-            artifactId = "jwt-spi"
+        create<MavenPublication>("jwt-core") {
+            artifactId = "jwt-core"
             from(components["java"])
         }
     }

--- a/docs/developer/modules.md
+++ b/docs/developer/modules.md
@@ -7,7 +7,7 @@ org.eclipse.dataspaceconnector:module-domain:0.0.1-milestone-6
 org.eclipse.dataspaceconnector:module-processor:0.0.1-milestone-6
 org.eclipse.dataspaceconnector:core-base:0.0.1-milestone-6
 org.eclipse.dataspaceconnector:core-boot:0.0.1-milestone-6
-org.eclipse.dataspaceconnector:jwt-spi:0.0.1-milestone-6
+org.eclipse.dataspaceconnector:jwt-core:0.0.1-milestone-6
 org.eclipse.dataspaceconnector:policy-engine:0.0.1-milestone-6
 org.eclipse.dataspaceconnector:policy-evaluator:0.0.1-milestone-6
 org.eclipse.dataspaceconnector:contract:0.0.1-milestone-6


### PR DESCRIPTION
## What this PR changes/adds

Deploys [JWT Core module](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/core/common/jwt-core) deployed to maven repo as `jwt-core`

## Why it does that

was wrong resp colliding with jwt-spi

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #1906

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)


<sub>Denis Neuling <denis.neuling@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [legal info/Impressum](https://github.com/mercedes-benz/daimler-foss/blob/master/LEGAL_IMPRINT.md) </sub>
