### PR TITLE
fix: use the `range` to limit offers, not definitions

### DIFF
--- a/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractDefinitionServiceImpl.java
+++ b/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractDefinitionServiceImpl.java
@@ -19,7 +19,6 @@ package org.eclipse.dataspaceconnector.contract.offer;
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgent;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractDefinitionService;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
-import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.policy.PolicyDefinition;
 import org.eclipse.dataspaceconnector.spi.policy.engine.PolicyEngine;
@@ -55,10 +54,8 @@ public class ContractDefinitionServiceImpl implements ContractDefinitionService 
 
     @NotNull
     @Override
-    public Stream<ContractDefinition> definitionsFor(ParticipantAgent agent, Range range) {
-        return definitionStore.findAll(QuerySpec.Builder.newInstance()
-                        .range(range)
-                        .build())
+    public Stream<ContractDefinition> definitionsFor(ParticipantAgent agent) {
+        return definitionStore.findAll(QuerySpec.max())
                 .filter(definition -> evaluateAccessPolicy(definition, agent));
     }
 

--- a/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractDefinitionServiceImplTest.java
+++ b/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractDefinitionServiceImplTest.java
@@ -66,7 +66,7 @@ class ContractDefinitionServiceImplTest {
         when(policyEngine.evaluate(CATALOGING_SCOPE, def.getPolicy(), agent)).thenReturn(Result.success(def.getPolicy()));
         when(definitionStore.findAll(any())).thenReturn(Stream.of(ContractDefinition.Builder.newInstance().id("1").accessPolicyId("access").contractPolicyId("contract").selectorExpression(SELECT_ALL).build()));
 
-        var definitions = definitionService.definitionsFor(agent, DEFAULT_RANGE);
+        var definitions = definitionService.definitionsFor(agent);
 
         assertThat(definitions).hasSize(1);
         verify(policyEngine, atLeastOnce()).evaluate(CATALOGING_SCOPE, def.getPolicy(), agent);
@@ -82,7 +82,7 @@ class ContractDefinitionServiceImplTest {
         when(policyEngine.evaluate(any(), any(), any())).thenReturn(Result.failure("invalid"));
         when(definitionStore.findAll(any())).thenReturn(Stream.of(contractDefinition));
 
-        var result = definitionService.definitionsFor(agent, DEFAULT_RANGE);
+        var result = definitionService.definitionsFor(agent);
 
         assertThat(result).isEmpty();
         verify(policyEngine, atLeastOnce()).evaluate(CATALOGING_SCOPE, definition.getPolicy(), agent);
@@ -97,7 +97,7 @@ class ContractDefinitionServiceImplTest {
         when(policyEngine.evaluate(CATALOGING_SCOPE, policy, agent)).thenReturn(Result.success(policy));
         when(definitionStore.findAll(QuerySpec.max())).thenReturn(Stream.of(ContractDefinition.Builder.newInstance().id("1").accessPolicyId("access").contractPolicyId("contract").selectorExpression(SELECT_ALL).build()));
 
-        var definitions = definitionService.definitionsFor(agent, DEFAULT_RANGE);
+        var definitions = definitionService.definitionsFor(agent);
 
         assertThat(definitions).hasSize(0);
         verify(policyEngine, never()).evaluate(any(), any(), any());

--- a/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImplIntegrationTest.java
+++ b/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImplIntegrationTest.java
@@ -89,12 +89,12 @@ class ContractOfferServiceImplIntegrationTest {
 
         when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
 
-        var query = ContractOfferQuery.builder().claimToken(ClaimToken.Builder.newInstance().build()).build();
 
         var from = 20;
         var to = 50;
+        var query = ContractOfferQuery.builder().range(new Range(from, to)).claimToken(ClaimToken.Builder.newInstance().build()).build();
 
-        assertThat(contractOfferService.queryContractOffers(query, new Range(from, to))).hasSize(to - from);
+        assertThat(contractOfferService.queryContractOffers(query)).hasSize(to - from);
         verify(agentService).createFor(isA(ClaimToken.class));
         verify(contractDefinitionService, times(1)).definitionsFor(isA(ParticipantAgent.class));
         verify(policyStore).findById("contract");
@@ -115,14 +115,12 @@ class ContractOfferServiceImplIntegrationTest {
         when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class))).thenAnswer(i -> Stream.of(def1, def2));
         when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
 
-
-        var query = ContractOfferQuery.builder().claimToken(ClaimToken.Builder.newInstance().build()).build();
-
         var from = 14;
         var to = 50;
+        var query = ContractOfferQuery.builder().range(new Range(from, to)).claimToken(ClaimToken.Builder.newInstance().build()).build();
 
         // 4 definitions, 10 assets each = 40 offers total -> offset 20 ==> result = 20
-        assertThat(contractOfferService.queryContractOffers(query, new Range(from, to))).hasSize(4);
+        assertThat(contractOfferService.queryContractOffers(query)).hasSize(4);
         verify(agentService).createFor(isA(ClaimToken.class));
         verify(contractDefinitionService).definitionsFor(isA(ParticipantAgent.class));
         verify(policyStore, atLeastOnce()).findById("contract");
@@ -138,13 +136,12 @@ class ContractOfferServiceImplIntegrationTest {
 
         when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
 
-        var query = ContractOfferQuery.builder().claimToken(ClaimToken.Builder.newInstance().build()).build();
-
         var from = 25;
         var to = 50;
+        var query = ContractOfferQuery.builder().range(new Range(from, to)).claimToken(ClaimToken.Builder.newInstance().build()).build();
 
         // 2 definitions, 10 assets each = 20 offers total -> offset of 25 is outside
-        assertThat(contractOfferService.queryContractOffers(query, new Range(from, to))).isEmpty();
+        assertThat(contractOfferService.queryContractOffers(query)).isEmpty();
         verify(agentService).createFor(isA(ClaimToken.class));
         verify(contractDefinitionService).definitionsFor(isA(ParticipantAgent.class));
         verify(policyStore, never()).findById("contract");

--- a/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImplIntegrationTest.java
+++ b/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImplIntegrationTest.java
@@ -1,0 +1,176 @@
+/*
+ *  Copyright (c) 2021 Daimler TSS GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Daimler TSS GmbH - Initial API and Implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
+ *
+ */
+
+package org.eclipse.dataspaceconnector.contract.offer;
+
+import org.eclipse.dataspaceconnector.core.controlplane.defaults.assetindex.InMemoryAssetIndex;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgent;
+import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgentService;
+import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
+import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
+import org.eclipse.dataspaceconnector.spi.contract.offer.ContractDefinitionService;
+import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferQuery;
+import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
+import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
+import org.eclipse.dataspaceconnector.spi.message.Range;
+import org.eclipse.dataspaceconnector.spi.policy.PolicyDefinition;
+import org.eclipse.dataspaceconnector.spi.policy.store.PolicyDefinitionStore;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.AssetEntry;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyMap;
+import static java.util.stream.IntStream.range;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * This could be seen as se second part of the {@code ContractOfferServiceImplTest}, using the in-mem asset index
+ */
+class ContractOfferServiceImplIntegrationTest {
+
+    private final ContractDefinitionService contractDefinitionService = mock(ContractDefinitionService.class);
+    private final ParticipantAgentService agentService = mock(ParticipantAgentService.class);
+    private final PolicyDefinitionStore policyStore = mock(PolicyDefinitionStore.class);
+    private AssetIndex assetIndex;
+    private ContractOfferService contractOfferService;
+
+    @BeforeEach
+    void setUp() {
+        assetIndex = new InMemoryAssetIndex();
+        contractOfferService = new ContractOfferServiceImpl(agentService, contractDefinitionService, assetIndex, policyStore);
+    }
+
+    @Test
+    void shouldLimitResult_withHeterogenousChunks() {
+        var assets1 = range(10, 24).mapToObj(i -> createAsset("asset" + i).build()).collect(Collectors.toList());
+        var assets2 = range(24, 113).mapToObj(i -> createAsset("asset" + i).build()).collect(Collectors.toList());
+        var assets3 = range(113, 178).mapToObj(i -> createAsset("asset" + i).build()).collect(Collectors.toList());
+
+        store(assets1);
+        store(assets2);
+        store(assets3);
+
+        var def1 = getContractDefBuilder("def1").selectorExpression(selectorFrom(assets1)).build();
+        var def2 = getContractDefBuilder("def2").selectorExpression(selectorFrom(assets2)).build();
+        var def3 = getContractDefBuilder("def3").selectorExpression(selectorFrom(assets3)).build();
+
+        when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
+        when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class))).thenAnswer(i -> Stream.of(def1, def2, def3));
+
+        when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
+
+        var query = ContractOfferQuery.builder().claimToken(ClaimToken.Builder.newInstance().build()).build();
+
+        var from = 20;
+        var to = 50;
+
+        assertThat(contractOfferService.queryContractOffers(query, new Range(from, to))).hasSize(to - from);
+        verify(agentService).createFor(isA(ClaimToken.class));
+        verify(contractDefinitionService, times(1)).definitionsFor(isA(ParticipantAgent.class));
+        verify(policyStore).findById("contract");
+    }
+
+    @Test
+    void shouldLimitResult_insufficientAssets() {
+        var assets1 = range(0, 12).mapToObj(i -> createAsset("asset" + i).build()).collect(Collectors.toList());
+        var assets2 = range(12, 18).mapToObj(i -> createAsset("asset" + i).build()).collect(Collectors.toList());
+
+        store(assets1);
+        store(assets2);
+
+        var def1 = getContractDefBuilder("def1").selectorExpression(selectorFrom(assets1)).build();
+        var def2 = getContractDefBuilder("def2").selectorExpression(selectorFrom(assets2)).build();
+
+        when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
+        when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class))).thenAnswer(i -> Stream.of(def1, def2));
+        when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
+
+
+        var query = ContractOfferQuery.builder().claimToken(ClaimToken.Builder.newInstance().build()).build();
+
+        var from = 14;
+        var to = 50;
+
+        // 4 definitions, 10 assets each = 40 offers total -> offset 20 ==> result = 20
+        assertThat(contractOfferService.queryContractOffers(query, new Range(from, to))).hasSize(4);
+        verify(agentService).createFor(isA(ClaimToken.class));
+        verify(contractDefinitionService).definitionsFor(isA(ParticipantAgent.class));
+        verify(policyStore, atLeastOnce()).findById("contract");
+    }
+
+    @Test
+    void shouldLimitResult_pageOffsetLargerThanNumAssets() {
+        var contractDefinition = range(0, 2).mapToObj(i -> getContractDefBuilder(String.valueOf(i))
+                .build());
+
+        when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
+        when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class))).thenAnswer(i -> contractDefinition);
+
+        when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
+
+        var query = ContractOfferQuery.builder().claimToken(ClaimToken.Builder.newInstance().build()).build();
+
+        var from = 25;
+        var to = 50;
+
+        // 2 definitions, 10 assets each = 20 offers total -> offset of 25 is outside
+        assertThat(contractOfferService.queryContractOffers(query, new Range(from, to))).isEmpty();
+        verify(agentService).createFor(isA(ClaimToken.class));
+        verify(contractDefinitionService).definitionsFor(isA(ParticipantAgent.class));
+        verify(policyStore, never()).findById("contract");
+    }
+
+    private void store(Collection<Asset> assets) {
+        assets.stream().map(a -> new AssetEntry(a, DataAddress.Builder.newInstance().type("test-type").build()))
+                .forEach(assetIndex::accept);
+    }
+
+    private AssetSelectorExpression selectorFrom(Collection<Asset> assets1) {
+        var builder = AssetSelectorExpression.Builder.newInstance();
+        var ids = assets1.stream().map(a -> a.getId()).collect(Collectors.toList());
+        return builder.criteria(List.of(new Criterion(Asset.PROPERTY_ID, "in", ids))).build();
+    }
+
+    private ContractDefinition.Builder getContractDefBuilder(String id) {
+        return ContractDefinition.Builder.newInstance()
+                .id(id)
+                .accessPolicyId("access")
+                .contractPolicyId("contract")
+                .selectorExpression(AssetSelectorExpression.SELECT_ALL);
+    }
+
+    private Asset.Builder createAsset(String id) {
+        return Asset.Builder.newInstance().id(id).name("test asset " + id);
+    }
+
+}

--- a/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImplTest.java
+++ b/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImplTest.java
@@ -31,6 +31,8 @@ import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -39,12 +41,16 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
+import static java.util.stream.IntStream.range;
 import static java.util.stream.Stream.concat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -65,45 +71,143 @@ class ContractOfferServiceImplTest {
 
     @Test
     void shouldGetContractOffers() {
-        var contractDefinition = ContractDefinition.Builder.newInstance()
-                .id("1")
-                .accessPolicyId("access")
-                .contractPolicyId("contract")
-                .selectorExpression(AssetSelectorExpression.SELECT_ALL)
+        var contractDefinition = getContractDefBuilder("1")
                 .build();
 
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
-        when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class), any())).thenReturn(Stream.of(contractDefinition));
+        when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class))).thenReturn(Stream.of(contractDefinition));
         var assetStream = Stream.of(Asset.Builder.newInstance().build(), Asset.Builder.newInstance().build());
+        when(assetIndex.countAssets(any())).thenReturn(2L);
         when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(assetStream);
         when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
 
-        var query = ContractOfferQuery.builder().range(DEFAULT_RANGE).claimToken(ClaimToken.Builder.newInstance().build()).build();
+        var query = getQuery();
 
         assertThat(contractOfferService.queryContractOffers(query)).hasSize(2);
+
         verify(agentService).createFor(isA(ClaimToken.class));
-        verify(contractDefinitionService).definitionsFor(isA(ParticipantAgent.class), eq(DEFAULT_RANGE));
-        verify(policyStore).findById("contract");
+        verify(contractDefinitionService).definitionsFor(isA(ParticipantAgent.class));
+        verify(assetIndex).queryAssets(isA(QuerySpec.class));
+        verify(policyStore, atLeastOnce()).findById("contract");
     }
 
     @Test
     void shouldNotGetContractOfferIfPolicyIsNotFound() {
-        var contractDefinition = ContractDefinition.Builder.newInstance()
-                .id("1")
-                .accessPolicyId("access")
-                .contractPolicyId("contract")
-                .selectorExpression(AssetSelectorExpression.SELECT_ALL)
+        var contractDefinition = getContractDefBuilder("1")
                 .build();
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
-        when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class), any())).thenReturn(Stream.of(contractDefinition));
-        when(assetIndex.queryAssets(isA(AssetSelectorExpression.class))).thenReturn(Stream.of(Asset.Builder.newInstance().build()));
+        when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class))).thenReturn(Stream.of(contractDefinition));
+        when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(Stream.of(Asset.Builder.newInstance().build()));
         when(policyStore.findById(any())).thenReturn(null);
 
-        var query = ContractOfferQuery.builder().claimToken(ClaimToken.Builder.newInstance().build()).build();
+        var query = getQuery();
 
         var result = contractOfferService.queryContractOffers(query);
 
         assertThat(result).hasSize(0);
+    }
+
+    @Test
+    void shouldLimitResult() {
+        var contractDefinition = range(0, 10).mapToObj(i -> getContractDefBuilder(String.valueOf(i))
+                .build());
+
+        when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
+        when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class))).thenAnswer(i -> contractDefinition);
+        when(assetIndex.countAssets(any())).thenReturn(100L);
+        when(assetIndex.queryAssets(isA(QuerySpec.class))).thenAnswer(inv -> range(20, 50).mapToObj(i -> createAsset("asset" + i).build()));
+
+        when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
+
+
+        var from = 20;
+        var to = 50;
+        var query = getQuery(new Range(from, to));
+
+        assertThat(contractOfferService.queryContractOffers(query)).hasSize(to - from)
+                .extracting(ContractOffer::getAsset)
+                .extracting(Asset::getId)
+                .allSatisfy(id -> {
+                    var idNumber = Integer.valueOf(id.replace("asset", ""));
+                    assertThat(idNumber).isStrictlyBetween(from - 1, to);
+                });
+        verify(agentService).createFor(isA(ClaimToken.class));
+        verify(contractDefinitionService).definitionsFor(isA(ParticipantAgent.class));
+        verify(assetIndex).queryAssets(isA(QuerySpec.class));
+        verify(policyStore).findById("contract");
+    }
+
+    @Test
+    void shouldLimitResult_insufficientAssets() {
+        var contractDefinition = range(0, 4).mapToObj(i -> getContractDefBuilder(String.valueOf(i))
+                .build());
+
+        when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
+        when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class))).thenAnswer(i -> contractDefinition);
+
+        when(assetIndex.queryAssets(isA(QuerySpec.class))).thenAnswer(inv -> range(0, 10).mapToObj(i -> createAsset("asset" + i).build()));
+        when(assetIndex.countAssets(any())).thenReturn(10L);
+
+        when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
+
+
+        var from = 20;
+        var to = 50;
+        var query = getQuery(new Range(from, to));
+
+        // 4 definitions, 10 assets each = 40 offers total -> offset 20 ==> result = 20
+        assertThat(contractOfferService.queryContractOffers(query)).hasSize(20);
+        verify(agentService).createFor(isA(ClaimToken.class));
+        verify(contractDefinitionService).definitionsFor(isA(ParticipantAgent.class));
+        verify(assetIndex, atLeastOnce()).queryAssets(isA(QuerySpec.class));
+        verify(policyStore, atLeastOnce()).findById("contract");
+    }
+
+    @Test
+    void shouldLimitResult_pageOffsetLargerThanNumAssets() {
+        var contractDefinition = range(0, 2).mapToObj(i -> getContractDefBuilder(String.valueOf(i))
+                .build());
+
+        when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
+        when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class))).thenAnswer(i -> contractDefinition);
+        when(assetIndex.countAssets(any())).thenReturn(10L);
+        when(assetIndex.queryAssets(isA(QuerySpec.class))).thenAnswer(inv -> range(0, 10).mapToObj(i -> createAsset("asset" + i).build()));
+
+        when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
+
+        var query = getQuery();
+
+        var from = 25;
+        var to = 50;
+
+        // 2 definitions, 10 assets each = 20 offers total -> offset of 25 is outside
+        assertThat(contractOfferService.queryContractOffers(query, new Range(from, to))).isEmpty();
+        verify(agentService).createFor(isA(ClaimToken.class));
+        verify(contractDefinitionService).definitionsFor(isA(ParticipantAgent.class));
+        verify(assetIndex, never()).queryAssets(isA(QuerySpec.class));
+        verify(policyStore, never()).findById("contract");
+    }
+
+    @Test
+    void shouldLimitResultOfSingleAssetForContractDefinition() {
+        var contractDefinitions = range(0, 80)
+                .mapToObj(i -> getContractDefBuilder(String.valueOf(i)).build());
+
+        when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
+        when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class))).thenAnswer(i -> contractDefinitions);
+        when(assetIndex.countAssets(any())).thenReturn(1L);
+        when(assetIndex.queryAssets(isA(QuerySpec.class))).thenAnswer(inv -> Stream.of(createAsset("asset").build()));
+        when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
+
+        var from = 20;
+        var to = 50;
+
+        var offers = contractOfferService.queryContractOffers(getQuery(new Range(from, to)));
+
+        assertThat(offers).hasSize(to - from);
+        verify(contractDefinitionService).definitionsFor(isA(ParticipantAgent.class));
+        verify(assetIndex, times(30)).queryAssets(isA(QuerySpec.class));
+        verify(policyStore, times(30)).findById("contract");
     }
 
     @Test
@@ -127,14 +231,35 @@ class ContractOfferServiceImplTest {
                 .assetsCriteria(List.of(new Criterion(Asset.PROPERTY_ID, "=", "2")))
                 .build();
 
-        var expectedQuerySpec =  QuerySpec.Builder.newInstance()
+        var expectedQuerySpec = QuerySpec.Builder.newInstance()
                 .filter(concat(contractDefinition.getSelectorExpression().getCriteria().stream(), query.getAssetsCriteria().stream())
-                      .collect(Collectors.toList())).build();
+                        .collect(Collectors.toList())).build();
 
         assertThat(contractOfferService.queryContractOffers(query)).hasSize(2);
         verify(agentService).createFor(isA(ClaimToken.class));
-        verify(contractDefinitionService).definitionsFor(isA(ParticipantAgent.class), eq(DEFAULT_RANGE));
+        verify(contractDefinitionService).definitionsFor(isA(ParticipantAgent.class));
         verify(policyStore).findById("contract");
         verify(assetIndex).queryAssets(eq(expectedQuerySpec));
+    }
+
+    @NotNull
+    private ContractOfferQuery getQuery() {
+        return ContractOfferQuery.builder().claimToken(ClaimToken.Builder.newInstance().build()).build();
+    }
+
+    private ContractOfferQuery getQuery(Range range) {
+        return ContractOfferQuery.builder().range(range).claimToken(ClaimToken.Builder.newInstance().build()).build();
+    }
+
+    private ContractDefinition.Builder getContractDefBuilder(String id) {
+        return ContractDefinition.Builder.newInstance()
+                .id(id)
+                .accessPolicyId("access")
+                .contractPolicyId("contract")
+                .selectorExpression(AssetSelectorExpression.SELECT_ALL);
+    }
+
+    private Asset.Builder createAsset(String id) {
+        return Asset.Builder.newInstance().id(id).name("test asset " + id);
     }
 }

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/dataspaceconnector/core/controlplane/defaults/assetindex/InMemoryAssetIndex.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/dataspaceconnector/core/controlplane/defaults/assetindex/InMemoryAssetIndex.java
@@ -114,25 +114,6 @@ public class InMemoryAssetIndex implements AssetIndex {
     }
 
     @Override
-    public DataAddress resolveForAsset(String assetId) {
-        Objects.requireNonNull(assetId, "assetId");
-        lock.readLock().lock();
-        try {
-            return dataAddresses.get(assetId);
-        } finally {
-            lock.readLock().unlock();
-        }
-    }
-
-    public Map<String, Asset> getAssets() {
-        return Collections.unmodifiableMap(cache);
-    }
-
-    public Map<String, DataAddress> getDataAddresses() {
-        return Collections.unmodifiableMap(dataAddresses);
-    }
-
-    @Override
     public void accept(AssetEntry item) {
         lock.writeLock().lock();
         try {
@@ -150,6 +131,30 @@ public class InMemoryAssetIndex implements AssetIndex {
         } finally {
             lock.writeLock().unlock();
         }
+    }
+
+    @Override
+    public long countAssets(QuerySpec querySpec) {
+        return queryAssets(querySpec).count();
+    }
+
+    @Override
+    public DataAddress resolveForAsset(String assetId) {
+        Objects.requireNonNull(assetId, "assetId");
+        lock.readLock().lock();
+        try {
+            return dataAddresses.get(assetId);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    public Map<String, Asset> getAssets() {
+        return Collections.unmodifiableMap(cache);
+    }
+
+    public Map<String, DataAddress> getDataAddresses() {
+        return Collections.unmodifiableMap(dataAddresses);
     }
 
     private @Nullable Comparable asComparable(Object property) {

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/dataspaceconnector/sql/assetindex/SqlAssetIndex.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/dataspaceconnector/sql/assetindex/SqlAssetIndex.java
@@ -177,6 +177,19 @@ public class SqlAssetIndex implements AssetIndex {
     }
 
     @Override
+    public long countAssets(QuerySpec querySpec) {
+        try (var connection = getConnection()) {
+            var statement = assetStatements.createQuery(querySpec);
+
+            var queryAsString = statement.getQueryAsString().replace("SELECT * ", "SELECT COUNT (*) ");
+
+            return single(executeQuery(connection, r -> r.getLong(1), queryAsString, statement.getParameters()));
+        } catch (SQLException e) {
+            throw new EdcPersistenceException(e);
+        }
+    }
+
+    @Override
     public DataAddress resolveForAsset(String assetId) {
         Objects.requireNonNull(assetId);
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/asset/AssetIndex.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/asset/AssetIndex.java
@@ -83,4 +83,11 @@ public interface AssetIndex extends DataAddressResolver {
      */
     Asset deleteById(String assetId);
 
+    /**
+     * Counts all assets that are selected by the given query
+     *
+     * @param querySpec the query
+     * @return the number of assets (potentially 0)
+     */
+    long countAssets(QuerySpec querySpec);
 }

--- a/spi/common/core-spi/src/testFixtures/java/org/eclipse/dataspaceconnector/spi/asset/AssetIndexTestBase.java
+++ b/spi/common/core-spi/src/testFixtures/java/org/eclipse/dataspaceconnector/spi/asset/AssetIndexTestBase.java
@@ -30,8 +30,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
+import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 
@@ -136,6 +136,21 @@ public abstract class AssetIndexTestBase {
         assertThat(assetDeleted).usingRecursiveComparison().isEqualTo(asset);
 
         assertThat(getAssetIndex().queryAssets(QuerySpec.none()).count()).isEqualTo(0L);
+    }
+
+    @Test
+    void count_withResults() {
+        var assets = range(0, 5).mapToObj(i -> getAsset("id" + i));
+        assets.forEach(a -> getAssetIndex().accept(a, getDataAddress()));
+
+        var count = getAssetIndex().countAssets(QuerySpec.none());
+        assertThat(count).isEqualTo(5);
+    }
+
+    @Test
+    void count_withNoResults() {
+        var count = getAssetIndex().countAssets(QuerySpec.none());
+        assertThat(count).isEqualTo(0);
     }
 
     @Test
@@ -260,7 +275,7 @@ public abstract class AssetIndexTestBase {
     @Test
     @DisplayName("Query assets with query spec and short asset count")
     void queryAsset_querySpecShortCount() {
-        IntStream.range(1, 5).forEach((item) -> {
+        range(1, 5).forEach((item) -> {
             var asset = getAsset("id" + item);
             getAssetIndex().accept(asset, getDataAddress());
         });

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/ContractDefinitionService.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/ContractDefinitionService.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.spi.contract.offer;
 
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgent;
-import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.policy.engine.PolicyScope;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
 import org.jetbrains.annotations.NotNull;
@@ -37,7 +36,7 @@ public interface ContractDefinitionService {
      * Returns the definitions for the given participant agent.
      */
     @NotNull
-    Stream<ContractDefinition> definitionsFor(ParticipantAgent agent, Range range);
+    Stream<ContractDefinition> definitionsFor(ParticipantAgent agent);
 
     /**
      * Returns a contract definition for the agent associated with the given contract definition id. If the definition

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/ContractOfferQuery.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/ContractOfferQuery.java
@@ -27,9 +27,9 @@ import java.util.List;
  * A query that returns contract offers for the given parameters.
  */
 public class ContractOfferQuery {
+    private final List<Criterion> assetsCriteria = new ArrayList<>();
     private ClaimToken claimToken;
-    private List<Criterion> assetsCriteria;
-    private Range range;
+    private Range range = new Range();
 
     private ContractOfferQuery() {
     }
@@ -51,11 +51,10 @@ public class ContractOfferQuery {
     }
 
     public static final class Builder {
-        private final List<Criterion> assetsCriteria = new ArrayList<>();
-        private ClaimToken claimToken;
-        private Range range;
+        private final ContractOfferQuery instance;
 
         private Builder() {
+            instance = new ContractOfferQuery();
         }
 
         public static Builder newInstance() {
@@ -63,31 +62,27 @@ public class ContractOfferQuery {
         }
 
         public Builder claimToken(ClaimToken claimToken) {
-            this.claimToken = claimToken;
+            instance.claimToken = claimToken;
             return this;
         }
 
         public Builder assetsCriterion(Criterion assetsCriterion) {
-            assetsCriteria.add(assetsCriterion);
+            instance.assetsCriteria.add(assetsCriterion);
             return this;
         }
 
         public Builder assetsCriteria(Collection<Criterion> assetsCriteria) {
-            this.assetsCriteria.addAll(assetsCriteria);
+            instance.assetsCriteria.addAll(assetsCriteria);
             return this;
         }
 
         public Builder range(Range range) {
-            this.range = range;
+            instance.range = range;
             return this;
         }
 
         public ContractOfferQuery build() {
-            ContractOfferQuery contractOfferQuery = new ContractOfferQuery();
-            contractOfferQuery.claimToken = claimToken;
-            contractOfferQuery.range = range;
-            contractOfferQuery.assetsCriteria = assetsCriteria;
-            return contractOfferQuery;
+            return instance;
         }
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

In the current implementation of the `ContractOfferSerivceImpl`, the `Range` parameter is used to limit `ContractDefinitions` rather than the resulting `ContractOffers`. This is a bug and could lead to more contractOffers than specified by `Range`.

This PR dynamically composes the `Stream<Asset>` based on the `from` and `to` parameters of the `Range`, skipping as many `Assets` as necessary, and applying the `skip` and `limit` parameters to the respective database query.

In doing that, it was necessary to add a method `AssetIndex.count(QuerySpec)` to obtain the number of Assets referenced by a particular `AssetSelectorExpression`.

## Why it does that

To guarantee the correct/expected behaviour of the paging.

## Further notes

- This solution works regardless of the underlying implementation of the Stream returned by the AssetIndex
- There are other pending changes to be made (#2015 and #2009) which will also influence this area of code. 

Closes #2008 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
