### PR TITLE
feat(DataSourceRegistry): provides a default impl for DataSourceRegistry

### DIFF
--- a/core/common/base/build.gradle.kts
+++ b/core/common/base/build.gradle.kts
@@ -28,6 +28,8 @@ dependencies {
     api(project(":spi:common:core-spi"))
     api(project(":spi:common:policy-engine-spi"))
     api(project(":spi:common:transaction-spi"))
+    api(project(":spi:common:transaction-datasource-spi"))
+
     implementation(project(":core:common:policy-engine"))
     implementation(project(":core:common:util"))
 

--- a/core/common/base/src/main/java/org/eclipse/dataspaceconnector/core/CoreDefaultServicesExtension.java
+++ b/core/common/base/src/main/java/org/eclipse/dataspaceconnector/core/CoreDefaultServicesExtension.java
@@ -34,6 +34,8 @@ import org.eclipse.dataspaceconnector.spi.system.vault.NoopPrivateKeyResolver;
 import org.eclipse.dataspaceconnector.spi.system.vault.NoopVault;
 import org.eclipse.dataspaceconnector.spi.transaction.NoopTransactionContext;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
+import org.eclipse.dataspaceconnector.spi.transaction.datasource.DataSourceRegistry;
+import org.eclipse.dataspaceconnector.spi.transaction.datasource.DefaultDataSourceRegistry;
 
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.Executors;
@@ -67,6 +69,13 @@ public class CoreDefaultServicesExtension implements ServiceExtension {
     public TransactionContext defaultTransactionContext(ServiceExtensionContext context) {
         context.getMonitor().warning("No TransactionContext registered, a no-op implementation will be used, not suitable for production environments");
         return new NoopTransactionContext();
+    }
+
+    @Provider(isDefault = true)
+    public DataSourceRegistry dataSourceRegistry(ServiceExtensionContext context) {
+        context.getMonitor().warning("No DataSourceRegistry registered, DefaultDataSourceRegistry will be used, not suitable for production environments");
+        return new DefaultDataSourceRegistry();
+
     }
 
     @Provider(isDefault = true)

--- a/spi/common/transaction-datasource-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transaction/datasource/DefaultDataSourceRegistry.java
+++ b/spi/common/transaction-datasource-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transaction/datasource/DefaultDataSourceRegistry.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.transaction.datasource;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+
+/**
+ * Default datasource registry without additional transaction manager logic
+ */
+public class DefaultDataSourceRegistry implements DataSourceRegistry {
+
+    private final Map<String, DataSource> datasources = new HashMap<>();
+
+    @Override
+    public void register(String name, DataSource dataSource) {
+        datasources.put(name, dataSource);
+    }
+
+    @Override
+    public DataSource resolve(String name) {
+        return datasources.get(name);
+    }
+}

--- a/spi/common/transaction-datasource-spi/src/test/java/org/eclipse/dataspaceconnector/spi/transaction/datasource/DefaultDataSourceRegistryTest.java
+++ b/spi/common/transaction-datasource-spi/src/test/java/org/eclipse/dataspaceconnector/spi/transaction/datasource/DefaultDataSourceRegistryTest.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.transaction.datasource;
+
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class DefaultDataSourceRegistryTest {
+
+
+    @Test
+    void verifyRegisterAndResolve() {
+        var registry = new DefaultDataSourceRegistry();
+        var datasource = mock(DataSource.class);
+
+        registry.register(DataSourceRegistry.DEFAULT_DATASOURCE, datasource);
+        assertThat(registry.resolve(DataSourceRegistry.DEFAULT_DATASOURCE)).isNotNull().isEqualTo(datasource);
+        assertThat(registry.resolve("foo")).isNull();
+
+    }
+}


### PR DESCRIPTION


## What this PR changes/adds

 Provide a default `DataSourceRegistry` 

## Why it does that

improve developer experience


## Linked Issue(s)

Closes #2032 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
