### PR TITLE
fix: Add missing result check in DecentralizedIdentityService

### DIFF
--- a/extensions/common/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityService.java
+++ b/extensions/common/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityService.java
@@ -87,12 +87,16 @@ public class DecentralizedIdentityService implements IdentityService {
             monitor.debug("Verifying JWT with public key...");
             var verified = JwtUtils.verify(jwt, publicKeyWrapper, audience);
             if (verified.failed()) {
-                verified.getFailureMessages().forEach(m -> monitor.debug(() -> "Failure in token verification: " + m));
+                monitor.debug(() -> "Failure in token verification: " + verified.getFailureDetail());
                 return Result.failure("Token could not be verified!");
             }
 
             monitor.debug("verification successful! Fetching data from IdentityHub");
             var credentialsResult = credentialsVerifier.getVerifiedCredentials(didResult.getContent());
+            if (credentialsResult.failed()) {
+                monitor.debug(() -> "Failed to retrieve verified credentials: " + credentialsResult.getFailureDetail());
+                return Result.failure("Failed to get verifiable credentials: " + credentialsResult.getFailureDetail());
+            }
 
             monitor.debug("Building ClaimToken");
             var tokenBuilder = ClaimToken.Builder.newInstance();


### PR DESCRIPTION
## What this PR changes/adds

Add assertion of `Result` returned by `CredentialsVerifier` invokation.

## Why it does that

Prevent `NullPointerException` when `CredentialsVerifier` invokation fails.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
