### PR TITLE
chore(workflows): add close-issue-reason for stale bot

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -18,6 +18,7 @@ jobs:
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 28 days with no activity."
           close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
+          close-issue-reason: 'not_planned'
           days-before-pr-stale: -1 # ignore PRs (overwrite default days-before-stale)
           days-before-pr-close: -1 # ignore PRs (overwrite default days-before-close)
           remove-issue-stale-when-updated: true
@@ -38,6 +39,7 @@ jobs:
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 14 days with no activity."
           close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
+          close-issue-reason: 'not_planned'
           days-before-pr-stale: -1 # ignore PRs (overwrite default days-before-stale)
           days-before-pr-close: -1 # ignore PRs (overwrite default days-before-close)
           remove-issue-stale-when-updated: true


### PR DESCRIPTION
## What this PR changes/adds

Adds `close-issue-reason` to close stale issues as "not planned" by default.

## Why it does that

--

## Further notes

--

## Linked Issue(s)

Closes #1947 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
