### PR TITLE
refactor: move duplicated code to `ids-core`

### DIFF
--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/IdsMultipartDispatcherServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/IdsMultipartDispatcherServiceExtension.java
@@ -27,21 +27,18 @@ import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.type.M
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.type.MultipartDescriptionRequestSender;
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.type.MultipartEndpointDataReferenceRequestSender;
 import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTransformerRegistry;
-import org.eclipse.dataspaceconnector.ids.spi.types.IdsId;
-import org.eclipse.dataspaceconnector.ids.spi.types.IdsType;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
-import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
-import org.jetbrains.annotations.NotNull;
 
 import java.net.URI;
-import java.util.Objects;
+
+import static org.eclipse.dataspaceconnector.ids.core.util.ConnectorIdUtil.resolveConnectorId;
 
 public class IdsMultipartDispatcherServiceExtension implements ServiceExtension {
 
@@ -96,26 +93,6 @@ public class IdsMultipartDispatcherServiceExtension implements ServiceExtension 
         dispatcher.register(new MultipartEndpointDataReferenceRequestSender(senderContext, typeManager));
 
         dispatcherRegistry.register(dispatcher);
-    }
-
-    private String resolveConnectorId(@NotNull ServiceExtensionContext context) {
-        Objects.requireNonNull(context);
-
-        var value = context.getSetting(EDC_IDS_ID, DEFAULT_EDC_IDS_ID);
-
-        // Hint: use stringified uri to keep uri path and query
-        var result = IdsId.from(value);
-        if (result.succeeded()) {
-            var idsId = result.getContent();
-            if (idsId.getType() == IdsType.CONNECTOR) {
-                return idsId.getValue();
-            }
-        } else {
-            var message = "IDS Settings: Expected valid URN for setting '%s', but was %s'. Expected format: 'urn:connector:[id]'";
-            throw new EdcException(String.format(message, EDC_IDS_ID, DEFAULT_EDC_IDS_ID));
-        }
-
-        return value;
     }
 
 }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/IdsMultipartDispatcherServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/IdsMultipartDispatcherServiceExtension.java
@@ -26,10 +26,9 @@ import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.type.M
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.type.MultipartContractRejectionSender;
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.type.MultipartDescriptionRequestSender;
 import org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.type.MultipartEndpointDataReferenceRequestSender;
+import org.eclipse.dataspaceconnector.ids.spi.service.DynamicAttributeTokenService;
 import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTransformerRegistry;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
-import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
@@ -42,10 +41,6 @@ import static org.eclipse.dataspaceconnector.ids.core.util.ConnectorIdUtil.resol
 
 public class IdsMultipartDispatcherServiceExtension implements ServiceExtension {
 
-    @EdcSetting
-    public static final String EDC_IDS_ID = "edc.ids.id";
-    public static final String DEFAULT_EDC_IDS_ID = "urn:connector:edc";
-
     @Inject
     private Monitor monitor;
 
@@ -53,7 +48,7 @@ public class IdsMultipartDispatcherServiceExtension implements ServiceExtension 
     private OkHttpClient httpClient;
 
     @Inject
-    private IdentityService identityService;
+    private DynamicAttributeTokenService dynamicAttributeTokenService;
 
     @Inject
     private IdsTransformerRegistry transformerRegistry;
@@ -82,7 +77,7 @@ public class IdsMultipartDispatcherServiceExtension implements ServiceExtension 
 
         var senderContext = new SenderDelegateContext(URI.create(connectorId), objectMapper, transformerRegistry, idsWebhookAddress);
 
-        var sender = new IdsMultipartSender(monitor, httpClient, identityService, objectMapper);
+        var sender = new IdsMultipartSender(monitor, httpClient, dynamicAttributeTokenService, objectMapper);
         var dispatcher = new IdsMultipartRemoteMessageDispatcher(sender);
         dispatcher.register(new MultipartArtifactRequestSender(senderContext, vault));
         dispatcher.register(new MultipartDescriptionRequestSender(senderContext));

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/IdsMultipartSenderTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/IdsMultipartSenderTest.java
@@ -17,7 +17,7 @@ package org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender;
 
 import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.ids.core.serialization.IdsTypeManagerUtil;
-import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
+import org.eclipse.dataspaceconnector.ids.spi.service.DynamicAttributeTokenService;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
@@ -32,15 +32,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class IdsMultipartSenderTest {
-    private final IdentityService identityService = mock(IdentityService.class);
+    private final DynamicAttributeTokenService tokenService = mock(DynamicAttributeTokenService.class);
 
     @Test
     void should_fail_if_token_retrieval_fails() {
-        when(identityService.obtainClientCredentials(any())).thenReturn(Result.failure("error"));
+        when(tokenService.obtainDynamicAttributeToken(any())).thenReturn(Result.failure("error"));
 
         var objectMapper = IdsTypeManagerUtil.getIdsObjectMapper(new TypeManager());
 
-        var sender = new IdsMultipartSender(mock(Monitor.class), mock(OkHttpClient.class), identityService, objectMapper);
+        var sender = new IdsMultipartSender(mock(Monitor.class), mock(OkHttpClient.class), tokenService, objectMapper);
         var senderDelegate = mock(MultipartSenderDelegate.class);
 
         var result = sender.send(new TestRemoteMessage(), senderDelegate);

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsMultipartApiServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsMultipartApiServiceExtension.java
@@ -30,11 +30,8 @@ import org.eclipse.dataspaceconnector.ids.api.multipart.handler.Handler;
 import org.eclipse.dataspaceconnector.ids.spi.service.CatalogService;
 import org.eclipse.dataspaceconnector.ids.spi.service.ConnectorService;
 import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTransformerRegistry;
-import org.eclipse.dataspaceconnector.ids.spi.types.IdsId;
-import org.eclipse.dataspaceconnector.ids.spi.types.IdsType;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
-import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.WebService;
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.ConsumerContractNegotiationManager;
@@ -50,9 +47,10 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
 import org.eclipse.dataspaceconnector.spi.transfer.edr.EndpointDataReferenceReceiverRegistry;
 import org.eclipse.dataspaceconnector.spi.transfer.edr.EndpointDataReferenceTransformerRegistry;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.LinkedList;
+
+import static org.eclipse.dataspaceconnector.ids.core.util.ConnectorIdUtil.resolveConnectorId;
 
 /**
  * ServiceExtension providing IDS multipart related API controllers
@@ -141,24 +139,6 @@ public final class IdsMultipartApiServiceExtension implements ServiceExtension {
         // create & register controller
         var multipartController = new MultipartController(monitor, connectorId, objectMapper, identityService, handlers, idsApiConfiguration.getIdsWebhookAddress());
         webService.registerResource(idsApiConfiguration.getContextAlias(), multipartController);
-    }
-
-    private String resolveConnectorId(@NotNull ServiceExtensionContext context) {
-        var value = context.getSetting(EDC_IDS_ID, DEFAULT_EDC_IDS_ID);
-
-        // Hint: use stringified uri to keep uri path and query
-        var result = IdsId.from(value);
-        if (result.succeeded()) {
-            var idsId = result.getContent();
-            if (idsId.getType() == IdsType.CONNECTOR) {
-                return idsId.getValue();
-            }
-        } else {
-            var message = "IDS Settings: Expected valid URN for setting '%s', but was %s'. Expected format: 'urn:connector:[id]'";
-            throw new EdcException(String.format(message, EDC_IDS_ID, DEFAULT_EDC_IDS_ID));
-        }
-
-        return value;
     }
 
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsMultipartApiServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsMultipartApiServiceExtension.java
@@ -29,8 +29,8 @@ import org.eclipse.dataspaceconnector.ids.api.multipart.handler.EndpointDataRefe
 import org.eclipse.dataspaceconnector.ids.api.multipart.handler.Handler;
 import org.eclipse.dataspaceconnector.ids.spi.service.CatalogService;
 import org.eclipse.dataspaceconnector.ids.spi.service.ConnectorService;
+import org.eclipse.dataspaceconnector.ids.spi.service.DynamicAttributeTokenService;
 import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTransformerRegistry;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
 import org.eclipse.dataspaceconnector.spi.WebService;
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
@@ -39,7 +39,6 @@ import org.eclipse.dataspaceconnector.spi.contract.negotiation.ProviderContractN
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
 import org.eclipse.dataspaceconnector.spi.contract.validation.ContractValidationService;
-import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
@@ -57,10 +56,6 @@ import static org.eclipse.dataspaceconnector.ids.core.util.ConnectorIdUtil.resol
  */
 public final class IdsMultipartApiServiceExtension implements ServiceExtension {
 
-    @EdcSetting
-    public static final String EDC_IDS_ID = "edc.ids.id";
-    public static final String DEFAULT_EDC_IDS_ID = "urn:connector:edc";
-
     @Inject
     private Monitor monitor;
 
@@ -68,7 +63,7 @@ public final class IdsMultipartApiServiceExtension implements ServiceExtension {
     private WebService webService;
 
     @Inject
-    private IdentityService identityService;
+    private DynamicAttributeTokenService dynamicAttributeTokenService;
 
     @Inject
     private CatalogService dataCatalogService;
@@ -137,7 +132,7 @@ public final class IdsMultipartApiServiceExtension implements ServiceExtension {
         handlers.add(new ContractRejectionHandler(monitor, connectorId, providerNegotiationManager, consumerNegotiationManager));
 
         // create & register controller
-        var multipartController = new MultipartController(monitor, connectorId, objectMapper, identityService, handlers, idsApiConfiguration.getIdsWebhookAddress());
+        var multipartController = new MultipartController(monitor, connectorId, objectMapper, dynamicAttributeTokenService, handlers, idsApiConfiguration.getIdsWebhookAddress());
         webService.registerResource(idsApiConfiguration.getContextAlias(), multipartController);
     }
 

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/IdsCoreServiceExtension.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/IdsCoreServiceExtension.java
@@ -46,9 +46,8 @@ import java.util.List;
 /**
  * Implements the IDS Controller REST API.
  */
-@Provides({ CatalogService.class, ConnectorService.class, IdsDescriptorService.class,
-        CatalogService.class, ConnectorService.class, IdsTransformerRegistry.class,
-        DynamicAttributeTokenService.class})
+@Provides({ IdsDescriptorService.class, CatalogService.class, ConnectorService.class,
+        IdsTransformerRegistry.class, DynamicAttributeTokenService.class})
 public class IdsCoreServiceExtension implements ServiceExtension {
 
     @EdcSetting

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/IdsCoreServiceExtension.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/IdsCoreServiceExtension.java
@@ -21,10 +21,12 @@ import org.eclipse.dataspaceconnector.ids.core.serialization.IdsTypeManagerUtil;
 import org.eclipse.dataspaceconnector.ids.core.service.CatalogServiceImpl;
 import org.eclipse.dataspaceconnector.ids.core.service.ConnectorServiceImpl;
 import org.eclipse.dataspaceconnector.ids.core.service.ConnectorServiceSettings;
+import org.eclipse.dataspaceconnector.ids.core.service.DynamicAttributeTokenServiceImpl;
 import org.eclipse.dataspaceconnector.ids.core.transform.IdsTransformerRegistryImpl;
 import org.eclipse.dataspaceconnector.ids.spi.descriptor.IdsDescriptorService;
 import org.eclipse.dataspaceconnector.ids.spi.service.CatalogService;
 import org.eclipse.dataspaceconnector.ids.spi.service.ConnectorService;
+import org.eclipse.dataspaceconnector.ids.spi.service.DynamicAttributeTokenService;
 import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTransformerRegistry;
 import org.eclipse.dataspaceconnector.ids.spi.types.IdsId;
 import org.eclipse.dataspaceconnector.ids.spi.types.IdsType;
@@ -45,7 +47,8 @@ import java.util.List;
  * Implements the IDS Controller REST API.
  */
 @Provides({ CatalogService.class, ConnectorService.class, IdsDescriptorService.class,
-        CatalogService.class, ConnectorService.class, IdsTransformerRegistry.class })
+        CatalogService.class, ConnectorService.class, IdsTransformerRegistry.class,
+        DynamicAttributeTokenService.class})
 public class IdsCoreServiceExtension implements ServiceExtension {
 
     @EdcSetting
@@ -107,6 +110,8 @@ public class IdsCoreServiceExtension implements ServiceExtension {
         context.registerService(ConnectorService.class, connectorService);
 
         context.registerService(IdsDescriptorService.class, new IdsDescriptorServiceImpl());
+    
+        context.registerService(DynamicAttributeTokenService.class, new DynamicAttributeTokenServiceImpl(identityService));
     }
 
     private String resolveCatalogId(ServiceExtensionContext context) {

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/DynamicAttributeTokenServiceImpl.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/DynamicAttributeTokenServiceImpl.java
@@ -25,7 +25,7 @@ import org.eclipse.dataspaceconnector.spi.iam.TokenRepresentation;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 
 import java.net.URI;
-import java.util.HashMap;
+import java.util.Map;
 
 public class DynamicAttributeTokenServiceImpl implements DynamicAttributeTokenService {
     
@@ -43,23 +43,18 @@ public class DynamicAttributeTokenServiceImpl implements DynamicAttributeTokenSe
                 .scope(TOKEN_SCOPE)
                 .audience(recipientAddress)
                 .build();
-        var tokenResult = identityService.obtainClientCredentials(tokenParameters);
-        
-        if (tokenResult.failed()) {
-            return Result.failure("Failed to obtain identity token.");
-        }
-        
-        return Result.success(new DynamicAttributeTokenBuilder()
-                ._tokenFormat_(TokenFormat.JWT)
-                ._tokenValue_(tokenResult.getContent().getToken())
-                .build());
+        return identityService.obtainClientCredentials(tokenParameters)
+                .map(credentials -> new DynamicAttributeTokenBuilder()
+                        ._tokenFormat_(TokenFormat.JWT)
+                        ._tokenValue_(credentials.getToken())
+                        .build()
+                );
     }
     
     @Override
     public Result<ClaimToken> verifyDynamicAttributeToken(DynamicAttributeToken token, URI issuerConnector, String audience) {
         // Prepare DAT validation: IDS token validation requires issuerConnector
-        var additional = new HashMap<String, Object>();
-        additional.put("issuerConnector", issuerConnector);
+        var additional = Map.<String, Object>of("issuerConnector", issuerConnector);
     
         var tokenRepresentation = TokenRepresentation.Builder.newInstance()
                 .token(token.getTokenValue())

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/DynamicAttributeTokenServiceImpl.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/DynamicAttributeTokenServiceImpl.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2021 - 2022 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.ids.core.service;
+
+import de.fraunhofer.iais.eis.DynamicAttributeToken;
+import de.fraunhofer.iais.eis.DynamicAttributeTokenBuilder;
+import de.fraunhofer.iais.eis.TokenFormat;
+import org.eclipse.dataspaceconnector.ids.spi.service.DynamicAttributeTokenService;
+import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
+import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
+import org.eclipse.dataspaceconnector.spi.iam.TokenParameters;
+import org.eclipse.dataspaceconnector.spi.iam.TokenRepresentation;
+import org.eclipse.dataspaceconnector.spi.result.Result;
+
+import java.net.URI;
+import java.util.HashMap;
+
+public class DynamicAttributeTokenServiceImpl implements DynamicAttributeTokenService {
+    
+    private static final String TOKEN_SCOPE = "idsc:IDS_CONNECTOR_ATTRIBUTES_ALL";
+    
+    private IdentityService identityService;
+    
+    public DynamicAttributeTokenServiceImpl(IdentityService identityService) {
+        this.identityService = identityService;
+    }
+    
+    @Override
+    public Result<DynamicAttributeToken> obtainDynamicAttributeToken(String recipientAddress) {
+        var tokenParameters = TokenParameters.Builder.newInstance()
+                .scope(TOKEN_SCOPE)
+                .audience(recipientAddress)
+                .build();
+        var tokenResult = identityService.obtainClientCredentials(tokenParameters);
+        
+        if (tokenResult.failed()) {
+            return Result.failure("Failed to obtain identity token.");
+        }
+        
+        return Result.success(new DynamicAttributeTokenBuilder()
+                ._tokenFormat_(TokenFormat.JWT)
+                ._tokenValue_(tokenResult.getContent().getToken())
+                .build());
+    }
+    
+    @Override
+    public Result<ClaimToken> verifyDynamicAttributeToken(DynamicAttributeToken token, URI issuerConnector, String audience) {
+        // Prepare DAT validation: IDS token validation requires issuerConnector
+        var additional = new HashMap<String, Object>();
+        additional.put("issuerConnector", issuerConnector);
+    
+        var tokenRepresentation = TokenRepresentation.Builder.newInstance()
+                .token(token.getTokenValue())
+                .additional(additional)
+                .build();
+        
+        return identityService.verifyJwtToken(tokenRepresentation, audience);
+    }
+}

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/util/ConnectorIdUtil.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/util/ConnectorIdUtil.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2021 - 2022 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.ids.core.util;
+
+import org.eclipse.dataspaceconnector.ids.spi.types.IdsId;
+import org.eclipse.dataspaceconnector.ids.spi.types.IdsType;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
+import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+
+/**
+ * Utility class for handling the connector's IDS ID.
+ */
+public class ConnectorIdUtil {
+    
+    @EdcSetting
+    public static final String EDC_IDS_ID = "edc.ids.id";
+    public static final String DEFAULT_EDC_IDS_ID = "urn:connector:edc";
+    
+    private ConnectorIdUtil() {}
+    
+    /**
+     * Returns the connector's ID from its IDS ID. Will use the IDS ID supplied in the configuration,
+     * if it is present, else will use a default IDS ID.
+     *
+     * @param context the context providing the configuration values.
+     * @return the connector's ID.
+     * @throws EdcException if a configuration value is present for the IDS ID but is not a valid URN.
+     */
+    public static String resolveConnectorId(ServiceExtensionContext context) {
+        var value = context.getSetting(EDC_IDS_ID, DEFAULT_EDC_IDS_ID);
+    
+        // Hint: use stringified uri to keep uri path and query
+        var result = IdsId.from(value);
+        if (result.succeeded()) {
+            var idsId = result.getContent();
+            if (idsId.getType() == IdsType.CONNECTOR) {
+                return idsId.getValue();
+            }
+        } else {
+            var message = "IDS Settings: Expected valid URN for setting '%s', but was %s'. Expected format: 'urn:connector:[id]'";
+            throw new EdcException(String.format(message, EDC_IDS_ID, DEFAULT_EDC_IDS_ID));
+        }
+    
+        return value;
+    }
+    
+}

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/DynamicAttributeTokenServiceImplTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/DynamicAttributeTokenServiceImplTest.java
@@ -1,0 +1,122 @@
+/*
+ *  Copyright (c) 2021 - 2022 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.ids.core.service;
+
+import de.fraunhofer.iais.eis.DynamicAttributeToken;
+import de.fraunhofer.iais.eis.DynamicAttributeTokenBuilder;
+import de.fraunhofer.iais.eis.TokenFormat;
+import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
+import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
+import org.eclipse.dataspaceconnector.spi.iam.TokenRepresentation;
+import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DynamicAttributeTokenServiceImplTest {
+    
+    private IdentityService identityService;
+    private DynamicAttributeTokenServiceImpl tokenService;
+    
+    @BeforeEach
+    void init() {
+        identityService = mock(IdentityService.class);
+        tokenService = new DynamicAttributeTokenServiceImpl(identityService);
+    }
+    
+    @Test
+    void obtainDynamicAttributeToken_tokenRequestSuccessful() {
+        var recipient = "recipient";
+        
+        var tokenRepresentation = TokenRepresentation.Builder.newInstance().token("token").build();
+        when(identityService.obtainClientCredentials(any())).thenReturn(Result.success(tokenRepresentation));
+        
+        var tokenResult = tokenService.obtainDynamicAttributeToken(recipient);
+        
+        assertThat(tokenResult.succeeded()).isTrue();
+        assertThat(tokenResult.getContent().getTokenValue()).isEqualTo(tokenRepresentation.getToken());
+        verify(identityService, times(1))
+                .obtainClientCredentials(argThat(tokenParams -> recipient.equals(tokenParams.getAudience())));
+    }
+    
+    @Test
+    void obtainDynamicAttributeToken_tokenRequestFailed() {
+        var recipient = "recipient";
+    
+        when(identityService.obtainClientCredentials(any())).thenReturn(Result.failure("error"));
+        
+        var tokenResult = tokenService.obtainDynamicAttributeToken(recipient);
+        
+        assertThat(tokenResult.succeeded()).isFalse();
+        verify(identityService, times(1))
+                .obtainClientCredentials(argThat(tokenParams -> recipient.equals(tokenParams.getAudience())));
+    }
+    
+    @Test
+    void verifyDynamicAttributeToken_verificationSuccessful() {
+        var issuer = URI.create("issuer");
+        var audience = "audience";
+        var token = getToken();
+        
+        var claimToken = ClaimToken.Builder.newInstance().build();
+        when(identityService.verifyJwtToken(any(), any())).thenReturn(Result.success(claimToken));
+        
+        var result = tokenService.verifyDynamicAttributeToken(token, issuer, audience);
+    
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent()).isEqualTo(claimToken);
+        verify(identityService, times(1))
+                .verifyJwtToken(argThat(getTokenRepresentationMatcher(token, issuer)), eq(audience));
+    }
+    
+    @Test
+    void verifyDynamicAttributeToken_verificationFailed() {
+        var issuer = URI.create("issuer");
+        var audience = "audience";
+        var token = getToken();
+        
+        when(identityService.verifyJwtToken(any(), any())).thenReturn(Result.failure("error"));
+        
+        var result = tokenService.verifyDynamicAttributeToken(token, issuer, audience);
+        
+        assertThat(result.succeeded()).isFalse();
+        verify(identityService, times(1))
+                .verifyJwtToken(argThat(getTokenRepresentationMatcher(token, issuer)), eq(audience));
+    }
+    
+    private DynamicAttributeToken getToken() {
+        return new DynamicAttributeTokenBuilder()
+                ._tokenFormat_(TokenFormat.JWT)
+                ._tokenValue_("token")
+                .build();
+    }
+    
+    private ArgumentMatcher<TokenRepresentation> getTokenRepresentationMatcher(DynamicAttributeToken token, URI issuer) {
+        return tokenRepresentation -> tokenRepresentation.getToken().equals(token.getTokenValue())
+                && tokenRepresentation.getAdditional().get("issuerConnector").equals(issuer);
+    }
+    
+}

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/DynamicAttributeTokenServiceImplTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/DynamicAttributeTokenServiceImplTest.java
@@ -115,8 +115,8 @@ class DynamicAttributeTokenServiceImplTest {
     }
     
     private ArgumentMatcher<TokenRepresentation> getTokenRepresentationMatcher(DynamicAttributeToken token, URI issuer) {
-        return tokenRepresentation -> tokenRepresentation.getToken().equals(token.getTokenValue())
-                && tokenRepresentation.getAdditional().get("issuerConnector").equals(issuer);
+        return tokenRepresentation -> tokenRepresentation.getToken().equals(token.getTokenValue()) &&
+                tokenRepresentation.getAdditional().get("issuerConnector").equals(issuer);
     }
     
 }

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/DynamicAttributeTokenService.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/DynamicAttributeTokenService.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2021 - 2022 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.ids.spi.service;
+
+import de.fraunhofer.iais.eis.DynamicAttributeToken;
+import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
+import org.eclipse.dataspaceconnector.spi.result.Result;
+
+import java.net.URI;
+
+/**
+ * Wrapper for the {@link org.eclipse.dataspaceconnector.spi.iam.IdentityService} that handles
+ * {@link DynamicAttributeToken}s.
+ */
+public interface DynamicAttributeTokenService {
+    
+    /**
+     * Obtains a client token as a DynamicAttributeToken.
+     *
+     * @param recipientAddress the recipient connector.
+     * @return the token result.
+     */
+    Result<DynamicAttributeToken> obtainDynamicAttributeToken(String recipientAddress);
+    
+    /**
+     * Verifies a received DynamicAttributeToken.
+     *
+     * @param token the token to verify.
+     * @param issuerConnector the connector that sent the token.
+     * @param audience the token audience.
+     * @return the result of the validation.
+     */
+    Result<ClaimToken> verifyDynamicAttributeToken(DynamicAttributeToken token, URI issuerConnector, String audience);
+    
+}


### PR DESCRIPTION
## What this PR changes/adds

Moves code that was duplicated between `ids-api-multipart-dispatcher-v1` and `ids-api-multipart-endpoint-v1` to `ids-core`. Adds a utility class for resolving the connector's IDS ID setting and introduces a service for handling `DynamicAttributeTokens`.

## Why it does that

To avoid duplications.

## Linked Issue(s)

Closes #1727  

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
