### PR TITLE
feat(store): implements array querying in Cosmos store

### DIFF
--- a/core/common/util/src/test/java/org/eclipse/dataspaceconnector/common/reflection/TestGenericArrayList.java
+++ b/core/common/util/src/test/java/org/eclipse/dataspaceconnector/common/reflection/TestGenericArrayList.java
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.common.reflection;
+
+import java.util.ArrayList;
+
+public class TestGenericArrayList<T> extends ArrayList<T> {
+}

--- a/core/common/util/src/test/java/org/eclipse/dataspaceconnector/common/reflection/TestGenericObject.java
+++ b/core/common/util/src/test/java/org/eclipse/dataspaceconnector/common/reflection/TestGenericObject.java
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.common.reflection;
+
+public class TestGenericObject<T> {
+    
+}
+

--- a/core/common/util/src/test/java/org/eclipse/dataspaceconnector/common/reflection/TestGenericSubclass.java
+++ b/core/common/util/src/test/java/org/eclipse/dataspaceconnector/common/reflection/TestGenericSubclass.java
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.common.reflection;
+
+public class TestGenericSubclass extends TestGenericObject<String> {
+}

--- a/core/common/util/src/test/java/org/eclipse/dataspaceconnector/common/reflection/TestObject.java
+++ b/core/common/util/src/test/java/org/eclipse/dataspaceconnector/common/reflection/TestObject.java
@@ -14,13 +14,26 @@
 
 package org.eclipse.dataspaceconnector.common.reflection;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class TestObject {
     private final String description;
     private final int priority;
 
+    private final List<AnotherObject> listField = new ArrayList<>();
+
+    private final AnotherObject embedded;
+
+
     public TestObject(String description, int priority) {
+        this(description, priority, null);
+    }
+
+    public TestObject(String description, int priority, AnotherObject embedded) {
         this.description = description;
         this.priority = priority;
+        this.embedded = embedded;
     }
 
     public String getDescription() {
@@ -29,5 +42,13 @@ public class TestObject {
 
     public int getPriority() {
         return priority;
+    }
+
+    public List<AnotherObject> getListField() {
+        return listField;
+    }
+
+    public AnotherObject getEmbedded() {
+        return embedded;
     }
 }

--- a/core/common/util/src/test/java/org/eclipse/dataspaceconnector/common/reflection/TestObjectWithList.java
+++ b/core/common/util/src/test/java/org/eclipse/dataspaceconnector/common/reflection/TestObjectWithList.java
@@ -20,12 +20,23 @@ public class TestObjectWithList extends TestObject {
 
     private final List<TestObject> nestedObjects;
 
+    private final TestObject nestedObject;
+
     public TestObjectWithList(String description, int priority, List<TestObject> nestedObjects) {
+        this(description, priority, nestedObjects, null);
+    }
+
+    public TestObjectWithList(String description, int priority, List<TestObject> nestedObjects, TestObject nestedObject) {
         super(description, priority);
         this.nestedObjects = nestedObjects;
+        this.nestedObject = nestedObject;
     }
 
     public List<TestObject> getNestedObjects() {
         return nestedObjects;
+    }
+
+    public TestObject getNestedObject() {
+        return nestedObject;
     }
 }

--- a/extensions/common/azure/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/ConditionExpression.java
+++ b/extensions/common/azure/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/ConditionExpression.java
@@ -22,32 +22,39 @@ import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
 
 import static java.lang.String.format;
-import static org.eclipse.dataspaceconnector.azure.cosmos.CosmosDocument.sanitize;
 
-class CosmosConditionExpression {
-    private static final String IN_OPERATOR = "in";
-    private static final String EQUALS_OPERATOR = "=";
-    private static final String LIKE_OPERATOR = "like";
-    private static final List<String> SUPPORTED_PREPARED_STATEMENT_OPERATORS = List.of(EQUALS_OPERATOR, IN_OPERATOR, LIKE_OPERATOR);
-    private static final String PREPARED_STATEMENT_PLACEHOLDER = "@";
+/**
+ * Represents an abstraction for Cosmos condition rewrite rules.
+ * Its responsibility is to validate and translate from {@link Criterion} to a Cosmos SQL condition expression.
+ */
+public abstract class ConditionExpression {
+
+    public static final String IN_OPERATOR = "in";
+    public static final String EQUALS_OPERATOR = "=";
+    public static final String LIKE_OPERATOR = "like";
+    public static final List<String> SUPPORTED_PREPARED_STATEMENT_OPERATORS = List.of(EQUALS_OPERATOR, IN_OPERATOR, LIKE_OPERATOR);
+
+    public static final List<String> RESERVED_WORDS = List.of("value");
+
+
+    public static final String PREPARED_STATEMENT_PLACEHOLDER = "@";
+
+
     private final Criterion criterion;
-    private final String objectPrefix;
 
-    CosmosConditionExpression(Criterion criterion) {
-        this(criterion, null);
-    }
-
-    CosmosConditionExpression(Criterion criterion, String objectPrefix) {
+    protected ConditionExpression(Criterion criterion) {
         this.criterion = parse(criterion);
-        this.objectPrefix = objectPrefix;
     }
+
 
     /**
      * Checks whether the given {@link Criterion} is valid or not, i.e. if its {@linkplain Criterion#getOperator()} is
@@ -55,10 +62,12 @@ class CosmosConditionExpression {
      * type.
      */
     public Result<Void> isValidExpression() {
+        var criterion = getCriterion();
         var isSupportedOperator = SUPPORTED_PREPARED_STATEMENT_OPERATORS.contains(criterion.getOperator().toLowerCase());
         if (!isSupportedOperator) {
             return Result.failure("unsupported operator " + criterion.getOperator());
         }
+
 
         Object operandRight = criterion.getOperandRight();
         if (IN_OPERATOR.equalsIgnoreCase(criterion.getOperator()) && !(operandRight instanceof Iterable)) {
@@ -68,10 +77,74 @@ class CosmosConditionExpression {
     }
 
     /**
+     * Returns the criterion
+     *
+     * @return {@link Criterion}
+     */
+
+    public Criterion getCriterion() {
+        return criterion;
+    }
+
+    /**
+     * Returns the criterion
+     *
+     * @return The field path of the left operand
+     */
+
+    public abstract String getFieldPath();
+
+    /**
+     * Converts the {@link Criterion} into a string representation, that uses statement placeholders ("@xyz"). The
+     * corresponding parameters are available using {@link ConditionExpression#getParameters()}.
+     */
+    public abstract String toExpressionString();
+
+    /**
+     * This method replace the dot notation with the quoted property operator [\"\"] using the {@link QuotedPathCollector}
+     *
+     * @param path The input path
+     * @return the quoted path
+     */
+    public String quotePath(String path) {
+        return Arrays.stream(path.split(Pattern.quote("."))).collect(QuotedPathCollector.quoteJoining(RESERVED_WORDS));
+    }
+
+    /**
+     * Converts a right-operand into a simple Cosmos SQL statement placeholder ("@example"), or, if the operand is
+     * actually a list, converts it into "(@val1, @val2,...)", with as many placeholders as there are list items. The
+     * resulting String does not include the left-operand or the operator.
+     */
+    protected String toValuePlaceholder() {
+        var name = getName();
+        var operandRight = getCriterion().getOperandRight();
+        if (operandRight instanceof Iterable) {
+            return "(" + String.join(", ", getPlaceholderValues()) + ")";
+        }
+        return PREPARED_STATEMENT_PLACEHOLDER + name;
+    }
+
+    protected Criterion parse(Criterion criterion) {
+        if (IN_OPERATOR.equalsIgnoreCase(criterion.getOperator())) {
+            var tr = new TypeReference<List<String>>() {
+            };
+            try {
+                var list = new ObjectMapper().readValue(criterion.getOperandRight().toString(), tr);
+                return new Criterion(criterion.getOperandLeft(), criterion.getOperator(), list);
+            } catch (JsonProcessingException e) {
+                // not a list
+            }
+        }
+        return criterion;
+    }
+
+    /**
      * Converts the {@link Criterion#getOperandRight()} to a {@link List} of {@link SqlParameter} which can then be used
      * to execute prepared statements against CosmosDB.
      */
-    public List<SqlParameter> getParameters() {
+    protected List<SqlParameter> getParameters() {
+
+        var criterion = getCriterion();
 
         var operandRight = criterion.getOperandRight();
 
@@ -88,59 +161,13 @@ class CosmosConditionExpression {
     }
 
     /**
-     * Converts the {@link Criterion} into a string representation, that uses statement placeholders ("@xyz"). The
-     * corresponding parameters are available using {@link CosmosConditionExpression#getParameters()}.
-     */
-    public String toExpressionString() {
-        var operandLeft = sanitize(criterion.getOperandLeft().toString());
-        return objectPrefix != null ?
-                String.format(" %s.%s %s %s", objectPrefix, operandLeft, criterion.getOperator(), toValuePlaceholder()) :
-                String.format(" %s %s %s", operandLeft, criterion.getOperator(), toValuePlaceholder());
-    }
-
-    private Criterion parse(Criterion criterion) {
-        if (IN_OPERATOR.equalsIgnoreCase(criterion.getOperator())) {
-            var tr = new TypeReference<List<String>>() {
-            };
-            try {
-                var list = new ObjectMapper().readValue(criterion.getOperandRight().toString(), tr);
-                return new Criterion(criterion.getOperandLeft(), criterion.getOperator(), list);
-            } catch (JsonProcessingException e) {
-                // not a list
-            }
-        }
-        return criterion;
-    }
-
-    /**
-     * Converts a right-operand into a simple Cosmos SQL statement placeholder ("@example"), or, if the operand is
-     * actually a list, converts it into "(@val1, @val2,...)", with as many placeholders as there are list items. The
-     * resulting String does not include the left-operand or the operator.
-     */
-    private String toValuePlaceholder() {
-        var name = getName();
-        var operandRight = criterion.getOperandRight();
-        if (operandRight instanceof Iterable) {
-            return "(" + String.join(", ", getPlaceholderValues()) + ")";
-        }
-        return PREPARED_STATEMENT_PLACEHOLDER + name;
-    }
-
-    private String getName() {
-        return criterion.getOperandLeft().toString()
-                .replace(":", "_")
-                .replace(".", "_")
-                .replace("[", "")
-                .replace("]", "")
-                .replaceAll("[0-9]", "");
-    }
-
-    /**
      * Converts the right-operand into a set of SQL parameter placeholders, e.g. converts {@code foo IN ["bar", "baz"]}
      * into a List containing {@code ["@foo0", "@foo1"]}. If the right-operand is not a list-type object, it would
      * simply return a singleton list
      */
     private List<String> getPlaceholderValues() {
+        var criterion = getCriterion();
+
         var operandRight = criterion.getOperandRight();
         var name = getName();
         if (operandRight instanceof Iterable) {
@@ -153,8 +180,18 @@ class CosmosConditionExpression {
         }
     }
 
+    private String getName() {
+        return getFieldPath()
+                .replace(":", "_")
+                .replace(".", "_")
+                .replace("[", "")
+                .replace("]", "")
+                .replaceAll("[0-9]", "");
+    }
+
     @NotNull
     private String generateParameter(String name) {
         return PREPARED_STATEMENT_PLACEHOLDER + name;
     }
+
 }

--- a/extensions/common/azure/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/ConditionExpressionParser.java
+++ b/extensions/common/azure/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/ConditionExpressionParser.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.azure.cosmos.dialect;
+
+import org.eclipse.dataspaceconnector.azure.cosmos.CosmosDocument;
+import org.eclipse.dataspaceconnector.common.reflection.ReflectionUtil;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * It's the main entry point for translating a {@link Criterion} to the right {@link ConditionExpression}
+ * It chooses which will be the correct translation strategy for mapping to a CosmosDB SQL condition expression
+ */
+public class ConditionExpressionParser {
+
+    private final Class<? extends CosmosDocument<?>> objectType;
+
+    /**
+     * The default constructor of {@link ConditionExpressionParser}.
+     * Since the objectType is missing the default translation strategy will
+     * be applied, which cannot leverage the reflection on objectType
+     */
+    public ConditionExpressionParser() {
+        this(null);
+    }
+
+    /**
+     * The default constructor of {@link ConditionExpressionParser}.
+     * If the objectType is present a translation strategy based on reflection can be applied
+     *
+     * @param objectType The runtime type of object which can be queried.
+     */
+    public ConditionExpressionParser(Class<? extends CosmosDocument<?>> objectType) {
+        this.objectType = objectType;
+    }
+
+    /**
+     * Returns a {@link ConditionExpression} for the given parameters
+     * This is an abstraction for condition rewrite rules. By default, there is no rewrite rule and
+     * the {@link Criterion} will be translated as path expression. E.g. `object.name = foo'
+     *
+     * @param criterion    The filtering condition
+     * @param objectPrefix The object prefix if any
+     * @return {@link ConditionExpression}
+     */
+    @NotNull
+    public ConditionExpression parse(Criterion criterion, String objectPrefix) {
+        ConditionExpression defaultExpression = new CosmosPathConditionExpression(criterion, objectPrefix);
+        if (objectType != null) {
+            var wrappedType = ReflectionUtil.getSingleSuperTypeGenericArgument(objectType, CosmosDocument.class);
+            if (wrappedType != null) {
+                var existExpression = CosmosExistsExpression.parse(wrappedType, criterion, objectPrefix);
+                if (existExpression != null) {
+                    defaultExpression = existExpression;
+                }
+            }
+        }
+        return defaultExpression;
+    }
+
+
+}

--- a/extensions/common/azure/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/CosmosExistsExpression.java
+++ b/extensions/common/azure/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/CosmosExistsExpression.java
@@ -1,0 +1,111 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.azure.cosmos.dialect;
+
+import org.eclipse.dataspaceconnector.common.reflection.ReflectionUtil;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.eclipse.dataspaceconnector.azure.cosmos.CosmosDocument.sanitize;
+
+/**
+ * This is an implementation of {@link ConditionExpression} which rewrite the path expression {@code obj.something = foo}
+ * with an EXISTS expression if a collection field is present in the dot notation path. This is a rewrite rule for
+ * supporting array querying in CosmosDB
+ * <p>
+ * For example the expression {@code obj.collections.name = foo }
+ * will be rewritten as {@code EXITS(SELECT VALUE t from t in obj.collections WHERE t.name = @obj.collections.name )}
+ * if the field collections is an actual Java collection detected in the {@link CosmosExistsExpression#parse } method
+ */
+public class CosmosExistsExpression extends ConditionExpression {
+
+    private static final String SUBQUERY_TARGET_ALIAS = "t";
+    private static final String EXISTS_SUBQUERY = " EXISTS(SELECT VALUE %s FROM %s IN %s WHERE %s %s %s)";
+    private final Class<?> target;
+    private final String objectPrefix;
+    private final String collectionPrefix;
+
+    private CosmosExistsExpression(Class<?> target, Criterion criterion, String collectionPrefix, String objectPrefix) {
+        super(criterion);
+        Objects.requireNonNull(collectionPrefix, "Collection prefix should not be null in case of exists expression");
+        this.target = target;
+        this.objectPrefix = objectPrefix;
+        this.collectionPrefix = collectionPrefix;
+    }
+
+
+    /**
+     * Construct the {@link CosmosExistsExpression} if the Exists expression can be applied to the input {@link Criterion} by checking if in the left operand dot notation,
+     * a field of type {@link Collection} is present in the path.
+     *
+     * @param clazz        the class used for checking the field collection
+     * @param criterion    the filter criteria
+     * @param objectPrefix the object prefix
+     * @return Optionally if the collection field is detected returns a {@link CosmosExistsExpression}
+     */
+    public static CosmosExistsExpression parse(Class<?> clazz, Criterion criterion, String objectPrefix) {
+        var path = criterion.getOperandLeft().toString();
+        var fields = ReflectionUtil.getAllFieldsRecursiveWithPath(clazz, path);
+        var collectionIndexes = collectionIndex(fields);
+        if (collectionIndexes.size() != 1) {
+            return null;
+        } else {
+            var collectionIdx = collectionIndexes.get(0);
+            // if the collection field is the last the exists expression cannot be used
+            if (collectionIdx == fields.size() - 1) {
+                return null;
+            }
+            var pathParts = Arrays.asList(path.split(Pattern.quote(".")));
+
+            // Partition the path in 2 groups based on the collection field index
+            // E.g. [obj, collections, name] => [obj, collections] - [name]
+            var pathPartitions = pathParts.stream().collect(Collectors.partitioningBy((item) -> pathParts.indexOf(item) <= collectionIdx));
+            var localPrefix = String.join(".", pathPartitions.get(true));
+            var localField = String.join(".", pathPartitions.get(false));
+            var newCriterion = new Criterion(localField, criterion.getOperator(), criterion.getOperandRight());
+
+            return new CosmosExistsExpression(clazz, newCriterion, localPrefix, objectPrefix);
+        }
+
+    }
+
+    private static List<Integer> collectionIndex(List<Field> fields) {
+        return IntStream.range(0, fields.size())
+                .filter(idx -> Collection.class.isAssignableFrom(fields.get(idx).getType()))
+                .boxed()
+                .collect(Collectors.toList());
+    }
+
+
+    @Override
+    public String getFieldPath() {
+        return collectionPrefix + "." + getCriterion().getOperandLeft().toString();
+    }
+
+    @Override
+    public String toExpressionString() {
+        var operandLeft = SUBQUERY_TARGET_ALIAS + "." + sanitize(getCriterion().getOperandLeft().toString());
+        var collectionField = objectPrefix != null ? objectPrefix + "." + collectionPrefix : collectionPrefix;
+        return String.format(EXISTS_SUBQUERY, SUBQUERY_TARGET_ALIAS, SUBQUERY_TARGET_ALIAS, quotePath(collectionField), quotePath(operandLeft), getCriterion().getOperator(), toValuePlaceholder());
+    }
+}

--- a/extensions/common/azure/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/CosmosPathConditionExpression.java
+++ b/extensions/common/azure/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/CosmosPathConditionExpression.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.azure.cosmos.dialect;
+
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+
+import static org.eclipse.dataspaceconnector.azure.cosmos.CosmosDocument.sanitize;
+
+class CosmosPathConditionExpression extends ConditionExpression {
+
+    private final String objectPrefix;
+
+    CosmosPathConditionExpression(Criterion criterion) {
+        this(criterion, null);
+    }
+
+    CosmosPathConditionExpression(Criterion criterion, String objectPrefix) {
+        super(criterion);
+        this.objectPrefix = objectPrefix;
+    }
+
+
+    @Override
+    public String getFieldPath() {
+        return getCriterion().getOperandLeft().toString();
+    }
+
+    /**
+     * Converts the {@link Criterion} into a string representation, that uses statement placeholders ("@xyz"). The
+     * corresponding parameters are available using {@link CosmosPathConditionExpression#getParameters()}.
+     */
+    @Override
+    public String toExpressionString() {
+        var operandLeft = sanitize(getCriterion().getOperandLeft().toString());
+        return objectPrefix != null ?
+                String.format(" %s.%s %s %s", objectPrefix, operandLeft, getCriterion().getOperator(), toValuePlaceholder()) :
+                String.format(" %s %s %s", operandLeft, getCriterion().getOperator(), toValuePlaceholder());
+    }
+
+
+}

--- a/extensions/common/azure/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/QuotedPathCollector.java
+++ b/extensions/common/azure/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/QuotedPathCollector.java
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.azure.cosmos.dialect;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+
+/**
+ * In Cosmos there are some reserved keywords that cannot be used in projections or filter condition e.g. {@code obj.value}.
+ * This collector join a list of strings taking the account the reserved words in input. The reserved word will not be joined
+ * with a dot, but they will be encapsulated in a quoted property operator [\"\"]
+ */
+public class QuotedPathCollector implements Collector<CharSequence, StringBuilder, String> {
+
+    private final List<String> reservedWords;
+    private CharSequence lastChar;
+
+    QuotedPathCollector(List<String> reservedWords) {
+        this.reservedWords = reservedWords;
+    }
+
+    public static QuotedPathCollector quoteJoining(List<String> reservedWords) {
+        return new QuotedPathCollector(reservedWords);
+    }
+
+    @Override
+    public Supplier<StringBuilder> supplier() {
+        return StringBuilder::new;
+    }
+
+    @Override
+    public BiConsumer<StringBuilder, CharSequence> accumulator() {
+        return (stringBuilder, charSequence) -> {
+            var isReservedKeyword = reservedWords.contains(charSequence.toString());
+            if (lastChar != null && !isReservedKeyword) {
+                stringBuilder.append(".");
+            }
+            if (isReservedKeyword) {
+                stringBuilder.append(String.format("[\"%s\"]", charSequence));
+
+            } else {
+                stringBuilder.append(charSequence);
+            }
+            lastChar = charSequence;
+        };
+    }
+
+    @Override
+    public BinaryOperator<StringBuilder> combiner() {
+        return (stringBuilder, stringBuilder2) -> {
+            stringBuilder.append(stringBuilder2);
+            return stringBuilder;
+        };
+    }
+
+    @Override
+    public Function<StringBuilder, String> finisher() {
+        return StringBuilder::toString;
+    }
+
+
+    @Override
+    public Set<Characteristics> characteristics() {
+        return Set.of(Characteristics.UNORDERED);
+    }
+}

--- a/extensions/common/azure/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/SqlStatement.java
+++ b/extensions/common/azure/cosmos-common/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/SqlStatement.java
@@ -58,7 +58,7 @@ public class SqlStatement<T extends CosmosDocument<?>> {
      * @param criteria A list of criteria
      */
     public SqlStatement<T> where(List<Criterion> criteria) {
-        whereClause = new WhereClause(criteria, String.join(".", objectType.getSimpleName(), wrapperPrefix));
+        whereClause = new WhereClause(objectType, criteria, String.join(".", objectType.getSimpleName(), wrapperPrefix));
         return this;
     }
 

--- a/extensions/common/azure/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/TestCollectionDocument.java
+++ b/extensions/common/azure/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/TestCollectionDocument.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.azure.cosmos;
+
+import java.util.List;
+
+public class TestCollectionDocument extends CosmosDocument<TestCollectionDocument.TestWrappedTarget> {
+
+
+    protected TestCollectionDocument(TestCollectionDocument.TestWrappedTarget wrappedInstance, String partitionKey) {
+        super(wrappedInstance, partitionKey);
+    }
+
+    @Override
+    public String getId() {
+        return null;
+    }
+
+    public static class TestWrappedTarget {
+        private TestEmbedded embedded;
+    }
+
+    static class TestEmbedded {
+        private List<TestCollection> collections;
+    }
+
+    static class TestCollection {
+        private String name;
+        private String value;
+    }
+}

--- a/extensions/common/azure/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/ConditionExpressionParserTest.java
+++ b/extensions/common/azure/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/ConditionExpressionParserTest.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.azure.cosmos.dialect;
+
+import org.eclipse.dataspaceconnector.azure.cosmos.TestCollectionDocument;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConditionExpressionParserTest {
+    private final String objectPrefix = "test";
+
+    @Test
+    void conditionExpression_isPathExpression_withoutTarget() {
+        assertThat(new ConditionExpressionParser(null).parse(new Criterion("foo", "in", "bar"), objectPrefix)).isInstanceOf(CosmosPathConditionExpression.class);
+    }
+
+    @Test
+    void conditionExpression_isPathExpression_withTarget() {
+        assertThat(new ConditionExpressionParser(TestCollectionDocument.class).parse(new Criterion("foo", "in", "bar"), objectPrefix)).isInstanceOf(CosmosPathConditionExpression.class);
+    }
+
+    @Test
+    void conditionExpression_isPathExpression_withTerminatorCollectionField() {
+        assertThat(new ConditionExpressionParser(TestCollectionDocument.class).parse(new Criterion("embedded.collections", "=", "bar"), objectPrefix)).isInstanceOf(CosmosPathConditionExpression.class);
+    }
+
+    @Test
+    void conditionExpression_isExistsExpression() {
+        assertThat(new ConditionExpressionParser(TestCollectionDocument.class).parse(new Criterion("embedded.collections.name", "=", "bar"), objectPrefix)).isInstanceOf(CosmosExistsExpression.class);
+    }
+
+
+}

--- a/extensions/common/azure/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/CosmosExistsExpressionTest.java
+++ b/extensions/common/azure/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/CosmosExistsExpressionTest.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.azure.cosmos.dialect;
+
+import org.eclipse.dataspaceconnector.azure.cosmos.TestCollectionDocument;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CosmosExistsExpressionTest {
+
+    private final String objectPrefix = "test";
+
+    @Test
+    void isInvalidExpression_withNoMatchedFields() {
+        var expr = CosmosExistsExpression.parse(TestCollectionDocument.TestWrappedTarget.class, new Criterion("foo", "in", List.of("bar")), objectPrefix);
+        assertThat(expr).isNull();
+
+    }
+
+    @Test
+    void isInvalidExpression_withNoCollectionField() {
+        var expr = CosmosExistsExpression.parse(TestCollectionDocument.TestWrappedTarget.class, new Criterion("embedded", "=", "bar"), objectPrefix);
+        assertThat(expr).isNull();
+
+    }
+
+    @Test
+    void isInvalidExpression_withTerminatorCollectionField() {
+        var expr = CosmosExistsExpression.parse(TestCollectionDocument.TestWrappedTarget.class, new Criterion("embedded.collections", "=", "bar"), objectPrefix);
+        assertThat(expr).isNull();
+
+    }
+
+
+    @Test
+    void isValidExpression() {
+        var expr = CosmosExistsExpression.parse(TestCollectionDocument.TestWrappedTarget.class, new Criterion("embedded.collections.name", "in", List.of("bar")), objectPrefix);
+        assertThat(expr).isNotNull();
+
+    }
+
+    @Test
+    void isValidExpression_invalidOperator() {
+        var expr = CosmosExistsExpression.parse(TestCollectionDocument.TestWrappedTarget.class, new Criterion("embedded.collections.name", "is_subset_of", List.of("bar")), objectPrefix);
+        assertThat(expr).isNotNull();
+        assertThat(expr.isValidExpression().succeeded()).isFalse();
+    }
+
+    @Test
+    void isValidExpression_wrongOperand() {
+        var expr = CosmosExistsExpression.parse(TestCollectionDocument.TestWrappedTarget.class, new Criterion("embedded.collections.name", "is_subset_of", List.of("bar")), objectPrefix);
+        assertThat(expr).isNotNull();
+        assertThat(expr.isValidExpression().succeeded()).isFalse();
+
+    }
+
+    @Test
+    void toExpressionString() {
+        var expr = CosmosExistsExpression.parse(TestCollectionDocument.TestWrappedTarget.class, new Criterion("embedded.collections.name", "=", "baz"), objectPrefix);
+        assertThat(expr).isNotNull();
+        assertThat(expr.toExpressionString()).isEqualToIgnoringWhitespace("EXISTS(SELECT VALUE t FROM t IN test.embedded.collections WHERE t.name = @embedded_collections_name)");
+    }
+
+    @Test
+    void toExpressionStringQuoted() {
+        var expr = CosmosExistsExpression.parse(TestCollectionDocument.TestWrappedTarget.class, new Criterion("embedded.collections.value", "=", "baz"), objectPrefix);
+        assertThat(expr).isNotNull();
+        assertThat(expr.toExpressionString()).isEqualToIgnoringWhitespace("EXISTS(SELECT VALUE t FROM t IN test.embedded.collections WHERE t[\"value\"] = @embedded_collections_value)");
+    }
+
+}

--- a/extensions/common/azure/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/CosmosPathConditionExpressionTest.java
+++ b/extensions/common/azure/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/CosmosPathConditionExpressionTest.java
@@ -21,58 +21,58 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class CosmosConditionExpressionTest {
+class CosmosPathConditionExpressionTest {
 
 
     private final String objectPrefix = "test";
 
     @Test
     void isValidExpression() {
-        var expr = new CosmosConditionExpression(new Criterion("foo", "in", List.of("bar")), objectPrefix);
+        var expr = new CosmosPathConditionExpression(new Criterion("foo", "in", List.of("bar")), objectPrefix);
         assertThat(expr.isValidExpression().succeeded()).isTrue();
 
     }
 
     @Test
     void isValidExpression_wrongOperand() {
-        var expr = new CosmosConditionExpression(new Criterion("foo", "in", "bar"), objectPrefix);
+        var expr = new CosmosPathConditionExpression(new Criterion("foo", "in", "bar"), objectPrefix);
         assertThat(expr.isValidExpression().succeeded()).isFalse();
 
     }
 
     @Test
     void isValidExpression_invalidOperator() {
-        var expr2 = new CosmosConditionExpression(new Criterion("foo", "is_subset_of", List.of("bar")), objectPrefix);
+        var expr2 = new CosmosPathConditionExpression(new Criterion("foo", "is_subset_of", List.of("bar")), objectPrefix);
         assertThat(expr2.isValidExpression().succeeded()).isFalse();
     }
 
     @Test
     void toExpressionString_withList() {
-        var expr = new CosmosConditionExpression(new Criterion("foo", "in", List.of("bar", "baz")), objectPrefix);
+        var expr = new CosmosPathConditionExpression(new Criterion("foo", "in", List.of("bar", "baz")), objectPrefix);
         assertThat(expr.toExpressionString()).isEqualToIgnoringWhitespace("test.foo in (@foo0, @foo1)");
     }
 
     @Test
     void toExpressionString() {
-        var expr = new CosmosConditionExpression(new Criterion("foo", "=", "baz"), objectPrefix);
+        var expr = new CosmosPathConditionExpression(new Criterion("foo", "=", "baz"), objectPrefix);
         assertThat(expr.toExpressionString()).isEqualToIgnoringWhitespace("test.foo = @foo");
     }
 
     @Test
     void toExpressionString_withList_noPrefix() {
-        var expr = new CosmosConditionExpression(new Criterion("foo", "in", List.of("bar", "baz")));
+        var expr = new CosmosPathConditionExpression(new Criterion("foo", "in", List.of("bar", "baz")));
         assertThat(expr.toExpressionString()).isEqualToIgnoringWhitespace("foo in (@foo0, @foo1)");
     }
 
     @Test
     void toExpressionString_noPrefix() {
-        var expr = new CosmosConditionExpression(new Criterion("foo", "=", "baz"));
+        var expr = new CosmosPathConditionExpression(new Criterion("foo", "=", "baz"));
         assertThat(expr.toExpressionString()).isEqualToIgnoringWhitespace("foo = @foo");
     }
 
     @Test
     void toParameters() {
-        var expr = new CosmosConditionExpression(new Criterion("foo", "=", "baz"), objectPrefix);
+        var expr = new CosmosPathConditionExpression(new Criterion("foo", "=", "baz"), objectPrefix);
         assertThat(expr.getParameters()).hasSize(1).allSatisfy(c -> {
             assertThat(c.getName()).isEqualTo("@foo");
             assertThat(c.getValue(String.class)).isEqualTo("baz");
@@ -81,7 +81,7 @@ class CosmosConditionExpressionTest {
 
     @Test
     void toParameters_list() {
-        var expr = new CosmosConditionExpression(new Criterion("foo", "in", List.of("bar", "baz")), objectPrefix);
+        var expr = new CosmosPathConditionExpression(new Criterion("foo", "in", List.of("bar", "baz")), objectPrefix);
         assertThat(expr.getParameters()).hasSize(2)
                 .anySatisfy(c -> {
                     assertThat(c.getName()).isEqualTo("@foo0");

--- a/extensions/common/azure/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/QuotedPathCollectorTest.java
+++ b/extensions/common/azure/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/QuotedPathCollectorTest.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.azure.cosmos.dialect;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class QuotedPathCollectorTest {
+
+    static final List<String> RESERVED_WORDS = List.of("value");
+
+
+    @Test
+    void quotedPathCollector_withFinalKeyword() {
+        assertThat(Stream.of("obj", "value").collect(QuotedPathCollector.quoteJoining(RESERVED_WORDS))).isEqualTo("obj[\"value\"]");
+    }
+
+    @Test
+    void quotedPathCollector_withNoKeyword() {
+        assertThat(Stream.of("obj", "bar").collect(QuotedPathCollector.quoteJoining(RESERVED_WORDS))).isEqualTo("obj.bar");
+    }
+
+    @Test
+    void quotedPathCollector_withMiddleKeyword() {
+        assertThat(Stream.of("obj", "value", "bar").collect(QuotedPathCollector.quoteJoining(RESERVED_WORDS))).isEqualTo("obj[\"value\"].bar");
+    }
+
+    @Test
+    void quotedPathCollector_withMultipleKeyword() {
+        assertThat(Stream.of("obj", "value", "value").collect(QuotedPathCollector.quoteJoining(RESERVED_WORDS))).isEqualTo("obj[\"value\"][\"value\"]");
+    }
+}

--- a/extensions/common/azure/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/SqlStatementTest.java
+++ b/extensions/common/azure/cosmos-common/src/test/java/org/eclipse/dataspaceconnector/azure/cosmos/dialect/SqlStatementTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.azure.cosmos.dialect;
 
+import org.eclipse.dataspaceconnector.azure.cosmos.TestCollectionDocument;
 import org.eclipse.dataspaceconnector.cosmos.azure.TestCosmosDocument;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.junit.jupiter.api.Test;
@@ -87,5 +88,16 @@ class SqlStatementTest {
 
         stmt.orderBy("priority", false);
         assertThat(stmt.getQueryAsString()).isEqualTo("SELECT * FROM TestCosmosDocument ORDER BY TestCosmosDocument.wrappedInstance.priority DESC OFFSET 10 LIMIT 15");
+    }
+
+    @Test
+    void getQuerySpec_withCollectionField() {
+        var stmt = new SqlStatement<>(TestCollectionDocument.class)
+                .where(List.of(new Criterion("embedded.collections.name", "=", "1")))
+                .offset(10)
+                .limit(15);
+        assertThat(stmt.getQueryAsString())
+                .isEqualTo("SELECT * FROM TestCollectionDocument WHERE EXISTS(SELECT VALUE t FROM t IN TestCollectionDocument.wrappedInstance.embedded.collections WHERE t.name = @embedded_collections_name) OFFSET 10 LIMIT 15");
+
     }
 }

--- a/extensions/control-plane/store/cosmos/policy-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/cosmos/policy/store/CosmosPolicyDefinitionStoreIntegrationTest.java
+++ b/extensions/control-plane/store/cosmos/policy-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/cosmos/policy/store/CosmosPolicyDefinitionStoreIntegrationTest.java
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.mock;
 public class CosmosPolicyDefinitionStoreIntegrationTest extends PolicyDefinitionStoreTestBase {
     private static final String TEST_ID = UUID.randomUUID().toString();
     private static final String DATABASE_NAME = "connector-itest-" + TEST_ID;
-    private static final String CONTAINER_PREFIX = "ContractDefinitionStore-";
+    private static final String CONTAINER_PREFIX = "ContractPolicyDefinitionStore-";
     private static final String TEST_PARTITION_KEY = "test-part-key";
     private static CosmosContainer container;
     private static CosmosDatabase database;
@@ -265,7 +265,7 @@ public class CosmosPolicyDefinitionStoreIntegrationTest extends PolicyDefinition
 
     @Override
     protected boolean supportCollectionQuery() {
-        return false;
+        return true;
     }
 
     @Override

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/dataspaceconnector/contract/offer/store/ContractDefinitionStoreTestBase.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/dataspaceconnector/contract/offer/store/ContractDefinitionStoreTestBase.java
@@ -396,6 +396,27 @@ public abstract class ContractDefinitionStoreTestBase {
 
     @Test
     @EnabledIfSystemProperty(named = "contractdefinitionstore.supports.collectionQuery", matches = "true", disabledReason = "This test only runs if querying collection fields is supported")
+    void find_queryBySelectorExpression_rightAndLeft() {
+        var definitionsExpected = createContractDefinitions(20);
+        definitionsExpected.get(0).getSelectorExpression().getCriteria().add(new Criterion(Asset.PROPERTY_ID, "=", "test-asset"));
+        definitionsExpected.get(5).getSelectorExpression().getCriteria().add(new Criterion(Asset.PROPERTY_ID, "=", "foobar-asset"));
+        getContractDefinitionStore().save(definitionsExpected);
+
+        var spec = QuerySpec.Builder.newInstance()
+                .filter(List.of(
+                        new Criterion("selectorExpression.criteria.operandLeft", "=", Asset.PROPERTY_ID),
+                        new Criterion("selectorExpression.criteria.operandRight", "=", "foobar-asset")))
+                .build();
+
+        var definitionsRetrieved = getContractDefinitionStore().findAll(spec).collect(Collectors.toList());
+
+        assertThat(definitionsRetrieved).hasSize(1)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsOnly(definitionsExpected.get(5));
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = "contractdefinitionstore.supports.collectionQuery", matches = "true", disabledReason = "This test only runs if querying collection fields is supported")
     void find_queryMultiple() {
         var definitionsExpected = createContractDefinitions(20);
         definitionsExpected.forEach(d -> d.getSelectorExpression().getCriteria().add(new Criterion(Asset.PROPERTY_ID, "=", "test-asset")));


### PR DESCRIPTION
## What this PR changes/adds

Adds the support for the querying arrays when using the Cosmos store. The changes has been done at dialect level of the implementation of Cosmos store. 

An additional Expression has been added when translating the where condition into the Cosmos one. 
If in the Criterion left operand a collection is detected via reflection of `objectType` class in `SqlStatement` the single expression is rewritten using Cosmos `EXISTS` expression.

## Why it does that

Have the same support of Posgres store when querying arrays.

## Further notes

The test `CosmosContractDefinitionStoreIntegrationTest#find_queryBySelectorExpression_entireCriterion` has been disabled since we do not support matching against JSON in our current implementation

## Linked Issue(s)

Closes #1981 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
