### PR TITLE
chore: bump aws-sdk version to 2.17.278

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,17 +1,19 @@
 groupId=org.eclipse.dataspaceconnector
 defaultVersion=0.0.1-SNAPSHOT
 javaVersion=11
+
 edcDeveloperId=mspiekermann
 edcDeveloperName=Markus Spiekermann
 edcDeveloperEmail=markus.spiekermann@isst.fraunhofer.de
 edcScmConnection=scm:git:git@github.com:eclipse-dataspaceconnector/DataSpaceConnector.git
 edcWebsiteUrl=https://github.com/eclipse-dataspaceconnector/DataSpaceConnector.git
 edcScmUrl=https://github.com/eclipse-dataspaceconnector/DataSpaceConnector.git
+
 apacheCommonsPool2Version=2.11.1
 assertj=3.22.0
 atomikosVersion=5.0.8
 awaitility=4.2.0
-awsVersion=2.16.60
+awsVersion=2.17.278
 azureIdentityVersion=1.4.6
 azureKeyVaultVersion=4.2.3
 azureResourceManagerDataFactory=1.0.0-beta.12
@@ -20,6 +22,7 @@ bouncycastleVersion=1.70
 cloudEvents=2.3.0
 cosmosSdkVersion=4.26.0
 eventGridSdkVersion=4.4.0
+failsafeVersion=3.2.4
 gatlingVersion=3.7.5
 h2Version=2.1.210
 httpMockServer=5.14.0
@@ -30,7 +33,6 @@ jerseyVersion=3.0.8
 jetBrainsAnnotationsVersion=15.0
 jettyVersion=11.0.8
 jlineVersion=3.19.0
-failsafeVersion=3.2.4
 jtaVersion=1.3
 jupiterVersion=5.8.2
 jwtVersion=3.13.0


### PR DESCRIPTION
## What this PR changes/adds

Bumps aws-sdk version to 2.17.278

## Why it does that

Keep dependencies updated

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
