### PR TITLE
feat(ServiceExtensionContext): freeze the ServiceExtensionContext before the prepare phase

### DIFF
--- a/core/common/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoader.java
+++ b/core/common/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoader.java
@@ -66,6 +66,8 @@ public class ExtensionLoader {
                 .map(ExtensionLifecycleManager::provide)
                 .collect(Collectors.toList());
 
+        context.freeze();
+
         var preparedExtensions = lifeCycles.stream().map(ExtensionLifecycleManager::prepare).collect(Collectors.toList());
         preparedExtensions.forEach(ExtensionLifecycleManager::start);
     }

--- a/core/common/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/DefaultServiceExtensionContextTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/DefaultServiceExtensionContextTest.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.dataspaceconnector.boot.system;
 
+import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.system.ConfigurationExtension;
 import org.eclipse.dataspaceconnector.spi.system.configuration.Config;
@@ -30,13 +31,14 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class DefaultServiceExtensionContextTest {
 
-    private DefaultServiceExtensionContext context;
     private final ConfigurationExtension configuration = mock(ConfigurationExtension.class);
+    private DefaultServiceExtensionContext context;
 
     @BeforeEach
     void setUp() {
@@ -165,6 +167,18 @@ class DefaultServiceExtensionContextTest {
         } finally {
             System.clearProperty("some.key");
         }
+    }
+
+    @Test
+    void registerService_throwsWhenFrozen() {
+        when(configuration.getConfig()).thenReturn(ConfigFactory.empty());
+        context.initialize();
+
+        context.freeze();
+        assertThatThrownBy(() -> context.registerService(Object.class, new Object() {
+        })).isInstanceOf(EdcException.class).hasMessageStartingWith("Cannot register service");
+
+
     }
 
 }

--- a/extensions/common/junit/src/test/java/org/eclipse/dataspaceconnector/junit/extensions/EdcExtensionTest.java
+++ b/extensions/common/junit/src/test/java/org/eclipse/dataspaceconnector/junit/extensions/EdcExtensionTest.java
@@ -15,12 +15,16 @@
 package org.eclipse.dataspaceconnector.junit.extensions;
 
 import okhttp3.OkHttpClient;
+import org.eclipse.dataspaceconnector.junit.testfixtures.MockVault;
+import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.system.MonitorExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -30,6 +34,7 @@ import static org.mockito.Mockito.verify;
 class EdcExtensionTest {
 
     private OkHttpClient testClient;
+
 
     @BeforeEach
     void setUp(EdcExtension extension) {
@@ -45,5 +50,12 @@ class EdcExtensionTest {
         var mockedMonitor = extension.getContext().getMonitor();
         assertThat(extension.getContext().getService(OkHttpClient.class)).isEqualTo(testClient);
         verify(mockedMonitor, atLeastOnce()).warning(startsWith("TestServiceExtensionContext: A service mock was registered for type okhttp3.OkHttpClient"));
+    }
+
+    @Test
+    void registerServiceMock_serviceContextReadOnlyMode(EdcExtension extension) {
+        assertThatThrownBy(() -> extension.getContext().registerService(Vault.class, new MockVault()))
+                .isInstanceOf(EdcException.class)
+                .hasMessageStartingWith("Cannot register service");
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ServiceExtensionContext.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ServiceExtensionContext.java
@@ -27,6 +27,14 @@ import java.time.Clock;
 public interface ServiceExtensionContext extends SettingResolver {
 
     /**
+     * Freeze the context. It should mark the ServiceExtensionContext as read-only, preventing the registration
+     * of new services after the initialization phase
+     */
+    default void freeze() {
+
+    }
+
+    /**
      * Fetches the unique ID of the connector. If the {@code dataspaceconnector.connector.name} config value has been set, that value is returned; otherwise  a random
      * name is chosen.
      */


### PR DESCRIPTION
## What this PR changes/adds

Marks the `ServiceExtensionContext` in read-only mode before the prepare phase in the EDC boostrap.

## Why it does that

Prevent undefined behavior when registering services in the prepare or start phase

## Linked Issue(s)

Closes #1852 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
