### PR TITLE
fix(DataPlaneTransferSyncExtension): remove default value for publickey alias

### DIFF
--- a/extensions/control-plane/data-plane-transfer/data-plane-transfer-sync/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/DataPlaneTransferSyncExtension.java
+++ b/extensions/control-plane/data-plane-transfer/data-plane-transfer-sync/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/DataPlaneTransferSyncExtension.java
@@ -144,7 +144,7 @@ public class DataPlaneTransferSyncExtension implements ServiceExtension {
         var privateKey = privateKeyResolver.resolvePrivateKey(privateKeyAlias, PrivateKey.class);
         Objects.requireNonNull(privateKey, "Failed to resolve private key with alias: " + privateKeyAlias);
 
-        var publicKeyAlias = config.getString(TOKEN_VERIFIER_PUBLIC_KEY_ALIAS, privateKeyAlias + "-pub");
+        var publicKeyAlias = config.getString(TOKEN_VERIFIER_PUBLIC_KEY_ALIAS);
         var publicKeyPem = vault.resolveSecret(publicKeyAlias);
         Objects.requireNonNull(publicKeyPem, "Failed to resolve public key secret with alias: " + publicKeyPem);
         var publicKey = PublicKeyParser.from(publicKeyPem);


### PR DESCRIPTION

## What this PR changes/adds

Removes default value for `edc.transfer.proxy.token.verifier.publickey.alias`

## Why it does that

Consistent setting public/private key, clear exception in case of settings missing

## Linked Issue(s)

Closes #1889 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
