### PR TITLE
feat(test): introduced a base class for all ContractNegotiationStore

### DIFF
--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/dataspaceconnector/core/controlplane/defaults/InMemoryStatefulEntityStore.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/dataspaceconnector/core/controlplane/defaults/InMemoryStatefulEntityStore.java
@@ -16,11 +16,13 @@ package org.eclipse.dataspaceconnector.core.controlplane.defaults;
 
 import org.eclipse.dataspaceconnector.common.concurrency.LockManager;
 import org.eclipse.dataspaceconnector.spi.entity.StatefulEntity;
+import org.eclipse.dataspaceconnector.spi.persistence.Lease;
 import org.eclipse.dataspaceconnector.spi.query.QueryResolver;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.ReflectionBasedQueryResolver;
 import org.jetbrains.annotations.NotNull;
 
+import java.time.Clock;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -31,16 +33,23 @@ import java.util.stream.Stream;
 import static java.util.stream.Collectors.toList;
 
 /**
- * An in-memory, threadsafe entity store for a {@link StatefulEntity}.
- * This implementation is intended for testing purposes only.
+ * An in-memory, threadsafe entity store for a {@link StatefulEntity}. This implementation is intended for testing
+ * purposes only.
  */
 public class InMemoryStatefulEntityStore<T extends StatefulEntity<T>> {
+    private static final long DEFAULT_LEASE_TIME_MILLIS = 60_000;
     private final Map<String, Item<T>> entitiesById = new ConcurrentHashMap<>();
     private final QueryResolver<T> queryResolver;
     private final LockManager lockManager = new LockManager(new ReentrantReadWriteLock());
+    private final String lockId;
+    private final Clock clock;
+    private final Map<String, Lease> leases;
 
-    public InMemoryStatefulEntityStore(Class<T> clazz) {
+    public InMemoryStatefulEntityStore(Class<T> clazz, String lockId, Clock clock, Map<String, Lease> leases) {
         queryResolver = new ReflectionBasedQueryResolver<>(clazz);
+        this.lockId = lockId;
+        this.clock = clock;
+        this.leases = leases;
     }
 
     public T find(String id) {
@@ -52,10 +61,15 @@ public class InMemoryStatefulEntityStore<T extends StatefulEntity<T>> {
     }
 
     public void upsert(T entity) {
+        acquireLease(entity.getId(), lockId);
         entitiesById.put(entity.getId(), new Item<>(entity.copy()));
+        freeLease(entity.getId());
     }
 
     public void delete(String id) {
+        if (isLeased(id)) {
+            throw new IllegalStateException("ContractNegotiation is leased and cannot be deleted!");
+        }
         entitiesById.remove(id);
     }
 
@@ -67,11 +81,11 @@ public class InMemoryStatefulEntityStore<T extends StatefulEntity<T>> {
         return lockManager.writeLock(() -> {
             var items = entitiesById.values().stream()
                     .filter(e -> e.item.getState() == state)
-                    .filter(e -> !e.leased)
+                    .filter(e -> !isLeased(e.item.getId()))
                     .sorted(Comparator.comparingLong(e -> e.item.getStateTimestamp())) //order by state timestamp, oldest first
                     .limit(max)
                     .collect(toList());
-            items.forEach(e -> e.leased = true);
+            items.forEach(i -> acquireLease(i.item.getId(), lockId));
             return items.stream().map(e -> e.item.copy()).collect(toList());
         });
     }
@@ -80,9 +94,28 @@ public class InMemoryStatefulEntityStore<T extends StatefulEntity<T>> {
         return entitiesById.values().stream().map(e -> e.item);
     }
 
+    private void freeLease(String id) {
+        leases.remove(id);
+    }
+
+    private void acquireLease(String id, String lockId) {
+        if (!isLeased(id) || isLeasedBy(id, lockId)) {
+            leases.put(id, new Lease(lockId, clock.millis(), DEFAULT_LEASE_TIME_MILLIS));
+        } else {
+            throw new IllegalStateException("Cannot acquire lease, is already leased by someone else!");
+        }
+    }
+
+    private boolean isLeased(String id) {
+        return leases.containsKey(id) && !leases.get(id).isExpired(clock.millis());
+    }
+
+    private boolean isLeasedBy(String id, String lockId) {
+        return isLeased(id) && leases.get(id).getLeasedBy().equals(lockId);
+    }
+
     private static class Item<V> {
         private final V item;
-        private boolean leased = false;
 
         Item(V item) {
             this.item = item;

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/dataspaceconnector/core/controlplane/defaults/transferprocessstore/InMemoryTransferProcessStore.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/dataspaceconnector/core/controlplane/defaults/transferprocessstore/InMemoryTransferProcessStore.java
@@ -15,22 +15,40 @@
 package org.eclipse.dataspaceconnector.core.controlplane.defaults.transferprocessstore;
 
 import org.eclipse.dataspaceconnector.core.controlplane.defaults.InMemoryStatefulEntityStore;
+import org.eclipse.dataspaceconnector.spi.persistence.Lease;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.time.Clock;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 /**
- * An in-memory, threadsafe process store.
- * This implementation is intended for testing purposes only.
+ * An in-memory, threadsafe process store. This implementation is intended for testing purposes only.
  */
 public class InMemoryTransferProcessStore implements TransferProcessStore {
 
-    private final InMemoryStatefulEntityStore<TransferProcess> store = new InMemoryStatefulEntityStore<>(TransferProcess.class);
+    private final InMemoryStatefulEntityStore<TransferProcess> store;
+
+    public InMemoryTransferProcessStore() {
+        this(UUID.randomUUID().toString(), Clock.systemUTC(), new HashMap<>());
+    }
+
+    public InMemoryTransferProcessStore(String leaserId, Clock clock, Map<String, Lease> leases) {
+        store = new InMemoryStatefulEntityStore<>(TransferProcess.class, leaserId, clock, leases);
+    }
+
+    @Nullable
+    @Override
+    public TransferProcess find(String id) {
+        return store.find(id);
+    }
 
     @Override
     @Nullable
@@ -50,12 +68,6 @@ public class InMemoryTransferProcessStore implements TransferProcessStore {
     @Override
     public void update(TransferProcess process) {
         store.upsert(process);
-    }
-
-    @Nullable
-    @Override
-    public TransferProcess find(String id) {
-        return store.find(id);
     }
 
     @Override

--- a/docs/swaggerui/swagger-spec.js
+++ b/docs/swaggerui/swagger-spec.js
@@ -20,630 +20,6 @@ window.swaggerSpec={
     "description" : "The public API of the Data Plane is a data proxy enabling a data consumer to actively querydata from the provider data source (e.g. backend Rest API, internal database...) through its Data Planeinstance. Thus the Data Plane is the only entry/output door for the data, which avoids the provider to exposedirectly its data externally.The Data Plane public API being a proxy, it supports all verbs (i.e. GET, POST, PUT, PATCH, DELETE), whichcan then conveyed until the data source is required. This is especially useful when the actual data sourceis a Rest API itself.In the same manner, any set of arbitrary query parameters, path parameters and request body are supported (in the limits fixed by the HTTP server) and can also conveyed to the actual data source."
   } ],
   "paths" : {
-    "/contractdefinitions" : {
-      "get" : {
-        "tags" : [ "Contract Definition" ],
-        "description" : "Returns all contract definitions according to a query",
-        "operationId" : "getAllContractDefinitions",
-        "parameters" : [ {
-          "name" : "offset",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int32"
-          }
-        }, {
-          "name" : "limit",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int32"
-          }
-        }, {
-          "name" : "filter",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "sort",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "ASC", "DESC" ]
-          }
-        }, {
-          "name" : "sortField",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ContractDefinitionResponseDto"
-                  }
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request was malformed",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "post" : {
-        "tags" : [ "Contract Definition" ],
-        "description" : "Creates a new contract definition",
-        "operationId" : "createContractDefinition",
-        "requestBody" : {
-          "content" : {
-            "*/*" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/ContractDefinitionRequestDto"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "200" : {
-            "description" : "contract definition was created successfully"
-          },
-          "400" : {
-            "description" : "Request body was malformed",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Could not create contract definition, because a contract definition with that ID already exists",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/contractdefinitions/{id}" : {
-      "get" : {
-        "tags" : [ "Contract Definition" ],
-        "description" : "Gets an contract definition with the given ID",
-        "operationId" : "getContractDefinition",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "The contract definition",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ContractDefinitionResponseDto"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request was malformed, e.g. id was null",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "An contract agreement with the given ID does not exist",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete" : {
-        "tags" : [ "Contract Definition" ],
-        "description" : "Removes a contract definition with the given ID if possible. DANGER ZONE: Note that deleting contract definitions can have unexpected results, especially for contract offers that have been sent out or ongoing or contract negotiations.",
-        "operationId" : "deleteContractDefinition",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Contract definition was deleted successfully"
-          },
-          "400" : {
-            "description" : "Request was malformed, e.g. id was null",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "A contract definition with the given ID does not exist",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/catalog" : {
-      "get" : {
-        "tags" : [ "Catalog" ],
-        "operationId" : "getCatalog",
-        "parameters" : [ {
-          "name" : "providerUrl",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "offset",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int32"
-          }
-        }, {
-          "name" : "limit",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int32"
-          }
-        }, {
-          "name" : "filter",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "sort",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "ASC", "DESC" ]
-          }
-        }, {
-          "name" : "sortField",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "default" : {
-            "description" : "Gets contract offers (=catalog) of a single connector",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Catalog"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/check/health" : {
-      "get" : {
-        "tags" : [ "Application Observability" ],
-        "description" : "Performs a liveness probe to determine whether the runtime is working properly.",
-        "operationId" : "checkHealth",
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/HealthStatus"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/check/liveness" : {
-      "get" : {
-        "tags" : [ "Application Observability" ],
-        "description" : "Performs a liveness probe to determine whether the runtime is working properly.",
-        "operationId" : "getLiveness",
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/HealthStatus"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/check/readiness" : {
-      "get" : {
-        "tags" : [ "Application Observability" ],
-        "description" : "Performs a readiness probe to determine whether the runtime is able to accept requests.",
-        "operationId" : "getReadiness",
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/HealthStatus"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/check/startup" : {
-      "get" : {
-        "tags" : [ "Application Observability" ],
-        "description" : "Performs a startup probe to determine whether the runtime has completed startup.",
-        "operationId" : "getStartup",
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/HealthStatus"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/contractagreements" : {
-      "get" : {
-        "tags" : [ "Contract Agreement" ],
-        "description" : "Gets all contract agreements according to a particular query",
-        "operationId" : "getAllAgreements",
-        "parameters" : [ {
-          "name" : "offset",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int32"
-          }
-        }, {
-          "name" : "limit",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int32"
-          }
-        }, {
-          "name" : "filter",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "sort",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "ASC", "DESC" ]
-          }
-        }, {
-          "name" : "sortField",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ContractAgreementDto"
-                  }
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request body was malformed",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/contractagreements/{id}" : {
-      "get" : {
-        "tags" : [ "Contract Agreement" ],
-        "description" : "Gets an contract agreement with the given ID",
-        "operationId" : "getContractAgreement",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "The contract agreement",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ContractAgreementDto"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request was malformed, e.g. id was null",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "An contract agreement with the given ID does not exist",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/instances" : {
-      "get" : {
-        "tags" : [ "Dataplane Selector" ],
-        "operationId" : "getAll",
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/DataPlaneInstance"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "post" : {
-        "tags" : [ "Dataplane Selector" ],
-        "operationId" : "addEntry",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/DataPlaneInstance"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "application/json" : { }
-            }
-          }
-        }
-      }
-    },
-    "/instances/select" : {
-      "post" : {
-        "tags" : [ "Dataplane Selector" ],
-        "operationId" : "find",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/SelectionRequest"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/DataPlaneInstance"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/token" : {
-      "get" : {
-        "tags" : [ "Token Validation" ],
-        "description" : "Checks that the provided token has been signed by the present entity and asserts its validity. If token is valid, then the data address contained in its claims is decrypted and returned back to the caller.",
-        "operationId" : "validate",
-        "parameters" : [ {
-          "name" : "Authorization",
-          "in" : "header",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Token is valid"
-          },
-          "400" : {
-            "description" : "Request was malformed"
-          },
-          "403" : {
-            "description" : "Token is invalid"
-          }
-        }
-      }
-    },
     "/policydefinitions" : {
       "get" : {
         "tags" : [ "Policy" ],
@@ -886,25 +262,34 @@ window.swaggerSpec={
         }
       }
     },
-    "/callback/{processId}/deprovision" : {
-      "post" : {
-        "tags" : [ "HTTP Provisioner Webhook" ],
-        "operationId" : "callDeprovisionWebhook",
-        "parameters" : [ {
-          "name" : "processId",
-          "in" : "path",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
+    "/instances" : {
+      "get" : {
+        "tags" : [ "Dataplane Selector" ],
+        "operationId" : "getAll",
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/DataPlaneInstance"
+                  }
+                }
+              }
+            }
           }
-        } ],
+        }
+      },
+      "post" : {
+        "tags" : [ "Dataplane Selector" ],
+        "operationId" : "addEntry",
         "requestBody" : {
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/DeprovisionedResource"
+                "$ref" : "#/components/schemas/DataPlaneInstance"
               }
             }
           }
@@ -919,25 +304,15 @@ window.swaggerSpec={
         }
       }
     },
-    "/callback/{processId}/provision" : {
+    "/instances/select" : {
       "post" : {
-        "tags" : [ "HTTP Provisioner Webhook" ],
-        "operationId" : "callProvisionWebhook",
-        "parameters" : [ {
-          "name" : "processId",
-          "in" : "path",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
+        "tags" : [ "Dataplane Selector" ],
+        "operationId" : "find",
         "requestBody" : {
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/ProvisionerWebhookRequest"
+                "$ref" : "#/components/schemas/SelectionRequest"
               }
             }
           }
@@ -946,44 +321,108 @@ window.swaggerSpec={
           "default" : {
             "description" : "default response",
             "content" : {
-              "application/json" : { }
-            }
-          }
-        }
-      }
-    },
-    "/transfer" : {
-      "post" : {
-        "tags" : [ "Data Plane control API" ],
-        "description" : "Initiates a data transfer for the given request. The transfer will be performed asynchronously.",
-        "operationId" : "initiateTransfer",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/DataFlowRequest"
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/DataPlaneInstance"
+                }
               }
             }
           }
-        },
+        }
+      }
+    },
+    "/check/health" : {
+      "get" : {
+        "tags" : [ "Application Observability" ],
+        "description" : "Performs a liveness probe to determine whether the runtime is working properly.",
+        "operationId" : "checkHealth",
         "responses" : {
           "200" : {
-            "description" : "Data transfer initiated"
-          },
-          "400" : {
-            "description" : "Failed to validate request"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/HealthStatus"
+                  }
+                }
+              }
+            }
           }
         }
       }
     },
-    "/transfer/{processId}" : {
+    "/check/liveness" : {
       "get" : {
-        "tags" : [ "Data Plane control API" ],
-        "description" : "Get the current state of a data transfer.",
-        "operationId" : "getTransferState",
+        "tags" : [ "Application Observability" ],
+        "description" : "Performs a liveness probe to determine whether the runtime is working properly.",
+        "operationId" : "getLiveness",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/HealthStatus"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/check/readiness" : {
+      "get" : {
+        "tags" : [ "Application Observability" ],
+        "description" : "Performs a readiness probe to determine whether the runtime is able to accept requests.",
+        "operationId" : "getReadiness",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/HealthStatus"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/check/startup" : {
+      "get" : {
+        "tags" : [ "Application Observability" ],
+        "description" : "Performs a startup probe to determine whether the runtime has completed startup.",
+        "operationId" : "getStartup",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/HealthStatus"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/token" : {
+      "get" : {
+        "tags" : [ "Token Validation" ],
+        "description" : "Checks that the provided token has been signed by the present entity and asserts its validity. If token is valid, then the data address contained in its claims is decrypted and returned back to the caller.",
+        "operationId" : "validate",
         "parameters" : [ {
-          "name" : "processId",
-          "in" : "path",
+          "name" : "Authorization",
+          "in" : "header",
           "required" : true,
           "style" : "simple",
           "explode" : false,
@@ -993,331 +432,13 @@ window.swaggerSpec={
         } ],
         "responses" : {
           "200" : {
-            "description" : "Missing access token"
-          }
-        }
-      }
-    },
-    "/{any}" : {
-      "get" : {
-        "tags" : [ "Data Plane public API" ],
-        "description" : "Send `GET` data query to the Data Plane.",
-        "operationId" : "get",
-        "responses" : {
+            "description" : "Token is valid"
+          },
           "400" : {
-            "description" : "Missing access token"
+            "description" : "Request was malformed"
           },
           "403" : {
-            "description" : "Access token is expired or invalid"
-          },
-          "500" : {
-            "description" : "Failed to transfer data"
-          }
-        }
-      },
-      "put" : {
-        "tags" : [ "Data Plane public API" ],
-        "description" : "Send `PUT` data query to the Data Plane.",
-        "operationId" : "put",
-        "responses" : {
-          "400" : {
-            "description" : "Missing access token"
-          },
-          "403" : {
-            "description" : "Access token is expired or invalid"
-          },
-          "500" : {
-            "description" : "Failed to transfer data"
-          }
-        }
-      },
-      "post" : {
-        "tags" : [ "Data Plane public API" ],
-        "description" : "Send `POST` data query to the Data Plane.",
-        "operationId" : "post",
-        "responses" : {
-          "400" : {
-            "description" : "Missing access token"
-          },
-          "403" : {
-            "description" : "Access token is expired or invalid"
-          },
-          "500" : {
-            "description" : "Failed to transfer data"
-          }
-        }
-      },
-      "delete" : {
-        "tags" : [ "Data Plane public API" ],
-        "description" : "Send `DELETE` data query to the Data Plane.",
-        "operationId" : "delete",
-        "responses" : {
-          "400" : {
-            "description" : "Missing access token"
-          },
-          "403" : {
-            "description" : "Access token is expired or invalid"
-          },
-          "500" : {
-            "description" : "Failed to transfer data"
-          }
-        }
-      },
-      "patch" : {
-        "tags" : [ "Data Plane public API" ],
-        "description" : "Send `PATCH` data query to the Data Plane.",
-        "operationId" : "patch",
-        "responses" : {
-          "400" : {
-            "description" : "Missing access token"
-          },
-          "403" : {
-            "description" : "Access token is expired or invalid"
-          },
-          "500" : {
-            "description" : "Failed to transfer data"
-          }
-        }
-      }
-    },
-    "/assets" : {
-      "get" : {
-        "tags" : [ "Asset" ],
-        "description" : "Gets all assets according to a particular query",
-        "operationId" : "getAllAssets",
-        "parameters" : [ {
-          "name" : "offset",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int32"
-          }
-        }, {
-          "name" : "limit",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int32"
-          }
-        }, {
-          "name" : "filter",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "sort",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "ASC", "DESC" ]
-          }
-        }, {
-          "name" : "sortField",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/AssetResponseDto"
-                  }
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request body was malformed",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "post" : {
-        "tags" : [ "Asset" ],
-        "description" : "Creates a new asset together with a data address",
-        "operationId" : "createAsset",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/AssetEntryDto"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "200" : {
-            "description" : "Asset was created successfully"
-          },
-          "400" : {
-            "description" : "Request body was malformed",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Could not create asset, because an asset with that ID already exists",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/assets/{id}" : {
-      "get" : {
-        "tags" : [ "Asset" ],
-        "description" : "Gets an asset with the given ID",
-        "operationId" : "getAsset",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "The asset",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AssetResponseDto"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request was malformed, e.g. id was null",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "An asset with the given ID does not exist",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete" : {
-        "tags" : [ "Asset" ],
-        "description" : "Removes an asset with the given ID if possible. Deleting an asset is only possible if that asset is not yet referenced by a contract agreement, in which case an error is returned. DANGER ZONE: Note that deleting assets can have unexpected results, especially for contract offers that have been sent out or ongoing or contract negotiations.",
-        "operationId" : "removeAsset",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Asset was deleted successfully"
-          },
-          "400" : {
-            "description" : "Request was malformed, e.g. id was null",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "An asset with the given ID does not exist",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "The asset cannot be deleted, because it is referenced by a contract agreement",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
+            "description" : "Token is invalid"
           }
         }
       }
@@ -1752,6 +873,643 @@ window.swaggerSpec={
         }
       }
     },
+    "/transfer" : {
+      "post" : {
+        "tags" : [ "Data Plane control API" ],
+        "description" : "Initiates a data transfer for the given request. The transfer will be performed asynchronously.",
+        "operationId" : "initiateTransfer",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/DataFlowRequest"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Data transfer initiated"
+          },
+          "400" : {
+            "description" : "Failed to validate request"
+          }
+        }
+      }
+    },
+    "/transfer/{processId}" : {
+      "get" : {
+        "tags" : [ "Data Plane control API" ],
+        "description" : "Get the current state of a data transfer.",
+        "operationId" : "getTransferState",
+        "parameters" : [ {
+          "name" : "processId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Missing access token"
+          }
+        }
+      }
+    },
+    "/{any}" : {
+      "get" : {
+        "tags" : [ "Data Plane public API" ],
+        "description" : "Send `GET` data query to the Data Plane.",
+        "operationId" : "get",
+        "responses" : {
+          "400" : {
+            "description" : "Missing access token"
+          },
+          "403" : {
+            "description" : "Access token is expired or invalid"
+          },
+          "500" : {
+            "description" : "Failed to transfer data"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "Data Plane public API" ],
+        "description" : "Send `PUT` data query to the Data Plane.",
+        "operationId" : "put",
+        "responses" : {
+          "400" : {
+            "description" : "Missing access token"
+          },
+          "403" : {
+            "description" : "Access token is expired or invalid"
+          },
+          "500" : {
+            "description" : "Failed to transfer data"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "Data Plane public API" ],
+        "description" : "Send `POST` data query to the Data Plane.",
+        "operationId" : "post",
+        "responses" : {
+          "400" : {
+            "description" : "Missing access token"
+          },
+          "403" : {
+            "description" : "Access token is expired or invalid"
+          },
+          "500" : {
+            "description" : "Failed to transfer data"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "Data Plane public API" ],
+        "description" : "Send `DELETE` data query to the Data Plane.",
+        "operationId" : "delete",
+        "responses" : {
+          "400" : {
+            "description" : "Missing access token"
+          },
+          "403" : {
+            "description" : "Access token is expired or invalid"
+          },
+          "500" : {
+            "description" : "Failed to transfer data"
+          }
+        }
+      },
+      "patch" : {
+        "tags" : [ "Data Plane public API" ],
+        "description" : "Send `PATCH` data query to the Data Plane.",
+        "operationId" : "patch",
+        "responses" : {
+          "400" : {
+            "description" : "Missing access token"
+          },
+          "403" : {
+            "description" : "Access token is expired or invalid"
+          },
+          "500" : {
+            "description" : "Failed to transfer data"
+          }
+        }
+      }
+    },
+    "/contractagreements" : {
+      "get" : {
+        "tags" : [ "Contract Agreement" ],
+        "description" : "Gets all contract agreements according to a particular query",
+        "operationId" : "getAllAgreements",
+        "parameters" : [ {
+          "name" : "offset",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "filter",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "sort",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "ASC", "DESC" ]
+          }
+        }, {
+          "name" : "sortField",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ContractAgreementDto"
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request body was malformed",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/contractagreements/{id}" : {
+      "get" : {
+        "tags" : [ "Contract Agreement" ],
+        "description" : "Gets an contract agreement with the given ID",
+        "operationId" : "getContractAgreement",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The contract agreement",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ContractAgreementDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request was malformed, e.g. id was null",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "An contract agreement with the given ID does not exist",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/contractdefinitions" : {
+      "get" : {
+        "tags" : [ "Contract Definition" ],
+        "description" : "Returns all contract definitions according to a query",
+        "operationId" : "getAllContractDefinitions",
+        "parameters" : [ {
+          "name" : "offset",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "filter",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "sort",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "ASC", "DESC" ]
+          }
+        }, {
+          "name" : "sortField",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ContractDefinitionResponseDto"
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request was malformed",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "Contract Definition" ],
+        "description" : "Creates a new contract definition",
+        "operationId" : "createContractDefinition",
+        "requestBody" : {
+          "content" : {
+            "*/*" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ContractDefinitionRequestDto"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "contract definition was created successfully"
+          },
+          "400" : {
+            "description" : "Request body was malformed",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Could not create contract definition, because a contract definition with that ID already exists",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/contractdefinitions/{id}" : {
+      "get" : {
+        "tags" : [ "Contract Definition" ],
+        "description" : "Gets an contract definition with the given ID",
+        "operationId" : "getContractDefinition",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The contract definition",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ContractDefinitionResponseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request was malformed, e.g. id was null",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "An contract agreement with the given ID does not exist",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "Contract Definition" ],
+        "description" : "Removes a contract definition with the given ID if possible. DANGER ZONE: Note that deleting contract definitions can have unexpected results, especially for contract offers that have been sent out or ongoing or contract negotiations.",
+        "operationId" : "deleteContractDefinition",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Contract definition was deleted successfully"
+          },
+          "400" : {
+            "description" : "Request was malformed, e.g. id was null",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "A contract definition with the given ID does not exist",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/callback/{processId}/deprovision" : {
+      "post" : {
+        "tags" : [ "HTTP Provisioner Webhook" ],
+        "operationId" : "callDeprovisionWebhook",
+        "parameters" : [ {
+          "name" : "processId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/DeprovisionedResource"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "application/json" : { }
+            }
+          }
+        }
+      }
+    },
+    "/callback/{processId}/provision" : {
+      "post" : {
+        "tags" : [ "HTTP Provisioner Webhook" ],
+        "operationId" : "callProvisionWebhook",
+        "parameters" : [ {
+          "name" : "processId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ProvisionerWebhookRequest"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "application/json" : { }
+            }
+          }
+        }
+      }
+    },
+    "/catalog" : {
+      "get" : {
+        "tags" : [ "Catalog" ],
+        "operationId" : "getCatalog",
+        "parameters" : [ {
+          "name" : "providerUrl",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "offset",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "filter",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "sort",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "ASC", "DESC" ]
+          }
+        }, {
+          "name" : "sortField",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "default" : {
+            "description" : "Gets contract offers (=catalog) of a single connector",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Catalog"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/transferprocess" : {
       "get" : {
         "tags" : [ "Transfer Process" ],
@@ -2084,6 +1842,248 @@ window.swaggerSpec={
           },
           "404" : {
             "description" : "An  transfer process with the given ID does not exist",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/assets" : {
+      "get" : {
+        "tags" : [ "Asset" ],
+        "description" : "Gets all assets according to a particular query",
+        "operationId" : "getAllAssets",
+        "parameters" : [ {
+          "name" : "offset",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "filter",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "sort",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "ASC", "DESC" ]
+          }
+        }, {
+          "name" : "sortField",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/AssetResponseDto"
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request body was malformed",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "Asset" ],
+        "description" : "Creates a new asset together with a data address",
+        "operationId" : "createAsset",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/AssetEntryDto"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Asset was created successfully"
+          },
+          "400" : {
+            "description" : "Request body was malformed",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Could not create asset, because an asset with that ID already exists",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/assets/{id}" : {
+      "get" : {
+        "tags" : [ "Asset" ],
+        "description" : "Gets an asset with the given ID",
+        "operationId" : "getAsset",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The asset",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AssetResponseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request was malformed, e.g. id was null",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "An asset with the given ID does not exist",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "Asset" ],
+        "description" : "Removes an asset with the given ID if possible. Deleting an asset is only possible if that asset is not yet referenced by a contract agreement, in which case an error is returned. DANGER ZONE: Note that deleting assets can have unexpected results, especially for contract offers that have been sent out or ongoing or contract negotiations.",
+        "operationId" : "removeAsset",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Asset was deleted successfully"
+          },
+          "400" : {
+            "description" : "Request was malformed, e.g. id was null",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "An asset with the given ID does not exist",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "The asset cannot be deleted, because it is referenced by a contract agreement",
             "content" : {
               "application/json" : {
                 "schema" : {

--- a/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/build.gradle.kts
+++ b/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/build.gradle.kts
@@ -31,6 +31,9 @@ dependencies {
     testImplementation(testFixtures(project(":extensions:common:azure:azure-test")))
     testImplementation(testFixtures(project(":extensions:common:azure:cosmos-common")))
     testImplementation("org.awaitility:awaitility:${awaitility}")
+
+    testImplementation(testFixtures(project(":spi:control-plane:contract-spi")))
+
 }
 
 

--- a/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreExtension.java
+++ b/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreExtension.java
@@ -26,6 +26,8 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.system.health.HealthCheckService;
 
+import java.time.Clock;
+
 
 @Provides({ ContractNegotiationStore.class })
 public class CosmosContractNegotiationStoreExtension implements ServiceExtension {
@@ -35,6 +37,9 @@ public class CosmosContractNegotiationStoreExtension implements ServiceExtension
 
     @Inject
     private CosmosClientProvider clientProvider;
+    
+    @Inject
+    private Clock clock;
 
     @Override
     public String name() {
@@ -46,7 +51,7 @@ public class CosmosContractNegotiationStoreExtension implements ServiceExtension
         var configuration = new CosmosContractNegotiationStoreConfig(context);
 
         var cosmosDbApi = new CosmosDbApiImpl(configuration, clientProvider.createClient(vault, configuration));
-        var store = new CosmosContractNegotiationStore(cosmosDbApi, context.getTypeManager(), (RetryPolicy<Object>) context.getService(RetryPolicy.class), configuration.getPartitionKey());
+        var store = new CosmosContractNegotiationStore(cosmosDbApi, context.getTypeManager(), (RetryPolicy<Object>) context.getService(RetryPolicy.class), configuration.getPartitionKey(), clock);
         context.registerService(ContractNegotiationStore.class, store);
 
         context.getTypeManager().registerTypes(ContractNegotiationDocument.class);

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/build.gradle.kts
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     testImplementation(testFixtures(project(":extensions:common:sql:lease-sql")))
     testImplementation("org.assertj:assertj-core:${assertj}")
     testImplementation(testFixtures(project(":core:common:util")))
+    testImplementation(testFixtures(project(":spi:control-plane:contract-spi")))
 
     testImplementation("org.postgresql:postgresql:${postgresVersion}")
 }

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -25,459 +25,6 @@ tags:
     \ path parameters and request body are supported (in the limits fixed by the HTTP\
     \ server) and can also conveyed to the actual data source."
 paths:
-  /contractdefinitions:
-    get:
-      tags:
-      - Contract Definition
-      description: Returns all contract definitions according to a query
-      operationId: getAllContractDefinitions
-      parameters:
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ContractDefinitionResponseDto'
-        "400":
-          description: Request was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-    post:
-      tags:
-      - Contract Definition
-      description: Creates a new contract definition
-      operationId: createContractDefinition
-      requestBody:
-        content:
-          '*/*':
-            schema:
-              $ref: '#/components/schemas/ContractDefinitionRequestDto'
-      responses:
-        "200":
-          description: contract definition was created successfully
-        "400":
-          description: Request body was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "409":
-          description: "Could not create contract definition, because a contract definition\
-            \ with that ID already exists"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /contractdefinitions/{id}:
-    get:
-      tags:
-      - Contract Definition
-      description: Gets an contract definition with the given ID
-      operationId: getContractDefinition
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: The contract definition
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ContractDefinitionResponseDto'
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: An contract agreement with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-    delete:
-      tags:
-      - Contract Definition
-      description: "Removes a contract definition with the given ID if possible. DANGER\
-        \ ZONE: Note that deleting contract definitions can have unexpected results,\
-        \ especially for contract offers that have been sent out or ongoing or contract\
-        \ negotiations."
-      operationId: deleteContractDefinition
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: Contract definition was deleted successfully
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: A contract definition with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /catalog:
-    get:
-      tags:
-      - Catalog
-      operationId: getCatalog
-      parameters:
-      - name: providerUrl
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: Gets contract offers (=catalog) of a single connector
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Catalog'
-  /check/health:
-    get:
-      tags:
-      - Application Observability
-      description: Performs a liveness probe to determine whether the runtime is working
-        properly.
-      operationId: checkHealth
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/HealthStatus'
-  /check/liveness:
-    get:
-      tags:
-      - Application Observability
-      description: Performs a liveness probe to determine whether the runtime is working
-        properly.
-      operationId: getLiveness
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/HealthStatus'
-  /check/readiness:
-    get:
-      tags:
-      - Application Observability
-      description: Performs a readiness probe to determine whether the runtime is
-        able to accept requests.
-      operationId: getReadiness
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/HealthStatus'
-  /check/startup:
-    get:
-      tags:
-      - Application Observability
-      description: Performs a startup probe to determine whether the runtime has completed
-        startup.
-      operationId: getStartup
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/HealthStatus'
-  /contractagreements:
-    get:
-      tags:
-      - Contract Agreement
-      description: Gets all contract agreements according to a particular query
-      operationId: getAllAgreements
-      parameters:
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ContractAgreementDto'
-        "400":
-          description: Request body was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /contractagreements/{id}:
-    get:
-      tags:
-      - Contract Agreement
-      description: Gets an contract agreement with the given ID
-      operationId: getContractAgreement
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: The contract agreement
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ContractAgreementDto'
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: An contract agreement with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /instances:
-    get:
-      tags:
-      - Dataplane Selector
-      operationId: getAll
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/DataPlaneInstance'
-    post:
-      tags:
-      - Dataplane Selector
-      operationId: addEntry
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DataPlaneInstance'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /instances/select:
-    post:
-      tags:
-      - Dataplane Selector
-      operationId: find
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SelectionRequest'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DataPlaneInstance'
-  /token:
-    get:
-      tags:
-      - Token Validation
-      description: "Checks that the provided token has been signed by the present\
-        \ entity and asserts its validity. If token is valid, then the data address\
-        \ contained in its claims is decrypted and returned back to the caller."
-      operationId: validate
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: Token is valid
-        "400":
-          description: Request was malformed
-        "403":
-          description: Token is invalid
   /policydefinitions:
     get:
       tags:
@@ -653,78 +200,122 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
-  /callback/{processId}/deprovision:
+  /instances:
+    get:
+      tags:
+      - Dataplane Selector
+      operationId: getAll
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DataPlaneInstance'
     post:
       tags:
-      - HTTP Provisioner Webhook
-      operationId: callDeprovisionWebhook
-      parameters:
-      - name: processId
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
+      - Dataplane Selector
+      operationId: addEntry
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeprovisionedResource'
+              $ref: '#/components/schemas/DataPlaneInstance'
       responses:
         default:
           description: default response
           content:
             application/json: {}
-  /callback/{processId}/provision:
+  /instances/select:
     post:
       tags:
-      - HTTP Provisioner Webhook
-      operationId: callProvisionWebhook
-      parameters:
-      - name: processId
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
+      - Dataplane Selector
+      operationId: find
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ProvisionerWebhookRequest'
+              $ref: '#/components/schemas/SelectionRequest'
       responses:
         default:
           description: default response
           content:
-            application/json: {}
-  /transfer:
-    post:
-      tags:
-      - Data Plane control API
-      description: Initiates a data transfer for the given request. The transfer will
-        be performed asynchronously.
-      operationId: initiateTransfer
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DataFlowRequest'
-      responses:
-        "200":
-          description: Data transfer initiated
-        "400":
-          description: Failed to validate request
-  /transfer/{processId}:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataPlaneInstance'
+  /check/health:
     get:
       tags:
-      - Data Plane control API
-      description: Get the current state of a data transfer.
-      operationId: getTransferState
+      - Application Observability
+      description: Performs a liveness probe to determine whether the runtime is working
+        properly.
+      operationId: checkHealth
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HealthStatus'
+  /check/liveness:
+    get:
+      tags:
+      - Application Observability
+      description: Performs a liveness probe to determine whether the runtime is working
+        properly.
+      operationId: getLiveness
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HealthStatus'
+  /check/readiness:
+    get:
+      tags:
+      - Application Observability
+      description: Performs a readiness probe to determine whether the runtime is
+        able to accept requests.
+      operationId: getReadiness
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HealthStatus'
+  /check/startup:
+    get:
+      tags:
+      - Application Observability
+      description: Performs a startup probe to determine whether the runtime has completed
+        startup.
+      operationId: getStartup
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HealthStatus'
+  /token:
+    get:
+      tags:
+      - Token Validation
+      description: "Checks that the provided token has been signed by the present\
+        \ entity and asserts its validity. If token is valid, then the data address\
+        \ contained in its claims is decrypted and returned back to the caller."
+      operationId: validate
       parameters:
-      - name: processId
-        in: path
+      - name: Authorization
+        in: header
         required: true
         style: simple
         explode: false
@@ -732,243 +323,11 @@ paths:
           type: string
       responses:
         "200":
-          description: Missing access token
-  /{any}:
-    get:
-      tags:
-      - Data Plane public API
-      description: Send `GET` data query to the Data Plane.
-      operationId: get
-      responses:
+          description: Token is valid
         "400":
-          description: Missing access token
+          description: Request was malformed
         "403":
-          description: Access token is expired or invalid
-        "500":
-          description: Failed to transfer data
-    put:
-      tags:
-      - Data Plane public API
-      description: Send `PUT` data query to the Data Plane.
-      operationId: put
-      responses:
-        "400":
-          description: Missing access token
-        "403":
-          description: Access token is expired or invalid
-        "500":
-          description: Failed to transfer data
-    post:
-      tags:
-      - Data Plane public API
-      description: Send `POST` data query to the Data Plane.
-      operationId: post
-      responses:
-        "400":
-          description: Missing access token
-        "403":
-          description: Access token is expired or invalid
-        "500":
-          description: Failed to transfer data
-    delete:
-      tags:
-      - Data Plane public API
-      description: Send `DELETE` data query to the Data Plane.
-      operationId: delete
-      responses:
-        "400":
-          description: Missing access token
-        "403":
-          description: Access token is expired or invalid
-        "500":
-          description: Failed to transfer data
-    patch:
-      tags:
-      - Data Plane public API
-      description: Send `PATCH` data query to the Data Plane.
-      operationId: patch
-      responses:
-        "400":
-          description: Missing access token
-        "403":
-          description: Access token is expired or invalid
-        "500":
-          description: Failed to transfer data
-  /assets:
-    get:
-      tags:
-      - Asset
-      description: Gets all assets according to a particular query
-      operationId: getAllAssets
-      parameters:
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/AssetResponseDto'
-        "400":
-          description: Request body was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-    post:
-      tags:
-      - Asset
-      description: Creates a new asset together with a data address
-      operationId: createAsset
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AssetEntryDto'
-      responses:
-        "200":
-          description: Asset was created successfully
-        "400":
-          description: Request body was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "409":
-          description: "Could not create asset, because an asset with that ID already\
-            \ exists"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /assets/{id}:
-    get:
-      tags:
-      - Asset
-      description: Gets an asset with the given ID
-      operationId: getAsset
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: The asset
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AssetResponseDto'
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: An asset with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-    delete:
-      tags:
-      - Asset
-      description: "Removes an asset with the given ID if possible. Deleting an asset\
-        \ is only possible if that asset is not yet referenced by a contract agreement,\
-        \ in which case an error is returned. DANGER ZONE: Note that deleting assets\
-        \ can have unexpected results, especially for contract offers that have been\
-        \ sent out or ongoing or contract negotiations."
-      operationId: removeAsset
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: Asset was deleted successfully
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: An asset with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "409":
-          description: "The asset cannot be deleted, because it is referenced by a\
-            \ contract agreement"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: Token is invalid
   /contractnegotiations:
     get:
       tags:
@@ -1276,6 +635,472 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ContractOffer'
+  /transfer:
+    post:
+      tags:
+      - Data Plane control API
+      description: Initiates a data transfer for the given request. The transfer will
+        be performed asynchronously.
+      operationId: initiateTransfer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataFlowRequest'
+      responses:
+        "200":
+          description: Data transfer initiated
+        "400":
+          description: Failed to validate request
+  /transfer/{processId}:
+    get:
+      tags:
+      - Data Plane control API
+      description: Get the current state of a data transfer.
+      operationId: getTransferState
+      parameters:
+      - name: processId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Missing access token
+  /{any}:
+    get:
+      tags:
+      - Data Plane public API
+      description: Send `GET` data query to the Data Plane.
+      operationId: get
+      responses:
+        "400":
+          description: Missing access token
+        "403":
+          description: Access token is expired or invalid
+        "500":
+          description: Failed to transfer data
+    put:
+      tags:
+      - Data Plane public API
+      description: Send `PUT` data query to the Data Plane.
+      operationId: put
+      responses:
+        "400":
+          description: Missing access token
+        "403":
+          description: Access token is expired or invalid
+        "500":
+          description: Failed to transfer data
+    post:
+      tags:
+      - Data Plane public API
+      description: Send `POST` data query to the Data Plane.
+      operationId: post
+      responses:
+        "400":
+          description: Missing access token
+        "403":
+          description: Access token is expired or invalid
+        "500":
+          description: Failed to transfer data
+    delete:
+      tags:
+      - Data Plane public API
+      description: Send `DELETE` data query to the Data Plane.
+      operationId: delete
+      responses:
+        "400":
+          description: Missing access token
+        "403":
+          description: Access token is expired or invalid
+        "500":
+          description: Failed to transfer data
+    patch:
+      tags:
+      - Data Plane public API
+      description: Send `PATCH` data query to the Data Plane.
+      operationId: patch
+      responses:
+        "400":
+          description: Missing access token
+        "403":
+          description: Access token is expired or invalid
+        "500":
+          description: Failed to transfer data
+  /contractagreements:
+    get:
+      tags:
+      - Contract Agreement
+      description: Gets all contract agreements according to a particular query
+      operationId: getAllAgreements
+      parameters:
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractAgreementDto'
+        "400":
+          description: Request body was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /contractagreements/{id}:
+    get:
+      tags:
+      - Contract Agreement
+      description: Gets an contract agreement with the given ID
+      operationId: getContractAgreement
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: The contract agreement
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContractAgreementDto'
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: An contract agreement with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /contractdefinitions:
+    get:
+      tags:
+      - Contract Definition
+      description: Returns all contract definitions according to a query
+      operationId: getAllContractDefinitions
+      parameters:
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractDefinitionResponseDto'
+        "400":
+          description: Request was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+    post:
+      tags:
+      - Contract Definition
+      description: Creates a new contract definition
+      operationId: createContractDefinition
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/ContractDefinitionRequestDto'
+      responses:
+        "200":
+          description: contract definition was created successfully
+        "400":
+          description: Request body was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "409":
+          description: "Could not create contract definition, because a contract definition\
+            \ with that ID already exists"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /contractdefinitions/{id}:
+    get:
+      tags:
+      - Contract Definition
+      description: Gets an contract definition with the given ID
+      operationId: getContractDefinition
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: The contract definition
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContractDefinitionResponseDto'
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: An contract agreement with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+    delete:
+      tags:
+      - Contract Definition
+      description: "Removes a contract definition with the given ID if possible. DANGER\
+        \ ZONE: Note that deleting contract definitions can have unexpected results,\
+        \ especially for contract offers that have been sent out or ongoing or contract\
+        \ negotiations."
+      operationId: deleteContractDefinition
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Contract definition was deleted successfully
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: A contract definition with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /callback/{processId}/deprovision:
+    post:
+      tags:
+      - HTTP Provisioner Webhook
+      operationId: callDeprovisionWebhook
+      parameters:
+      - name: processId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeprovisionedResource'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /callback/{processId}/provision:
+    post:
+      tags:
+      - HTTP Provisioner Webhook
+      operationId: callProvisionWebhook
+      parameters:
+      - name: processId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProvisionerWebhookRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /catalog:
+    get:
+      tags:
+      - Catalog
+      operationId: getCatalog
+      parameters:
+      - name: providerUrl
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        default:
+          description: Gets contract offers (=catalog) of a single connector
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Catalog'
   /transferprocess:
     get:
       tags:
@@ -1520,6 +1345,181 @@ paths:
                   $ref: '#/components/schemas/ApiErrorDetail'
         "404":
           description: An  transfer process with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /assets:
+    get:
+      tags:
+      - Asset
+      description: Gets all assets according to a particular query
+      operationId: getAllAssets
+      parameters:
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AssetResponseDto'
+        "400":
+          description: Request body was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+    post:
+      tags:
+      - Asset
+      description: Creates a new asset together with a data address
+      operationId: createAsset
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssetEntryDto'
+      responses:
+        "200":
+          description: Asset was created successfully
+        "400":
+          description: Request body was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "409":
+          description: "Could not create asset, because an asset with that ID already\
+            \ exists"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /assets/{id}:
+    get:
+      tags:
+      - Asset
+      description: Gets an asset with the given ID
+      operationId: getAsset
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: The asset
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetResponseDto'
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: An asset with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+    delete:
+      tags:
+      - Asset
+      description: "Removes an asset with the given ID if possible. Deleting an asset\
+        \ is only possible if that asset is not yet referenced by a contract agreement,\
+        \ in which case an error is returned. DANGER ZONE: Note that deleting assets\
+        \ can have unexpected results, especially for contract offers that have been\
+        \ sent out or ongoing or contract negotiations."
+      operationId: removeAsset
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Asset was deleted successfully
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: An asset with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "409":
+          description: "The asset cannot be deleted, because it is referenced by a\
+            \ contract agreement"
           content:
             application/json:
               schema:

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/persistence/Lease.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/persistence/Lease.java
@@ -55,4 +55,8 @@ public class Lease {
     public long getLeaseDuration() {
         return leaseDuration;
     }
+
+    public boolean isExpired(long now) {
+        return leasedAt + leaseDuration < now;
+    }
 }

--- a/spi/control-plane/contract-spi/build.gradle.kts
+++ b/spi/control-plane/contract-spi/build.gradle.kts
@@ -12,14 +12,14 @@
  *
  */
 
-val jupiterVersion: String by project
-val assertj: String by project
-
-
 plugins {
     `java-library`
     `java-test-fixtures`
 }
+
+val jupiterVersion: String by project
+val mockitoVersion: String by project
+val assertj: String by project
 
 
 dependencies {
@@ -27,10 +27,12 @@ dependencies {
     api(project(":spi:common:policy-engine-spi"))
     api(project(":spi:control-plane:policy-spi"))
 
+    // needed by the abstract test spec located in testFixtures
     testFixturesImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
     testFixturesImplementation("org.junit.jupiter:junit-jupiter-params:${jupiterVersion}")
+    testFixturesImplementation("org.mockito:mockito-core:${mockitoVersion}")
     testFixturesImplementation("org.assertj:assertj-core:${assertj}")
-
+    testFixturesRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")
 }
 
 publishing {

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/store/TestFunctions.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/store/TestFunctions.java
@@ -13,7 +13,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.sql.contractnegotiation;
+package org.eclipse.dataspaceconnector.spi.contract.negotiation.store;
 
 import org.eclipse.dataspaceconnector.policy.model.Action;
 import org.eclipse.dataspaceconnector.policy.model.AtomicConstraint;


### PR DESCRIPTION
variants

## What this PR changes/adds

Adds a base class for all (integration) tests of the `ContractNegotiationStore`.

## Why it does that

to have a common test specification for all stores, and to provide consistent behaviour.

## Further notes

- the `InMemory` implementation now supports leases as well

## Linked Issue(s)

Closes #1940 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
