### PR TITLE
fix(ContractOfferServiceImpl): check for existing criteria list in AssetSelectorExpression

### DIFF
--- a/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImplTest.java
+++ b/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImplTest.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.dataspaceconnector.contract.offer;
 
+import org.eclipse.dataspaceconnector.core.controlplane.defaults.assetindex.InMemoryAssetIndex;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgent;
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgentService;
@@ -29,12 +30,15 @@ import org.eclipse.dataspaceconnector.spi.policy.PolicyDefinition;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyDefinitionStore;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -64,12 +68,36 @@ class ContractOfferServiceImplTest {
     }
 
     @Test
-    void shouldGetContractOffers() {
+    void selectAll_shouldGetContractOffers() {
         var contractDefinition = ContractDefinition.Builder.newInstance()
                 .id("1")
                 .accessPolicyId("access")
                 .contractPolicyId("contract")
                 .selectorExpression(AssetSelectorExpression.SELECT_ALL)
+                .build();
+
+        when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
+        when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class), any())).thenReturn(Stream.of(contractDefinition));
+        var assetStream = Stream.of(Asset.Builder.newInstance().build(), Asset.Builder.newInstance().build());
+        when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(assetStream);
+        when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
+
+        var query = ContractOfferQuery.builder().range(DEFAULT_RANGE).claimToken(ClaimToken.Builder.newInstance().build()).build();
+
+        assertThat(contractOfferService.queryContractOffers(query)).hasSize(2);
+        verify(agentService).createFor(isA(ClaimToken.class));
+        verify(contractDefinitionService).definitionsFor(isA(ParticipantAgent.class), eq(DEFAULT_RANGE));
+        verify(assetIndex).queryAssets(isA(QuerySpec.class));
+        verify(policyStore).findById("contract");
+    }
+
+    @Test
+    void shouldGetContractOffers() {
+        var contractDefinition = ContractDefinition.Builder.newInstance()
+                .id("1")
+                .accessPolicyId("access")
+                .contractPolicyId("contract")
+                .selectorExpression(AssetSelectorExpression.Builder.newInstance().whenEquals("id", "1").build())
                 .build();
 
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
@@ -96,7 +124,7 @@ class ContractOfferServiceImplTest {
                 .build();
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
         when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class), any())).thenReturn(Stream.of(contractDefinition));
-        when(assetIndex.queryAssets(isA(AssetSelectorExpression.class))).thenReturn(Stream.of(Asset.Builder.newInstance().build()));
+        when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(Stream.of(Asset.Builder.newInstance().build()));
         when(policyStore.findById(any())).thenReturn(null);
 
         var query = ContractOfferQuery.builder().claimToken(ClaimToken.Builder.newInstance().build()).build();
@@ -136,5 +164,88 @@ class ContractOfferServiceImplTest {
         verify(contractDefinitionService).definitionsFor(isA(ParticipantAgent.class), eq(DEFAULT_RANGE));
         verify(policyStore).findById("contract");
         verify(assetIndex).queryAssets(eq(expectedQuerySpec));
+    }
+
+    @Test
+    void queryContractOffers_missingCriteriaList_inMemory_returnsEmpty() {
+        var contractDefinition = ContractDefinition.Builder.newInstance()
+                .id("1")
+                .accessPolicyId("access")
+                .contractPolicyId("contract")
+                .selectorExpression(AssetSelectorExpression.Builder.newInstance().build())
+                .build();
+
+        when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
+        when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class), any())).thenReturn(Stream.of(contractDefinition));
+        when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
+
+        var testAsset = createAsset("foobar");
+        var index = new InMemoryAssetIndex();
+        index.accept(testAsset, createDataAddress(testAsset));
+
+        var offerSvc = new ContractOfferServiceImpl(agentService, contractDefinitionService, index, policyStore);
+
+        var query = ContractOfferQuery.builder()
+                .range(DEFAULT_RANGE)
+                .claimToken(ClaimToken.Builder.newInstance().build())
+                .assetsCriteria(List.of(new Criterion(Asset.PROPERTY_ID, "=", "2")))
+                .build();
+
+        var result = offerSvc.queryContractOffers(query).toArray();
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void queryContractOffers_emptyCriteriaList_inMemory_returnsEmpty() {
+        var contractDefinition = ContractDefinition.Builder.newInstance()
+                .id("1")
+                .accessPolicyId("access")
+                .contractPolicyId("contract")
+                .selectorExpression(AssetSelectorExpression.Builder.newInstance().criteria(List.of()).build())
+                .build();
+
+        when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
+        when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class), any())).thenReturn(Stream.of(contractDefinition));
+        when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
+
+        var testAsset = createAsset("foobar");
+        var index = new InMemoryAssetIndex();
+        index.accept(testAsset, createDataAddress(testAsset));
+
+        var offerSvc = new ContractOfferServiceImpl(agentService, contractDefinitionService, index, policyStore);
+
+        var query = ContractOfferQuery.builder()
+                .range(DEFAULT_RANGE)
+                .claimToken(ClaimToken.Builder.newInstance().build())
+                .assetsCriteria(List.of(new Criterion(Asset.PROPERTY_ID, "=", "2")))
+                .build();
+
+        var result = offerSvc.queryContractOffers(query).toArray();
+
+        assertThat(result).isEmpty();
+    }
+
+    @NotNull
+    private Asset createAsset(String name) {
+        return createAsset(name, UUID.randomUUID().toString());
+    }
+
+    @NotNull
+    private Asset createAsset(String name, String id) {
+        return createAsset(name, id, "contentType");
+    }
+
+    @NotNull
+    private Asset createAsset(String name, String id, String contentType) {
+        return Asset.Builder.newInstance().id(id).name(name).version("1").contentType(contentType).build();
+    }
+
+    @NotNull
+    private DataAddress createDataAddress(Asset asset) {
+        return DataAddress.Builder.newInstance()
+                .keyName("test-keyname")
+                .type(asset.getContentType())
+                .build();
     }
 }

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/dataspaceconnector/core/controlplane/defaults/assetindex/InMemoryAssetIndex.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/dataspaceconnector/core/controlplane/defaults/assetindex/InMemoryAssetIndex.java
@@ -55,11 +55,6 @@ public class InMemoryAssetIndex implements AssetIndex {
     public Stream<Asset> queryAssets(AssetSelectorExpression expression) {
         Objects.requireNonNull(expression, "AssetSelectorExpression can not be null!");
 
-        // select everything ONLY if the special constant is used
-        if (expression == AssetSelectorExpression.SELECT_ALL) {
-            return queryAssets(QuerySpec.none());
-        }
-
         return queryAssets(QuerySpec.Builder.newInstance().filter(expression.getCriteria()).build());
     }
 

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/Oauth2DefaultServicesExtension.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/Oauth2DefaultServicesExtension.java
@@ -12,7 +12,6 @@
  *
  */
 
-
 package org.eclipse.dataspaceconnector.iam.oauth2.core;
 
 import org.eclipse.dataspaceconnector.iam.oauth2.spi.CredentialsRequestAdditionalParametersProvider;

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/rule/Oauth2AudienceValidationRule.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/rule/Oauth2AudienceValidationRule.java
@@ -12,7 +12,6 @@
  *
  */
 
-
 package org.eclipse.dataspaceconnector.iam.oauth2.core.rule;
 
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/rule/Oauth2ExpirationIssuedAtValidationRule.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/rule/Oauth2ExpirationIssuedAtValidationRule.java
@@ -12,7 +12,6 @@
  *
  */
 
-
 package org.eclipse.dataspaceconnector.iam.oauth2.core.rule;
 
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/rule/Oauth2NotBeforeValidationRule.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/rule/Oauth2NotBeforeValidationRule.java
@@ -12,7 +12,6 @@
  *
  */
 
-
 package org.eclipse.dataspaceconnector.iam.oauth2.core.rule;
 
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;

--- a/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/dataspaceconnector/iam/oauth2/core/rule/Oauth2NotBeforeValidationRuleTest.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/dataspaceconnector/iam/oauth2/core/rule/Oauth2NotBeforeValidationRuleTest.java
@@ -12,7 +12,6 @@
  *
  */
 
-
 package org.eclipse.dataspaceconnector.iam.oauth2.core.rule;
 
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;

--- a/extensions/control-plane/api/data-management/contractdefinition-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/CriterionDto.java
+++ b/extensions/control-plane/api/data-management/contractdefinition-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/CriterionDto.java
@@ -12,7 +12,6 @@
  *
  */
 
-
 package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/extensions/control-plane/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/validation/ExpirationDateValidationRuleTest.java
+++ b/extensions/control-plane/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/validation/ExpirationDateValidationRuleTest.java
@@ -12,7 +12,6 @@
  *
  */
 
-
 package org.eclipse.dataspaceconnector.transfer.dataplane.sync.validation;
 
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;

--- a/extensions/control-plane/store/cosmos/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndex.java
+++ b/extensions/control-plane/store/cosmos/assetindex-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/CosmosAssetIndex.java
@@ -65,10 +65,6 @@ public class CosmosAssetIndex implements AssetIndex {
     public Stream<Asset> queryAssets(AssetSelectorExpression expression) {
         Objects.requireNonNull(expression, "AssetSelectorExpression can not be null!");
 
-        if (expression.equals(AssetSelectorExpression.SELECT_ALL)) {
-            return queryAssets(QuerySpec.none());
-        }
-
         SqlQuerySpec query = queryBuilder.from(expression.getCriteria());
 
         var response = with(retryPolicy).get(() -> assetDb.queryItems(query));

--- a/spi/common/oauth2-spi/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/spi/NoopCredentialsRequestAdditionalParametersProvider.java
+++ b/spi/common/oauth2-spi/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/spi/NoopCredentialsRequestAdditionalParametersProvider.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.iam.oauth2.spi;
 
 import org.eclipse.dataspaceconnector.spi.iam.TokenParameters;

--- a/spi/federated-catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/FederatedCacheNodeFilter.java
+++ b/spi/federated-catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/FederatedCacheNodeFilter.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi;
 
 import java.util.function.Predicate;


### PR DESCRIPTION
## What this PR changes/adds

Moves/Adds business logic to `ContractOfferServiceImpl`:
(1) Query `Assets` with `QuerySpec.none()` if `AssetSelectorExpression == AssetSelectorExpression.SELECT_ALL`
(2) Filter `ContractDefinitions` with empty or null criteria list if `AssetSelectorExpression != AssetSelectorExpression.SELECT_ALL`

Removes check (1) from `InMemoryAssetIndex` and `CosmosAssetIndex`.

## Why it does that

For database queries, no filter criteria means "select all" (equal to "*"). In terms of data sovereignty and our domain model, `ContractDefinitions` that provide no selector expression are not pointing to an `Asset` and should therefore not result in a valid `ContractOffer` as part of the conntector's `Catalog`.

## Further notes

Unit tests added for `InMemoryAssetIndex`. As the logic is added to the `ContractOfferServiceImpl`, this behavior will exist for all `AssetIndex` implementations. 

Tested locally with sample 4.0: Registering a `ContractDefinition` in `FileTransferExtension` with an empty or null criteria list results in a catalog with 0 `contractOffers` during catalog querying. (This was not the case before the added filter.)

Local style check hinted to missing license headers and redundant line spaces --> fixed this.

## Linked Issue(s)

Closes #2009 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
