### PR TITLE
feat(build): add/apply autodoc plugin

### DIFF
--- a/docs/developer/autodoc.md
+++ b/docs/developer/autodoc.md
@@ -1,0 +1,8 @@
+# The `autodoc` Gradle plugin
+
+Please find the comprehensive documentation about the `autodoc` plugin in
+the [Github Repo](https://github.com/eclipse-dataspaceconnector/GradlePlugins/blob/main/docs/developer/autodoc.md) of
+the plugin.
+
+In EDC, the plugin is intended to be used to generate metamodel manifests for every Gradle module, which then
+transformed into Markdown files, subsequently rendered for publication in static web content. 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,17 @@
 groupId=org.eclipse.dataspaceconnector
 defaultVersion=0.0.1-SNAPSHOT
 javaVersion=11
-
 edcDeveloperId=mspiekermann
 edcDeveloperName=Markus Spiekermann
 edcDeveloperEmail=markus.spiekermann@isst.fraunhofer.de
 edcScmConnection=scm:git:git@github.com:eclipse-dataspaceconnector/DataSpaceConnector.git
 edcWebsiteUrl=https://github.com/eclipse-dataspaceconnector/DataSpaceConnector.git
 edcScmUrl=https://github.com/eclipse-dataspaceconnector/DataSpaceConnector.git
-
+# for now, we're using the same version for the autodoc plugin, the processor and the runtime-metamodel lib, but that could
+# change in the future
 metaModelVersion=0.0.1-SNAPSHOT
+autodocPluginVersion=0.0.1-SNAPSHOT
+annotationProcessorVersion=0.0.1-SNAPSHOT
 apacheCommonsPool2Version=2.11.1
 assertj=3.22.0
 atomikosVersion=5.0.8


### PR DESCRIPTION
## What this PR changes/adds

Applies the `autodoc` plugin to the EDC code base.

## Why it does that

metadata manifests should be auto-generated

## Further notes

- At this time we only have a `0.0.1-SNAPSHOT` version available
- The plugin, the annotation processor and the metamodel all use the same version, but I created three different variables, because their versioning might deviate in the future.
- the plugin's name and group id looks wrong, but actually needs to be this way, otherwise publishing to OSSRH Snapshots and the Gradle Portal would not be possible
- documentation will follow shortly, once the documentation-PR (https://github.com/eclipse-dataspaceconnector/GradlePlugins/pull/12) of the plugin itself is merged, because it will link there.

## Linked Issue(s)


## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
