### PR TITLE
feat(Event Frame Work): add intermediate superclass for ContractDefinition Events hierarchy

### DIFF
--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractdefinition/ContractDefinitionCreated.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractdefinition/ContractDefinitionCreated.java
@@ -48,6 +48,10 @@ public class ContractDefinitionCreated extends Event<ContractDefinitionCreated.P
         }
     }
 
+    /**
+     * This class contains all event specific attributes of a ContractDefinition Creation Event
+     *
+     */
     public static class Payload extends ContractDefinitionEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractdefinition/ContractDefinitionCreated.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractdefinition/ContractDefinitionCreated.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - expending Event classes
  *
  */
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractdefinition/ContractDefinitionCreated.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractdefinition/ContractDefinitionCreated.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.spi.event.contractdefinition;
 
 import org.eclipse.dataspaceconnector.spi.event.Event;
-import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
 import java.util.Objects;
 
@@ -48,11 +47,6 @@ public class ContractDefinitionCreated extends Event<ContractDefinitionCreated.P
         }
     }
 
-    public static class Payload extends EventPayload {
-        private String contractDefinitionId;
-
-        public String getContractDefinitionId() {
-            return contractDefinitionId;
-        }
+    public static class Payload extends ContractDefinitionEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractdefinition/ContractDefinitionDeleted.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractdefinition/ContractDefinitionDeleted.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - expending Event classes
  *
  */
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractdefinition/ContractDefinitionDeleted.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractdefinition/ContractDefinitionDeleted.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.spi.event.contractdefinition;
 
 import org.eclipse.dataspaceconnector.spi.event.Event;
-import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
 import java.util.Objects;
 
@@ -48,11 +47,6 @@ public class ContractDefinitionDeleted extends Event<ContractDefinitionDeleted.P
         }
     }
 
-    public static class Payload extends EventPayload {
-        private String contractDefinitionId;
-
-        public String getContractDefinitionId() {
-            return contractDefinitionId;
-        }
+    public static class Payload extends ContractDefinitionEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractdefinition/ContractDefinitionDeleted.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractdefinition/ContractDefinitionDeleted.java
@@ -48,6 +48,10 @@ public class ContractDefinitionDeleted extends Event<ContractDefinitionDeleted.P
         }
     }
 
+    /**
+     * This class contains all event specific attributes of a ContractDefinition Deletion Event
+     *
+     */
     public static class Payload extends ContractDefinitionEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractdefinition/ContractDefinitionEventPayload.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractdefinition/ContractDefinitionEventPayload.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - expending Event classes
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.event.contractdefinition;
+
+import org.eclipse.dataspaceconnector.spi.event.EventPayload;
+
+public class ContractDefinitionEventPayload extends EventPayload {
+    protected String contractDefinitionId;
+
+    public String getContractDefinitionId() {
+        return contractDefinitionId;
+    }
+}

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractdefinition/ContractDefinitionEventPayload.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractdefinition/ContractDefinitionEventPayload.java
@@ -17,6 +17,11 @@ package org.eclipse.dataspaceconnector.spi.event.contractdefinition;
 
 import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
+/**
+ *  Class as organizational between level to catch events of type PolicyDefinition to catch them together in an Event Subscriber
+ *  Contains data related to contract definition events
+ *
+ */
 public class ContractDefinitionEventPayload extends EventPayload {
     protected String contractDefinitionId;
 


### PR DESCRIPTION
## What this PR changes/adds

Add a 'intermediate' superclass for the Event Payload Classes of the ContractDefinition classes.

## Why it does that

Improve the work with the Event Framework and give the possibility to filter Events on a bigger group of events.


## Linked Issue(s)

Closes #1910

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
