### PR TITLE
fix(MultipartController): use message recipient as token audience

### DIFF
--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/controller/MultipartController.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/controller/MultipartController.java
@@ -197,11 +197,14 @@ public class MultipartController {
      * @return the token.
      */
     private DynamicAttributeToken getToken(Message header) {
-        var tokenResult = tokenService.obtainDynamicAttributeToken(header.getIssuerConnector().toString());
-        if (tokenResult.succeeded()) {
-            return tokenResult.getContent();
+        if (header.getRecipientConnector() != null && !header.getRecipientConnector().isEmpty()) {
+            var recipient = header.getRecipientConnector().get(0);
+            var tokenResult = tokenService.obtainDynamicAttributeToken(recipient.toString());
+            if (tokenResult.succeeded()) {
+                return tokenResult.getContent();
+            }
         }
-    
+        
         return new DynamicAttributeTokenBuilder()
                 ._tokenFormat_(TokenFormat.JWT)
                 ._tokenValue_("invalid")


### PR DESCRIPTION
## What this PR changes/adds

The `MultipartController` now uses the recipient of a response message as the audience for the token request.

## Why it does that

Previously, the issuer of the message was used. Thus, the connector used itself as the token audience for responses.

## Linked Issue(s)

Closes #2017 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
