### PR TITLE
feat(Event Frame Work): add intermediate superclass for PolicyDefinition Events hierarchy

### DIFF
--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/policydefinition/PolicyDefinitionCreated.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/policydefinition/PolicyDefinitionCreated.java
@@ -9,13 +9,13 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - expending Event classes
  *
  */
 
 package org.eclipse.dataspaceconnector.spi.event.policydefinition;
 
 import org.eclipse.dataspaceconnector.spi.event.Event;
-import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
 import java.util.Objects;
 
@@ -48,11 +48,6 @@ public class PolicyDefinitionCreated extends Event<PolicyDefinitionCreated.Paylo
         }
     }
 
-    public static class Payload extends EventPayload {
-        private String policyDefinitionId;
-
-        public String getPolicyDefinitionId() {
-            return policyDefinitionId;
-        }
+    public static class Payload extends PolicyDefinitionEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/policydefinition/PolicyDefinitionDeleted.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/policydefinition/PolicyDefinitionDeleted.java
@@ -9,13 +9,13 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - expending Event classes
  *
  */
 
 package org.eclipse.dataspaceconnector.spi.event.policydefinition;
 
 import org.eclipse.dataspaceconnector.spi.event.Event;
-import org.eclipse.dataspaceconnector.spi.event.EventPayload;
 
 import java.util.Objects;
 
@@ -48,11 +48,6 @@ public class PolicyDefinitionDeleted extends Event<PolicyDefinitionDeleted.Paylo
         }
     }
 
-    public static class Payload extends EventPayload {
-        private String policyDefinitionId;
-
-        public String getPolicyDefinitionId() {
-            return policyDefinitionId;
-        }
+    public static class Payload extends PolicyDefinitionEventPayload {
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/policydefinition/PolicyDefinitionEventPayload.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/event/policydefinition/PolicyDefinitionEventPayload.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - expending Event classes
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.event.policydefinition;
+
+import org.eclipse.dataspaceconnector.spi.event.EventPayload;
+
+public class PolicyDefinitionEventPayload extends EventPayload {
+
+    protected String policyDefinitionId;
+
+    public String getPolicyDefinitionId() {
+        return policyDefinitionId;
+    }
+
+}


### PR DESCRIPTION
## What this PR changes/adds

Add a 'intermediate' superclass for the Event Payload Classes of the PolicyDefinition classes.

## Why it does that

Improve the work with the Event Framework and give the possibility to filter Events on a bigger group of events.


## Linked Issue(s)

Closes #1914 

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
