### PR TITLE
feat: IDS catalog request filtering

### DIFF
--- a/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImpl.java
+++ b/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImpl.java
@@ -36,6 +36,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.stream.Stream.concat;
+
 /**
  * Implementation of the {@link ContractOfferService}.
  */
@@ -60,7 +62,7 @@ public class ContractOfferServiceImpl implements ContractOfferService {
         return definitionService.definitionsFor(agent, query.getDefinitionsRange())
                 .flatMap(definition -> {
                     var assetFilterQuery = QuerySpec.Builder.newInstance()
-                            .filter(Stream.concat(definition.getSelectorExpression().getCriteria().stream(), query.getAssetsCriteria().stream()).collect(Collectors.toList())).build();
+                            .filter(concat(definition.getSelectorExpression().getCriteria().stream(), query.getAssetsCriteria().stream()).collect(Collectors.toList())).build();
                     var assets = assetIndex.queryAssets(assetFilterQuery);
                     return Optional.of(definition.getContractPolicyId())
                             .map(policyStore::findById)

--- a/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImpl.java
+++ b/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImpl.java
@@ -59,7 +59,7 @@ public class ContractOfferServiceImpl implements ContractOfferService {
     public Stream<ContractOffer> queryContractOffers(ContractOfferQuery query) {
         var agent = agentService.createFor(query.getClaimToken());
 
-        return definitionService.definitionsFor(agent, query.getDefinitionsRange())
+        return definitionService.definitionsFor(agent, query.getRange())
                 .flatMap(definition -> {
                     var assetFilterQuery = QuerySpec.Builder.newInstance()
                             .filter(concat(definition.getSelectorExpression().getCriteria().stream(), query.getAssetsCriteria().stream()).collect(Collectors.toList())).build();

--- a/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImpl.java
+++ b/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImpl.java
@@ -57,10 +57,11 @@ public class ContractOfferServiceImpl implements ContractOfferService {
     public Stream<ContractOffer> queryContractOffers(ContractOfferQuery query) {
         var agent = agentService.createFor(query.getClaimToken());
 
-        return definitionService.definitionsFor(agent, query.getRange())
+        return definitionService.definitionsFor(agent, query.getDefinitionsRange())
                 .flatMap(definition -> {
-                    var assets = assetIndex.queryAssets(QuerySpec.Builder.newInstance()
-                            .filter(Stream.concat(definition.getSelectorExpression().getCriteria().stream(), query.getCriteria().stream()).collect(Collectors.toList())).build());
+                    var assetFilterQuery = QuerySpec.Builder.newInstance()
+                        .filter(Stream.concat(definition.getSelectorExpression().getCriteria().stream(), query.getAssetsCriteria().stream()).collect(Collectors.toList())).build();
+                    var assets = assetIndex.queryAssets(assetFilterQuery);
                     return Optional.of(definition.getContractPolicyId())
                             .map(policyStore::findById)
                             .map(policy -> assets.map(asset -> createContractOffer(definition, policy.getPolicy(), asset)))

--- a/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImpl.java
+++ b/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImpl.java
@@ -60,7 +60,7 @@ public class ContractOfferServiceImpl implements ContractOfferService {
         return definitionService.definitionsFor(agent, query.getDefinitionsRange())
                 .flatMap(definition -> {
                     var assetFilterQuery = QuerySpec.Builder.newInstance()
-                        .filter(Stream.concat(definition.getSelectorExpression().getCriteria().stream(), query.getAssetsCriteria().stream()).collect(Collectors.toList())).build();
+                            .filter(Stream.concat(definition.getSelectorExpression().getCriteria().stream(), query.getAssetsCriteria().stream()).collect(Collectors.toList())).build();
                     var assets = assetIndex.queryAssets(assetFilterQuery);
                     return Optional.of(definition.getContractPolicyId())
                             .map(policyStore::findById)

--- a/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImplTest.java
+++ b/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImplTest.java
@@ -112,7 +112,7 @@ class ContractOfferServiceImplTest {
                 .id("1")
                 .accessPolicyId("access")
                 .contractPolicyId("contract")
-                .selectorExpression(AssetSelectorExpression.Builder.newInstance().whenEquals(Asset.PROPERTY_ID, "1").build())
+                .selectorExpression(AssetSelectorExpression.Builder.newInstance().whenEquals(Asset.PROPERTY_NAME, "assetName").build())
                 .build();
 
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
@@ -124,7 +124,7 @@ class ContractOfferServiceImplTest {
         var query = ContractOfferQuery.builder()
                 .range(DEFAULT_RANGE)
                 .claimToken(ClaimToken.Builder.newInstance().build())
-                .assetsCriteria(List.of(new Criterion("asset:prop:id", "=", "2")))
+                .assetsCriteria(List.of(new Criterion(Asset.PROPERTY_ID, "=", "2")))
                 .build();
 
         var expectedQuerySpec =  QuerySpec.Builder.newInstance()

--- a/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImplTest.java
+++ b/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImplTest.java
@@ -74,7 +74,7 @@ class ContractOfferServiceImplTest {
         when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(assetStream);
         when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
 
-        var query = ContractOfferQuery.builder().range(DEFAULT_RANGE).claimToken(ClaimToken.Builder.newInstance().build()).build();
+        var query = ContractOfferQuery.builder().definitionsRange(DEFAULT_RANGE).claimToken(ClaimToken.Builder.newInstance().build()).build();
 
         assertThat(contractOfferService.queryContractOffers(query)).hasSize(2);
         verify(agentService).createFor(isA(ClaimToken.class));

--- a/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImplTest.java
+++ b/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImplTest.java
@@ -27,15 +27,19 @@ import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.policy.PolicyDefinition;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyDefinitionStore;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
+import static java.util.stream.Stream.concat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -74,7 +78,7 @@ class ContractOfferServiceImplTest {
         when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(assetStream);
         when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
 
-        var query = ContractOfferQuery.builder().definitionsRange(DEFAULT_RANGE).claimToken(ClaimToken.Builder.newInstance().build()).build();
+        var query = ContractOfferQuery.builder().range(DEFAULT_RANGE).claimToken(ClaimToken.Builder.newInstance().build()).build();
 
         assertThat(contractOfferService.queryContractOffers(query)).hasSize(2);
         verify(agentService).createFor(isA(ClaimToken.class));
@@ -100,5 +104,37 @@ class ContractOfferServiceImplTest {
         var result = contractOfferService.queryContractOffers(query);
 
         assertThat(result).hasSize(0);
+    }
+
+    @Test
+    void shouldGetContractOffersWithAssetFilteringApplied() {
+        var contractDefinition = ContractDefinition.Builder.newInstance()
+                .id("1")
+                .accessPolicyId("access")
+                .contractPolicyId("contract")
+                .selectorExpression(AssetSelectorExpression.Builder.newInstance().whenEquals(Asset.PROPERTY_ID, "1").build())
+                .build();
+
+        when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
+        when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class), any())).thenReturn(Stream.of(contractDefinition));
+        var assetStream = Stream.of(Asset.Builder.newInstance().build(), Asset.Builder.newInstance().build());
+        when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(assetStream);
+        when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
+
+        var query = ContractOfferQuery.builder()
+                .range(DEFAULT_RANGE)
+                .claimToken(ClaimToken.Builder.newInstance().build())
+                .assetsCriteria(List.of(new Criterion("asset:prop:id", "=", "2")))
+                .build();
+
+        var expectedQuerySpec =  QuerySpec.Builder.newInstance()
+                .filter(concat(contractDefinition.getSelectorExpression().getCriteria().stream(), query.getAssetsCriteria().stream())
+                      .collect(Collectors.toList())).build();
+
+        assertThat(contractOfferService.queryContractOffers(query)).hasSize(2);
+        verify(agentService).createFor(isA(ClaimToken.class));
+        verify(contractDefinitionService).definitionsFor(isA(ParticipantAgent.class), eq(DEFAULT_RANGE));
+        verify(policyStore).findById("contract");
+        verify(assetIndex).queryAssets(eq(expectedQuerySpec));
     }
 }

--- a/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImplTest.java
+++ b/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImplTest.java
@@ -27,6 +27,7 @@ import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.policy.PolicyDefinition;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyDefinitionStore;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
 import org.junit.jupiter.api.BeforeEach;
@@ -70,15 +71,14 @@ class ContractOfferServiceImplTest {
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
         when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class), any())).thenReturn(Stream.of(contractDefinition));
         var assetStream = Stream.of(Asset.Builder.newInstance().build(), Asset.Builder.newInstance().build());
-        when(assetIndex.queryAssets(isA(AssetSelectorExpression.class))).thenReturn(assetStream);
+        when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(assetStream);
         when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
 
-        var query = ContractOfferQuery.builder().claimToken(ClaimToken.Builder.newInstance().build()).build();
+        var query = ContractOfferQuery.builder().range(DEFAULT_RANGE).claimToken(ClaimToken.Builder.newInstance().build()).build();
 
-        assertThat(contractOfferService.queryContractOffers(query, DEFAULT_RANGE)).hasSize(2);
+        assertThat(contractOfferService.queryContractOffers(query)).hasSize(2);
         verify(agentService).createFor(isA(ClaimToken.class));
         verify(contractDefinitionService).definitionsFor(isA(ParticipantAgent.class), eq(DEFAULT_RANGE));
-        verify(assetIndex).queryAssets(isA(AssetSelectorExpression.class));
         verify(policyStore).findById("contract");
     }
 
@@ -97,7 +97,7 @@ class ContractOfferServiceImplTest {
 
         var query = ContractOfferQuery.builder().claimToken(ClaimToken.Builder.newInstance().build()).build();
 
-        var result = contractOfferService.queryContractOffers(query, DEFAULT_RANGE);
+        var result = contractOfferService.queryContractOffers(query);
 
         assertThat(result).hasSize(0);
     }

--- a/core/federated-catalog/federated-catalog-core/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/BatchedRequestFetcher.java
+++ b/core/federated-catalog/federated-catalog-core/src/main/java/org/eclipse/dataspaceconnector/catalog/cache/query/BatchedRequestFetcher.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.catalog.cache.query;
 import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.CatalogRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
@@ -53,7 +54,7 @@ public class BatchedRequestFetcher {
     @NotNull
     public CompletableFuture<List<ContractOffer>> fetch(CatalogRequest catalogRequest, int from, int batchSize) {
         var range = new Range(from, from + batchSize);
-        var rq = catalogRequest.toBuilder().range(range).build();
+        var rq = catalogRequest.toBuilder().querySpec(QuerySpec.Builder.newInstance().range(range).build()).build();
 
         return dispatcherRegistry.send(Catalog.class, rq, () -> null)
                 .thenApply(Catalog::getContractOffers)
@@ -72,11 +73,4 @@ public class BatchedRequestFetcher {
         list1.addAll(list2);
         return list1;
     }
-
-
-    private Catalog getCatalog(CatalogRequest catalogRequest, int from, int to) {
-        var future = dispatcherRegistry.send(Catalog.class, catalogRequest.toBuilder().range(new Range(from, to)).build(), () -> null);
-        return future.join();
-    }
-
 }

--- a/core/federated-catalog/federated-catalog-core/src/test/java/org/eclipse/dataspaceconnector/catalog/query/BatchedRequestFetcherTest.java
+++ b/core/federated-catalog/federated-catalog-core/src/test/java/org/eclipse/dataspaceconnector/catalog/query/BatchedRequestFetcherTest.java
@@ -70,10 +70,9 @@ class BatchedRequestFetcherTest {
 
         // verify the sequence of requests
         assertThat(captor.getAllValues())
-                .extracting(CatalogRequest::getRange)
+                .extracting(l -> l.getQuerySpec().getRange())
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactly(new Range(0, 5), new Range(5, 10), new Range(10, 15), new Range(15, 20));
-
     }
 
     private CatalogRequest createRequest() {

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/type/MultipartCatalogDescriptionRequestSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/type/MultipartCatalogDescriptionRequestSender.java
@@ -30,6 +30,7 @@ import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.respon
 import org.eclipse.dataspaceconnector.ids.core.util.CalendarUtil;
 import org.eclipse.dataspaceconnector.ids.spi.domain.IdsConstants;
 import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.CatalogRequest;
 
@@ -78,8 +79,7 @@ public class MultipartCatalogDescriptionRequestSender implements MultipartSender
                 ._recipientConnector_(Collections.singletonList(URI.create(request.getConnectorId())))
                 .build();
         //TODO: IDS REFACTORING: incorporate this into the protocol itself
-        message.setProperty(CatalogRequest.RANGE, request.getRange());
-        message.setProperty(CatalogRequest.FILTER, request.getFilter());
+        message.setProperty(QuerySpec.QUERY_SPEC, QuerySpec.Builder.newInstance().filter(request.getFilter()).range(request.getRange()).build());
         return message;
     }
 

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/type/MultipartCatalogDescriptionRequestSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/type/MultipartCatalogDescriptionRequestSender.java
@@ -79,7 +79,7 @@ public class MultipartCatalogDescriptionRequestSender implements MultipartSender
                 ._recipientConnector_(Collections.singletonList(URI.create(request.getConnectorId())))
                 .build();
         //TODO: IDS REFACTORING: incorporate this into the protocol itself
-        message.setProperty(QuerySpec.QUERY_SPEC, QuerySpec.Builder.newInstance().filter(request.getFilter()).range(request.getRange()).build());
+        message.setProperty(QuerySpec.QUERY_SPEC, request.getQuerySpec());
         return message;
     }
 

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/type/MultipartCatalogDescriptionRequestSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/type/MultipartCatalogDescriptionRequestSender.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
- *
+ *       ZF Friedrichshafen AG - enable asset filtering
  */
 
 package org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.type;
@@ -30,7 +30,6 @@ import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.respon
 import org.eclipse.dataspaceconnector.ids.core.util.CalendarUtil;
 import org.eclipse.dataspaceconnector.ids.spi.domain.IdsConstants;
 import org.eclipse.dataspaceconnector.spi.EdcException;
-import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.CatalogRequest;
 
@@ -79,16 +78,16 @@ public class MultipartCatalogDescriptionRequestSender implements MultipartSender
                 ._recipientConnector_(Collections.singletonList(URI.create(request.getConnectorId())))
                 .build();
         //TODO: IDS REFACTORING: incorporate this into the protocol itself
-        message.setProperty(Range.FROM, request.getRange().getFrom());
-        message.setProperty(Range.TO, request.getRange().getTo());
+        message.setProperty(CatalogRequest.RANGE, request.getRange());
+        message.setProperty(CatalogRequest.FILTER, request.getFilter());
         return message;
     }
-    
+
     @Override
     public String buildMessagePayload(CatalogRequest request) throws Exception {
         return null;
     }
-    
+
     /**
      * Parses the response content and extracts the catalog from the received self description.
      *

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsMultipartApiServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsMultipartApiServiceExtension.java
@@ -131,7 +131,7 @@ public final class IdsMultipartApiServiceExtension implements ServiceExtension {
 
         // create request handlers
         var handlers = new LinkedList<Handler>();
-        handlers.add(new DescriptionRequestHandler(monitor, connectorId, transformerRegistry, assetIndex, dataCatalogService, contractOfferService, connectorService));
+        handlers.add(new DescriptionRequestHandler(monitor, connectorId, transformerRegistry, assetIndex, dataCatalogService, contractOfferService, connectorService, objectMapper));
         handlers.add(new ArtifactRequestHandler(monitor, connectorId, objectMapper, contractNegotiationStore, contractValidationService, transferProcessManager, vault));
         handlers.add(new EndpointDataReferenceHandler(monitor, connectorId, endpointDataReferenceReceiverRegistry, endpointDataReferenceTransformerRegistry, context.getTypeManager()));
         handlers.add(new ContractRequestHandler(monitor, connectorId, objectMapper, providerNegotiationManager, transformerRegistry, assetIndex));

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/DescriptionRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/DescriptionRequestHandler.java
@@ -148,8 +148,7 @@ public class DescriptionRequestHandler implements Handler {
 
                 var contractOfferQuery = ContractOfferQuery.Builder.newInstance()
                         .claimToken(claimToken)
-                        .criterion(new Criterion(Asset.PROPERTY_ID, "=", assetId))
-                        .range(range)
+                        .assetsCriterion(new Criterion(Asset.PROPERTY_ID, "=", assetId))
                         .build();
                 var targetingContractOffers = contractOfferService.queryContractOffers(contractOfferQuery).collect(toList());
 

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/DescriptionRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/DescriptionRequestHandler.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.dataspaceconnector.ids.api.multipart.handler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import de.fraunhofer.iais.eis.Artifact;
 import de.fraunhofer.iais.eis.Connector;
 import de.fraunhofer.iais.eis.DescriptionRequestMessage;
@@ -57,6 +58,7 @@ public class DescriptionRequestHandler implements Handler {
     private final CatalogService catalogService;
     private final ContractOfferService contractOfferService;
     private final ConnectorService connectorService;
+    private final ObjectMapper objectMapper;
 
     public DescriptionRequestHandler(
             @NotNull Monitor monitor,
@@ -65,7 +67,8 @@ public class DescriptionRequestHandler implements Handler {
             @NotNull AssetIndex assetIndex,
             @NotNull CatalogService catalogService,
             @NotNull ContractOfferService contractOfferService,
-            @NotNull ConnectorService connectorService) {
+            @NotNull ConnectorService connectorService,
+            @NotNull ObjectMapper objectMapper) {
         this.monitor = monitor;
         this.connectorId = connectorId;
         this.transformerRegistry = transformerRegistry;
@@ -73,6 +76,7 @@ public class DescriptionRequestHandler implements Handler {
         this.catalogService = catalogService;
         this.contractOfferService = contractOfferService;
         this.connectorService = connectorService;
+        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -88,7 +92,7 @@ public class DescriptionRequestHandler implements Handler {
         // Get ID of requested element
         var requestedElement = IdsId.from(message.getRequestedElement());
 
-        var querySpec = getQuerySpec(message);
+        var querySpec = getQuerySpec(message, objectMapper);
 
         // Retrieve and transform requested element
         Result<? extends ModelClass> result;

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/util/RequestUtil.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/util/RequestUtil.java
@@ -14,17 +14,10 @@
 
 package org.eclipse.dataspaceconnector.ids.api.multipart.util;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import de.fraunhofer.iais.eis.DescriptionRequestMessage;
-import org.eclipse.dataspaceconnector.spi.message.Range;
-import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
-import org.eclipse.dataspaceconnector.spi.types.domain.catalog.CatalogRequest;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import static java.util.Optional.ofNullable;
 
@@ -34,33 +27,13 @@ public class RequestUtil {
      * Extracts an arbitrary property from a {@link DescriptionRequestMessage}
      *
      * @param message The message
+     * @param objectMapper The objectMapper
      * @return either the property parsed into specific type, or the default value
      */
-    public static QuerySpec getQuerySpec(@NotNull DescriptionRequestMessage message) {
+    public static QuerySpec getQuerySpec(@NotNull DescriptionRequestMessage message, ObjectMapper objectMapper) {
         return ofNullable(message.getProperties())
-            .map(map -> (Map) map.get(QuerySpec.QUERY_SPEC))
-            .map(spec -> QuerySpec.Builder.newInstance().filter(getFilter(spec)).range(getRange(spec)).build())
+            .map(map -> map.get(QuerySpec.QUERY_SPEC))
+            .map(specEntry -> objectMapper.convertValue(specEntry, QuerySpec.class))
             .orElse(QuerySpec.none());
-    }
-
-    private static Range getRange(Map map) {
-        return ofNullable(map.get(CatalogRequest.RANGE))
-            .map(v -> mapToRange((Map) v))
-            .orElse(new Range());
-    }
-
-    private static List<Criterion> getFilter(Map map) {
-        return ofNullable(map.get(QuerySpec.FILTER_EXPRESSION))
-            .map(v -> mapToListOfCriteria((List<Map>) v))
-            .orElse(Collections.emptyList());
-    }
-
-    private static Range mapToRange(Map map) {
-        return new Range((int) map.get(Range.FROM), (int) map.get(Range.TO));
-    }
-
-    private static List<Criterion> mapToListOfCriteria(List<Map> maps) {
-        return maps.stream().map(map -> new Criterion(map.get("operandLeft"), (String) map.get("operator"), map.get("operandRight")))
-            .collect(Collectors.toList());
     }
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/util/RequestUtil.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/util/RequestUtil.java
@@ -14,8 +14,6 @@
 
 package org.eclipse.dataspaceconnector.ids.api.multipart.util;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import de.fraunhofer.iais.eis.DescriptionRequestMessage;
 import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
@@ -24,12 +22,12 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static java.util.Optional.ofNullable;
 
 public class RequestUtil {
-
-    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     /**
      * Extracts an arbitrary property from a {@link DescriptionRequestMessage}
@@ -38,14 +36,25 @@ public class RequestUtil {
      * @return either the property parsed into specific type, or the default value
      */
     public static Range getRange(@NotNull DescriptionRequestMessage message) {
-        return ofNullable(message.getProperties().get(CatalogRequest.RANGE))
-            .map(v -> MAPPER.convertValue(v, Range.class))
+        return ofNullable(message.getProperties())
+            .map(map -> map.get(CatalogRequest.RANGE))
+            .map(v -> mapToRange((Map) v))
             .orElse(new Range());
     }
 
     public static List<Criterion> getFilter(@NotNull DescriptionRequestMessage message) {
-        return ofNullable(message.getProperties().get(CatalogRequest.FILTER))
-            .map(v -> MAPPER.convertValue(v, new TypeReference<List<Criterion>>() {}))
+        return ofNullable(message.getProperties())
+            .map(map -> map.get(CatalogRequest.FILTER))
+            .map(v -> mapToListOfCriterions((List<Map>) v))
             .orElse(Collections.emptyList());
+    }
+
+    private static Range mapToRange(Map map) {
+        return new Range((int) map.get("from"), (int) map.get("to"));
+    }
+
+    private static List<Criterion> mapToListOfCriterions(List<Map> maps) {
+        return maps.stream().map(map -> new Criterion(map.get("operandLeft"), (String) map.get("operator"), map.get("operandRight"))).collect(
+            Collectors.toList());
     }
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/util/RequestUtil.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/util/RequestUtil.java
@@ -14,25 +14,38 @@
 
 package org.eclipse.dataspaceconnector.ids.api.multipart.util;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import de.fraunhofer.iais.eis.DescriptionRequestMessage;
+import org.eclipse.dataspaceconnector.spi.message.Range;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.types.domain.catalog.CatalogRequest;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.List;
 
 import static java.util.Optional.ofNullable;
 
 public class RequestUtil {
 
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
     /**
      * Extracts an arbitrary property from a {@link DescriptionRequestMessage}
      *
      * @param message The message
-     * @param propertyName the name of the property
-     * @param defaultValue If the message does not contain that property the default value is returned.
-     * @return either the property parsed into an Integer, or the default value
+     * @return either the property parsed into specific type, or the default value
      */
-    public static int getInt(@NotNull DescriptionRequestMessage message, String propertyName, int defaultValue) {
-        return ofNullable(message.getProperties())
-                .map(map -> map.get(propertyName))
-                .map(v -> Integer.parseInt(v.toString()))
-                .orElse(defaultValue);
+    public static Range getRange(@NotNull DescriptionRequestMessage message) {
+        return ofNullable(message.getProperties().get(CatalogRequest.RANGE))
+            .map(v -> MAPPER.convertValue(v, Range.class))
+            .orElse(new Range());
+    }
+
+    public static List<Criterion> getFilter(@NotNull DescriptionRequestMessage message) {
+        return ofNullable(message.getProperties().get(CatalogRequest.FILTER))
+            .map(v -> MAPPER.convertValue(v, new TypeReference<List<Criterion>>() {}))
+            .orElse(Collections.emptyList());
     }
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/util/RequestUtil.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/util/RequestUtil.java
@@ -36,14 +36,11 @@ public class RequestUtil {
      * @param message The message
      * @return either the property parsed into specific type, or the default value
      */
-
     public static QuerySpec getQuerySpec(@NotNull DescriptionRequestMessage message) {
-        Map specsMap = (Map) ofNullable(message.getProperties()).map(map -> map.get(QuerySpec.QUERY_SPEC)).orElse(Map.of());
-
-        QuerySpec.Builder querySpecBuilder = QuerySpec.Builder.newInstance();
-        querySpecBuilder.filter(getFilter(specsMap));
-        querySpecBuilder.range(getRange(specsMap));
-        return querySpecBuilder.build();
+        return ofNullable(message.getProperties())
+            .map(map -> (Map) map.get(QuerySpec.QUERY_SPEC))
+            .map(spec -> QuerySpec.Builder.newInstance().filter(getFilter(spec)).range(getRange(spec)).build())
+            .orElse(QuerySpec.none());
     }
 
     private static Range getRange(Map map) {

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/util/RequestUtil.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/util/RequestUtil.java
@@ -54,7 +54,7 @@ public class RequestUtil {
     }
 
     private static List<Criterion> mapToListOfCriterions(List<Map> maps) {
-        return maps.stream().map(map -> new Criterion(map.get("operandLeft"), (String) map.get("operator"), map.get("operandRight"))).collect(
-            Collectors.toList());
+        return maps.stream().map(map -> new Criterion(map.get("operandLeft"), (String) map.get("operator"), map.get("operandRight")))
+            .collect(Collectors.toList());
     }
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/MultipartControllerIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/MultipartControllerIntegrationTest.java
@@ -253,7 +253,7 @@ public class MultipartControllerIntegrationTest {
                 .asset(asset)
                 .policy(createEverythingAllowedPolicy())
                 .build();
-        when(contractOfferService.queryContractOffers(any(), any())).thenReturn(Stream.of(contractOffer));
+        when(contractOfferService.queryContractOffers(any())).thenReturn(Stream.of(contractOffer));
 
         var request = createRequest(getDescriptionRequestMessage(
                 IdsId.Builder.newInstance().value(CATALOG_ID).type(IdsType.CATALOG).build()
@@ -496,7 +496,7 @@ public class MultipartControllerIntegrationTest {
                 .asset(asset)
                 .policy(createEverythingAllowedPolicy())
                 .build();
-        when(contractOfferService.queryContractOffers(any(), any())).thenReturn(Stream.of(contractOffer));
+        when(contractOfferService.queryContractOffers(any())).thenReturn(Stream.of(contractOffer));
 
         var request = createRequest(getDescriptionRequestMessage(
                 IdsId.Builder.newInstance().value(assetId).type(IdsType.RESOURCE).build()

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/DescriptionRequestHandlerTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/DescriptionRequestHandlerTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.ids.api.multipart.handler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import de.fraunhofer.iais.eis.Artifact;
 import de.fraunhofer.iais.eis.ArtifactBuilder;
 import de.fraunhofer.iais.eis.ArtifactRequestMessageBuilder;
@@ -46,7 +47,6 @@ import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
-import org.eclipse.dataspaceconnector.spi.types.domain.catalog.CatalogRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -97,7 +97,7 @@ class DescriptionRequestHandlerTest {
         connectorService = mock(ConnectorService.class);
 
         handler = new DescriptionRequestHandler(mock(Monitor.class), CONNECTOR_ID, transformerRegistry,
-                assetIndex, catalogService, contractOfferService, connectorService);
+                assetIndex, catalogService, contractOfferService, connectorService, new ObjectMapper());
     }
 
     @Test
@@ -271,7 +271,8 @@ class DescriptionRequestHandlerTest {
                 .build();
 
         Map<String, Object> specsMap = new HashMap<>();
-        specsMap.put(CatalogRequest.RANGE, Map.of("from", rangeFrom, "to", rangeTo));
+        specsMap.put(QuerySpec.OFFSET, rangeFrom);
+        specsMap.put(QuerySpec.LIMIT, rangeFrom + rangeTo);
         specsMap.put(QuerySpec.FILTER_EXPRESSION, List.of(Map.of("operandLeft", PROPERTY, "operator", EQUALS_SIGN, "operandRight", VALUE)));
         message.setProperty(QuerySpec.QUERY_SPEC, specsMap);
         return message;

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/DescriptionRequestHandlerTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/DescriptionRequestHandlerTest.java
@@ -79,6 +79,9 @@ class DescriptionRequestHandlerTest {
     private static final String PROPERTY = "property";
     private static final String VALUE = "value";
     private static final String EQUALS_SIGN = "=";
+    private static final String FILTER_EXPRESSION = "filterExpression";
+    private static final String OFFSET = "offset";
+    private static final String LIMIT = "limit";
 
     private DescriptionRequestHandler handler;
 
@@ -271,9 +274,9 @@ class DescriptionRequestHandlerTest {
                 .build();
 
         Map<String, Object> specsMap = new HashMap<>();
-        specsMap.put(QuerySpec.OFFSET, rangeFrom);
-        specsMap.put(QuerySpec.LIMIT, rangeFrom + rangeTo);
-        specsMap.put(QuerySpec.FILTER_EXPRESSION, List.of(Map.of("operandLeft", PROPERTY, "operator", EQUALS_SIGN, "operandRight", VALUE)));
+        specsMap.put(OFFSET, rangeFrom);
+        specsMap.put(LIMIT, rangeFrom + rangeTo);
+        specsMap.put(FILTER_EXPRESSION, List.of(Map.of("operandLeft", PROPERTY, "operator", EQUALS_SIGN, "operandRight", VALUE)));
         message.setProperty(QuerySpec.QUERY_SPEC, specsMap);
         return message;
     }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/util/RequestUtilTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/util/RequestUtilTest.java
@@ -1,0 +1,59 @@
+package org.eclipse.dataspaceconnector.ids.api.multipart.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.fraunhofer.iais.eis.DescriptionRequestMessageBuilder;
+import de.fraunhofer.iais.eis.DescriptionRequestMessageImpl;
+import org.eclipse.dataspaceconnector.spi.message.Range;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RequestUtilTest {
+
+    private static final int FROM = 0;
+    private static final int TO = 10;
+
+    private static final String PROPERTY = "property";
+    private static final String VALUE = "value";
+    private static final String EQUALS_SIGN = "=";
+    private static final String FILTER_EXPRESSION = "filterExpression";
+    private static final String OFFSET = "offset";
+    private static final String LIMIT = "limit";
+
+    @Test
+    public void shouldExtractQuerySpec() {
+        // given
+        var message = (DescriptionRequestMessageImpl) new DescriptionRequestMessageBuilder().build();
+        Map<String, Object> specsMap = new HashMap<>();
+
+        specsMap.put(OFFSET, FROM);
+        specsMap.put(LIMIT, TO);
+        specsMap.put(FILTER_EXPRESSION, List.of(Map.of("operandLeft", PROPERTY, "operator", EQUALS_SIGN, "operandRight", VALUE)));
+        message.setProperty(QuerySpec.QUERY_SPEC, specsMap);
+
+        var expectedSpec = QuerySpec.Builder.newInstance().filter(PROPERTY + EQUALS_SIGN + VALUE).range(new Range(FROM, TO)).build();
+
+        // when
+        var result = RequestUtil.getQuerySpec(message, new ObjectMapper());
+
+        // then
+        assertThat(result).isEqualTo(expectedSpec);
+    }
+
+    @Test
+    public void shouldExtractQuerySpec_defaultWhenMissing() {
+        // given
+        var message = (DescriptionRequestMessageImpl) new DescriptionRequestMessageBuilder().build();
+
+        // when
+        var result = RequestUtil.getQuerySpec(message, new ObjectMapper());
+
+        // then
+        assertThat(result).isEqualTo(QuerySpec.none());
+    }
+}

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImpl.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImpl.java
@@ -55,7 +55,7 @@ public class CatalogServiceImpl implements CatalogService {
         var query = ContractOfferQuery.Builder.newInstance()
                 .claimToken(claimToken)
                 .assetsCriteria(querySpec.getFilterExpression())
-                .definitionsRange(querySpec.getRange()).build();
+                .range(querySpec.getRange()).build();
 
         var offers = contractOfferService.queryContractOffers(query).collect(toList());
 

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImpl.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImpl.java
@@ -20,13 +20,11 @@ import org.eclipse.dataspaceconnector.ids.spi.service.CatalogService;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferQuery;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
-import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
 import java.util.Objects;
 
 import static java.util.stream.Collectors.toList;
@@ -52,9 +50,12 @@ public class CatalogServiceImpl implements CatalogService {
      */
     @Override
     @NotNull
-    public Catalog getDataCatalog(ClaimToken claimToken, Range range, List<Criterion> filters) {
+    public Catalog getDataCatalog(ClaimToken claimToken, QuerySpec querySpec) {
 
-        var query = ContractOfferQuery.Builder.newInstance().claimToken(claimToken).assetsCriteria(filters).definitionsRange(range).build();
+        var query = ContractOfferQuery.Builder.newInstance()
+                .claimToken(claimToken)
+                .assetsCriteria(querySpec.getFilterExpression())
+                .definitionsRange(querySpec.getRange()).build();
 
         var offers = contractOfferService.queryContractOffers(query).collect(toList());
 

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImpl.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImpl.java
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
+ *       ZF Friedrichshafen AG - enable asset filtering
  *
  */
 
@@ -21,9 +22,11 @@ import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
 import java.util.Objects;
 
 import static java.util.stream.Collectors.toList;
@@ -49,10 +52,11 @@ public class CatalogServiceImpl implements CatalogService {
      */
     @Override
     @NotNull
-    public Catalog getDataCatalog(ClaimToken claimToken, Range range) {
-        var query = ContractOfferQuery.Builder.newInstance().claimToken(claimToken).build();
+    public Catalog getDataCatalog(ClaimToken claimToken, Range range, List<Criterion> filters) {
 
-        var offers = contractOfferService.queryContractOffers(query, range).collect(toList());
+        var query = ContractOfferQuery.Builder.newInstance().claimToken(claimToken).criteria(filters).range(range).build();
+
+        var offers = contractOfferService.queryContractOffers(query).collect(toList());
 
         return Catalog.Builder.newInstance().id(dataCatalogId).contractOffers(offers).build();
     }

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImpl.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImpl.java
@@ -54,7 +54,7 @@ public class CatalogServiceImpl implements CatalogService {
     @NotNull
     public Catalog getDataCatalog(ClaimToken claimToken, Range range, List<Criterion> filters) {
 
-        var query = ContractOfferQuery.Builder.newInstance().claimToken(claimToken).criteria(filters).range(range).build();
+        var query = ContractOfferQuery.Builder.newInstance().claimToken(claimToken).assetsCriteria(filters).definitionsRange(range).build();
 
         var offers = contractOfferService.queryContractOffers(query).collect(toList());
 

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImpl.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImpl.java
@@ -23,7 +23,6 @@ import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
-import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
@@ -51,7 +50,7 @@ public class ConnectorServiceImpl implements ConnectorService {
     public Connector getConnector(@NotNull ClaimToken claimToken, Range range, List<Criterion> filters) {
         Objects.requireNonNull(claimToken);
 
-        Catalog catalog = dataCatalogService.getDataCatalog(claimToken, range, filters);
+        var catalog = dataCatalogService.getDataCatalog(claimToken, range, filters);
 
         return Connector.Builder
                 .newInstance()

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImpl.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImpl.java
@@ -20,13 +20,11 @@ import org.eclipse.dataspaceconnector.ids.spi.domain.connector.Connector;
 import org.eclipse.dataspaceconnector.ids.spi.service.CatalogService;
 import org.eclipse.dataspaceconnector.ids.spi.service.ConnectorService;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
-import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 
 public class ConnectorServiceImpl implements ConnectorService {
@@ -47,10 +45,10 @@ public class ConnectorServiceImpl implements ConnectorService {
 
     @NotNull
     @Override
-    public Connector getConnector(@NotNull ClaimToken claimToken, Range range, List<Criterion> filters) {
+    public Connector getConnector(@NotNull ClaimToken claimToken, QuerySpec querySpec) {
         Objects.requireNonNull(claimToken);
 
-        var catalog = dataCatalogService.getDataCatalog(claimToken, range, filters);
+        var catalog = dataCatalogService.getDataCatalog(claimToken, querySpec);
 
         return Connector.Builder
                 .newInstance()

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImpl.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImpl.java
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Daimler TSS GmbH - Initial API and Implementation
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
+ *       ZF Friedrichshafen AG - enable asset filtering
  *
  */
 
@@ -21,10 +22,12 @@ import org.eclipse.dataspaceconnector.ids.spi.service.ConnectorService;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 public class ConnectorServiceImpl implements ConnectorService {
@@ -45,10 +48,10 @@ public class ConnectorServiceImpl implements ConnectorService {
 
     @NotNull
     @Override
-    public Connector getConnector(@NotNull ClaimToken claimToken, Range range) {
+    public Connector getConnector(@NotNull ClaimToken claimToken, Range range, List<Criterion> filters) {
         Objects.requireNonNull(claimToken);
 
-        Catalog catalog = dataCatalogService.getDataCatalog(claimToken, range);
+        Catalog catalog = dataCatalogService.getDataCatalog(claimToken, range, filters);
 
         return Connector.Builder
                 .newInstance()

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImplTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImplTest.java
@@ -18,13 +18,12 @@ import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferQuery;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
-import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,7 +58,7 @@ class CatalogServiceImplTest {
                         .build());
         when(contractOfferService.queryContractOffers(any(ContractOfferQuery.class))).thenReturn(offers.stream());
 
-        var result = dataCatalogService.getDataCatalog(claimToken, new Range(0, 100), new ArrayList<>());
+        var result = dataCatalogService.getDataCatalog(claimToken, QuerySpec.none());
 
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(CATALOG_ID);

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImplTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImplTest.java
@@ -24,6 +24,7 @@ import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOf
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,14 +57,14 @@ class CatalogServiceImplTest {
                         .policy(Policy.Builder.newInstance().build())
                         .id("1")
                         .build());
-        when(contractOfferService.queryContractOffers(any(ContractOfferQuery.class), any())).thenReturn(offers.stream());
+        when(contractOfferService.queryContractOffers(any(ContractOfferQuery.class))).thenReturn(offers.stream());
 
-        var result = dataCatalogService.getDataCatalog(claimToken, new Range(0, 100));
+        var result = dataCatalogService.getDataCatalog(claimToken, new Range(0, 100), new ArrayList<>());
 
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(CATALOG_ID);
         assertThat(result.getContractOffers()).hasSameElementsAs(offers);
-        verify(contractOfferService).queryContractOffers(any(ContractOfferQuery.class), any());
+        verify(contractOfferService).queryContractOffers(any(ContractOfferQuery.class));
     }
 
 }

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImplTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImplTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.util.ArrayList;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -53,7 +54,7 @@ class ConnectorServiceImplTest {
 
     @Test
     void getConnector() {
-        when(dataCatalogService.getDataCatalog(any(), any())).thenReturn(mock(Catalog.class));
+        when(dataCatalogService.getDataCatalog(any(), any(), any())).thenReturn(mock(Catalog.class));
         when(connectorServiceSettings.getId()).thenReturn(CONNECTOR_ID);
         when(connectorServiceSettings.getTitle()).thenReturn(CONNECTOR_TITLE);
         when(connectorServiceSettings.getDescription()).thenReturn(CONNECTOR_DESCRIPTION);
@@ -63,7 +64,7 @@ class ConnectorServiceImplTest {
         when(connectorServiceSettings.getCurator()).thenReturn(CONNECTOR_CURATOR);
         var claimToken = ClaimToken.Builder.newInstance().build();
 
-        var result = connectorService.getConnector(claimToken, new Range(0, 100));
+        var result = connectorService.getConnector(claimToken, new Range(0, 100), new ArrayList<>());
 
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(CONNECTOR_ID);
@@ -74,7 +75,7 @@ class ConnectorServiceImplTest {
         assertThat(result.getMaintainer()).isEqualTo(CONNECTOR_MAINTAINER);
         assertThat(result.getCurator()).isEqualTo(CONNECTOR_CURATOR);
         assertThat(result.getConnectorVersion()).isEqualTo(CONNECTOR_VERSION);
-        verify(dataCatalogService).getDataCatalog(any(), any());
+        verify(dataCatalogService).getDataCatalog(any(), any(), any());
         verify(connectorServiceSettings).getId();
         verify(connectorServiceSettings).getTitle();
         verify(connectorServiceSettings).getDescription();

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImplTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImplTest.java
@@ -18,14 +18,13 @@ package org.eclipse.dataspaceconnector.ids.core.service;
 import org.eclipse.dataspaceconnector.ids.spi.domain.connector.SecurityProfile;
 import org.eclipse.dataspaceconnector.ids.spi.service.CatalogService;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
-import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
-import java.util.ArrayList;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -54,7 +53,7 @@ class ConnectorServiceImplTest {
 
     @Test
     void getConnector() {
-        when(dataCatalogService.getDataCatalog(any(), any(), any())).thenReturn(mock(Catalog.class));
+        when(dataCatalogService.getDataCatalog(any(), any())).thenReturn(mock(Catalog.class));
         when(connectorServiceSettings.getId()).thenReturn(CONNECTOR_ID);
         when(connectorServiceSettings.getTitle()).thenReturn(CONNECTOR_TITLE);
         when(connectorServiceSettings.getDescription()).thenReturn(CONNECTOR_DESCRIPTION);
@@ -64,7 +63,7 @@ class ConnectorServiceImplTest {
         when(connectorServiceSettings.getCurator()).thenReturn(CONNECTOR_CURATOR);
         var claimToken = ClaimToken.Builder.newInstance().build();
 
-        var result = connectorService.getConnector(claimToken, new Range(0, 100), new ArrayList<>());
+        var result = connectorService.getConnector(claimToken, QuerySpec.none());
 
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(CONNECTOR_ID);
@@ -75,7 +74,7 @@ class ConnectorServiceImplTest {
         assertThat(result.getMaintainer()).isEqualTo(CONNECTOR_MAINTAINER);
         assertThat(result.getCurator()).isEqualTo(CONNECTOR_CURATOR);
         assertThat(result.getConnectorVersion()).isEqualTo(CONNECTOR_VERSION);
-        verify(dataCatalogService).getDataCatalog(any(), any(), any());
+        verify(dataCatalogService).getDataCatalog(any(), any());
         verify(connectorServiceSettings).getId();
         verify(connectorServiceSettings).getTitle();
         verify(connectorServiceSettings).getDescription();

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/CatalogService.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/CatalogService.java
@@ -16,12 +16,9 @@
 package org.eclipse.dataspaceconnector.ids.spi.service;
 
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
-import org.eclipse.dataspaceconnector.spi.message.Range;
-import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.List;
 
 /**
  * The IDS service is able to create a description of the EDC data catalog.
@@ -34,5 +31,5 @@ public interface CatalogService {
      * @return data catalog
      */
     @NotNull
-    Catalog getDataCatalog(ClaimToken claimToken, Range range, List<Criterion> filters);
+    Catalog getDataCatalog(ClaimToken claimToken, QuerySpec querySpec);
 }

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/CatalogService.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/CatalogService.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
+ *       ZF Friedrichshafen AG - enable asset filtering
  *
  */
 
@@ -16,8 +17,11 @@ package org.eclipse.dataspaceconnector.ids.spi.service;
 
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.message.Range;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 /**
  * The IDS service is able to create a description of the EDC data catalog.
@@ -30,5 +34,5 @@ public interface CatalogService {
      * @return data catalog
      */
     @NotNull
-    Catalog getDataCatalog(ClaimToken claimToken, Range range);
+    Catalog getDataCatalog(ClaimToken claimToken, Range range, List<Criterion> filters);
 }

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/ConnectorService.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/ConnectorService.java
@@ -18,7 +18,10 @@ package org.eclipse.dataspaceconnector.ids.spi.service;
 import org.eclipse.dataspaceconnector.ids.spi.domain.connector.Connector;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.message.Range;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 /**
  * The IDS service is able to create IDS compliant descriptions of resources. These descriptions may be used to create a
@@ -32,5 +35,5 @@ public interface ConnectorService {
      * @return connector description
      */
     @NotNull
-    Connector getConnector(@NotNull ClaimToken claimToken, Range range);
+    Connector getConnector(@NotNull ClaimToken claimToken, Range range, List<Criterion> filters);
 }

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/ConnectorService.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/ConnectorService.java
@@ -17,11 +17,9 @@ package org.eclipse.dataspaceconnector.ids.spi.service;
 
 import org.eclipse.dataspaceconnector.ids.spi.domain.connector.Connector;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
-import org.eclipse.dataspaceconnector.spi.message.Range;
-import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
 
 /**
  * The IDS service is able to create IDS compliant descriptions of resources. These descriptions may be used to create a
@@ -35,5 +33,5 @@ public interface ConnectorService {
      * @return connector description
      */
     @NotNull
-    Connector getConnector(@NotNull ClaimToken claimToken, Range range, List<Criterion> filters);
+    Connector getConnector(@NotNull ClaimToken claimToken, QuerySpec querySpec);
 }

--- a/extensions/control-plane/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/service/CatalogServiceImpl.java
+++ b/extensions/control-plane/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/service/CatalogServiceImpl.java
@@ -36,8 +36,7 @@ public class CatalogServiceImpl implements CatalogService {
                 .protocol("ids-multipart")
                 .connectorId(providerUrl)
                 .connectorAddress(providerUrl)
-                .range(spec.getRange())
-                .filter(spec.getFilterExpression())
+                .querySpec(spec)
                 .build();
 
         return dispatcher.send(Catalog.class, request, () -> null);

--- a/extensions/control-plane/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/service/CatalogServiceImpl.java
+++ b/extensions/control-plane/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/service/CatalogServiceImpl.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft - initial API and implementation
+ *       ZF Friedrichshafen AG - enable asset filtering
  *
  */
 
@@ -36,6 +37,7 @@ public class CatalogServiceImpl implements CatalogService {
                 .connectorId(providerUrl)
                 .connectorAddress(providerUrl)
                 .range(spec.getRange())
+                .filter(spec.getFilterExpression())
                 .build();
 
         return dispatcher.send(Catalog.class, request, () -> null);

--- a/extensions/control-plane/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerTest.java
+++ b/extensions/control-plane/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerTest.java
@@ -53,7 +53,6 @@ class CatalogApiControllerTest {
         when(transformerRegistry.transform(any(), any())).thenReturn(Result.success(new QuerySpec()));
     }
 
-
     @Test
     void shouldGetTheCatalog() {
         var controller = new CatalogApiController(service, transformerRegistry, monitor);

--- a/spi/common/catalog-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/catalog/CatalogRequest.java
+++ b/spi/common/catalog-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/catalog/CatalogRequest.java
@@ -16,13 +16,11 @@ package org.eclipse.dataspaceconnector.spi.types.domain.catalog;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.eclipse.dataspaceconnector.spi.message.Range;
-import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.types.domain.message.RemoteMessage;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -31,21 +29,17 @@ import java.util.Objects;
 @JsonDeserialize(builder = CatalogRequest.Builder.class)
 public class CatalogRequest implements RemoteMessage {
 
-    public static final String RANGE = "range";
-
     private final String protocol;
     private final String connectorId;
     private final String connectorAddress;
-    private final Range range;
-    private final List<Criterion> filter;
+    private final QuerySpec querySpec;
 
-    private CatalogRequest(@NotNull String protocol, @NotNull String connectorId, @NotNull String connectorAddress, @Nullable Range range,
-            @Nullable List<Criterion> filter) {
+    private CatalogRequest(@NotNull String protocol, @NotNull String connectorId, @NotNull String connectorAddress,
+            @Nullable QuerySpec querySpec) {
         this.protocol = protocol;
         this.connectorId = connectorId;
         this.connectorAddress = connectorAddress;
-        this.range = range;
-        this.filter = filter;
+        this.querySpec = querySpec;
     }
 
     @NotNull
@@ -65,35 +59,27 @@ public class CatalogRequest implements RemoteMessage {
         return connectorId;
     }
 
-    public Range getRange() {
-        return range;
-    }
-
-    public List<Criterion> getFilter() {
-        return filter;
+    public QuerySpec getQuerySpec() {
+        return querySpec;
     }
 
     public Builder toBuilder() {
-        return new Builder(protocol, connectorId, connectorAddress, range, filter);
+        return new Builder(protocol, connectorId, connectorAddress, querySpec);
     }
 
     public static class Builder {
         private String protocol;
         private String connectorId;
         private String connectorAddress;
-        private Range range;
-        private List<Criterion> criteria;
+        private QuerySpec querySpec;
 
-        private Builder() {
+        private Builder() {}
 
-        }
-
-        private Builder(String protocol, String connectorId, String connectorAddress, Range range, List<Criterion> criteria) {
+        private Builder(String protocol, String connectorId, String connectorAddress, QuerySpec querySpec) {
             this.protocol = protocol;
             this.connectorId = connectorId;
             this.connectorAddress = connectorAddress;
-            this.range = range;
-            this.criteria = criteria;
+            this.querySpec = querySpec;
         }
 
         @JsonCreator
@@ -116,13 +102,8 @@ public class CatalogRequest implements RemoteMessage {
             return this;
         }
 
-        public CatalogRequest.Builder range(Range range) {
-            this.range = range;
-            return this;
-        }
-
-        public CatalogRequest.Builder filter(List<Criterion> criteria) {
-            this.criteria = criteria;
+        public CatalogRequest.Builder querySpec(QuerySpec querySpec) {
+            this.querySpec = querySpec;
             return this;
         }
 
@@ -131,7 +112,7 @@ public class CatalogRequest implements RemoteMessage {
             Objects.requireNonNull(connectorId, "connectorId");
             Objects.requireNonNull(connectorAddress, "connectorAddress");
 
-            return new CatalogRequest(protocol, connectorId, connectorAddress, range, criteria);
+            return new CatalogRequest(protocol, connectorId, connectorAddress, querySpec);
         }
     }
 }

--- a/spi/common/catalog-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/catalog/CatalogRequest.java
+++ b/spi/common/catalog-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/catalog/CatalogRequest.java
@@ -17,10 +17,12 @@ package org.eclipse.dataspaceconnector.spi.types.domain.catalog;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.eclipse.dataspaceconnector.spi.message.Range;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.types.domain.message.RemoteMessage;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -29,16 +31,22 @@ import java.util.Objects;
 @JsonDeserialize(builder = CatalogRequest.Builder.class)
 public class CatalogRequest implements RemoteMessage {
 
+    public static final String FILTER = "filter";
+    public static final String RANGE = "range";
+
     private final String protocol;
     private final String connectorId;
     private final String connectorAddress;
     private final Range range;
+    private final List<Criterion> filter;
 
-    private CatalogRequest(@NotNull String protocol, @NotNull String connectorId, @NotNull String connectorAddress, @Nullable Range range) {
+    private CatalogRequest(@NotNull String protocol, @NotNull String connectorId, @NotNull String connectorAddress, @Nullable Range range,
+            @Nullable List<Criterion> filter) {
         this.protocol = protocol;
         this.connectorId = connectorId;
         this.connectorAddress = connectorAddress;
         this.range = range;
+        this.filter = filter;
     }
 
     @NotNull
@@ -62,9 +70,12 @@ public class CatalogRequest implements RemoteMessage {
         return range;
     }
 
+    public List<Criterion> getFilter() {
+        return filter;
+    }
 
     public Builder toBuilder() {
-        return new Builder(protocol, connectorId, connectorAddress, range);
+        return new Builder(protocol, connectorId, connectorAddress, range, filter);
     }
 
     public static class Builder {
@@ -72,16 +83,18 @@ public class CatalogRequest implements RemoteMessage {
         private String connectorId;
         private String connectorAddress;
         private Range range;
+        private List<Criterion> criteria;
 
         private Builder() {
 
         }
 
-        private Builder(String protocol, String connectorId, String connectorAddress, Range range) {
+        private Builder(String protocol, String connectorId, String connectorAddress, Range range, List<Criterion> criteria) {
             this.protocol = protocol;
             this.connectorId = connectorId;
             this.connectorAddress = connectorAddress;
             this.range = range;
+            this.criteria = criteria;
         }
 
         @JsonCreator
@@ -109,12 +122,17 @@ public class CatalogRequest implements RemoteMessage {
             return this;
         }
 
+        public CatalogRequest.Builder filter(List<Criterion> criteria) {
+            this.criteria = criteria;
+            return this;
+        }
+
         public CatalogRequest build() {
             Objects.requireNonNull(protocol, "protocol");
             Objects.requireNonNull(connectorId, "connectorId");
             Objects.requireNonNull(connectorAddress, "connectorAddress");
 
-            return new CatalogRequest(protocol, connectorId, connectorAddress, range);
+            return new CatalogRequest(protocol, connectorId, connectorAddress, range, criteria);
         }
     }
 }

--- a/spi/common/catalog-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/catalog/CatalogRequest.java
+++ b/spi/common/catalog-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/catalog/CatalogRequest.java
@@ -31,7 +31,6 @@ import java.util.Objects;
 @JsonDeserialize(builder = CatalogRequest.Builder.class)
 public class CatalogRequest implements RemoteMessage {
 
-    public static final String FILTER = "filter";
     public static final String RANGE = "range";
 
     private final String protocol;

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/message/Range.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/message/Range.java
@@ -28,6 +28,11 @@ public class Range {
         this.to = to;
     }
 
+    public Range() {
+        this.from = 0;
+        this.to = Integer.MAX_VALUE;
+    }
+
     /**
      * The index of the last item to be included in the range. Note that the actual number may be lower if the range
      * overshoots the bounds of the collection

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/QuerySpec.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/QuerySpec.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.spi.query;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.eclipse.dataspaceconnector.spi.message.Range;
 
 import java.util.ArrayList;
@@ -29,6 +28,10 @@ import java.util.stream.Collectors;
  * is tunnelled through to the database level.
  */
 public class QuerySpec {
+
+    public static final String QUERY_SPEC = "querySpec";
+    public static final String FILTER_EXPRESSION = "filterExpression";
+
     private int offset = 0;
     private int limit = 50;
     private List<Criterion> filterExpression = new ArrayList<>();
@@ -86,7 +89,6 @@ public class QuerySpec {
         return limit;
     }
 
-    @JsonIgnore
     public Range getRange() {
         return new Range(offset, offset + limit);
     }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/QuerySpec.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/QuerySpec.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.spi.query;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.eclipse.dataspaceconnector.spi.message.Range;
 
 import java.util.ArrayList;
@@ -31,6 +32,8 @@ public class QuerySpec {
 
     public static final String QUERY_SPEC = "querySpec";
     public static final String FILTER_EXPRESSION = "filterExpression";
+    public static final String OFFSET = "offset";
+    public static final String LIMIT = "limit";
 
     private int offset = 0;
     private int limit = 50;
@@ -89,6 +92,7 @@ public class QuerySpec {
         return limit;
     }
 
+    @JsonIgnore
     public Range getRange() {
         return new Range(offset, offset + limit);
     }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/QuerySpec.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/QuerySpec.java
@@ -31,9 +31,6 @@ import java.util.stream.Collectors;
 public class QuerySpec {
 
     public static final String QUERY_SPEC = "querySpec";
-    public static final String FILTER_EXPRESSION = "filterExpression";
-    public static final String OFFSET = "offset";
-    public static final String LIMIT = "limit";
 
     private int offset = 0;
     private int limit = 50;

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/ContractOfferQuery.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/ContractOfferQuery.java
@@ -28,8 +28,8 @@ import java.util.List;
  */
 public class ContractOfferQuery {
     private ClaimToken claimToken;
-    private List<Criterion> criteria;
-    private Range range;
+    private List<Criterion> assetsCriteria;
+    private Range definitionsRange;
 
     private ContractOfferQuery() {
     }
@@ -42,18 +42,18 @@ public class ContractOfferQuery {
         return claimToken;
     }
 
-    public List<Criterion> getCriteria() {
-        return criteria;
+    public List<Criterion> getAssetsCriteria() {
+        return assetsCriteria;
     }
 
-    public Range getRange() {
-        return range;
+    public Range getDefinitionsRange() {
+        return definitionsRange;
     }
 
     public static final class Builder {
-        private final List<Criterion> criteria = new ArrayList<>();
+        private final List<Criterion> assetsCriteria = new ArrayList<>();
         private ClaimToken claimToken;
-        private Range range;
+        private Range definitionsRange;
 
         private Builder() {
         }
@@ -67,26 +67,26 @@ public class ContractOfferQuery {
             return this;
         }
 
-        public Builder criterion(Criterion criterion) {
-            criteria.add(criterion);
+        public Builder assetsCriterion(Criterion assetsCriterion) {
+            assetsCriteria.add(assetsCriterion);
             return this;
         }
 
-        public Builder criteria(Collection<Criterion> criteria) {
-            this.criteria.addAll(criteria);
+        public Builder assetsCriteria(Collection<Criterion> assetsCriteria) {
+            this.assetsCriteria.addAll(assetsCriteria);
             return this;
         }
 
-        public Builder range(Range range) {
-            this.range = range;
+        public Builder definitionsRange(Range definitionsRange) {
+            this.definitionsRange = definitionsRange;
             return this;
         }
 
         public ContractOfferQuery build() {
             ContractOfferQuery contractOfferQuery = new ContractOfferQuery();
             contractOfferQuery.claimToken = claimToken;
-            contractOfferQuery.range = range;
-            contractOfferQuery.criteria = criteria;
+            contractOfferQuery.definitionsRange = definitionsRange;
+            contractOfferQuery.assetsCriteria = assetsCriteria;
             return contractOfferQuery;
         }
     }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/ContractOfferQuery.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/ContractOfferQuery.java
@@ -29,7 +29,7 @@ import java.util.List;
 public class ContractOfferQuery {
     private ClaimToken claimToken;
     private List<Criterion> assetsCriteria;
-    private Range definitionsRange;
+    private Range range;
 
     private ContractOfferQuery() {
     }
@@ -46,14 +46,14 @@ public class ContractOfferQuery {
         return assetsCriteria;
     }
 
-    public Range getDefinitionsRange() {
-        return definitionsRange;
+    public Range getRange() {
+        return range;
     }
 
     public static final class Builder {
         private final List<Criterion> assetsCriteria = new ArrayList<>();
         private ClaimToken claimToken;
-        private Range definitionsRange;
+        private Range range;
 
         private Builder() {
         }
@@ -77,15 +77,15 @@ public class ContractOfferQuery {
             return this;
         }
 
-        public Builder definitionsRange(Range definitionsRange) {
-            this.definitionsRange = definitionsRange;
+        public Builder range(Range range) {
+            this.range = range;
             return this;
         }
 
         public ContractOfferQuery build() {
             ContractOfferQuery contractOfferQuery = new ContractOfferQuery();
             contractOfferQuery.claimToken = claimToken;
-            contractOfferQuery.definitionsRange = definitionsRange;
+            contractOfferQuery.range = range;
             contractOfferQuery.assetsCriteria = assetsCriteria;
             return contractOfferQuery;
         }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/ContractOfferQuery.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/ContractOfferQuery.java
@@ -16,6 +16,7 @@
 package org.eclipse.dataspaceconnector.spi.contract.offer;
 
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
+import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
 
 import java.util.ArrayList;
@@ -28,8 +29,7 @@ import java.util.List;
 public class ContractOfferQuery {
     private ClaimToken claimToken;
     private List<Criterion> criteria;
-    private long offset;
-    private long limit;
+    private Range range;
 
     private ContractOfferQuery() {
     }
@@ -46,19 +46,14 @@ public class ContractOfferQuery {
         return criteria;
     }
 
-    public long getOffset() {
-        return offset;
-    }
-
-    public long getLimit() {
-        return limit;
+    public Range getRange() {
+        return range;
     }
 
     public static final class Builder {
         private final List<Criterion> criteria = new ArrayList<>();
         private ClaimToken claimToken;
-        private long offset;
-        private long limit;
+        private Range range;
 
         private Builder() {
         }
@@ -82,21 +77,15 @@ public class ContractOfferQuery {
             return this;
         }
 
-        public Builder offset(long offset) {
-            this.offset = offset;
-            return this;
-        }
-
-        public Builder limit(long limit) {
-            this.limit = limit;
+        public Builder range(Range range) {
+            this.range = range;
             return this;
         }
 
         public ContractOfferQuery build() {
             ContractOfferQuery contractOfferQuery = new ContractOfferQuery();
             contractOfferQuery.claimToken = claimToken;
-            contractOfferQuery.offset = offset;
-            contractOfferQuery.limit = limit;
+            contractOfferQuery.range = range;
             contractOfferQuery.criteria = criteria;
             return contractOfferQuery;
         }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/ContractOfferService.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/ContractOfferService.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.spi.contract.offer;
 
-import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 
@@ -29,6 +28,6 @@ public interface ContractOfferService {
      * Resolves contract offers.
      */
     @NotNull
-    Stream<ContractOffer> queryContractOffers(ContractOfferQuery query, Range range);
+    Stream<ContractOffer> queryContractOffers(ContractOfferQuery query);
 
 }


### PR DESCRIPTION
## What this PR changes/adds

Extend existing CatalogRequest object with list of criteria used to filter Assets within Catalog response.

## Why it does that

In a large scale environment, with multiple EDCs holding the information about hundreds of thousands of Assets, instead of looping thought all of the ContractOffers, there is a need to narrow the results down to even single offer. For example, an Asset might hold the 'special' type of data (like registry or database) and should be searchable by its type.

## Linked Issue(s)

Closes #1966

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
