### PR TITLE
feat: avoid log azure vault

### DIFF
--- a/extensions/common/vault/azure-vault/src/main/java/org/eclipse/dataspaceconnector/core/security/azure/AzureVault.java
+++ b/extensions/common/vault/azure-vault/src/main/java/org/eclipse/dataspaceconnector/core/security/azure/AzureVault.java
@@ -73,7 +73,7 @@ public class AzureVault implements Vault {
         } catch (ResourceNotFoundException ex) {
             return null;
         } catch (Exception ex) {
-            monitor.severe("Error accessing secret:", ex);
+            monitor.severe("Error accessing secret " + key, ex);
             return null;
         }
     }

--- a/extensions/common/vault/azure-vault/src/main/java/org/eclipse/dataspaceconnector/core/security/azure/AzureVault.java
+++ b/extensions/common/vault/azure-vault/src/main/java/org/eclipse/dataspaceconnector/core/security/azure/AzureVault.java
@@ -82,7 +82,7 @@ public class AzureVault implements Vault {
     public Result<Void> storeSecret(String key, String value) {
         try {
             var sanitizedKey = sanitizeKey(key);
-            var secret = secretClient.setSecret(sanitizedKey, value);
+            secretClient.setSecret(sanitizedKey, value);
             monitor.debug("storing secret successful");
             return Result.success();
         } catch (Exception ex) {

--- a/extensions/common/vault/azure-vault/src/test/java/org/eclipse/dataspaceconnector/core/security/azure/AzureVaultTest.java
+++ b/extensions/common/vault/azure-vault/src/test/java/org/eclipse/dataspaceconnector/core/security/azure/AzureVaultTest.java
@@ -26,7 +26,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class AzureVaultTest {
@@ -56,13 +55,13 @@ class AzureVaultTest {
     }
 
     @Test
-    void resolveSecret_shouldNotLogIfSecretNotFound() {
+    void resolveSecret_shouldNotLogSevereIfSecretNotFound() {
         when(secretClient.getSecret("key")).thenThrow(new ResourceNotFoundException("error", mock(HttpResponse.class)));
 
         var result = vault.resolveSecret("key");
 
         assertThat(result).isNull();
-        verifyNoInteractions(monitor);
+        verify(monitor).debug(anyString());
     }
 
     @Test

--- a/extensions/common/vault/azure-vault/src/test/java/org/eclipse/dataspaceconnector/core/security/azure/AzureVaultTest.java
+++ b/extensions/common/vault/azure-vault/src/test/java/org/eclipse/dataspaceconnector/core/security/azure/AzureVaultTest.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2020, 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.core.security.azure;
+
+import com.azure.core.exception.ResourceNotFoundException;
+import com.azure.core.http.HttpResponse;
+import com.azure.security.keyvault.secrets.SecretClient;
+import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class AzureVaultTest {
+
+    private final Monitor monitor = mock(Monitor.class);
+    private final SecretClient secretClient = mock(SecretClient.class);
+
+    private final AzureVault vault = new AzureVault(monitor, secretClient);
+
+    @Test
+    void resolveSecret() {
+        when(secretClient.getSecret("key")).thenReturn(new KeyVaultSecret("key", "secret"));
+
+        var result = vault.resolveSecret("key");
+
+        assertThat(result).isEqualTo("secret");
+    }
+
+    @Test
+    void resolveSecret_sanitizeKeyName() {
+        when(secretClient.getSecret("key-name")).thenReturn(new KeyVaultSecret("key-name", "secret"));
+
+        var result = vault.resolveSecret("key.name");
+
+        assertThat(result).isEqualTo("secret");
+        verify(secretClient).getSecret("key-name");
+    }
+
+    @Test
+    void resolveSecret_shouldNotLogIfSecretNotFound() {
+        when(secretClient.getSecret("key")).thenThrow(new ResourceNotFoundException("error", mock(HttpResponse.class)));
+
+        var result = vault.resolveSecret("key");
+
+        assertThat(result).isNull();
+        verifyNoInteractions(monitor);
+    }
+}

--- a/extensions/common/vault/azure-vault/src/test/java/org/eclipse/dataspaceconnector/core/security/azure/AzureVaultTest.java
+++ b/extensions/common/vault/azure-vault/src/test/java/org/eclipse/dataspaceconnector/core/security/azure/AzureVaultTest.java
@@ -22,6 +22,8 @@ import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -61,5 +63,15 @@ class AzureVaultTest {
 
         assertThat(result).isNull();
         verifyNoInteractions(monitor);
+    }
+
+    @Test
+    void resolveSecret_shouldReturnNullAndLogErrorOnGenericException() {
+        when(secretClient.getSecret("key")).thenThrow(new RuntimeException("error"));
+
+        var result = vault.resolveSecret("key");
+
+        assertThat(result).isNull();
+        verify(monitor).severe(anyString(), isA(RuntimeException.class));
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Avoid "severe" log on `AzureVault` when secret is not found.

## Why it does that

To avoid misleading logs

## Further notes

- test-covered the `resolveSecret` method
- remove useless `CountDownLatch` on `AzureVaultExtensionTest`

## Linked Issue(s)

Closes #1962

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
