### PR TITLE
fix(docs): change broken link in styleguide.md

### DIFF
--- a/styleguide.md
+++ b/styleguide.md
@@ -53,7 +53,7 @@ If you absolutely want to make sure that no piece of ever-so-slightly misformatt
 advise you to use the [SaveActions plugin](https://plugins.jetbrains.com/plugin/7642-save-actions) for IntelliJ IDEA. It
 takes care that your code is always correctly formatted. Unfortunately SaveActions has no export feature, so please just
 copy this configuration:
-![](/home/paul/dev/DataSpaceConnector/resources/save_actions_screenshot.png)
+![](resources/save_actions_screenshot.png)
 
 ## [Optional] Generic `.editorConfig`
 


### PR DESCRIPTION
## What this PR changes/adds

Fixes broken link

## Why it does that

--

## Further notes

--

## Linked Issue(s)

Closes #1932

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
