### PR TITLE
feat(store): remove cache on CosmosPolicyDefinitionStore

### DIFF
--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/dataspaceconnector/core/controlplane/defaults/policystore/InMemoryPolicyDefinitionStoreTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/dataspaceconnector/core/controlplane/defaults/policystore/InMemoryPolicyDefinitionStoreTest.java
@@ -25,9 +25,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.dataspaceconnector.spi.policy.TestFunctions.createPolicy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
@@ -76,6 +79,16 @@ class InMemoryPolicyDefinitionStoreTest extends PolicyDefinitionStoreTestBase {
         assertThatExceptionOfType(EdcPersistenceException.class).isThrownBy(() -> store.deleteById("any-policy-id"));
     }
 
+    @Test
+    void findAll_verifyFiltering_invalidFilterExpression() {
+        IntStream.range(0, 10).mapToObj(i -> createPolicy("test-id")).forEach(d -> getPolicyDefinitionStore().save(d));
+
+        var query = QuerySpec.Builder.newInstance().filter("something contains other").build();
+
+        assertThatThrownBy(() -> getPolicyDefinitionStore().findAll(query)).isInstanceOfAny(EdcPersistenceException.class);
+    }
+
+
     @Override
     protected PolicyDefinitionStore getPolicyDefinitionStore() {
         return store;
@@ -84,6 +97,11 @@ class InMemoryPolicyDefinitionStoreTest extends PolicyDefinitionStoreTestBase {
     @Override
     protected boolean supportCollectionQuery() {
         return false;
+    }
+
+    @Override
+    protected boolean supportCollectionIndexQuery() {
+        return true;
     }
 
     @Override

--- a/extensions/common/azure/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/CosmosConditionExpression.java
+++ b/extensions/common/azure/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/CosmosConditionExpression.java
@@ -129,7 +129,10 @@ class CosmosConditionExpression {
     private String getName() {
         return criterion.getOperandLeft().toString()
                 .replace(":", "_")
-                .replace(".", "_");
+                .replace(".", "_")
+                .replace("[", "")
+                .replace("]", "")
+                .replaceAll("[0-9]", "");
     }
 
     /**

--- a/extensions/control-plane/store/cosmos/policy-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/cosmos/policy/store/CosmosPolicyDefinitionStore.java
+++ b/extensions/control-plane/store/cosmos/policy-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/cosmos/policy/store/CosmosPolicyDefinitionStore.java
@@ -17,22 +17,16 @@ package org.eclipse.dataspaceconnector.cosmos.policy.store;
 import com.azure.cosmos.implementation.NotFoundException;
 import dev.failsafe.RetryPolicy;
 import org.eclipse.dataspaceconnector.azure.cosmos.CosmosDbApi;
-import org.eclipse.dataspaceconnector.common.concurrency.LockManager;
+import org.eclipse.dataspaceconnector.azure.cosmos.dialect.SqlStatement;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.policy.PolicyDefinition;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyDefinitionStore;
-import org.eclipse.dataspaceconnector.spi.query.QueryResolver;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
-import org.eclipse.dataspaceconnector.spi.query.ReflectionBasedQueryResolver;
+import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static dev.failsafe.Failsafe.with;
@@ -46,10 +40,7 @@ public class CosmosPolicyDefinitionStore implements PolicyDefinitionStore {
     private final CosmosDbApi cosmosDbApi;
     private final TypeManager typeManager;
     private final RetryPolicy<Object> retryPolicy;
-    private final LockManager lockManager;
     private final String partitionKey;
-    private final QueryResolver<PolicyDefinition> queryResolver;
-    private final AtomicReference<Map<String, PolicyDefinition>> objectCache;
     private final Monitor monitor;
 
     public CosmosPolicyDefinitionStore(CosmosDbApi cosmosDbApi, TypeManager typeManager, RetryPolicy<Object> retryPolicy, String partitionKey, Monitor monitor) {
@@ -57,75 +48,49 @@ public class CosmosPolicyDefinitionStore implements PolicyDefinitionStore {
         this.typeManager = typeManager;
         this.retryPolicy = retryPolicy;
         this.partitionKey = partitionKey;
-        lockManager = new LockManager(new ReentrantReadWriteLock(true));
-        queryResolver = new ReflectionBasedQueryResolver<>(PolicyDefinition.class);
-        objectCache = new AtomicReference<>(new HashMap<>());
         this.monitor = monitor;
     }
 
     @Override
     public PolicyDefinition findById(String policyId) {
-        return lockManager.readLock(() -> getCache().get(policyId));
+        var policyDefinition = cosmosDbApi.queryItemById(policyId);
+        return policyDefinition != null ? convert(policyDefinition) : null;
     }
 
     @Override
     public Stream<PolicyDefinition> findAll(QuerySpec spec) {
-        return lockManager.readLock(() -> queryResolver.query(getCache().values().stream(), spec));
+        var statement = new SqlStatement<>(PolicyDocument.class);
+        var query = statement.where(spec.getFilterExpression())
+                .offset(spec.getOffset())
+                .limit(spec.getLimit())
+                .orderBy(spec.getSortField(), spec.getSortOrder() == SortOrder.ASC)
+                .getQueryAsSqlQuerySpec();
+
+        var objects = with(retryPolicy).get(() -> cosmosDbApi.queryItems(query));
+        return objects.map(this::convert);
     }
 
     @Override
     public void save(PolicyDefinition policy) {
-        lockManager.writeLock(() -> {
-            with(retryPolicy).run(() -> cosmosDbApi.saveItem(convertToDocument(policy)));
-            storeInCache(policy);
-            return null;
-        });
+        with(retryPolicy).run(() -> cosmosDbApi.saveItem(convertToDocument(policy)));
     }
 
     @Override
     public @Nullable PolicyDefinition deleteById(String policyId) {
-        return lockManager.writeLock(() -> {
-
-            try {
-                var deletedItem = cosmosDbApi.deleteItem(policyId);
-                if (deletedItem == null) {
-                    return null;
-                }
-                removeFromCache(policyId);
-                return convert(deletedItem);
-            } catch (NotFoundException e) {
-                monitor.debug(() -> String.format("PolicyDefinition with id %s not found", policyId));
+        try {
+            var deletedItem = cosmosDbApi.deleteItem(policyId);
+            if (deletedItem == null) {
                 return null;
             }
-        });
+            return convert(deletedItem);
+        } catch (NotFoundException e) {
+            monitor.debug(() -> String.format("PolicyDefinition with id %s not found", policyId));
+            return null;
+        }
     }
 
     @Override
     public void reload() {
-        lockManager.readLock(() -> {
-            // this reloads ALL items from the database. We might want something more elaborate in the future, especially
-            // if large amounts of ContractDefinitions need to be held in memory
-            var databaseObjects = with(retryPolicy)
-                    .get(() -> cosmosDbApi.queryAllItems())
-                    .stream()
-                    .map(this::convert)
-                    .collect(Collectors.toMap(PolicyDefinition::getUid, cd -> cd));
-
-            objectCache.set(databaseObjects);
-            return null;
-        });
-    }
-
-    private PolicyDefinition removeFromCache(String policyId) {
-        return lockManager.readLock(() -> {
-            var map = getCache();
-            return map.remove(policyId);
-        });
-
-    }
-
-    private void storeInCache(PolicyDefinition definition) {
-        getCache().put(definition.getUid(), definition);
     }
 
     @NotNull
@@ -133,12 +98,6 @@ public class CosmosPolicyDefinitionStore implements PolicyDefinitionStore {
         return new PolicyDocument(policy, partitionKey);
     }
 
-    private Map<String, PolicyDefinition> getCache() {
-        if (objectCache.get().isEmpty()) {
-            reload();
-        }
-        return objectCache.get();
-    }
 
     private PolicyDefinition convert(Object object) {
         var json = typeManager.writeValueAsString(object);

--- a/extensions/control-plane/store/sql/policy-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/policy/store/PostgresPolicyDefinitionStoreTest.java
+++ b/extensions/control-plane/store/sql/policy-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/policy/store/PostgresPolicyDefinitionStoreTest.java
@@ -145,6 +145,11 @@ class PostgresPolicyDefinitionStoreTest extends PolicyDefinitionStoreTestBase {
     }
 
     @Override
+    protected boolean supportCollectionIndexQuery() {
+        return false;
+    }
+
+    @Override
     protected Boolean supportSortOrder() {
         return false;
     }


### PR DESCRIPTION
## What this PR changes/adds

Removes in-memory local cache for CRUD and querying in `CosmosPolicyDefinitionStore`.

## Why it does that

Cleanup and remove the limitation of local cache growth and querying mechanism.

## Further notes

* Querying over arrays will be supported with #1981 

## Linked Issue(s)

Closes #1965 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
