### PR TITLE
fix(transferprocessApi): add id field in DataRequestDTO 

### DIFF
--- a/docs/swaggerui/swagger-spec.js
+++ b/docs/swaggerui/swagger-spec.js
@@ -2540,6 +2540,9 @@ window.swaggerSpec={
           },
           "contractId" : {
             "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
           }
         }
       },

--- a/extensions/control-plane/api/data-management/transferprocess-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/DataRequestDto.java
+++ b/extensions/control-plane/api/data-management/transferprocess-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/DataRequestDto.java
@@ -20,11 +20,16 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 @JsonDeserialize(builder = DataRequestDto.Builder.class)
 public class DataRequestDto {
+    private String id;
     private String assetId;
     private String contractId;
     private String connectorId;
 
     private DataRequestDto() {
+    }
+
+    public String getId() {
+        return id;
     }
 
     public String getAssetId() {
@@ -51,6 +56,11 @@ public class DataRequestDto {
         @JsonCreator
         public static Builder newInstance() {
             return new Builder();
+        }
+
+        public Builder id(String id) {
+            dataRequestDto.id = id;
+            return this;
         }
 
         public Builder assetId(String assetId) {

--- a/extensions/control-plane/api/data-management/transferprocess-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/DataRequestToDataRequestDtoTransformer.java
+++ b/extensions/control-plane/api/data-management/transferprocess-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/DataRequestToDataRequestDtoTransformer.java
@@ -42,6 +42,7 @@ public class DataRequestToDataRequestDtoTransformer implements DtoTransformer<Da
             return null;
         }
         return DataRequestDto.Builder.newInstance()
+                .id(object.getId())
                 .assetId(object.getAssetId())
                 .contractId(object.getContractId())
                 .connectorId(object.getConnectorId())

--- a/extensions/control-plane/api/data-management/transferprocess-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/data-management/transferprocess-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerIntegrationTest.java
@@ -38,6 +38,8 @@ import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferP
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
 
 @ExtendWith(EdcExtension.class)
 class TransferProcessApiControllerIntegrationTest {
@@ -85,7 +87,8 @@ class TransferProcessApiControllerIntegrationTest {
                 .then()
                 .statusCode(200)
                 .contentType(JSON)
-                .body("id", is(PROCESS_ID));
+                .body("id", is(PROCESS_ID))
+                .body("dataRequest.id", notNullValue());
 
     }
 
@@ -249,7 +252,7 @@ class TransferProcessApiControllerIntegrationTest {
     private TransferProcess createTransferProcess(String processId) {
         return createTransferProcessBuilder()
                 .id(processId)
-                .dataRequest(DataRequest.Builder.newInstance().destinationType("file").build())
+                .dataRequest(DataRequest.Builder.newInstance().id("id").destinationType("file").build())
                 .build();
     }
 

--- a/extensions/control-plane/api/data-management/transferprocess-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferProcessDtoTest.java
+++ b/extensions/control-plane/api/data-management/transferprocess-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferProcessDtoTest.java
@@ -32,8 +32,12 @@ class TransferProcessDtoTest {
 
     @Test
     void verifySerialization() throws JsonProcessingException {
-        var drq = DataRequestDto.Builder.newInstance().assetId("test-asset").connectorId("test-conn")
-                .contractId("test-contract").build();
+        var drq = DataRequestDto.Builder.newInstance()
+                .assetId("test-asset")
+                .connectorId("test-conn")
+                .contractId("test-contract")
+                .id("request-test-id")
+                .build();
         var dto = TransferProcessDto.Builder.newInstance()
                 .id("test-id")
                 .errorDetail("some-error")

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -1845,6 +1845,8 @@ components:
           type: string
         contractId:
           type: string
+        id:
+          type: string
     DeprovisionedResource:
       type: object
       properties:

--- a/resources/openapi/yaml/transferprocess-api.yaml
+++ b/resources/openapi/yaml/transferprocess-api.yaml
@@ -263,6 +263,8 @@ components:
           type: string
         contractId:
           type: string
+        id:
+          type: string
     IdResponseDto:
       type: object
       properties:


### PR DESCRIPTION


## What this PR changes/adds

Adds the field `id` in `DataRequestDTO`

## Why it does that

For correlating data requests across EDC instances via Data Management APIs

## Linked Issue(s)

Closes #1866 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
