### PR TITLE
fix: map DataRequest properties to DataFlowRequest

### DIFF
--- a/extensions/control-plane/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/flow/DataPlaneTransferFlowController.java
+++ b/extensions/control-plane/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/flow/DataPlaneTransferFlowController.java
@@ -71,6 +71,7 @@ public class DataPlaneTransferFlowController implements DataFlowController {
                 .sourceDataAddress(sourceAddress)
                 .destinationType(dataRequest.getDestinationType())
                 .destinationDataAddress(dataRequest.getDataDestination())
+                .properties(dataRequest.getProperties())
                 .build();
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Maps properties from a `DataRequest` when creating a `DataFlowRequest`.

## Why it does that

Otherwise, properties of a `DataRequest` are lost.

## Linked Issue(s)

Closes #1972 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
