### PR TITLE
fix: map policy properties to contract request

### DIFF
--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractOfferSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractOfferSender.java
@@ -167,7 +167,7 @@ public class MultipartContractOfferSender extends IdsMultipartSender<ContractOff
     }
 
     private ContractRequest createIdsRequestFromOffer(de.fraunhofer.iais.eis.ContractOffer offer) {
-        return new ContractRequestBuilder(offer.getId())
+        var request = new ContractRequestBuilder(offer.getId())
                 ._consumer_(offer.getConsumer())
                 ._contractAnnex_(offer.getContractAnnex())
                 ._contractDate_(offer.getContractDate())
@@ -179,5 +179,11 @@ public class MultipartContractOfferSender extends IdsMultipartSender<ContractOff
                 ._prohibition_(offer.getProhibition())
                 ._provider_(offer.getProvider())
                 .build();
+    
+        if (offer.getProperties() != null) {
+            offer.getProperties().forEach(request::setProperty);
+        }
+    
+        return request;
     }
 }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractOfferSenderTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/MultipartContractOfferSenderTest.java
@@ -1,0 +1,114 @@
+/*
+ *  Copyright (c) 2022 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.fraunhofer.iais.eis.ContractRequest;
+import okhttp3.OkHttpClient;
+import org.eclipse.dataspaceconnector.ids.core.serialization.IdsTypeManagerUtil;
+import org.eclipse.dataspaceconnector.ids.core.transform.IdsTransformerRegistryImpl;
+import org.eclipse.dataspaceconnector.ids.transform.type.contract.ContractOfferToIdsContractOfferTransformer;
+import org.eclipse.dataspaceconnector.ids.transform.type.policy.ActionToIdsActionTransformer;
+import org.eclipse.dataspaceconnector.ids.transform.type.policy.PermissionToIdsPermissionTransformer;
+import org.eclipse.dataspaceconnector.policy.model.Action;
+import org.eclipse.dataspaceconnector.policy.model.Permission;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractOfferRequest;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class MultipartContractOfferSenderTest {
+    
+    private MultipartContractOfferSender sender;
+    private ObjectMapper objectMapper;
+    
+    @BeforeEach
+    void setUp() {
+        var httpClient = mock(OkHttpClient.class);
+        var monitor = mock(Monitor.class);
+        var identityService = mock(IdentityService.class);
+        
+        var connectorId = "connector";
+        var webhookAddress = "https://webhook";
+        
+        var transformerRegistry = new IdsTransformerRegistryImpl();
+        transformerRegistry.register(new ContractOfferToIdsContractOfferTransformer());
+        transformerRegistry.register(new PermissionToIdsPermissionTransformer());
+        transformerRegistry.register(new ActionToIdsActionTransformer());
+    
+        objectMapper = IdsTypeManagerUtil.getIdsObjectMapper(new TypeManager());
+        
+        sender = new MultipartContractOfferSender(connectorId, httpClient, objectMapper, monitor, identityService, transformerRegistry, webhookAddress);
+    }
+    
+    @Test
+    void buildMessagePayload_initialRequest_mapPolicyProperties() throws Exception {
+        var policy = getPolicy();
+        var request = getContractOfferRequest(policy, ContractOfferRequest.Type.INITIAL);
+        
+        var result = sender.buildMessagePayload(request);
+        
+        var contractRequest = objectMapper.readValue(result, ContractRequest.class);
+        assertThat(contractRequest.getProperties())
+                .hasSize(2)
+                .containsAllEntriesOf(policy.getExtensibleProperties());
+    }
+    
+    @Test
+    void buildMessagePayload_notInitialRequest_mapPolicyProperties() throws Exception {
+        var policy = getPolicy();
+        var request = getContractOfferRequest(policy, ContractOfferRequest.Type.COUNTER_OFFER);
+    
+        var result = sender.buildMessagePayload(request);
+    
+        var contractOffer = objectMapper.readValue(result, de.fraunhofer.iais.eis.ContractOffer.class);
+        assertThat(contractOffer.getProperties())
+                .hasSize(2)
+                .containsAllEntriesOf(policy.getExtensibleProperties());
+    }
+    
+    private ContractOfferRequest getContractOfferRequest(Policy policy, ContractOfferRequest.Type type) {
+        return ContractOfferRequest.Builder.newInstance()
+                .contractOffer(ContractOffer.Builder.newInstance()
+                        .id("contract-offer")
+                        .policy(policy)
+                        .assetId("asset-id")
+                        .build())
+                .protocol("protocol")
+                .connectorId("connector")
+                .connectorAddress("https://connector")
+                .type(type)
+                .build();
+    }
+    
+    private Policy getPolicy() {
+        var usePermission = Permission.Builder.newInstance()
+                .action(Action.Builder.newInstance().type("USE").build())
+                .build();
+        
+        return Policy.Builder.newInstance()
+                .permission(usePermission)
+                .extensibleProperty("key1", "value1")
+                .extensibleProperty("key2", "value2")
+                .build();
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

Maps properties, when an IDS `ContractOffer` is mapped to an IDS `ContractRequest`.

## Why it does that

To allow sending additional policy properties to the provider during the contract negotiation.

## Linked Issue(s)

Closes #1901 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
