### PR TITLE
feat(Event Frame Work): add intermediate superclass for ContractNegotiation Events hierarchy

### DIFF
--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationApproved.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationApproved.java
@@ -9,13 +9,13 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - expending Event classes
  *
  */
 
 package org.eclipse.dataspaceconnector.spi.event.contractnegotiation;
 
 import org.eclipse.dataspaceconnector.spi.event.Event;
-import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
 import java.util.Objects;
 
@@ -48,11 +48,6 @@ public class ContractNegotiationApproved extends Event<ContractNegotiationApprov
         }
     }
 
-    public static class Payload extends EventPayload {
-        private String contractNegotiationId;
-
-        public String getContractNegotiationId() {
-            return contractNegotiationId;
-        }
+    public static class Payload extends ContractNegotiationEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationApproved.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationApproved.java
@@ -48,6 +48,10 @@ public class ContractNegotiationApproved extends Event<ContractNegotiationApprov
         }
     }
 
+    /**
+     * This class contains all event specific attributes of a ContractNegotiation Approved Event
+     *
+     */
     public static class Payload extends ContractNegotiationEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationConfirmed.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationConfirmed.java
@@ -48,6 +48,10 @@ public class ContractNegotiationConfirmed extends Event<ContractNegotiationConfi
         }
     }
 
+    /**
+     * This class contains all event specific attributes of a ContractNegotiation Confirmed Event
+     *
+     */
     public static class Payload extends ContractNegotiationEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationConfirmed.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationConfirmed.java
@@ -9,13 +9,13 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - expending Event classes
  *
  */
 
 package org.eclipse.dataspaceconnector.spi.event.contractnegotiation;
 
 import org.eclipse.dataspaceconnector.spi.event.Event;
-import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
 import java.util.Objects;
 
@@ -48,11 +48,6 @@ public class ContractNegotiationConfirmed extends Event<ContractNegotiationConfi
         }
     }
 
-    public static class Payload extends EventPayload {
-        private String contractNegotiationId;
-
-        public String getContractNegotiationId() {
-            return contractNegotiationId;
-        }
+    public static class Payload extends ContractNegotiationEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationDeclined.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationDeclined.java
@@ -9,13 +9,13 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - expending Event classes
  *
  */
 
 package org.eclipse.dataspaceconnector.spi.event.contractnegotiation;
 
 import org.eclipse.dataspaceconnector.spi.event.Event;
-import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
 import java.util.Objects;
 
@@ -48,11 +48,6 @@ public class ContractNegotiationDeclined extends Event<ContractNegotiationDeclin
         }
     }
 
-    public static class Payload extends EventPayload {
-        private String contractNegotiationId;
-
-        public String getContractNegotiationId() {
-            return contractNegotiationId;
-        }
+    public static class Payload extends ContractNegotiationEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationDeclined.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationDeclined.java
@@ -48,6 +48,10 @@ public class ContractNegotiationDeclined extends Event<ContractNegotiationDeclin
         }
     }
 
+    /**
+     * This class contains all event specific attributes of a ContractNegotiation Declined Event
+     *
+     */
     public static class Payload extends ContractNegotiationEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationEventPayload.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationEventPayload.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - expending Event classes
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.event.contractnegotiation;
+
+import org.eclipse.dataspaceconnector.spi.event.EventPayload;
+
+public class ContractNegotiationEventPayload extends EventPayload {
+    protected String contractNegotiationId;
+
+    public String getContractNegotiationId() {
+        return contractNegotiationId;
+    }
+}

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationEventPayload.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationEventPayload.java
@@ -17,6 +17,11 @@ package org.eclipse.dataspaceconnector.spi.event.contractnegotiation;
 
 import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
+/**
+ *  Class as organizational between level to catch events of type PolicyDefinition to catch them together in an Event Subscriber
+ *  Contains data related to contract negotiation events
+ *
+ */
 public class ContractNegotiationEventPayload extends EventPayload {
     protected String contractNegotiationId;
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationFailed.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationFailed.java
@@ -9,13 +9,13 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - expending Event classes
  *
  */
 
 package org.eclipse.dataspaceconnector.spi.event.contractnegotiation;
 
 import org.eclipse.dataspaceconnector.spi.event.Event;
-import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
 import java.util.Objects;
 
@@ -48,11 +48,6 @@ public class ContractNegotiationFailed extends Event<ContractNegotiationFailed.P
         }
     }
 
-    public static class Payload extends EventPayload {
-        private String contractNegotiationId;
-
-        public String getContractNegotiationId() {
-            return contractNegotiationId;
-        }
+    public static class Payload extends ContractNegotiationEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationFailed.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationFailed.java
@@ -48,6 +48,10 @@ public class ContractNegotiationFailed extends Event<ContractNegotiationFailed.P
         }
     }
 
+    /**
+     * This class contains all event specific attributes of a ContractNegotiation Failed Event
+     *
+     */
     public static class Payload extends ContractNegotiationEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationInitiated.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationInitiated.java
@@ -48,6 +48,10 @@ public class ContractNegotiationInitiated extends Event<ContractNegotiationIniti
         }
     }
 
+    /**
+     * This class contains all event specific attributes of a ContractNegotiation Initiated Event
+     *
+     */
     public static class Payload extends ContractNegotiationEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationInitiated.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationInitiated.java
@@ -9,13 +9,13 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - expending Event classes
  *
  */
 
 package org.eclipse.dataspaceconnector.spi.event.contractnegotiation;
 
 import org.eclipse.dataspaceconnector.spi.event.Event;
-import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
 import java.util.Objects;
 
@@ -48,11 +48,6 @@ public class ContractNegotiationInitiated extends Event<ContractNegotiationIniti
         }
     }
 
-    public static class Payload extends EventPayload {
-        private String contractNegotiationId;
-
-        public String getContractNegotiationId() {
-            return contractNegotiationId;
-        }
+    public static class Payload extends ContractNegotiationEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationOffered.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationOffered.java
@@ -48,6 +48,10 @@ public class ContractNegotiationOffered extends Event<ContractNegotiationOffered
         }
     }
 
+    /**
+     * This class contains all event specific attributes of a ContractNegotiation Offered Event
+     *
+     */
     public static class Payload extends ContractNegotiationEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationOffered.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationOffered.java
@@ -9,13 +9,13 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - expending Event classes
  *
  */
 
 package org.eclipse.dataspaceconnector.spi.event.contractnegotiation;
 
 import org.eclipse.dataspaceconnector.spi.event.Event;
-import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
 import java.util.Objects;
 
@@ -48,11 +48,6 @@ public class ContractNegotiationOffered extends Event<ContractNegotiationOffered
         }
     }
 
-    public static class Payload extends EventPayload {
-        private String contractNegotiationId;
-
-        public String getContractNegotiationId() {
-            return contractNegotiationId;
-        }
+    public static class Payload extends ContractNegotiationEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationRequested.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationRequested.java
@@ -48,6 +48,10 @@ public class ContractNegotiationRequested extends Event<ContractNegotiationReque
         }
     }
 
+    /**
+     * This class contains all event specific attributes of a ContractNegotiation Requested Event
+     *
+     */
     public static class Payload extends ContractNegotiationEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationRequested.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/contractnegotiation/ContractNegotiationRequested.java
@@ -9,13 +9,13 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - expending Event classes
  *
  */
 
 package org.eclipse.dataspaceconnector.spi.event.contractnegotiation;
 
 import org.eclipse.dataspaceconnector.spi.event.Event;
-import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
 import java.util.Objects;
 
@@ -48,11 +48,6 @@ public class ContractNegotiationRequested extends Event<ContractNegotiationReque
         }
     }
 
-    public static class Payload extends EventPayload {
-        private String contractNegotiationId;
-
-        public String getContractNegotiationId() {
-            return contractNegotiationId;
-        }
+    public static class Payload extends ContractNegotiationEventPayload {
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Add a 'intermediate' superclass for the Event Payload Classes of the ContractNegotiation classes.

## Why it does that

Improve the work with the Event Framework and give the possibility to filter Events on a bigger group of events.


## Linked Issue(s)

Closes #1912

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
