### PR TITLE
chore(ContractOffer): remove field assetId

### DIFF
--- a/core/federated-catalog/federated-catalog-core/src/test/java/org/eclipse/dataspaceconnector/catalog/query/BatchedRequestFetcherTest.java
+++ b/core/federated-catalog/federated-catalog-core/src/test/java/org/eclipse/dataspaceconnector/catalog/query/BatchedRequestFetcherTest.java
@@ -19,6 +19,7 @@ import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.CatalogRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
@@ -92,7 +93,7 @@ class BatchedRequestFetcherTest {
                 .mapToObj(i -> ContractOffer.Builder.newInstance()
                         .id("id" + i)
                         .policy(Policy.Builder.newInstance().build())
-                        .assetId("asset" + i)
+                        .asset(Asset.Builder.newInstance().id("asset" + i).build())
                         .build())
                 .collect(Collectors.toList());
 

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/type/MultipartContractOfferSenderTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/type/MultipartContractOfferSenderTest.java
@@ -26,6 +26,7 @@ import org.eclipse.dataspaceconnector.policy.model.Action;
 import org.eclipse.dataspaceconnector.policy.model.Permission;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractOfferRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,58 +37,58 @@ import java.net.URI;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class MultipartContractOfferSenderTest {
-    
+
     private MultipartContractOfferSender sender;
     private ObjectMapper objectMapper;
-    
+
     @BeforeEach
     void setUp() {
         var connectorId = URI.create("https://connector");
         var webhookAddress = "https://webhook";
-        
+
         var transformerRegistry = new IdsTransformerRegistryImpl();
         transformerRegistry.register(new ContractOfferToIdsContractOfferTransformer());
         transformerRegistry.register(new PermissionToIdsPermissionTransformer());
         transformerRegistry.register(new ActionToIdsActionTransformer());
-    
+
         objectMapper = IdsTypeManagerUtil.getIdsObjectMapper(new TypeManager());
-        
+
         var senderContext = new SenderDelegateContext(connectorId, objectMapper, transformerRegistry, webhookAddress);
         sender = new MultipartContractOfferSender(senderContext);
     }
-    
+
     @Test
     void buildMessagePayload_initialRequest_mapPolicyProperties() throws Exception {
         var policy = getPolicy();
         var request = getContractOfferRequest(policy, ContractOfferRequest.Type.INITIAL);
-        
+
         var result = sender.buildMessagePayload(request);
-        
+
         var contractRequest = objectMapper.readValue(result, ContractRequest.class);
         assertThat(contractRequest.getProperties())
                 .hasSize(2)
                 .containsAllEntriesOf(policy.getExtensibleProperties());
     }
-    
+
     @Test
     void buildMessagePayload_notInitialRequest_mapPolicyProperties() throws Exception {
         var policy = getPolicy();
         var request = getContractOfferRequest(policy, ContractOfferRequest.Type.COUNTER_OFFER);
-    
+
         var result = sender.buildMessagePayload(request);
-    
+
         var contractOffer = objectMapper.readValue(result, de.fraunhofer.iais.eis.ContractOffer.class);
         assertThat(contractOffer.getProperties())
                 .hasSize(2)
                 .containsAllEntriesOf(policy.getExtensibleProperties());
     }
-    
+
     private ContractOfferRequest getContractOfferRequest(Policy policy, ContractOfferRequest.Type type) {
         return ContractOfferRequest.Builder.newInstance()
                 .contractOffer(ContractOffer.Builder.newInstance()
                         .id("contract-offer")
                         .policy(policy)
-                        .assetId("asset-id")
+                        .asset(Asset.Builder.newInstance().id("asset-id").build())
                         .build())
                 .protocol("protocol")
                 .connectorId("connector")
@@ -95,12 +96,12 @@ class MultipartContractOfferSenderTest {
                 .type(type)
                 .build();
     }
-    
+
     private Policy getPolicy() {
         var usePermission = Permission.Builder.newInstance()
                 .action(Action.Builder.newInstance().type("USE").build())
                 .build();
-        
+
         return Policy.Builder.newInstance()
                 .permission(usePermission)
                 .extensibleProperty("key1", "value1")

--- a/docs/swaggerui/swagger-spec.js
+++ b/docs/swaggerui/swagger-spec.js
@@ -2361,9 +2361,6 @@ window.swaggerSpec={
           "asset" : {
             "$ref" : "#/components/schemas/Asset"
           },
-          "assetId" : {
-            "type" : "string"
-          },
           "consumer" : {
             "type" : "string",
             "format" : "uri"

--- a/extensions/control-plane/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerIntegrationTest.java
@@ -24,6 +24,7 @@ import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcher;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.junit.jupiter.api.BeforeEach;
@@ -71,7 +72,7 @@ public class CatalogApiControllerIntegrationTest {
         var contractOffer = ContractOffer.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .policy(Policy.Builder.newInstance().build())
-                .assetId(UUID.randomUUID().toString())
+                .asset(Asset.Builder.newInstance().id(UUID.randomUUID().toString()).build())
                 .build();
         var catalog = Catalog.Builder.newInstance().id("id").contractOffers(List.of(contractOffer)).build();
         var emptyCatalog = Catalog.Builder.newInstance().id("id2").contractOffers(List.of()).build();
@@ -93,7 +94,7 @@ public class CatalogApiControllerIntegrationTest {
         var contractOffer = ContractOffer.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .policy(Policy.Builder.newInstance().build())
-                .assetId(UUID.randomUUID().toString())
+                .asset(Asset.Builder.newInstance().id(UUID.randomUUID().toString()).build())
                 .build();
         var catalog = Catalog.Builder.newInstance().id("id").contractOffers(List.of(contractOffer)).build();
         var emptyCatalog = Catalog.Builder.newInstance().id("id2").contractOffers(List.of()).build();

--- a/extensions/control-plane/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerTest.java
+++ b/extensions/control-plane/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerTest.java
@@ -23,6 +23,7 @@ import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,7 +61,7 @@ class CatalogApiControllerTest {
         var offer = ContractOffer.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .policy(Policy.Builder.newInstance().build())
-                .assetId(UUID.randomUUID().toString())
+                .asset(Asset.Builder.newInstance().id(UUID.randomUUID().toString()).build())
                 .build();
         var catalog = Catalog.Builder.newInstance().id("any").contractOffers(List.of(offer)).build();
         var url = "test.url";

--- a/extensions/control-plane/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/service/CatalogServiceImplTest.java
+++ b/extensions/control-plane/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/service/CatalogServiceImplTest.java
@@ -18,6 +18,7 @@ import org.assertj.core.api.InstanceOfAssertFactories;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.CatalogRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
@@ -47,7 +48,7 @@ class CatalogServiceImplTest {
         var contractOffer = ContractOffer.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .policy(Policy.Builder.newInstance().build())
-                .assetId(UUID.randomUUID().toString())
+                .asset(Asset.Builder.newInstance().id(UUID.randomUUID().toString()).build())
                 .build();
         var catalog = Catalog.Builder.newInstance().id("id").contractOffers(List.of(contractOffer)).build();
         when(dispatcher.send(any(), any(), any())).thenReturn(completedFuture(catalog))

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -1718,8 +1718,6 @@ components:
       properties:
         asset:
           $ref: '#/components/schemas/Asset'
-        assetId:
-          type: string
         consumer:
           type: string
           format: uri

--- a/resources/openapi/yaml/catalog-api.yaml
+++ b/resources/openapi/yaml/catalog-api.yaml
@@ -89,8 +89,6 @@ components:
       properties:
         asset:
           $ref: '#/components/schemas/Asset'
-        assetId:
-          type: string
         consumer:
           type: string
           format: uri

--- a/resources/openapi/yaml/federated-catalog-core.yaml
+++ b/resources/openapi/yaml/federated-catalog-core.yaml
@@ -54,8 +54,6 @@ components:
       properties:
         asset:
           $ref: '#/components/schemas/Asset'
-        assetId:
-          type: string
         consumer:
           type: string
           format: uri

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/offer/ContractOffer.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/offer/ContractOffer.java
@@ -41,16 +41,8 @@ public class ContractOffer {
 
     /**
      * The offered asset
-     * Must be mutually exclusive with {@link ContractOffer#getAssetId()} ()}
      */
     private Asset asset;
-    /**
-     * Refers to the asset that is offered. Note that this is only to be used during the actual negotiation and cannot
-     * be
-     * used in the initial offer from the provider to the consumer.
-     * Must be mutually exclusive with {@link ContractOffer#getAsset()}
-     */
-    private String assetId;
     /**
      * The participant who provides the offered data
      */
@@ -76,10 +68,6 @@ public class ContractOffer {
      */
     private ZonedDateTime contractEnd;
 
-    @Nullable
-    public String getAssetId() {
-        return assetId;
-    }
 
     @NotNull
     public String getId() {
@@ -156,7 +144,6 @@ public class ContractOffer {
         private ZonedDateTime offerEnd;
         private ZonedDateTime contractStart;
         private ZonedDateTime contractEnd;
-        private String assetId;
 
         private Builder() {
         }
@@ -212,17 +199,8 @@ public class ContractOffer {
         }
 
 
-        public Builder assetId(String assetId) {
-            this.assetId = assetId;
-            return this;
-        }
-
         public ContractOffer build() {
             Objects.requireNonNull(id);
-
-            if (assetId != null && asset != null) {
-                throw new IllegalArgumentException("Asset and AssetId are mutually exclusive");
-            }
 
             if (policy == null) {
                 throw new IllegalArgumentException("Policy must not be null!");
@@ -238,7 +216,6 @@ public class ContractOffer {
             offer.offerEnd = offerEnd;
             offer.contractStart = contractStart;
             offer.contractEnd = contractEnd;
-            offer.assetId = assetId;
             return offer;
         }
     }

--- a/spi/control-plane/contract-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/offer/ContractOfferTest.java
+++ b/spi/control-plane/contract-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/offer/ContractOfferTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.spi.types.domain.contract.offer;
 
-import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,26 +26,13 @@ class ContractOfferTest {
     void setUp() {
     }
 
-    @Test
-    void verifyMutualExclusivity() {
-        var p = ContractOffer.Builder.newInstance().id("test-offer");
-
-        assertThatThrownBy(() -> ContractOffer.Builder.newInstance()
-                .id("some-id")
-                .policy(Policy.Builder.newInstance().build())
-                .asset(Asset.Builder.newInstance().build())
-                .assetId("violating-id")
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Asset and AssetId are mutually exclusive");
-    }
 
     @Test
     void verifyRequiredFields() {
         assertThatThrownBy(() -> ContractOffer.Builder.newInstance().build()).isInstanceOf(NullPointerException.class);
 
         assertThatThrownBy(() -> ContractOffer.Builder.newInstance().id("some-id")
-                .assetId("test-assetId")
+                .asset(Asset.Builder.newInstance().id("test-assetId").build())
                 .build())
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Policy must not be null!");


### PR DESCRIPTION
## What this PR changes/adds

Removes `assetId` from `ContractOffer`

## Why it does that

Cleanup, since `assetId` is not used  by anyone

## Linked Issue(s)

Closes #2030 

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
