### PR TITLE
fix(ContractOffer): add asset not null check when building a ContractOffer

### DIFF
--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/dataspaceconnector/core/controlplane/defaults/negotiationstore/TestFunctions.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/dataspaceconnector/core/controlplane/defaults/negotiationstore/TestFunctions.java
@@ -21,6 +21,7 @@ import org.eclipse.dataspaceconnector.policy.model.LiteralExpression;
 import org.eclipse.dataspaceconnector.policy.model.Operator;
 import org.eclipse.dataspaceconnector.policy.model.Permission;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
@@ -43,7 +44,8 @@ public class TestFunctions {
                 .id(id)
                 .type(ContractNegotiation.Type.CONSUMER)
                 .contractOffers(List.of(ContractOffer.Builder.newInstance().id("contractId")
-                        .policy(Policy.Builder.newInstance().build()).build()))
+                        .policy(Policy.Builder.newInstance().build())
+                        .asset(Asset.Builder.newInstance().id("test-asset").build()).build()))
                 .counterPartyAddress("consumer")
                 .counterPartyId("consumerId")
                 .protocol("ids-multipart");

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/MultipartDispatcherIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/client/MultipartDispatcherIntegrationTest.java
@@ -145,7 +145,7 @@ class MultipartDispatcherIntegrationTest {
 
     @Test
     void testSendContractOfferMessage(RemoteMessageDispatcherRegistry dispatcher) {
-        var contractOffer = ContractOffer.Builder.newInstance().id("id").policy(Policy.Builder.newInstance().build()).build();
+        var contractOffer = contractOffer("id");
         when(transformerRegistry.transform(any(), any()))
                 .thenReturn(Result.success(getIdsContractOffer()));
 
@@ -166,8 +166,7 @@ class MultipartDispatcherIntegrationTest {
 
     @Test
     void testSendContractRequestMessage(RemoteMessageDispatcherRegistry dispatcher, AssetIndex assetIndex) {
-        var policy = Policy.Builder.newInstance().build();
-        var contractOffer = ContractOffer.Builder.newInstance().id("id").policy(policy).build();
+        var contractOffer = contractOffer("id");
         assetIndex.accept(Asset.Builder.newInstance().id("1").build(), DataAddress.Builder.newInstance().type("any").build());
         when(transformerRegistry.transform(any(), eq(de.fraunhofer.iais.eis.ContractOffer.class))).thenReturn(Result.success(getIdsContractOffer()));
         when(transformerRegistry.transform(any(), eq(ContractOffer.class))).thenReturn(Result.success(contractOffer));
@@ -234,6 +233,14 @@ class MultipartDispatcherIntegrationTest {
 
     protected String getUrl() {
         return String.format("http://localhost:%s/api/v1/ids%s", IDS_PORT, MultipartController.PATH);
+    }
+
+    protected ContractOffer contractOffer(String id) {
+        return ContractOffer.Builder.newInstance()
+                .id(id)
+                .policy(Policy.Builder.newInstance().build())
+                .asset(Asset.Builder.newInstance().id("test-asset").build())
+                .build();
     }
 
     private de.fraunhofer.iais.eis.ContractOffer getIdsContractOffer() {

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/DescriptionRequestHandlerTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/DescriptionRequestHandlerTest.java
@@ -71,18 +71,16 @@ import static org.mockito.Mockito.when;
 
 class DescriptionRequestHandlerTest {
 
-    private final int rangeFrom = 0;
-    private final int rangeTo = 10;
-    
-    private IdsId connectorId;
-
+    private static final String CONNECTOR_ID = "urn:connector:edc";
     private static final String PROPERTY = "property";
     private static final String VALUE = "value";
     private static final String EQUALS_SIGN = "=";
     private static final String FILTER_EXPRESSION = "filterExpression";
     private static final String OFFSET = "offset";
     private static final String LIMIT = "limit";
-
+    private final int rangeFrom = 0;
+    private final int rangeTo = 10;
+    private IdsId connectorId;
     private DescriptionRequestHandler handler;
 
     private IdsTransformerRegistry transformerRegistry;
@@ -94,7 +92,7 @@ class DescriptionRequestHandlerTest {
     @BeforeEach
     void init() {
         connectorId = IdsId.from("urn:connector:edc").getContent();
-    
+
         transformerRegistry = mock(IdsTransformerRegistry.class);
         assetIndex = mock(AssetIndex.class);
         catalogService = mock(CatalogService.class);
@@ -167,10 +165,10 @@ class DescriptionRequestHandlerTest {
 
         verify(catalogService, times(1))
                 .getDataCatalog(any(),
-                    argThat(query -> query.getRange().getFrom() == rangeFrom && query.getRange().getTo() == rangeTo &&
-                        query.getFilterExpression().get(0).getOperandLeft().equals(PROPERTY) &&
-                        query.getFilterExpression().get(0).getOperandRight().equals(VALUE) &&
-                        query.getFilterExpression().get(0).getOperator().equals(EQUALS_SIGN)));
+                        argThat(query -> query.getRange().getFrom() == rangeFrom && query.getRange().getTo() == rangeTo &&
+                                query.getFilterExpression().get(0).getOperandLeft().equals(PROPERTY) &&
+                                query.getFilterExpression().get(0).getOperandRight().equals(VALUE) &&
+                                query.getFilterExpression().get(0).getOperator().equals(EQUALS_SIGN)));
         verifyNoMoreInteractions(catalogService);
         verifyNoInteractions(connectorService, contractOfferService, assetIndex);
     }
@@ -184,6 +182,7 @@ class DescriptionRequestHandlerTest {
         var contractOffer = ContractOffer.Builder.newInstance()
                 .id("id")
                 .policy(Policy.Builder.newInstance().build())
+                .asset(Asset.Builder.newInstance().id("test-asset").build())
                 .build();
         var request = MultipartRequest.Builder.newInstance()
                 .header(descriptionRequestMessage(URI.create("urn:resource:" + assetId)))

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImplTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImplTest.java
@@ -20,6 +20,7 @@ import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,10 +51,12 @@ class CatalogServiceImplTest {
         var offers = Arrays.asList(
                 ContractOffer.Builder.newInstance()
                         .policy(Policy.Builder.newInstance().build())
+                        .asset(Asset.Builder.newInstance().id("test-asset").build())
                         .id("1")
                         .build(),
                 ContractOffer.Builder.newInstance()
                         .policy(Policy.Builder.newInstance().build())
+                        .asset(Asset.Builder.newInstance().id("test-asset").build())
                         .id("1")
                         .build());
         when(contractOfferService.queryContractOffers(any(ContractOfferQuery.class))).thenReturn(offers.stream());

--- a/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/dataspaceconnector/ids/transform/ContractOfferToIdsContractOfferTransformerTest.java
+++ b/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/dataspaceconnector/ids/transform/ContractOfferToIdsContractOfferTransformerTest.java
@@ -21,6 +21,7 @@ import org.eclipse.dataspaceconnector.policy.model.Permission;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.policy.model.Prohibition;
 import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
@@ -115,6 +116,7 @@ public class ContractOfferToIdsContractOfferTransformerTest {
         return ContractOffer.Builder.newInstance()
                 .id(CONTRACT_OFFER_ID)
                 .policy(policy)
+                .asset(Asset.Builder.newInstance().id("test-asset").build())
                 .provider(PROVIDER_URI)
                 .build();
     }

--- a/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/dataspaceconnector/ids/transform/OfferedAssetToIdsResourceTransformerTest.java
+++ b/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/dataspaceconnector/ids/transform/OfferedAssetToIdsResourceTransformerTest.java
@@ -50,6 +50,15 @@ class OfferedAssetToIdsResourceTransformerTest {
 
     private OfferedAssetToIdsResourceTransformer transformer;
 
+    @NotNull
+    private static ContractOffer createContractOffer() {
+        return ContractOffer.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .policy(Policy.Builder.newInstance().build())
+                .asset(Asset.Builder.newInstance().id("test-asset").build())
+                .build();
+    }
+
     @BeforeEach
     void setUp() {
         transformer = new OfferedAssetToIdsResourceTransformer();
@@ -80,14 +89,6 @@ class OfferedAssetToIdsResourceTransformerTest {
         assertThat(result.getContractOffer()).hasSize(2);
         verify(context).transform(any(Asset.class), eq(Representation.class));
         verify(context, times(2)).transform(any(ContractOffer.class), eq(de.fraunhofer.iais.eis.ContractOffer.class));
-    }
-
-    @NotNull
-    private static ContractOffer createContractOffer() {
-        return ContractOffer.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
-                .policy(Policy.Builder.newInstance().build())
-                .build();
     }
 
 }

--- a/extensions/control-plane/api/data-management/contractnegotiation-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerTest.java
+++ b/extensions/control-plane/api/data-management/contractnegotiation-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerTest.java
@@ -31,6 +31,7 @@ import org.eclipse.dataspaceconnector.spi.exception.ObjectNotFoundException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractOfferRequest;
@@ -298,6 +299,7 @@ class ContractNegotiationApiControllerTest {
                 .contractOffer(ContractOffer.Builder.newInstance()
                         .id(UUID.randomUUID().toString())
                         .policy(Policy.Builder.newInstance().build())
+                        .asset(Asset.Builder.newInstance().id("test-asset").build())
                         .build())
                 .build();
     }

--- a/extensions/control-plane/api/data-management/contractnegotiation-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/service/ContractNegotiationServiceImplTest.java
+++ b/extensions/control-plane/api/data-management/contractnegotiation-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/service/ContractNegotiationServiceImplTest.java
@@ -22,6 +22,7 @@ import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.response.StatusResult;
 import org.eclipse.dataspaceconnector.spi.transaction.NoopTransactionContext;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.agreement.ContractAgreement;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.command.CancelNegotiationCommand;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
@@ -192,7 +193,11 @@ class ContractNegotiationServiceImplTest {
                 .connectorId("connectorId")
                 .connectorAddress("address")
                 .protocol("protocol")
-                .contractOffer(ContractOffer.Builder.newInstance().id(UUID.randomUUID().toString()).policy(Policy.Builder.newInstance().build()).build())
+                .contractOffer(ContractOffer.Builder.newInstance()
+                        .id(UUID.randomUUID().toString())
+                        .policy(Policy.Builder.newInstance().build())
+                        .asset(Asset.Builder.newInstance().id("test-asset").build())
+                        .build())
                 .build();
 
         var result = service.initiateNegotiation(request);

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/offer/ContractOffer.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/offer/ContractOffer.java
@@ -135,17 +135,11 @@ public class ContractOffer {
 
     @JsonPOJOBuilder(withPrefix = "")
     public static final class Builder {
-        private Asset asset;
-        private Policy policy;
-        private String id;
-        private URI provider;
-        private URI consumer;
-        private ZonedDateTime offerStart;
-        private ZonedDateTime offerEnd;
-        private ZonedDateTime contractStart;
-        private ZonedDateTime contractEnd;
+
+        private final ContractOffer contractOffer;
 
         private Builder() {
+            contractOffer = new ContractOffer();
         }
 
         @JsonCreator
@@ -154,69 +148,57 @@ public class ContractOffer {
         }
 
         public Builder id(String id) {
-            this.id = id;
+            contractOffer.id = id;
             return this;
         }
 
         public Builder provider(URI provider) {
-            this.provider = provider;
+            contractOffer.provider = provider;
             return this;
         }
 
         public Builder consumer(URI consumer) {
-            this.consumer = consumer;
+            contractOffer.consumer = consumer;
             return this;
         }
 
         public Builder asset(Asset asset) {
-            this.asset = asset;
+            contractOffer.asset = asset;
             return this;
         }
 
         public Builder offerStart(ZonedDateTime date) {
-            offerStart = date;
+            contractOffer.offerStart = date;
             return this;
         }
 
         public Builder offerEnd(ZonedDateTime date) {
-            offerEnd = date;
+            contractOffer.offerEnd = date;
             return this;
         }
 
         public Builder contractStart(ZonedDateTime date) {
-            contractStart = date;
+            contractOffer.contractStart = date;
             return this;
         }
 
         public Builder contractEnd(ZonedDateTime date) {
-            contractEnd = date;
+            contractOffer.contractEnd = date;
             return this;
         }
 
         public Builder policy(Policy policy) {
-            this.policy = policy;
+            contractOffer.policy = policy;
             return this;
         }
 
 
         public ContractOffer build() {
-            Objects.requireNonNull(id);
+            Objects.requireNonNull(contractOffer.id);
+            Objects.requireNonNull(contractOffer.asset, "Asset must not be null");
+            Objects.requireNonNull(contractOffer.policy, "Policy must not be null");
 
-            if (policy == null) {
-                throw new IllegalArgumentException("Policy must not be null!");
-            }
-
-            ContractOffer offer = new ContractOffer();
-            offer.id = id;
-            offer.policy = policy;
-            offer.asset = asset;
-            offer.provider = provider;
-            offer.consumer = consumer;
-            offer.offerStart = offerStart;
-            offer.offerEnd = offerEnd;
-            offer.contractStart = contractStart;
-            offer.contractEnd = contractEnd;
-            return offer;
+            return contractOffer;
         }
     }
 }

--- a/spi/control-plane/contract-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/offer/ContractOfferTest.java
+++ b/spi/control-plane/contract-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/offer/ContractOfferTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.spi.types.domain.contract.offer;
 
+import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,17 @@ class ContractOfferTest {
         assertThatThrownBy(() -> ContractOffer.Builder.newInstance().id("some-id")
                 .asset(Asset.Builder.newInstance().id("test-assetId").build())
                 .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Policy must not be null!");
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("Policy must not be null");
+    }
+
+
+    @Test
+    void verifyAssetNotNull() {
+        assertThatThrownBy(() -> ContractOffer.Builder.newInstance().id("some-id")
+                .policy(Policy.Builder.newInstance().build())
+                .build())
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("Asset must not be null");
     }
 }


### PR DESCRIPTION

## What this PR changes/adds

Adds the check on asset field when building a ContractOffer

## Why it does that

For consistency with the `getAsset` API, since the Asset is mandatory in the `ContractOffer`

## Further notes

While fixing this the style of the `ContractOffer.Builder` has been changed following our usual builder pattern

## Linked Issue(s)

Closes #2052 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
