### PR TITLE
fix(BaseRuntime): adds the exception messagge in the log before exit

### DIFF
--- a/core/common/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/runtime/BaseRuntime.java
+++ b/core/common/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/runtime/BaseRuntime.java
@@ -58,8 +58,8 @@ public class BaseRuntime {
     protected final ServiceLocator serviceLocator;
     private final AtomicReference<HealthCheckResult> startupStatus = new AtomicReference<>(HealthCheckResult.failed("Startup not complete"));
     private final ExtensionLoader extensionLoader;
-    protected Monitor monitor;
     private final List<ServiceExtension> serviceExtensions = new ArrayList<>();
+    protected Monitor monitor;
 
     public BaseRuntime() {
         this(new ServiceLocatorImpl());
@@ -100,11 +100,16 @@ public class BaseRuntime {
         monitor = createMonitor();
         MonitorProvider.setInstance(monitor);
 
-        var telemetry = loadTelemetry();
+        var telemetry = createTelemetry();
 
         var context = createContext(typeManager, monitor, telemetry);
         initializeContext(context);
         return context;
+    }
+
+    @NotNull
+    protected Telemetry createTelemetry() {
+        return loadTelemetry();
     }
 
     /**
@@ -129,7 +134,11 @@ public class BaseRuntime {
      * Callback for any error that happened during runtime initialization
      */
     protected void onError(Exception e) {
-        monitor.severe("Error booting runtime", e);
+        monitor.severe(String.format("Error booting runtime: %s", e.getMessage()), e);
+        exit();
+    }
+
+    protected void exit() {
         System.exit(-1);  // stop the process
     }
 

--- a/core/common/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/BaseRuntimeTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/BaseRuntimeTest.java
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.boot.system;
+
+import org.eclipse.dataspaceconnector.boot.system.testextensions.BaseExtension;
+import org.eclipse.dataspaceconnector.boot.system.testextensions.BaseRuntimeFixture;
+import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class BaseRuntimeTest {
+
+
+    private BaseRuntimeFixture runtime;
+
+    @AfterEach
+    void teardown() {
+        if (runtime != null) {
+            runtime.stop();
+        }
+    }
+
+    @Test
+    void baseRuntime_shouldBoot() {
+
+        var monitor = mock(Monitor.class);
+
+        runtime = new BaseRuntimeFixture(monitor, List.of(new BaseExtension()));
+
+        runtime.start();
+
+        verify(monitor, never()).severe(anyString(), any());
+
+    }
+
+    @Test
+    void baseRuntime_shouldNotBootWithoutExtensions() {
+
+        var monitor = mock(Monitor.class);
+
+        var runtime = new BaseRuntimeFixture(monitor);
+
+        runtime.start();
+
+        verify(monitor).severe(startsWith("Error booting runtime:"), any(EdcException.class));
+
+    }
+
+    @Test
+    void baseRuntime_shouldNotBootWithException() {
+        var monitor = mock(Monitor.class);
+        var extension = spy(new BaseExtension());
+
+        doThrow(new EdcException("Failed to start base extension")).when(extension).start();
+
+        var runtime = new BaseRuntimeFixture(monitor, List.of(extension));
+
+        runtime.start();
+
+        verify(monitor).severe(startsWith("Error booting runtime: Failed to start base extension"), any(EdcException.class));
+
+    }
+
+
+}

--- a/core/common/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/testextensions/BaseRuntimeFixture.java
+++ b/core/common/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/testextensions/BaseRuntimeFixture.java
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.boot.system.testextensions;
+
+import org.eclipse.dataspaceconnector.boot.system.DependencyGraph;
+import org.eclipse.dataspaceconnector.boot.system.runtime.BaseRuntime;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.system.health.HealthCheckService;
+import org.eclipse.dataspaceconnector.spi.system.injection.InjectionContainer;
+import org.eclipse.dataspaceconnector.spi.telemetry.Telemetry;
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+
+public class BaseRuntimeFixture extends BaseRuntime {
+
+
+    private final Monitor monitor;
+    private final List<ServiceExtension> extensions;
+
+    private final HealthCheckService healthCheckService = mock(HealthCheckService.class);
+
+    private final Telemetry telemetry = mock(Telemetry.class);
+
+    public BaseRuntimeFixture(Monitor monitor) {
+        this(monitor, new ArrayList<>());
+    }
+
+    public BaseRuntimeFixture(Monitor monitor, List<ServiceExtension> extensions) {
+        this.monitor = monitor;
+        this.extensions = extensions;
+
+
+    }
+
+    public void start() {
+        bootWithoutShutdownHook();
+    }
+
+    public void stop() {
+        super.shutdown();
+    }
+
+    @Override
+    protected @NotNull Telemetry createTelemetry() {
+        return telemetry;
+    }
+
+    @Override
+    protected void exit() {
+        // do nothing
+    }
+
+    @Override
+    protected List<InjectionContainer<ServiceExtension>> createExtensions() {
+
+        if (extensions != null && !extensions.isEmpty()) {
+            return new DependencyGraph().of(extensions);
+        } else {
+            return super.createExtensions();
+        }
+    }
+
+    @Override
+    protected @NotNull ServiceExtensionContext createContext(TypeManager typeManager, Monitor monitor, Telemetry telemetry) {
+        var ctx = super.createContext(typeManager, monitor, telemetry);
+        ctx.registerService(HealthCheckService.class, healthCheckService);
+        return ctx;
+    }
+
+    @Override
+    protected @NotNull Monitor createMonitor() {
+        return monitor;
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

Adds the exception message to the severe log before exit

## Why it does that

To have a clear information and diagnostic on why the system didn't boot

## Linked Issue(s)

Closes #1960 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
