### PR TITLE
feat(catalog): make FederatedCatalogNode filtering extensible

### DIFF
--- a/core/federated-catalog/federated-catalog-core/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheExtensionTest.java
+++ b/core/federated-catalog/federated-catalog-core/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheExtensionTest.java
@@ -45,7 +45,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -80,7 +79,7 @@ class FederatedCatalogCacheExtensionTest {
         verify(webserviceMock).registerResource(any(FederatedCatalogApiController.class));
         verify(context, atLeastOnce()).getMonitor();
         verify(context).getSetting("edc.catalog.cache.partition.num.crawlers", 2);
-        verify(context, times(2)).getConnectorId();
+        verify(context).getConnectorId();
     }
 
     @Test

--- a/spi/federated-catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/FederatedCacheNodeFilter.java
+++ b/spi/federated-catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/FederatedCacheNodeFilter.java
@@ -1,0 +1,7 @@
+package org.eclipse.dataspaceconnector.catalog.spi;
+
+import java.util.function.Predicate;
+
+public interface FederatedCacheNodeFilter extends Predicate<FederatedCacheNode> {
+    // marker interface to make it easily injectable
+}


### PR DESCRIPTION
## What this PR changes/adds

This PR makes the filtering method (essentially a `Predicate`) extensible, so that users of the Federated Catalog can choose which nodes to crawl and which not to.


## Why it does that

In some situations users may decide to skip crawling nodes, for example when the last X attempts to crawl them had failed, or any other elaborate metric. 

## Further notes

- The `ExecutionManager` initialises the filter method with a noop filter to enable fluent code and to avoid NPE's 
- By default, the `FederatedCatalogCacheExtension` uses a filtering method based on the connector name, that excludes the executing connector, so as to not crawl "ourself".
- users can provide a `FederatedCacheNodeFilter` object using the `@Provider` mechanism.


## Linked Issue(s)

Closes #1979 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
