### PR TITLE
Fix: Add controlplane dependency for transfer onto contract

### DIFF
--- a/core/control-plane/transfer/build.gradle.kts
+++ b/core/control-plane/transfer/build.gradle.kts
@@ -22,6 +22,7 @@ plugins {
 dependencies {
     api(project(":spi:control-plane:policy-spi"))
     api(project(":spi:control-plane:transfer-spi"))
+    api(project(":core:control-plane:contract"))
     implementation(project(":common:state-machine-lib"))
     implementation(project(":common:util"))
     implementation("io.opentelemetry:opentelemetry-extension-annotations:${openTelemetryVersion}")


### PR DESCRIPTION
## What this PR changes/adds

Add a dependency for controlplane transfer onto contract

## Why it does that

We are having a problem downstream that PolicyArchive is not injected, even though it's required by an upstream dependency:
`Field "policyArchive" of type [interface org.eclipse.dataspaceconnector.spi.policy.store.PolicyArchive] required by org.eclipse.dataspaceconnector.transfer.core.CoreTransferExtension
`
## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)

<sub>Brendan Cronin brendan.cronin@mercedes-benz.com, Mercedes Benz Tech Innovation GmbH, [legal info/Impressum](https://github.com/mercedes-benz/foss/blob/master/LEGAL_IMPRINT.md)</sub>