### PR TITLE
docs: add previous and next links to samples tutorial

### DIFF
--- a/samples/01-basic-connector/README.md
+++ b/samples/01-basic-connector/README.md
@@ -59,5 +59,4 @@ scenarios.
 
 ---
 
-[Next Chapter](02-health-endpoint/README.md)
-<!-- ../02 seems to have the same behavior -->
+[Next Chapter](../02-health-endpoint/README.md)

--- a/samples/01-basic-connector/README.md
+++ b/samples/01-basic-connector/README.md
@@ -56,3 +56,8 @@ INFO 2022-01-13T13:43:57.866073376 edc-e796b518-35f0-4c45-a333-79ca20a6be06 read
 This basic connector - while perfectly fine - does not offer any outward-facing API, nor does it provide any
 connector-to-connector communication protocols. However, it will serve us as platform to build out more complex
 scenarios.
+
+---
+
+[Next Chapter](02-health-endpoint/README.md)
+<!-- ../02 seems to have the same behavior -->

--- a/samples/02-health-endpoint/README.md
+++ b/samples/02-health-endpoint/README.md
@@ -68,3 +68,7 @@ this whenever you have two connectors running on the same machine.
 Also, the default path is `/api/*`, which is defined
 in [`JettyConfiguration.java`](../../extensions/common/http/jetty/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyConfiguration.java)
 .
+
+---
+
+[Previous Chapter](../01-basic-connector/README.md) | [Next Chapter](../03-configuration/README.md)

--- a/samples/03-configuration/README.md
+++ b/samples/03-configuration/README.md
@@ -173,3 +173,7 @@ web.http.data.path=/api/v1/data
 _**Caution**: If you do not provide this configuration, it leads to the problem that the authentication mechanism is
 also applied to EVERY request in the _default_ context of Jetty, which includes the IDS communication between two
 connectors._
+
+---
+
+[Previous Chapter](../02-health-endpoint/README.md) | [Next Chapter](../04.0-file-transfer/README.md)

--- a/samples/04.0-file-transfer/README.md
+++ b/samples/04.0-file-transfer/README.md
@@ -284,3 +284,7 @@ DEBUG 2022-05-03T10:38:06.246755642 Process f925131b-d61e-48b9-aa15-0f5e2e749064
 
 After the file transfer is completed, we can check the destination path specified in the request for the file. Here,
 we'll now find a file with the same content as the original file offered by the provider.
+
+---
+
+[Previous Chapter](../03-configuration/README.md) | [Next Chapter](../04.1-file-transfer-listener/README.md)

--- a/samples/04.1-file-transfer-listener/README.md
+++ b/samples/04.1-file-transfer-listener/README.md
@@ -79,3 +79,7 @@ INFO 2022-04-14T16:23:18.9048494 Transfer Listener successfully wrote file C:\Us
 ```
 
 Then check `/path/on/yourmachine`, which should now contain a file named `marker.txt` in addition to the file defined in `dataDestination.properties.path` in `samples/04.0-file-transfer/filetransfer.json`.
+
+---
+
+[Previous Chapter](../04.0-file-transfer/README.md) | [Next Chapter](../04.2-modify-transferprocess/README.md)

--- a/samples/04.2-modify-transferprocess/README.md
+++ b/samples/04.2-modify-transferprocess/README.md
@@ -122,3 +122,7 @@ In order to run the sample, enter the following commands in a shell:
 ./gradlew samples:04.2-modify-transferprocess:consumer:build
 java -Dedc.fs.config=samples/04.2-modify-transferprocess/consumer/config.properties -jar samples/04.2-modify-transferprocess/consumer/build/libs/consumer.jar
 ```
+
+---
+
+[Previous Chapter](../04.1-file-transfer-listener/README.md) | [Next Chapter](../04.3-open-telemetry/README.md)

--- a/samples/04.3-open-telemetry/README.md
+++ b/samples/04.3-open-telemetry/README.md
@@ -99,3 +99,7 @@ In order to provide your own OpenTelemetry implementation, you have to "deploy a
 
 EDC uses a [ServiceLoader](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html) to load an implementation of OpenTelemetry. If it finds an OpenTelemetry service provider on the class path it will use it, otherwise it will use the registered global OpenTelemetry.
 You can look at the section `Deploying service providers on the class path` of the [ServiceLoader documentation](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html) to have more information about service providers.
+
+---
+
+[Previous Chapter](../04.2-modify-transferprocess/README.md) | [Next Chapter](../05-file-transfer-cloud/README.md)

--- a/samples/05-file-transfer-cloud/README.md
+++ b/samples/05-file-transfer-cloud/README.md
@@ -181,3 +181,7 @@ Finally, run terraform to clean-up the vault and other remaining stuffs:
 cd samples/05-file-transfer-cloud/terraform 
 terraform destroy
 ```
+
+---
+
+[Previous Chapter](../04.3-open-telemetry/README.md)


### PR DESCRIPTION
## What this PR changes/adds

Adds a Previous Chapter | Next Chapter links to each tutorial under samples

## Why it does that

Because it is not easy to navigate the tutorials without going back to the initial ToC or clicking a couple times through GitHub

## Further notes


## Linked Issue(s)

Closes #1822 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
