### PR TITLE
feat(store): remove cache on CosmosContractDefinitionStore

### DIFF
--- a/core/common/util/src/main/java/org/eclipse/dataspaceconnector/common/reflection/ReflectionUtil.java
+++ b/core/common/util/src/main/java/org/eclipse/dataspaceconnector/common/reflection/ReflectionUtil.java
@@ -40,7 +40,7 @@ public class ReflectionUtil {
      *     someObject[2].someValue //someObject must impement the List interface
      * </pre>
      *
-     * @param object The object
+     * @param object       The object
      * @param propertyName The name of the field
      * @return The field's value.
      * @throws ReflectionException if the field does not exist or is not accessible
@@ -89,14 +89,14 @@ public class ReflectionUtil {
      * Utility function to get value of a field from an object. Essentially the same as
      * {@link ReflectionUtil#getFieldValue(String, Object)} but it does not throw an exception
      *
-     * @param object The object
+     * @param object       The object
      * @param propertyName The name of the field
      * @return The field's value. Returns null if the field does not exist or is inaccessible.
      */
     public static <T> T getFieldValueSilent(String propertyName, Object object) {
         try {
             return getFieldValue(propertyName, object);
-        } catch (ReflectionException ignored) {
+        } catch (ReflectionException | IndexOutOfBoundsException ignored) {
             return null;
         }
     }
@@ -125,7 +125,7 @@ public class ReflectionUtil {
      * Gets a field with a given name from all declared fields of a class including supertypes. Will include protected
      * and private fields.
      *
-     * @param clazz The class of the object
+     * @param clazz     The class of the object
      * @param fieldName The fieldname
      * @return A field with the given name, null if the field does not exist
      */

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/dataspaceconnector/core/controlplane/defaults/contractdefinition/InMemoryContractDefinitionStoreTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/dataspaceconnector/core/controlplane/defaults/contractdefinition/InMemoryContractDefinitionStoreTest.java
@@ -28,12 +28,17 @@ class InMemoryContractDefinitionStoreTest extends ContractDefinitionStoreTestBas
 
 
     @Override
-    protected Boolean supportCollectionQuery() {
+    protected boolean supportsCollectionQuery() {
         return false;
     }
 
     @Override
-    protected Boolean supportSortOrder() {
+    protected boolean supportsCollectionIndexQuery() {
+        return true;
+    }
+
+    @Override
+    protected boolean supportsSortOrder() {
         return true;
     }
 }

--- a/extensions/control-plane/store/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStore.java
+++ b/extensions/control-plane/store/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStore.java
@@ -17,25 +17,18 @@ package org.eclipse.dataspaceconnector.contract.definition.store;
 
 import com.azure.cosmos.implementation.NotFoundException;
 import dev.failsafe.RetryPolicy;
-import dev.failsafe.function.CheckedSupplier;
 import org.eclipse.dataspaceconnector.azure.cosmos.CosmosDbApi;
-import org.eclipse.dataspaceconnector.common.concurrency.LockManager;
+import org.eclipse.dataspaceconnector.azure.cosmos.dialect.SqlStatement;
 import org.eclipse.dataspaceconnector.cosmos.policy.store.model.ContractDefinitionDocument;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.query.QueryResolver;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
-import org.eclipse.dataspaceconnector.spi.query.ReflectionBasedQueryResolver;
+import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -50,95 +43,64 @@ public class CosmosContractDefinitionStore implements ContractDefinitionStore {
     private final CosmosDbApi cosmosDbApi;
     private final TypeManager typeManager;
     private final RetryPolicy<Object> retryPolicy;
-    private final LockManager lockManager;
     private final String partitionKey;
-    private final QueryResolver<ContractDefinition> queryResolver;
     private final Monitor monitor;
-    private AtomicReference<Map<String, ContractDefinition>> objectCache;
 
     public CosmosContractDefinitionStore(CosmosDbApi cosmosDbApi, TypeManager typeManager, RetryPolicy<Object> retryPolicy, String partitionKey, Monitor monitor) {
         this.cosmosDbApi = cosmosDbApi;
         this.typeManager = typeManager;
         this.retryPolicy = retryPolicy;
         this.partitionKey = partitionKey;
-        lockManager = new LockManager(new ReentrantReadWriteLock(true));
-        queryResolver = new ReflectionBasedQueryResolver<>(ContractDefinition.class);
         this.monitor = monitor;
     }
 
     @Override
     public @NotNull Stream<ContractDefinition> findAll(QuerySpec spec) {
-        return lockManager.readLock(() -> queryResolver.query(getCache().values().stream(), spec));
+        var statement = new SqlStatement<>(ContractDefinitionDocument.class);
+        var query = statement.where(spec.getFilterExpression())
+                .offset(spec.getOffset())
+                .limit(spec.getLimit())
+                .orderBy(spec.getSortField(), spec.getSortOrder() == SortOrder.ASC)
+                .getQueryAsSqlQuerySpec();
+
+        var objects = with(retryPolicy).get(() -> cosmosDbApi.queryItems(query));
+        return objects.map(this::convert);
     }
 
     @Override
     public ContractDefinition findById(String definitionId) {
-        return lockManager.readLock(() -> getCache().get(definitionId));
+        var definition = with(retryPolicy).get(() -> cosmosDbApi.queryItemById(definitionId));
+        return definition != null ? convert(definition) : null;
     }
 
     @Override
     public void save(Collection<ContractDefinition> definitions) {
-        lockManager.writeLock(() -> {
-            with(retryPolicy).run(() -> cosmosDbApi.saveItems(definitions.stream().map(this::convertToDocument).collect(Collectors.toList())));
-            definitions.forEach(this::storeInCache);
-            return null;
-        });
+        with(retryPolicy).run(() -> cosmosDbApi.saveItems(definitions.stream().map(this::convertToDocument).collect(Collectors.toList())));
     }
 
     @Override
     public void save(ContractDefinition definition) {
-        lockManager.writeLock(() -> {
-            with(retryPolicy).run(() -> cosmosDbApi.saveItem(convertToDocument(definition)));
-            storeInCache(definition);
-            return null;
-        });
+        with(retryPolicy).run(() -> cosmosDbApi.saveItem(convertToDocument(definition)));
     }
 
     @Override
     public void update(ContractDefinition definition) {
-        lockManager.writeLock(() -> {
-            save(definition); //cosmos db api internally uses "upsert" semantics
-            storeInCache(definition);
-            return null;
-        });
+        save(definition); //cosmos db api internally uses "upsert" semantics
     }
 
     @Override
     public ContractDefinition deleteById(String id) {
-        return lockManager.writeLock(() -> {
-
-            try {
-                var deletedItem = with(retryPolicy).get(() -> cosmosDbApi.deleteItem(id));
-                getCache().remove(id);
-                return deletedItem == null ? null : convert(deletedItem);
-            } catch (NotFoundException e) {
-                monitor.debug(() -> String.format("ContractDefinition with id %s not found", id));
-                return null;
-            }
-        });
+        try {
+            var deletedItem = with(retryPolicy).get(() -> cosmosDbApi.deleteItem(id));
+            return deletedItem == null ? null : convert(deletedItem);
+        } catch (NotFoundException e) {
+            monitor.debug(() -> String.format("ContractDefinition with id %s not found", id));
+            return null;
+        }
     }
 
     @Override
     public void reload() {
-        lockManager.readLock(() -> {
-            // this reloads ALL items from the database. We might want something more elaborate in the future, especially
-            // if large amounts of ContractDefinitions need to be held in memory
-            var databaseObjects = with(retryPolicy)
-                    .get((CheckedSupplier<List<Object>>) cosmosDbApi::queryAllItems)
-                    .stream()
-                    .map(this::convert)
-                    .collect(Collectors.toMap(ContractDefinition::getId, cd -> cd));
-
-            if (objectCache == null) {
-                objectCache = new AtomicReference<>(new HashMap<>());
-            }
-            objectCache.set(databaseObjects);
-            return null;
-        });
-    }
-
-    private void storeInCache(ContractDefinition definition) {
-        getCache().put(definition.getId(), definition);
     }
 
     @NotNull
@@ -146,13 +108,6 @@ public class CosmosContractDefinitionStore implements ContractDefinitionStore {
         return new ContractDefinitionDocument(def, partitionKey);
     }
 
-    private Map<String, ContractDefinition> getCache() {
-        if (objectCache == null) {
-            objectCache = new AtomicReference<>(new HashMap<>());
-            reload();
-        }
-        return objectCache.get();
-    }
 
     private ContractDefinition convert(Object object) {
         var json = typeManager.writeValueAsString(object);

--- a/extensions/control-plane/store/sql/contract-definition-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/PostgresContractDefinitionStoreTest.java
+++ b/extensions/control-plane/store/sql/contract-definition-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/PostgresContractDefinitionStoreTest.java
@@ -152,12 +152,17 @@ class PostgresContractDefinitionStoreTest extends ContractDefinitionStoreTestBas
 
 
     @Override
-    protected Boolean supportCollectionQuery() {
+    protected boolean supportsCollectionQuery() {
         return true;
     }
 
     @Override
-    protected Boolean supportSortOrder() {
+    protected boolean supportsCollectionIndexQuery() {
+        return false;
+    }
+
+    @Override
+    protected boolean supportsSortOrder() {
         return false;
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Removes in-memory local cache for CRUD and querying in `CosmosContractDefinitionStore`.

## Why it does that

Cleanup and remove the limitation of local cache growth and querying mechanism.  

## Linked Issue(s)

Closes #1964 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
