### PR TITLE
feat: add toBuilder for resource definitions

### DIFF
--- a/core/control-plane/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/TestResourceDefinition.java
+++ b/core/control-plane/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/TestResourceDefinition.java
@@ -23,7 +23,12 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceDefiniti
 @JsonTypeName("dataspaceconnector:testresourcedefinition")
 @JsonDeserialize(builder = TestResourceDefinition.Builder.class)
 public class TestResourceDefinition extends ResourceDefinition {
-
+    
+    @Override
+    public <RD extends ResourceDefinition, B extends ResourceDefinition.Builder<RD, B>> B toBuilder() {
+        return null;
+    }
+    
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder extends ResourceDefinition.Builder<TestResourceDefinition, Builder> {
         private Builder() {

--- a/extensions/control-plane/provision/blob-provision/src/main/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageResourceDefinition.java
+++ b/extensions/control-plane/provision/blob-provision/src/main/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageResourceDefinition.java
@@ -34,10 +34,9 @@ public class ObjectStorageResourceDefinition extends ResourceDefinition {
     
     @Override
     public Builder toBuilder() {
-        var builder = Builder.newInstance()
+        return initializeBuilder(new Builder())
                 .containerName(containerName)
                 .accountName(accountName);
-        return super.toBuilder(builder);
     }
     
     public static class Builder extends ResourceDefinition.Builder<ObjectStorageResourceDefinition, Builder> {

--- a/extensions/control-plane/provision/blob-provision/src/main/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageResourceDefinition.java
+++ b/extensions/control-plane/provision/blob-provision/src/main/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageResourceDefinition.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - add toBuilder method
  *
  */
 
@@ -30,7 +31,16 @@ public class ObjectStorageResourceDefinition extends ResourceDefinition {
     public String getAccountName() {
         return accountName;
     }
-
+    
+    @Override
+    public Builder toBuilder() {
+        return Builder.newInstance()
+                .id(id)
+                .transferProcessId(transferProcessId)
+                .containerName(containerName)
+                .accountName(accountName);
+    }
+    
     public static class Builder extends ResourceDefinition.Builder<ObjectStorageResourceDefinition, Builder> {
 
         private Builder() {

--- a/extensions/control-plane/provision/blob-provision/src/main/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageResourceDefinition.java
+++ b/extensions/control-plane/provision/blob-provision/src/main/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageResourceDefinition.java
@@ -34,11 +34,10 @@ public class ObjectStorageResourceDefinition extends ResourceDefinition {
     
     @Override
     public Builder toBuilder() {
-        return Builder.newInstance()
-                .id(id)
-                .transferProcessId(transferProcessId)
+        var builder = Builder.newInstance()
                 .containerName(containerName)
                 .accountName(accountName);
+        return super.toBuilder(builder);
     }
     
     public static class Builder extends ResourceDefinition.Builder<ObjectStorageResourceDefinition, Builder> {

--- a/extensions/control-plane/provision/blob-provision/src/test/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageProvisionerTest.java
+++ b/extensions/control-plane/provision/blob-provision/src/test/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageProvisionerTest.java
@@ -53,6 +53,10 @@ class ObjectStorageProvisionerTest {
     void canProvision() {
         assertThat(provisioner.canProvision(new ObjectStorageResourceDefinition())).isTrue();
         assertThat(provisioner.canProvision(new ResourceDefinition() {
+            @Override
+            public <RD extends ResourceDefinition, B extends Builder<RD, B>> B toBuilder() {
+                return null;
+            }
         })).isFalse();
     }
 

--- a/extensions/control-plane/provision/blob-provision/src/test/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageResourceDefinitionTest.java
+++ b/extensions/control-plane/provision/blob-provision/src/test/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageResourceDefinitionTest.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2022 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.provision.azure.blob;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ObjectStorageResourceDefinitionTest {
+    
+    @Test
+    void toBuilder_verifyEqualResourceDefinition() {
+        var definition = ObjectStorageResourceDefinition.Builder.newInstance()
+                .id("id")
+                .transferProcessId("tp-id")
+                .accountName("account")
+                .containerName("container")
+                .build();
+        var builder = definition.toBuilder();
+        var rebuiltDefinition = builder.build();
+    
+        assertThat(rebuiltDefinition).usingRecursiveComparison().isEqualTo(definition);
+    }
+    
+}

--- a/extensions/control-plane/provision/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/AbstractHttpResourceDefinition.java
+++ b/extensions/control-plane/provision/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/AbstractHttpResourceDefinition.java
@@ -39,6 +39,11 @@ public abstract class AbstractHttpResourceDefinition extends ResourceDefinition 
     public String getTransferProcessId() {
         return transferProcessId;
     }
+    
+    protected <RD extends AbstractHttpResourceDefinition, B extends AbstractHttpResourceDefinition.Builder<RD, B>> B toBuilder(B builder) {
+        return super.toBuilder(builder)
+                .dataAddressType(dataAddressType);
+    }
 
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder<RD extends AbstractHttpResourceDefinition, B extends ResourceDefinition.Builder<RD, B>> extends ResourceDefinition.Builder<RD, B> {

--- a/extensions/control-plane/provision/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/AbstractHttpResourceDefinition.java
+++ b/extensions/control-plane/provision/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/AbstractHttpResourceDefinition.java
@@ -40,8 +40,8 @@ public abstract class AbstractHttpResourceDefinition extends ResourceDefinition 
         return transferProcessId;
     }
     
-    protected <RD extends AbstractHttpResourceDefinition, B extends AbstractHttpResourceDefinition.Builder<RD, B>> B toBuilder(B builder) {
-        return super.toBuilder(builder)
+    protected <RD extends AbstractHttpResourceDefinition, B extends AbstractHttpResourceDefinition.Builder<RD, B>> B initializeBuilder(B builder) {
+        return super.initializeBuilder(builder)
                 .dataAddressType(dataAddressType);
     }
 

--- a/extensions/control-plane/provision/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderResourceDefinition.java
+++ b/extensions/control-plane/provision/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderResourceDefinition.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - add toBuilder method
  *
  */
 
@@ -36,7 +37,16 @@ public class HttpProviderResourceDefinition extends AbstractHttpResourceDefiniti
     public String getAssetId() {
         return assetId;
     }
-
+    
+    @Override
+    public Builder toBuilder() {
+        return Builder.newInstance()
+                .id(id)
+                .transferProcessId(transferProcessId)
+                .dataAddressType(dataAddressType)
+                .assetId(assetId);
+    }
+    
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder extends AbstractHttpResourceDefinition.Builder<HttpProviderResourceDefinition, Builder> {
 

--- a/extensions/control-plane/provision/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderResourceDefinition.java
+++ b/extensions/control-plane/provision/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderResourceDefinition.java
@@ -40,11 +40,9 @@ public class HttpProviderResourceDefinition extends AbstractHttpResourceDefiniti
     
     @Override
     public Builder toBuilder() {
-        return Builder.newInstance()
-                .id(id)
-                .transferProcessId(transferProcessId)
-                .dataAddressType(dataAddressType)
+        var builder = Builder.newInstance()
                 .assetId(assetId);
+        return super.toBuilder(builder);
     }
     
     @JsonPOJOBuilder(withPrefix = "")

--- a/extensions/control-plane/provision/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderResourceDefinition.java
+++ b/extensions/control-plane/provision/http-provisioner/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderResourceDefinition.java
@@ -40,9 +40,8 @@ public class HttpProviderResourceDefinition extends AbstractHttpResourceDefiniti
     
     @Override
     public Builder toBuilder() {
-        var builder = Builder.newInstance()
+        return initializeBuilder(new Builder())
                 .assetId(assetId);
-        return super.toBuilder(builder);
     }
     
     @JsonPOJOBuilder(withPrefix = "")

--- a/extensions/control-plane/provision/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderProvisionerTest.java
+++ b/extensions/control-plane/provision/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderProvisionerTest.java
@@ -200,7 +200,10 @@ class HttpProviderProvisionerTest {
 
 
     private static class TestResourceDefinition extends ResourceDefinition {
-
+        @Override
+        public <RD extends ResourceDefinition, B extends Builder<RD, B>> B toBuilder() {
+            return null;
+        }
     }
 
     private static class TestProvisionedResource extends ProvisionedResource {

--- a/extensions/control-plane/provision/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderResourceDefinitionTest.java
+++ b/extensions/control-plane/provision/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderResourceDefinitionTest.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - add test
  *
  */
 
@@ -36,5 +37,19 @@ class HttpProviderResourceDefinitionTest {
         assertThat(deserialized.getTransferProcessId()).isEqualTo("1");
         assertThat(deserialized.getDataAddressType()).isEqualTo("test");
 
+    }
+    
+    @Test
+    void toBuilder_verifyEqualResourceDefinition() {
+        var definition = HttpProviderResourceDefinition.Builder.newInstance()
+                .id("id")
+                .transferProcessId("tp-id")
+                .assetId("asset")
+                .dataAddressType("type")
+                .build();
+        var builder = definition.toBuilder();
+        var rebuiltDefinition = builder.build();
+    
+        assertThat(rebuiltDefinition).usingRecursiveComparison().isEqualTo(definition);
     }
 }

--- a/extensions/control-plane/provision/s3-provision/src/main/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3BucketResourceDefinition.java
+++ b/extensions/control-plane/provision/s3-provision/src/main/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3BucketResourceDefinition.java
@@ -41,11 +41,10 @@ public class S3BucketResourceDefinition extends ResourceDefinition {
     
     @Override
     public Builder toBuilder() {
-        return Builder.newInstance()
-                .id(id)
-                .transferProcessId(transferProcessId)
+        var builder = Builder.newInstance()
                 .regionId(regionId)
                 .bucketName(bucketName);
+        return super.toBuilder(builder);
     }
     
     public static class Builder extends ResourceDefinition.Builder<S3BucketResourceDefinition, Builder> {

--- a/extensions/control-plane/provision/s3-provision/src/main/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3BucketResourceDefinition.java
+++ b/extensions/control-plane/provision/s3-provision/src/main/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3BucketResourceDefinition.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - add toBuilder method
  *
  */
 
@@ -37,8 +38,16 @@ public class S3BucketResourceDefinition extends ResourceDefinition {
     public String getBucketName() {
         return bucketName;
     }
-
-
+    
+    @Override
+    public Builder toBuilder() {
+        return Builder.newInstance()
+                .id(id)
+                .transferProcessId(transferProcessId)
+                .regionId(regionId)
+                .bucketName(bucketName);
+    }
+    
     public static class Builder extends ResourceDefinition.Builder<S3BucketResourceDefinition, Builder> {
 
         private Builder() {

--- a/extensions/control-plane/provision/s3-provision/src/main/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3BucketResourceDefinition.java
+++ b/extensions/control-plane/provision/s3-provision/src/main/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3BucketResourceDefinition.java
@@ -41,10 +41,9 @@ public class S3BucketResourceDefinition extends ResourceDefinition {
     
     @Override
     public Builder toBuilder() {
-        var builder = Builder.newInstance()
+        return initializeBuilder(new Builder())
                 .regionId(regionId)
                 .bucketName(bucketName);
-        return super.toBuilder(builder);
     }
     
     public static class Builder extends ResourceDefinition.Builder<S3BucketResourceDefinition, Builder> {

--- a/extensions/control-plane/provision/s3-provision/src/test/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3BucketResourceDefinitionTest.java
+++ b/extensions/control-plane/provision/s3-provision/src/test/java/org/eclipse/dataspaceconnector/aws/s3/provision/S3BucketResourceDefinitionTest.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2022 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.aws.s3.provision;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class S3BucketResourceDefinitionTest {
+    
+    @Test
+    void toBuilder_verifyEqualResourceDefinition() {
+        var definition = S3BucketResourceDefinition.Builder.newInstance()
+                .id("id")
+                .transferProcessId("tp-id")
+                .regionId("region")
+                .bucketName("bucket")
+                .build();
+        var builder = definition.toBuilder();
+        var rebuiltDefinition = builder.build();
+        
+        assertThat(rebuiltDefinition).usingRecursiveComparison().isEqualTo(definition);
+    }
+    
+}

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ResourceDefinition.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ResourceDefinition.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - add toBuilder method
  *
  */
 
@@ -41,6 +42,15 @@ public abstract class ResourceDefinition implements Polymorphic {
     void setTransferProcessId(String transferProcessId) {
         this.transferProcessId = transferProcessId;
     }
+    
+    /**
+     * Converts the resource definition to a builder to allow for easy modification.
+     *
+     * @param <RD> the type of resource definition.
+     * @param <B> the respective builder type.
+     * @return the builder.
+     */
+    public abstract <RD extends ResourceDefinition, B extends Builder<RD, B>> B toBuilder();
 
     @JsonPOJOBuilder
     public static class Builder<RD extends ResourceDefinition, B extends Builder<RD, B>> {

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ResourceDefinition.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ResourceDefinition.java
@@ -51,6 +51,20 @@ public abstract class ResourceDefinition implements Polymorphic {
      * @return the builder.
      */
     public abstract <RD extends ResourceDefinition, B extends Builder<RD, B>> B toBuilder();
+    
+    /**
+     * Sets the base class properties on a sub class builder.
+     *
+     * @param builder the builder.
+     * @param <RD> the type of resource definition.
+     * @param <B> the respective builder type.
+     * @return the builder with class properties set.
+     */
+    protected <RD extends ResourceDefinition, B extends Builder<RD, B>> B toBuilder(B builder) {
+        return builder
+                .id(id)
+                .transferProcessId(transferProcessId);
+    }
 
     @JsonPOJOBuilder
     public static class Builder<RD extends ResourceDefinition, B extends Builder<RD, B>> {

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ResourceDefinition.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/ResourceDefinition.java
@@ -60,7 +60,7 @@ public abstract class ResourceDefinition implements Polymorphic {
      * @param <B> the respective builder type.
      * @return the builder with class properties set.
      */
-    protected <RD extends ResourceDefinition, B extends Builder<RD, B>> B toBuilder(B builder) {
+    protected <RD extends ResourceDefinition, B extends Builder<RD, B>> B initializeBuilder(B builder) {
         return builder
                 .id(id)
                 .transferProcessId(transferProcessId);

--- a/spi/control-plane/transfer-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TestResourceDefinition.java
+++ b/spi/control-plane/transfer-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TestResourceDefinition.java
@@ -22,7 +22,12 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 @JsonTypeName("dataspaceconnector:testresourcedefinition")
 @JsonDeserialize(builder = TestResourceDefinition.Builder.class)
 class TestResourceDefinition extends ResourceDefinition {
-
+    
+    @Override
+    public <RD extends ResourceDefinition, B extends ResourceDefinition.Builder<RD, B>> B toBuilder() {
+        return null;
+    }
+    
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder extends ResourceDefinition.Builder<TestResourceDefinition, Builder> {
         private Builder() {

--- a/spi/control-plane/transfer-spi/src/testFixtures/java/org/eclipse/dataspaceconnector/transfer/store/TestFunctions.java
+++ b/spi/control-plane/transfer-spi/src/testFixtures/java/org/eclipse/dataspaceconnector/transfer/store/TestFunctions.java
@@ -111,7 +111,12 @@ public class TestFunctions {
     @JsonTypeName("dataspaceconnector:testresourcedef")
     @JsonDeserialize(builder = TestResourceDef.Builder.class)
     public static class TestResourceDef extends ResourceDefinition {
-
+    
+        @Override
+        public <RD extends ResourceDefinition, B extends ResourceDefinition.Builder<RD, B>> B toBuilder() {
+            return null;
+        }
+    
         @JsonPOJOBuilder(withPrefix = "")
         public static class Builder extends ResourceDefinition.Builder<TestResourceDef, Builder> {
             private Builder() {


### PR DESCRIPTION
## What this PR changes/adds

It adds a `toBuilder()` method for all `ResourceDefinitions`.

## Why it does that

During policy evaluation, functions may modify a `ResourceDefinition`. When each definition is re-created from scratch, information may get lost. Therefore, definitions should be convertable to a builder that can be easily modified.

## Linked Issue(s)

Closes #1717 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
