### PR TITLE
feat(SqlAssetIndex): Lower default limit from Integer.MAX_VALUE to 50

### DIFF
--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/dataspaceconnector/sql/assetindex/SqlAssetIndex.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/dataspaceconnector/sql/assetindex/SqlAssetIndex.java
@@ -62,14 +62,14 @@ public class SqlAssetIndex implements AssetIndex {
 
     @Override
     public Stream<Asset> queryAssets(AssetSelectorExpression expression) {
-        Objects.requireNonNull(expression);
+        Objects.requireNonNull(expression, "AssetSelectorExpression can not be null!");
 
-        var criteria = expression.getCriteria();
-        var querySpec = QuerySpec.Builder.newInstance().filter(criteria)
-                .offset(0)
-                .limit(Integer.MAX_VALUE) // means effectively no limit
-                .build();
-        return queryAssets(querySpec);
+        // select everything ONLY if the special constant is used
+        if (expression == AssetSelectorExpression.SELECT_ALL) {
+            return queryAssets(QuerySpec.none());
+        }
+
+        return queryAssets(QuerySpec.Builder.newInstance().filter(expression.getCriteria()).build());
     }
 
     @Override


### PR DESCRIPTION
## What this PR changes/adds

Changes the [SqlAssetIndex](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/0d85e3f2e9cab0f8cdea36852777f2a7e66b1aec/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/dataspaceconnector/sql/assetindex/SqlAssetIndex.java) to use the same default limit (50) as the [`InMemoryAssetIndex`](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/0d85e3f2e9cab0f8cdea36852777f2a7e66b1aec/core/control-plane/control-plane-core/src/main/java/org/eclipse/dataspaceconnector/core/controlplane/defaults/assetindex/InMemoryAssetIndex.java) and the [`CosmosAssetIndex`](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/0d85e3f2e9cab0f8cdea36852777f2a7e66b1aec/extensions/control-plane/store/cosmos/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndex.java) do.

## Why it does that

For alignment reasons and to limit the result set to the default 50 elements as the inmemeory and cosmosdb counterpart do. 

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #1990

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)

<sub>Denis Neuling <denis.neuling@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [legal info/Impressum](https://github.com/mercedes-benz/daimler-foss/blob/master/LEGAL_IMPRINT.md) </sub>