### PR TITLE
chore: bump swagger version to 2.2.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -114,7 +114,7 @@ subprojects {
 
 buildscript {
     dependencies {
-        classpath("io.swagger.core.v3:swagger-gradle-plugin:2.1.13")
+        classpath("io.swagger.core.v3:swagger-gradle-plugin:2.2.2")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -114,7 +114,8 @@ subprojects {
 
 buildscript {
     dependencies {
-        classpath("io.swagger.core.v3:swagger-gradle-plugin:2.2.2")
+        val swagger: String by project
+        classpath("io.swagger.core.v3:swagger-gradle-plugin:${swagger}")
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,5 +45,5 @@ rsApi=3.1.0
 servletApi=4.0.4
 slf4jVersion=2.0.0-alpha7
 storageBlobVersion=12.14.2
-swagger=2.1.13
+swagger=2.2.2
 websocketVersion=2.0.0


### PR DESCRIPTION
## What this PR changes/adds

Bumps swagger version to 2.2.2

## Why it does that

Keep dependencies updated

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
