### PR TITLE
feat(asset): use vault for sensitive data (#1977)

### DIFF
--- a/extensions/control-plane/api/data-management/asset-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiExtension.java
+++ b/extensions/control-plane/api/data-management/asset-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiExtension.java
@@ -11,6 +11,7 @@
  *       ZF Friedrichshafen AG - Initial API and Implementation
  *       Microsoft Corporation - name refactoring
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
+ *       SAP SE - use vault for sensitive data
  *
  */
 
@@ -29,6 +30,7 @@ import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
 import org.eclipse.dataspaceconnector.spi.event.EventRouter;
 import org.eclipse.dataspaceconnector.spi.observe.asset.AssetObservableImpl;
+import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.Provides;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
@@ -64,6 +66,9 @@ public class AssetApiExtension implements ServiceExtension {
     @Inject
     Clock clock;
 
+    @Inject
+    Vault vault;
+
     @Override
     public String name() {
         return "Data Management API: Asset";
@@ -76,7 +81,7 @@ public class AssetApiExtension implements ServiceExtension {
         var assetObservable = new AssetObservableImpl();
         assetObservable.registerListener(new AssetEventListener(clock, eventRouter));
 
-        var assetService = new AssetServiceImpl(assetIndex, contractNegotiationStore, transactionContext, assetObservable);
+        var assetService = new AssetServiceImpl(assetIndex, contractNegotiationStore, transactionContext, assetObservable, vault);
         context.registerService(AssetService.class, assetService);
 
         transformerRegistry.register(new AssetRequestDtoToAssetTransformer());

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/DataAddress.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/DataAddress.java
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
  *       Siemens AG - enable read property and return a default value is missing
+ *       SAP SE - use vault for sensitive data
  *
  */
 
@@ -55,6 +56,10 @@ public class DataAddress {
 
     public String getProperty(String key) {
         return properties.get(key);
+    }
+
+    public String setProperty(String key, String value) {
+        return properties.put(key, value);
     }
 
     public String getProperty(String key, String defaultValue) {

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/HttpDataAddress.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/HttpDataAddress.java
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Amadeus - Initial implementation
  *       Siemens AG - added additionalHeaders
+ *       SAP SE - use vault for sensitive data
  *
  */
 
@@ -53,6 +54,7 @@ public class HttpDataAddress extends DataAddress {
     public static final String OCTET_STREAM = "application/octet-stream";
     public static final String NON_CHUNKED_TRANSFER = "nonChunkedTransfer";
     public static final Set<String> ADDITIONAL_HEADERS_TO_IGNORE = Set.of("content-type");
+    public static final String VAULT_ENTRY = "vault:";
 
     private HttpDataAddress() {
         super();
@@ -123,7 +125,13 @@ public class HttpDataAddress extends DataAddress {
         return getProperties().entrySet().stream()
                 .filter(entry -> entry.getKey().startsWith(ADDITIONAL_HEADER))
                 .collect(Collectors.toMap(entry -> entry.getKey().replace(ADDITIONAL_HEADER, ""), Map.Entry::getValue));
+    }
 
+    @JsonIgnore
+    public Map<String, String> getVaultEntries() {
+        return getProperties().entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(VAULT_ENTRY))
+                .collect(Collectors.toMap(entry -> entry.getKey().replace(VAULT_ENTRY, ""), Map.Entry::getValue));
     }
 
     @JsonIgnore
@@ -216,6 +224,11 @@ public class HttpDataAddress extends DataAddress {
 
         public Builder nonChunkedTransfer(boolean nonChunkedTransfer) {
             this.property(NON_CHUNKED_TRANSFER, String.valueOf(nonChunkedTransfer));
+            return this;
+        }
+
+        public Builder addVaultEntry(String propertyName, String vaultKey) {
+            address.getProperties().put(VAULT_ENTRY + propertyName, Objects.requireNonNull(vaultKey));
             return this;
         }
 

--- a/spi/common/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/HttpDataAddressTest.java
+++ b/spi/common/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/HttpDataAddressTest.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Siemens AG - initial implementation
+ *       SAP SE - use vault for sensitive data
  *
  */
 
@@ -70,5 +71,17 @@ class HttpDataAddressTest {
         assertThat(dataAddress.getAdditionalHeaders()).isEmpty();
         assertThat(dataAddress.getNonChunkedTransfer()).isFalse();
         assertThat(dataAddress.getContentType()).isEqualTo("application/octet-stream");
+    }
+
+    @Test
+    void verifyVaultProperties() {
+        var dataAddress = HttpDataAddress.Builder.newInstance()
+                .name("name1")
+                .baseUrl("http://myendpoint")
+                .addVaultEntry("authCode", "HASHEDKEY1")
+                .build();
+
+        assertThat(dataAddress.getVaultEntries())
+                .containsEntry("authCode", "HASHEDKEY1");
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

By tagging items in dataAddress with ```vault:``` the value is persisted in the vault and vault's key (hash of value) is used as value for persistence of the address.

On data plane the reverse logic is applied. Once ```vault:``` tagged item is received, the value is used as vault key and the real value is replacing the content in the address. The tag is removed and this might overwrite redundant items, vault contents win.

## Why it does that

To not expose the sensitive data of http data addresses to consumer connectors.



## Linked Issue(s)

Closes #1977

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
