### PR TITLE
refactor: Replace CountDownLatch with Awaitility

### DIFF
--- a/core/common/state-machine/build.gradle.kts
+++ b/core/common/state-machine/build.gradle.kts
@@ -12,6 +12,8 @@
  *
  */
 
+val awaitility: String by project
+
 plugins {
     `java-library`
     `java-test-fixtures`
@@ -20,6 +22,8 @@ plugins {
 
 dependencies {
     api(project(":spi:common:core-spi"))
+    testImplementation("org.awaitility:awaitility:${awaitility}")
+
 }
 
 publishing {

--- a/core/common/state-machine/src/test/java/org/eclipse/dataspaceconnector/common/statemachine/StateMachineManagerTest.java
+++ b/core/common/state-machine/src/test/java/org/eclipse/dataspaceconnector/common/statemachine/StateMachineManagerTest.java
@@ -21,10 +21,9 @@ import org.eclipse.dataspaceconnector.spi.system.ExecutorInstrumentation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.CountDownLatch;
-
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -32,6 +31,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+
 
 class StateMachineManagerTest {
 
@@ -46,10 +46,8 @@ class StateMachineManagerTest {
 
     @Test
     void shouldExecuteProcessorsAsyncAndCanBeStopped() throws InterruptedException {
-        var latch = new CountDownLatch(2);
         var processor = mock(StateProcessor.class);
         when(processor.process()).thenAnswer(i -> {
-            latch.countDown();
             Thread.sleep(100L);
             return 1L;
         });
@@ -59,20 +57,20 @@ class StateMachineManagerTest {
                 .build();
 
         stateMachine.start();
-        assertThat(latch.await(1, SECONDS)).isTrue();
-        verify(processor, atLeastOnce()).process();
 
-        assertThat(stateMachine.stop()).succeedsWithin(2, SECONDS);
-        verifyNoMoreInteractions(processor);
+        await().untilAsserted(() -> {
+            verify(processor, atLeastOnce()).process();
+
+            assertThat(stateMachine.stop()).succeedsWithin(2, SECONDS);
+            verifyNoMoreInteractions(processor);
+        });
     }
 
     @Test
     void shouldNotWaitForSomeTimeIfTheresAtLeastOneProcessedEntity() throws InterruptedException {
         var processor = mock(StateProcessor.class);
         when(processor.process()).thenReturn(1L);
-        var latch = new CountDownLatch(1);
         doAnswer(i -> {
-            latch.countDown();
             return 1L;
         }).when(waitStrategy).success();
         var stateMachine = StateMachineManager.Builder.newInstance("test", monitor, instrumentation, waitStrategy)
@@ -81,19 +79,18 @@ class StateMachineManagerTest {
 
         stateMachine.start();
 
-        assertThat(latch.await(1, SECONDS)).isTrue();
-        verify(waitStrategy, never()).waitForMillis();
-        verify(waitStrategy, atLeastOnce()).success();
+        await().untilAsserted(() -> {
+            verify(waitStrategy, never()).waitForMillis();
+            verify(waitStrategy, atLeastOnce()).success();
+        });
     }
 
     @Test
     void shouldWaitForSomeTimeIfNoEntityIsProcessed() throws InterruptedException {
         var processor = mock(StateProcessor.class);
         when(processor.process()).thenReturn(0L);
-        var latch = new CountDownLatch(1);
         var waitStrategy = mock(WaitStrategy.class);
         doAnswer(i -> {
-            latch.countDown();
             return 0L;
         }).when(waitStrategy).waitForMillis();
         var stateMachine = StateMachineManager.Builder.newInstance("test", monitor, instrumentation, waitStrategy)
@@ -102,9 +99,10 @@ class StateMachineManagerTest {
 
         stateMachine.start();
 
-        assertThat(latch.await(1, SECONDS)).isTrue();
-        verify(waitStrategy, atLeastOnce()).waitForMillis();
-        verify(waitStrategy, atLeastOnce()).success();
+        await().untilAsserted(() -> {
+            verify(waitStrategy, atLeastOnce()).waitForMillis();
+            verify(waitStrategy, atLeastOnce()).success();
+        });
     }
 
     @Test
@@ -121,11 +119,9 @@ class StateMachineManagerTest {
 
     @Test
     void shouldWaitRetryTimeWhenAnExceptionIsThrownByAnProcessor() throws InterruptedException {
-        var latch = new CountDownLatch(1);
         var processor = mock(StateProcessor.class);
         when(processor.process()).thenThrow(new EdcException("exception")).thenReturn(0L);
         when(waitStrategy.retryInMillis()).thenAnswer(i -> {
-            latch.countDown();
             return 1L;
         });
         var stateMachine = StateMachineManager.Builder.newInstance("test", monitor, instrumentation, waitStrategy)
@@ -134,8 +130,9 @@ class StateMachineManagerTest {
 
         stateMachine.start();
 
-        assertThat(latch.await(1, SECONDS)).isTrue();
-        assertThat(stateMachine.isActive()).isTrue();
-        verify(waitStrategy).retryInMillis();
+        await().untilAsserted(() -> {
+            assertThat(stateMachine.isActive()).isTrue();
+            verify(waitStrategy).retryInMillis();
+        });
     }
 }

--- a/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/command/ContractNegotiationCommandQueueIntegrationTest.java
+++ b/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/command/ContractNegotiationCommandQueueIntegrationTest.java
@@ -36,10 +36,8 @@ import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.comm
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -54,9 +52,6 @@ class ContractNegotiationCommandQueueIntegrationTest {
     private final String errorDetail = "Updated by command handler";
     private CommandQueue<ContractNegotiationCommand> commandQueue;
     private CommandRunner<ContractNegotiationCommand> commandRunner;
-
-    private CountDownLatch countDownLatch;
-
     private String negotiationId;
     private ContractNegotiation negotiation;
     private TestCommand command;
@@ -66,8 +61,7 @@ class ContractNegotiationCommandQueueIntegrationTest {
     void setUp() {
         var commandHandlerRegistry = mock(CommandHandlerRegistry.class);
 
-        countDownLatch = new CountDownLatch(1);
-        TestCommandHandler handler = new TestCommandHandler(store, countDownLatch, errorDetail);
+        TestCommandHandler handler = new TestCommandHandler(store, errorDetail);
 
         when(commandHandlerRegistry.get(TestCommand.class)).thenReturn(handler);
 
@@ -100,13 +94,11 @@ class ContractNegotiationCommandQueueIntegrationTest {
 
         negotiationManager.enqueueCommand(command);
 
-        // Wait for CommandHandler to modify negotiation with time out at 15 seconds
-        var success = countDownLatch.await(15, TimeUnit.SECONDS);
 
-        assertThat(success).isTrue();
-
-        assertThat(negotiation.getState()).isEqualTo(ContractNegotiationStates.ERROR.code());
-        assertThat(negotiation.getErrorDetail()).isEqualTo(errorDetail);
+        await().untilAsserted(() -> {
+            assertThat(negotiation.getState()).isEqualTo(ContractNegotiationStates.ERROR.code());
+            assertThat(negotiation.getErrorDetail()).isEqualTo(errorDetail);
+        });
 
         // Stop the negotiation manager
         negotiationManager.stop();
@@ -133,13 +125,12 @@ class ContractNegotiationCommandQueueIntegrationTest {
         // Enqueue command
         negotiationManager.enqueueCommand(command);
 
-        // Wait for CommandHandler to modify negotiation with time out at 15 seconds
-        var success = countDownLatch.await(15, TimeUnit.SECONDS);
 
-        assertThat(success).isTrue();
+        await().untilAsserted(() -> {
+            assertThat(negotiation.getState()).isEqualTo(ContractNegotiationStates.ERROR.code());
+            assertThat(negotiation.getErrorDetail()).isEqualTo(errorDetail);
+        });
 
-        assertThat(negotiation.getState()).isEqualTo(ContractNegotiationStates.ERROR.code());
-        assertThat(negotiation.getErrorDetail()).isEqualTo(errorDetail);
 
         // Stop the negotiation manager
         negotiationManager.stop();
@@ -170,12 +161,10 @@ class ContractNegotiationCommandQueueIntegrationTest {
      */
     private static class TestCommandHandler extends SingleContractNegotiationCommandHandler<TestCommand> {
 
-        private final CountDownLatch countDownLatch;
         private final String errorDetail;
 
-        TestCommandHandler(ContractNegotiationStore store, CountDownLatch countDownLatch, String errorDetail) {
+        TestCommandHandler(ContractNegotiationStore store, String errorDetail) {
             super(store);
-            this.countDownLatch = countDownLatch;
             this.errorDetail = errorDetail;
         }
 
@@ -188,7 +177,6 @@ class ContractNegotiationCommandQueueIntegrationTest {
         protected boolean modify(ContractNegotiation negotiation) {
             negotiation.transitionError(errorDetail);
             store.save(negotiation);
-            countDownLatch.countDown();
             return true;
         }
     }

--- a/core/control-plane/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplIntegrationTest.java
+++ b/core/control-plane/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplIntegrationTest.java
@@ -49,13 +49,12 @@ import org.junit.jupiter.api.Test;
 import java.time.Clock;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.INITIAL;
 import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.UNSAVED;
 import static org.mockito.ArgumentMatchers.any;
@@ -64,6 +63,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 
 @ComponentTest
 class TransferProcessManagerImplIntegrationTest {
@@ -106,9 +106,7 @@ class TransferProcessManagerImplIntegrationTest {
     @DisplayName("Verify that no process 'starves' during two consecutive runs, when the batch size > number of processes")
     void verifyProvision_shouldNotStarve() throws InterruptedException {
         var numProcesses = TRANSFER_MANAGER_BATCHSIZE * 2;
-        var processesToProvision = new CountDownLatch(numProcesses);
         when(provisionManager.provision(any(), any(Policy.class))).thenAnswer(i -> {
-            processesToProvision.countDown();
             return completedFuture(List.of(ProvisionResponse.Builder.newInstance().resource(new TestProvisionedDataDestinationResource("any", "1")).build()));
         });
 
@@ -122,15 +120,18 @@ class TransferProcessManagerImplIntegrationTest {
 
         transferProcessManager.start();
 
-        assertThat(processesToProvision.await(10, SECONDS)).isTrue();
-        assertThat(processes).describedAs("All transfer processes state should be greater than INITIAL")
-                .allSatisfy(process -> {
-                    var id = process.getId();
-                    var storedProcess = store.find(id);
-                    assertThat(storedProcess).describedAs("Should exist in the TransferProcessStore").isNotNull();
-                    assertThat(storedProcess.getState()).isGreaterThan(INITIAL.code());
-                });
-        verify(provisionManager, times(numProcesses)).provision(any(), any());
+
+        await().untilAsserted(() -> {
+            assertThat(processes).describedAs("All transfer processes state should be greater than INITIAL")
+                    .allSatisfy(process -> {
+                        var id = process.getId();
+                        var storedProcess = store.find(id);
+                        assertThat(storedProcess).describedAs("Should exist in the TransferProcessStore").isNotNull();
+                        assertThat(storedProcess.getState()).isGreaterThan(INITIAL.code());
+                    });
+            verify(provisionManager, times(numProcesses)).provision(any(), any());
+        });
+
     }
 
     private ProvisionedResourceSet provisionedResourceSet() {

--- a/core/data-plane/data-plane-framework/build.gradle.kts
+++ b/core/data-plane/data-plane-framework/build.gradle.kts
@@ -13,6 +13,8 @@
  */
 
 val openTelemetryVersion: String by project
+val awaitility: String by project
+
 
 plugins {
     `java-library`
@@ -24,6 +26,7 @@ dependencies {
     implementation(project(":core:common:util"))
     implementation("io.opentelemetry:opentelemetry-extension-annotations:${openTelemetryVersion}")
     testImplementation(project(":extensions:common:junit"))
+    testImplementation("org.awaitility:awaitility:${awaitility}")
 }
 
 

--- a/extensions/control-plane/api/data-management/asset-api/build.gradle.kts
+++ b/extensions/control-plane/api/data-management/asset-api/build.gradle.kts
@@ -17,6 +17,8 @@ val jerseyVersion: String by project
 val okHttpVersion: String by project
 val restAssured: String by project
 val rsApi: String by project
+val awaitility: String by project
+
 
 plugins {
     `java-library`
@@ -36,6 +38,8 @@ dependencies {
     testImplementation(project(":extensions:common:http"))
     testImplementation(project(":extensions:common:junit"))
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
+    testImplementation("org.awaitility:awaitility:${awaitility}")
+
 }
 
 publishing {

--- a/extensions/control-plane/api/data-management/policydefinition-api/build.gradle.kts
+++ b/extensions/control-plane/api/data-management/policydefinition-api/build.gradle.kts
@@ -17,6 +17,7 @@ val jerseyVersion: String by project
 val okHttpVersion: String by project
 val rsApi: String by project
 val restAssured: String by project
+val awaitility: String by project
 
 plugins {
     `java-library`
@@ -38,6 +39,7 @@ dependencies {
     testImplementation(project(":extensions:common:http"))
     testImplementation(project(":extensions:common:transaction:transaction-local"))
     testImplementation(project(":extensions:common:junit"))
+    testImplementation("org.awaitility:awaitility:${awaitility}")
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
 }
 


### PR DESCRIPTION
## What this PR changes/adds

Replace CountDownLatch  with Awaitility where needed, according to the decision record #1789 

## Why it does that

Improve test cohesion, help contributions

## Further notes

I'm not sure if this PR covers/refactor all tests that needed to be migrated to Awaitility.

## Linked Issue(s)

Closes #1583 

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
