### PR TITLE
feat(api): add a `POST` endpoint to request the catalog

### DIFF
--- a/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImpl.java
+++ b/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferServiceImpl.java
@@ -12,6 +12,7 @@
  *       Microsoft Corporation - Refactoring
  *       Fraunhofer Institute for Software and Systems Engineering - extended method implementation
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
+ *       ZF Friedrichshafen AG - enable asset filtering
  *
  */
 

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/type/MultipartCatalogDescriptionRequestSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/dispatcher/sender/type/MultipartCatalogDescriptionRequestSender.java
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
  *       ZF Friedrichshafen AG - enable asset filtering
+ *
  */
 
 package org.eclipse.dataspaceconnector.ids.api.multipart.dispatcher.sender.type;
@@ -53,11 +54,6 @@ public class MultipartCatalogDescriptionRequestSender implements MultipartSender
 
     public MultipartCatalogDescriptionRequestSender(SenderDelegateContext context) {
         this.context = context;
-    }
-
-    @Override
-    public Class<CatalogRequest> getMessageType() {
-        return CatalogRequest.class;
     }
 
     /**
@@ -127,6 +123,11 @@ public class MultipartCatalogDescriptionRequestSender implements MultipartSender
     @Override
     public List<Class<? extends Message>> getAllowedResponseTypes() {
         return List.of(DescriptionResponseMessageImpl.class);
+    }
+
+    @Override
+    public Class<CatalogRequest> getMessageType() {
+        return CatalogRequest.class;
     }
 
     private BaseConnector getBaseConnector(IdsMultipartParts parts) {

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/util/RequestUtilTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/util/RequestUtilTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 ZF Friedrichshafen AG
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       ZF Friedrichshafen AG - initial implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.ids.api.multipart.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/docs/swaggerui/swagger-spec.js
+++ b/docs/swaggerui/swagger-spec.js
@@ -20,148 +20,6 @@ window.swaggerSpec={
     "description" : "The public API of the Data Plane is a data proxy enabling a data consumer to actively querydata from the provider data source (e.g. backend Rest API, internal database...) through its Data Planeinstance. Thus the Data Plane is the only entry/output door for the data, which avoids the provider to exposedirectly its data externally.The Data Plane public API being a proxy, it supports all verbs (i.e. GET, POST, PUT, PATCH, DELETE), whichcan then conveyed until the data source is required. This is especially useful when the actual data sourceis a Rest API itself.In the same manner, any set of arbitrary query parameters, path parameters and request body are supported (in the limits fixed by the HTTP server) and can also conveyed to the actual data source."
   } ],
   "paths" : {
-    "/callback/{processId}/deprovision" : {
-      "post" : {
-        "tags" : [ "HTTP Provisioner Webhook" ],
-        "operationId" : "callDeprovisionWebhook",
-        "parameters" : [ {
-          "name" : "processId",
-          "in" : "path",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/DeprovisionedResource"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "application/json" : { }
-            }
-          }
-        }
-      }
-    },
-    "/callback/{processId}/provision" : {
-      "post" : {
-        "tags" : [ "HTTP Provisioner Webhook" ],
-        "operationId" : "callProvisionWebhook",
-        "parameters" : [ {
-          "name" : "processId",
-          "in" : "path",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/ProvisionerWebhookRequest"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "application/json" : { }
-            }
-          }
-        }
-      }
-    },
-    "/catalog" : {
-      "get" : {
-        "tags" : [ "Catalog" ],
-        "operationId" : "getCatalog",
-        "parameters" : [ {
-          "name" : "providerUrl",
-          "in" : "query",
-          "required" : true,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "offset",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int32"
-          }
-        }, {
-          "name" : "limit",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int32"
-          }
-        }, {
-          "name" : "filter",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "sort",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "ASC", "DESC" ]
-          }
-        }, {
-          "name" : "sortField",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "default" : {
-            "description" : "Gets contract offers (=catalog) of a single connector",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Catalog"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/policydefinitions" : {
       "get" : {
         "tags" : [ "Policy" ],
@@ -397,6 +255,588 @@ window.swaggerSpec={
           },
           "409" : {
             "description" : "The policy definition cannot be deleted, because it is referenced by a contract definition",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/instances" : {
+      "get" : {
+        "tags" : [ "Dataplane Selector" ],
+        "operationId" : "getAll",
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/DataPlaneInstance"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "Dataplane Selector" ],
+        "operationId" : "addEntry",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/DataPlaneInstance"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "application/json" : { }
+            }
+          }
+        }
+      }
+    },
+    "/instances/select" : {
+      "post" : {
+        "tags" : [ "Dataplane Selector" ],
+        "operationId" : "find",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SelectionRequest"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/DataPlaneInstance"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/check/health" : {
+      "get" : {
+        "tags" : [ "Application Observability" ],
+        "description" : "Performs a liveness probe to determine whether the runtime is working properly.",
+        "operationId" : "checkHealth",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/HealthStatus"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/check/liveness" : {
+      "get" : {
+        "tags" : [ "Application Observability" ],
+        "description" : "Performs a liveness probe to determine whether the runtime is working properly.",
+        "operationId" : "getLiveness",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/HealthStatus"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/check/readiness" : {
+      "get" : {
+        "tags" : [ "Application Observability" ],
+        "description" : "Performs a readiness probe to determine whether the runtime is able to accept requests.",
+        "operationId" : "getReadiness",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/HealthStatus"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/check/startup" : {
+      "get" : {
+        "tags" : [ "Application Observability" ],
+        "description" : "Performs a startup probe to determine whether the runtime has completed startup.",
+        "operationId" : "getStartup",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/HealthStatus"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/token" : {
+      "get" : {
+        "tags" : [ "Token Validation" ],
+        "description" : "Checks that the provided token has been signed by the present entity and asserts its validity. If token is valid, then the data address contained in its claims is decrypted and returned back to the caller.",
+        "operationId" : "validate",
+        "parameters" : [ {
+          "name" : "Authorization",
+          "in" : "header",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Token is valid"
+          },
+          "400" : {
+            "description" : "Request was malformed"
+          },
+          "403" : {
+            "description" : "Token is invalid"
+          }
+        }
+      }
+    },
+    "/contractnegotiations" : {
+      "get" : {
+        "tags" : [ "Contract Negotiation" ],
+        "description" : "Returns all contract negotiations according to a query",
+        "operationId" : "getNegotiations",
+        "parameters" : [ {
+          "name" : "offset",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "filter",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "sort",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "ASC", "DESC" ]
+          }
+        }, {
+          "name" : "sortField",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ContractNegotiationDto"
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request was malformed",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "Contract Negotiation" ],
+        "description" : "Initiates a contract negotiation for a given offer and with the given counter part. Please note that successfully invoking this endpoint only means that the negotiation was initiated. Clients must poll the /{id}/state endpoint to track the state",
+        "operationId" : "initiateContractNegotiation",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/NegotiationInitiateRequestDto"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "The negotiation was successfully initiated. Returns the contract negotiation ID and created timestamp",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/IdResponseDto"
+                }
+              }
+            },
+            "links" : {
+              "poll-state" : {
+                "operationId" : "getNegotiationState",
+                "parameters" : {
+                  "id" : "$response.body#/id"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request body was malformed",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/contractnegotiations/{id}" : {
+      "get" : {
+        "tags" : [ "Contract Negotiation" ],
+        "description" : "Gets an contract negotiation with the given ID",
+        "operationId" : "getNegotiation",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The contract negotiation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ContractNegotiationDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request was malformed, e.g. id was null",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "An contract negotiation with the given ID does not exist",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/contractnegotiations/{id}/agreement" : {
+      "get" : {
+        "tags" : [ "Contract Negotiation" ],
+        "description" : "Gets a contract agreement for a contract negotiation with the given ID",
+        "operationId" : "getAgreementForNegotiation",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The contract agreement that is attached to the negotiation, or null",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ContractNegotiationDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request was malformed, e.g. id was null",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "An contract negotiation with the given ID does not exist",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/contractnegotiations/{id}/cancel" : {
+      "post" : {
+        "tags" : [ "Contract Negotiation" ],
+        "description" : "Requests aborting the contract negotiation. Due to the asynchronous nature of contract negotiations, a successful response only indicates that the request was successfully received. Clients must poll the /{id}/state endpoint to track the state.",
+        "operationId" : "cancelNegotiation",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Request to cancel the Contract negotiation was successfully received",
+            "links" : {
+              "poll-state" : {
+                "operationId" : "getNegotiationState"
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request was malformed, e.g. id was null",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "A contract negotiation with the given ID does not exist",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/contractnegotiations/{id}/decline" : {
+      "post" : {
+        "tags" : [ "Contract Negotiation" ],
+        "description" : "Requests cancelling the contract negotiation. Due to the asynchronous nature of contract negotiations, a successful response only indicates that the request was successfully received. Clients must poll the /{id}/state endpoint to track the state.",
+        "operationId" : "declineNegotiation",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Request to decline the Contract negotiation was successfully received",
+            "links" : {
+              "poll-state" : {
+                "operationId" : "getNegotiationState"
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request was malformed, e.g. id was null",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "A contract negotiation with the given ID does not exist",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/contractnegotiations/{id}/state" : {
+      "get" : {
+        "tags" : [ "Contract Negotiation" ],
+        "description" : "Gets the state of a contract negotiation with the given ID",
+        "operationId" : "getNegotiationState",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The contract negotiation's state",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/NegotiationState"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request was malformed, e.g. id was null",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "An contract negotiation with the given ID does not exist",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -942,12 +1382,86 @@ window.swaggerSpec={
         }
       }
     },
-    "/assets" : {
-      "get" : {
-        "tags" : [ "Asset" ],
-        "description" : "Gets all assets according to a particular query",
-        "operationId" : "getAllAssets",
+    "/callback/{processId}/deprovision" : {
+      "post" : {
+        "tags" : [ "HTTP Provisioner Webhook" ],
+        "operationId" : "callDeprovisionWebhook",
         "parameters" : [ {
+          "name" : "processId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/DeprovisionedResource"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "application/json" : { }
+            }
+          }
+        }
+      }
+    },
+    "/callback/{processId}/provision" : {
+      "post" : {
+        "tags" : [ "HTTP Provisioner Webhook" ],
+        "operationId" : "callProvisionWebhook",
+        "parameters" : [ {
+          "name" : "processId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ProvisionerWebhookRequest"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "application/json" : { }
+            }
+          }
+        }
+      }
+    },
+    "/catalog" : {
+      "get" : {
+        "tags" : [ "Catalog" ],
+        "operationId" : "getCatalog",
+        "parameters" : [ {
+          "name" : "providerUrl",
+          "in" : "query",
+          "required" : true,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
           "name" : "offset",
           "in" : "query",
           "required" : false,
@@ -997,346 +1511,41 @@ window.swaggerSpec={
           }
         } ],
         "responses" : {
-          "200" : {
+          "default" : {
+            "description" : "Gets contract offers (=catalog) of a single connector",
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/AssetResponseDto"
-                  }
+                  "$ref" : "#/components/schemas/Catalog"
                 }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request body was malformed",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "post" : {
-        "tags" : [ "Asset" ],
-        "description" : "Creates a new asset together with a data address",
-        "operationId" : "createAsset",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/AssetEntryDto"
               }
             }
           }
         },
-        "responses" : {
-          "200" : {
-            "description" : "Asset was created successfully. Returns the asset Id and created timestamp",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/IdResponseDto"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request body was malformed",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Could not create asset, because an asset with that ID already exists",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
+        "deprecated" : true
       }
     },
-    "/assets/{id}" : {
-      "get" : {
-        "tags" : [ "Asset" ],
-        "description" : "Gets an asset with the given ID",
-        "operationId" : "getAsset",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "The asset",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AssetResponseDto"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request was malformed, e.g. id was null",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "An asset with the given ID does not exist",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete" : {
-        "tags" : [ "Asset" ],
-        "description" : "Removes an asset with the given ID if possible. Deleting an asset is only possible if that asset is not yet referenced by a contract agreement, in which case an error is returned. DANGER ZONE: Note that deleting assets can have unexpected results, especially for contract offers that have been sent out or ongoing or contract negotiations.",
-        "operationId" : "removeAsset",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Asset was deleted successfully"
-          },
-          "400" : {
-            "description" : "Request was malformed, e.g. id was null",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "An asset with the given ID does not exist",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "The asset cannot be deleted, because it is referenced by a contract agreement",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/instances" : {
-      "get" : {
-        "tags" : [ "Dataplane Selector" ],
-        "operationId" : "getAll",
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/DataPlaneInstance"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
+    "/catalog/request" : {
       "post" : {
-        "tags" : [ "Dataplane Selector" ],
-        "operationId" : "addEntry",
+        "tags" : [ "Catalog" ],
+        "operationId" : "requestCatalog",
         "requestBody" : {
           "content" : {
-            "application/json" : {
+            "*/*" : {
               "schema" : {
-                "$ref" : "#/components/schemas/DataPlaneInstance"
+                "$ref" : "#/components/schemas/CatalogRequestDto"
               }
             }
-          }
+          },
+          "required" : true
         },
         "responses" : {
           "default" : {
-            "description" : "default response",
-            "content" : {
-              "application/json" : { }
-            }
-          }
-        }
-      }
-    },
-    "/instances/select" : {
-      "post" : {
-        "tags" : [ "Dataplane Selector" ],
-        "operationId" : "find",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/SelectionRequest"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "default" : {
-            "description" : "default response",
+            "description" : "Gets contract offers (=catalog) of a single connector",
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/DataPlaneInstance"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/check/health" : {
-      "get" : {
-        "tags" : [ "Application Observability" ],
-        "description" : "Performs a liveness probe to determine whether the runtime is working properly.",
-        "operationId" : "checkHealth",
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/HealthStatus"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/check/liveness" : {
-      "get" : {
-        "tags" : [ "Application Observability" ],
-        "description" : "Performs a liveness probe to determine whether the runtime is working properly.",
-        "operationId" : "getLiveness",
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/HealthStatus"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/check/readiness" : {
-      "get" : {
-        "tags" : [ "Application Observability" ],
-        "description" : "Performs a readiness probe to determine whether the runtime is able to accept requests.",
-        "operationId" : "getReadiness",
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/HealthStatus"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/check/startup" : {
-      "get" : {
-        "tags" : [ "Application Observability" ],
-        "description" : "Performs a startup probe to determine whether the runtime has completed startup.",
-        "operationId" : "getStartup",
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/HealthStatus"
-                  }
+                  "$ref" : "#/components/schemas/Catalog"
                 }
               }
             }
@@ -1690,39 +1899,11 @@ window.swaggerSpec={
         }
       }
     },
-    "/token" : {
+    "/assets" : {
       "get" : {
-        "tags" : [ "Token Validation" ],
-        "description" : "Checks that the provided token has been signed by the present entity and asserts its validity. If token is valid, then the data address contained in its claims is decrypted and returned back to the caller.",
-        "operationId" : "validate",
-        "parameters" : [ {
-          "name" : "Authorization",
-          "in" : "header",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Token is valid"
-          },
-          "400" : {
-            "description" : "Request was malformed"
-          },
-          "403" : {
-            "description" : "Token is invalid"
-          }
-        }
-      }
-    },
-    "/contractnegotiations" : {
-      "get" : {
-        "tags" : [ "Contract Negotiation" ],
-        "description" : "Returns all contract negotiations according to a query",
-        "operationId" : "getNegotiations",
+        "tags" : [ "Asset" ],
+        "description" : "Gets all assets according to a particular query",
+        "operationId" : "getAllAssets",
         "parameters" : [ {
           "name" : "offset",
           "in" : "query",
@@ -1779,55 +1960,8 @@ window.swaggerSpec={
                 "schema" : {
                   "type" : "array",
                   "items" : {
-                    "$ref" : "#/components/schemas/ContractNegotiationDto"
+                    "$ref" : "#/components/schemas/AssetResponseDto"
                   }
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request was malformed",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "post" : {
-        "tags" : [ "Contract Negotiation" ],
-        "description" : "Initiates a contract negotiation for a given offer and with the given counter part. Please note that successfully invoking this endpoint only means that the negotiation was initiated. Clients must poll the /{id}/state endpoint to track the state",
-        "operationId" : "initiateContractNegotiation",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/NegotiationInitiateRequestDto"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "200" : {
-            "description" : "The negotiation was successfully initiated. Returns the contract negotiation ID and created timestamp",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/IdResponseDto"
-                }
-              }
-            },
-            "links" : {
-              "poll-state" : {
-                "operationId" : "getNegotiationState",
-                "parameters" : {
-                  "id" : "$response.body#/id"
                 }
               }
             }
@@ -1846,144 +1980,33 @@ window.swaggerSpec={
             }
           }
         }
-      }
-    },
-    "/contractnegotiations/{id}" : {
-      "get" : {
-        "tags" : [ "Contract Negotiation" ],
-        "description" : "Gets an contract negotiation with the given ID",
-        "operationId" : "getNegotiation",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "The contract negotiation",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ContractNegotiationDto"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request was malformed, e.g. id was null",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "An contract negotiation with the given ID does not exist",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/contractnegotiations/{id}/agreement" : {
-      "get" : {
-        "tags" : [ "Contract Negotiation" ],
-        "description" : "Gets a contract agreement for a contract negotiation with the given ID",
-        "operationId" : "getAgreementForNegotiation",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "The contract agreement that is attached to the negotiation, or null",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ContractNegotiationDto"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request was malformed, e.g. id was null",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "An contract negotiation with the given ID does not exist",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/contractnegotiations/{id}/cancel" : {
+      },
       "post" : {
-        "tags" : [ "Contract Negotiation" ],
-        "description" : "Requests aborting the contract negotiation. Due to the asynchronous nature of contract negotiations, a successful response only indicates that the request was successfully received. Clients must poll the /{id}/state endpoint to track the state.",
-        "operationId" : "cancelNegotiation",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
+        "tags" : [ "Asset" ],
+        "description" : "Creates a new asset together with a data address",
+        "operationId" : "createAsset",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/AssetEntryDto"
+              }
+            }
           }
-        } ],
+        },
         "responses" : {
           "200" : {
-            "description" : "Request to cancel the Contract negotiation was successfully received",
-            "links" : {
-              "poll-state" : {
-                "operationId" : "getNegotiationState"
+            "description" : "Asset was created successfully. Returns the asset Id and created timestamp",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/IdResponseDto"
+                }
               }
             }
           },
           "400" : {
-            "description" : "Request was malformed, e.g. id was null",
+            "description" : "Request body was malformed",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1995,8 +2018,8 @@ window.swaggerSpec={
               }
             }
           },
-          "404" : {
-            "description" : "A contract negotiation with the given ID does not exist",
+          "409" : {
+            "description" : "Could not create asset, because an asset with that ID already exists",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2011,64 +2034,11 @@ window.swaggerSpec={
         }
       }
     },
-    "/contractnegotiations/{id}/decline" : {
-      "post" : {
-        "tags" : [ "Contract Negotiation" ],
-        "description" : "Requests cancelling the contract negotiation. Due to the asynchronous nature of contract negotiations, a successful response only indicates that the request was successfully received. Clients must poll the /{id}/state endpoint to track the state.",
-        "operationId" : "declineNegotiation",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Request to decline the Contract negotiation was successfully received",
-            "links" : {
-              "poll-state" : {
-                "operationId" : "getNegotiationState"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request was malformed, e.g. id was null",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "A contract negotiation with the given ID does not exist",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/contractnegotiations/{id}/state" : {
+    "/assets/{id}" : {
       "get" : {
-        "tags" : [ "Contract Negotiation" ],
-        "description" : "Gets the state of a contract negotiation with the given ID",
-        "operationId" : "getNegotiationState",
+        "tags" : [ "Asset" ],
+        "description" : "Gets an asset with the given ID",
+        "operationId" : "getAsset",
         "parameters" : [ {
           "name" : "id",
           "in" : "path",
@@ -2081,11 +2051,11 @@ window.swaggerSpec={
         } ],
         "responses" : {
           "200" : {
-            "description" : "The contract negotiation's state",
+            "description" : "The asset",
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/NegotiationState"
+                  "$ref" : "#/components/schemas/AssetResponseDto"
                 }
               }
             }
@@ -2104,7 +2074,66 @@ window.swaggerSpec={
             }
           },
           "404" : {
-            "description" : "An contract negotiation with the given ID does not exist",
+            "description" : "An asset with the given ID does not exist",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "Asset" ],
+        "description" : "Removes an asset with the given ID if possible. Deleting an asset is only possible if that asset is not yet referenced by a contract agreement, in which case an error is returned. DANGER ZONE: Note that deleting assets can have unexpected results, especially for contract offers that have been sent out or ongoing or contract negotiations.",
+        "operationId" : "removeAsset",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Asset was deleted successfully"
+          },
+          "400" : {
+            "description" : "Request was malformed, e.g. id was null",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "An asset with the given ID does not exist",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "The asset cannot be deleted, because it is referenced by a contract agreement",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2227,6 +2256,36 @@ window.swaggerSpec={
           },
           "id" : {
             "type" : "string"
+          }
+        }
+      },
+      "CatalogRequestDto" : {
+        "required" : [ "providerUrl" ],
+        "type" : "object",
+        "properties" : {
+          "filter" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Criterion"
+            }
+          },
+          "limit" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "offset" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "providerUrl" : {
+            "type" : "string"
+          },
+          "sortField" : {
+            "type" : "string"
+          },
+          "sortOrder" : {
+            "type" : "string",
+            "enum" : [ "ASC", "DESC" ]
           }
         }
       },

--- a/docs/swaggerui/swagger-spec.js
+++ b/docs/swaggerui/swagger-spec.js
@@ -2266,7 +2266,7 @@ window.swaggerSpec={
           "filter" : {
             "type" : "array",
             "items" : {
-              "$ref" : "#/components/schemas/Criterion"
+              "$ref" : "#/components/schemas/CriterionDto"
             }
           },
           "limit" : {

--- a/extensions/common/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/ApiCoreExtension.java
+++ b/extensions/common/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/ApiCoreExtension.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.dataspaceconnector.api;
 
+import org.eclipse.dataspaceconnector.api.transformer.CriterionDtoToCriterionTransformer;
+import org.eclipse.dataspaceconnector.api.transformer.CriterionToCriterionDtoTransformer;
 import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
 import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistryImpl;
 import org.eclipse.dataspaceconnector.api.transformer.QuerySpecDtoToQuerySpecTransformer;
@@ -37,6 +39,8 @@ public class ApiCoreExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         var transformerRegistry = new DtoTransformerRegistryImpl();
         transformerRegistry.register(new QuerySpecDtoToQuerySpecTransformer());
+        transformerRegistry.register(new CriterionToCriterionDtoTransformer());
+        transformerRegistry.register(new CriterionDtoToCriterionTransformer());
         context.registerService(DtoTransformerRegistry.class, transformerRegistry);
     }
 }

--- a/extensions/common/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/model/CriterionDto.java
+++ b/extensions/common/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/model/CriterionDto.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model;
+package org.eclipse.dataspaceconnector.api.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/extensions/common/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/query/QuerySpecDto.java
+++ b/extensions/common/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/query/QuerySpecDto.java
@@ -69,11 +69,7 @@ public class QuerySpecDto {
             return false;
         }
 
-        if (sortField != null && sortField.isBlank()) {
-            return false;
-        }
-
-        return true;
+        return sortField == null || !sortField.isBlank();
     }
 
     public static final class Builder {

--- a/extensions/common/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/transformer/CriterionDtoToCriterionTransformer.java
+++ b/extensions/common/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/transformer/CriterionDtoToCriterionTransformer.java
@@ -12,10 +12,9 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.transform;
+package org.eclipse.dataspaceconnector.api.transformer;
 
-import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model.CriterionDto;
-import org.eclipse.dataspaceconnector.api.transformer.DtoTransformer;
+import org.eclipse.dataspaceconnector.api.model.CriterionDto;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
 import org.jetbrains.annotations.NotNull;

--- a/extensions/common/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/transformer/CriterionToCriterionDtoTransformer.java
+++ b/extensions/common/api/api-core/src/main/java/org/eclipse/dataspaceconnector/api/transformer/CriterionToCriterionDtoTransformer.java
@@ -12,10 +12,9 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.transform;
+package org.eclipse.dataspaceconnector.api.transformer;
 
-import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model.CriterionDto;
-import org.eclipse.dataspaceconnector.api.transformer.DtoTransformer;
+import org.eclipse.dataspaceconnector.api.model.CriterionDto;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
 import org.jetbrains.annotations.NotNull;

--- a/extensions/common/api/api-core/src/test/java/org/eclipse/dataspaceconnector/api/transformer/CriterionDtoToCriterionTransformerTest.java
+++ b/extensions/common/api/api-core/src/test/java/org/eclipse/dataspaceconnector/api/transformer/CriterionDtoToCriterionTransformerTest.java
@@ -12,9 +12,9 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.transform;
+package org.eclipse.dataspaceconnector.api.transformer;
 
-import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model.CriterionDto;
+import org.eclipse.dataspaceconnector.api.model.CriterionDto;
 import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
 import org.junit.jupiter.api.Test;
 

--- a/extensions/common/api/api-core/src/test/java/org/eclipse/dataspaceconnector/api/transformer/CriterionToCriterionDtoTransformerTest.java
+++ b/extensions/common/api/api-core/src/test/java/org/eclipse/dataspaceconnector/api/transformer/CriterionToCriterionDtoTransformerTest.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.transform;
+package org.eclipse.dataspaceconnector.api.transformer;
 
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/Oauth2DefaultServicesExtension.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/Oauth2DefaultServicesExtension.java
@@ -12,7 +12,6 @@
  *
  */
 
-
 package org.eclipse.dataspaceconnector.iam.oauth2.core;
 
 import org.eclipse.dataspaceconnector.iam.oauth2.spi.CredentialsRequestAdditionalParametersProvider;

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/rule/Oauth2AudienceValidationRule.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/rule/Oauth2AudienceValidationRule.java
@@ -12,7 +12,6 @@
  *
  */
 
-
 package org.eclipse.dataspaceconnector.iam.oauth2.core.rule;
 
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/rule/Oauth2ExpirationIssuedAtValidationRule.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/rule/Oauth2ExpirationIssuedAtValidationRule.java
@@ -12,7 +12,6 @@
  *
  */
 
-
 package org.eclipse.dataspaceconnector.iam.oauth2.core.rule;
 
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/rule/Oauth2NotBeforeValidationRule.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/rule/Oauth2NotBeforeValidationRule.java
@@ -12,7 +12,6 @@
  *
  */
 
-
 package org.eclipse.dataspaceconnector.iam.oauth2.core.rule;
 
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;

--- a/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/dataspaceconnector/iam/oauth2/core/rule/Oauth2NotBeforeValidationRuleTest.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/dataspaceconnector/iam/oauth2/core/rule/Oauth2NotBeforeValidationRuleTest.java
@@ -12,7 +12,6 @@
  *
  */
 
-
 package org.eclipse.dataspaceconnector.iam.oauth2.core.rule;
 
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;

--- a/extensions/control-plane/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApi.java
+++ b/extensions/control-plane/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApi.java
@@ -23,6 +23,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.container.AsyncResponse;
+import org.eclipse.dataspaceconnector.api.datamanagement.catalog.model.CatalogRequestDto;
 import org.eclipse.dataspaceconnector.api.query.QuerySpecDto;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 
@@ -34,7 +35,11 @@ public interface CatalogApi {
 
     @Operation(responses = {
             @ApiResponse(content = @Content(mediaType = "application/json", schema = @Schema(implementation = Catalog.class)), description = "Gets contract offers (=catalog) of a single connector")
-    })
+    }, deprecated = true)
     void getCatalog(@NotNull(message = PROVIDER_URL_NOT_NULL_MESSAGE) String providerUrl, @Valid QuerySpecDto querySpec, AsyncResponse response);
 
+    @Operation(responses = {
+            @ApiResponse(content = @Content(mediaType = "application/json", schema = @Schema(implementation = Catalog.class)), description = "Gets contract offers (=catalog) of a single connector")
+    })
+    void requestCatalog(@Valid @NotNull CatalogRequestDto requestDto, AsyncResponse response);
 }

--- a/extensions/control-plane/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiController.java
+++ b/extensions/control-plane/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiController.java
@@ -71,16 +71,12 @@ public class CatalogApiController implements CatalogApi {
     @POST
     @Path("/request")
     public void requestCatalog(@RequestBody(required = true) CatalogRequestDto requestDto, @Suspended AsyncResponse response) {
+        var result = transformerRegistry.transform(requestDto, QuerySpec.class);
 
-        var query = QuerySpec.Builder.newInstance()
-                .filter(requestDto.getFilter())
-                .limit(requestDto.getLimit())
-                .offset(requestDto.getOffset())
-                .sortOrder(requestDto.getSortOrder())
-                .sortField((requestDto.getSortField()))
-                .build();
-
-        performQuery(requestDto.getProviderUrl(), query, response);
+        if (result.failed()) {
+            throw new InvalidRequestException(result.getFailureMessages());
+        }
+        performQuery(requestDto.getProviderUrl(), result.getContent(), response);
     }
 
     private void performQuery(String providerUrl, QuerySpec spec, AsyncResponse response) {

--- a/extensions/control-plane/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiController.java
+++ b/extensions/control-plane/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiController.java
@@ -14,15 +14,18 @@
 
 package org.eclipse.dataspaceconnector.api.datamanagement.catalog;
 
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import jakarta.validation.Valid;
 import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.dataspaceconnector.api.datamanagement.catalog.model.CatalogRequestDto;
 import org.eclipse.dataspaceconnector.api.datamanagement.catalog.service.CatalogService;
 import org.eclipse.dataspaceconnector.api.query.QuerySpecDto;
 import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
@@ -61,6 +64,26 @@ public class CatalogApiController implements CatalogApi {
             monitor.debug("No paging parameters were supplied, using 0...Integer.MAX_VALUE");
         }
 
+        performQuery(providerUrl, spec, response);
+    }
+
+    @Override
+    @POST
+    @Path("/request")
+    public void requestCatalog(@RequestBody(required = true) CatalogRequestDto requestDto, @Suspended AsyncResponse response) {
+
+        var query = QuerySpec.Builder.newInstance()
+                .filter(requestDto.getFilter())
+                .limit(requestDto.getLimit())
+                .offset(requestDto.getOffset())
+                .sortOrder(requestDto.getSortOrder())
+                .sortField((requestDto.getSortField()))
+                .build();
+
+        performQuery(requestDto.getProviderUrl(), query, response);
+    }
+
+    private void performQuery(String providerUrl, QuerySpec spec, AsyncResponse response) {
         service.getByProviderUrl(providerUrl, spec)
                 .whenComplete((content, throwable) -> {
                     if (throwable == null) {

--- a/extensions/control-plane/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiExtension.java
+++ b/extensions/control-plane/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiExtension.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.api.datamanagement.catalog;
 
 import org.eclipse.dataspaceconnector.api.datamanagement.catalog.service.CatalogServiceImpl;
+import org.eclipse.dataspaceconnector.api.datamanagement.catalog.transform.CatalogRequestDtoToQuerySpecTransformer;
 import org.eclipse.dataspaceconnector.api.datamanagement.configuration.DataManagementApiConfiguration;
 import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
@@ -46,6 +47,7 @@ public class CatalogApiExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
+        transformerRegistry.register(new CatalogRequestDtoToQuerySpecTransformer());
         var service = new CatalogServiceImpl(dispatcher);
         webService.registerResource(config.getContextAlias(), new CatalogApiController(service, transformerRegistry, context.getMonitor()));
     }

--- a/extensions/control-plane/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/model/CatalogRequestDto.java
+++ b/extensions/control-plane/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/model/CatalogRequestDto.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
-import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.api.model.CriterionDto;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 
 import java.util.ArrayList;
@@ -35,7 +35,7 @@ public class CatalogRequestDto {
     @Positive(message = "limit must be greater than 0")
     private Integer limit = 50;
     private SortOrder sortOrder = SortOrder.ASC;
-    private List<Criterion> filter = new ArrayList<>();
+    private List<CriterionDto> filter = new ArrayList<>();
     private String sortField;
     @NotNull
     private String providerUrl;
@@ -55,7 +55,7 @@ public class CatalogRequestDto {
         return sortOrder;
     }
 
-    public List<Criterion> getFilter() {
+    public List<CriterionDto> getFilter() {
         return filter;
     }
 
@@ -101,7 +101,7 @@ public class CatalogRequestDto {
             return this;
         }
 
-        public Builder filter(List<Criterion> criteria) {
+        public Builder filter(List<CriterionDto> criteria) {
             instance.filter = criteria;
             return this;
         }

--- a/extensions/control-plane/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/model/CatalogRequestDto.java
+++ b/extensions/control-plane/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/model/CatalogRequestDto.java
@@ -1,0 +1,119 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.datamanagement.catalog.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.SortOrder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+@JsonDeserialize(builder = CatalogRequestDto.Builder.class)
+public class CatalogRequestDto {
+    @PositiveOrZero(message = "offset must be greater or equal to zero")
+    private Integer offset = 0;
+    @Positive(message = "limit must be greater than 0")
+    private Integer limit = 50;
+    private SortOrder sortOrder = SortOrder.ASC;
+    private List<Criterion> filter = new ArrayList<>();
+    private String sortField;
+    @NotNull
+    private String providerUrl;
+
+    private CatalogRequestDto() {
+    }
+
+    public Integer getOffset() {
+        return offset;
+    }
+
+    public Integer getLimit() {
+        return limit;
+    }
+
+    public SortOrder getSortOrder() {
+        return sortOrder;
+    }
+
+    public List<Criterion> getFilter() {
+        return filter;
+    }
+
+    public String getSortField() {
+        return sortField;
+    }
+
+    public String getProviderUrl() {
+        return providerUrl;
+    }
+
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder {
+        private final CatalogRequestDto instance;
+
+        private Builder() {
+            instance = new CatalogRequestDto();
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder offset(Integer offset) {
+            instance.offset = offset;
+            return this;
+        }
+
+        public Builder limit(Integer limit) {
+            instance.limit = limit;
+            return this;
+        }
+
+        public Builder sortOrder(SortOrder sortOrder) {
+            instance.sortOrder = sortOrder;
+            return this;
+        }
+
+        public Builder providerUrl(String providerUrl) {
+            instance.providerUrl = providerUrl;
+            return this;
+        }
+
+        public Builder filter(List<Criterion> criteria) {
+            instance.filter = criteria;
+            return this;
+        }
+
+        public Builder sortField(String sortField) {
+            instance.sortField = sortField;
+            return this;
+        }
+
+        public CatalogRequestDto build() {
+            requireNonNull(instance.providerUrl, "providerUrl");
+            return instance;
+        }
+    }
+}

--- a/extensions/control-plane/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/transform/CatalogRequestDtoToQuerySpecTransformer.java
+++ b/extensions/control-plane/api/data-management/catalog-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/transform/CatalogRequestDtoToQuerySpecTransformer.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.datamanagement.catalog.transform;
+
+import org.eclipse.dataspaceconnector.api.datamanagement.catalog.model.CatalogRequestDto;
+import org.eclipse.dataspaceconnector.api.transformer.DtoTransformer;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.stream.Collectors;
+
+public class CatalogRequestDtoToQuerySpecTransformer implements DtoTransformer<CatalogRequestDto, QuerySpec> {
+    @Override
+    public Class<CatalogRequestDto> getInputType() {
+        return CatalogRequestDto.class;
+    }
+
+    @Override
+    public Class<QuerySpec> getOutputType() {
+        return QuerySpec.class;
+    }
+
+    @Override
+    public @Nullable QuerySpec transform(@Nullable CatalogRequestDto requestDto, @NotNull TransformerContext context) {
+
+        var spec = QuerySpec.Builder.newInstance();
+        if (requestDto == null) {
+            context.reportProblem("Input DTO is null");
+            return null;
+        }
+
+        spec.sortField(requestDto.getSortField())
+                .sortOrder(requestDto.getSortOrder())
+                .limit(requestDto.getLimit())
+                .offset(requestDto.getOffset());
+
+
+        var criteria = requestDto.getFilter().stream()
+                .map(dto -> context.transform(dto, Criterion.class))
+                .collect(Collectors.toList());
+
+        spec.filter(criteria);
+
+        return spec.build();
+    }
+}

--- a/extensions/control-plane/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerIntegrationTest.java
@@ -24,7 +24,6 @@ import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
 import org.eclipse.dataspaceconnector.spi.message.MessageContext;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcher;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
-import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
@@ -45,6 +44,7 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.api.datamanagement.catalog.TestFunctions.createCriterionDto;
 import static org.eclipse.dataspaceconnector.junit.testfixtures.TestUtils.getFreePort;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.is;
@@ -136,7 +136,7 @@ public class CatalogApiControllerIntegrationTest {
                 .sortField("someField")
                 .sortOrder(SortOrder.DESC)
                 .providerUrl("some.provider.url")
-                .filter(List.of(new Criterion("fooProp", "", "bar"), new Criterion("bazProp", "in", List.of("blip", "blup", "blop"))))
+                .filter(List.of(createCriterionDto("fooProp", "", "bar"), createCriterionDto("bazProp", "in", List.of("blip", "blup", "blop"))))
                 .build();
 
         baseRequest()
@@ -155,7 +155,8 @@ public class CatalogApiControllerIntegrationTest {
         assertThat(rq.getLimit()).isEqualTo(requestDto.getLimit());
         assertThat(rq.getSortField()).isEqualTo(requestDto.getSortField());
         assertThat(rq.getSortOrder()).isEqualTo(requestDto.getSortOrder());
-        assertThat(rq.getFilterExpression()).isEqualTo(requestDto.getFilter());
+        // technically we're comparing a Criterion and a CriterionDto, but they have the same fields, so recursive comp. works
+        assertThat(rq.getFilterExpression()).usingRecursiveFieldByFieldElementComparator().isEqualTo(requestDto.getFilter());
     }
 
     @Test
@@ -204,6 +205,7 @@ public class CatalogApiControllerIntegrationTest {
                 .then()
                 .statusCode(400);
     }
+
 
     private RequestSpecification baseRequest() {
         return given()

--- a/extensions/control-plane/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerIntegrationTest.java
@@ -15,21 +15,27 @@
 package org.eclipse.dataspaceconnector.api.datamanagement.catalog;
 
 import io.restassured.specification.RequestSpecification;
+import org.eclipse.dataspaceconnector.api.datamanagement.catalog.model.CatalogRequestDto;
 import org.eclipse.dataspaceconnector.junit.extensions.EdcExtension;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
+import org.eclipse.dataspaceconnector.spi.message.MessageContext;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcher;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
+import org.eclipse.dataspaceconnector.spi.types.domain.catalog.CatalogRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 
 import java.util.List;
 import java.util.Map;
@@ -38,11 +44,14 @@ import java.util.UUID;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.junit.testfixtures.TestUtils.getFreePort;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(EdcExtension.class)
@@ -106,6 +115,94 @@ public class CatalogApiControllerIntegrationTest {
                 .then()
                 .statusCode(400)
                 .body("message[0]", is("providerUrl must not be null"));
+    }
+
+    @Test
+    void postCatalogRequest() {
+        var contractOffer = ContractOffer.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .policy(Policy.Builder.newInstance().build())
+                .asset(Asset.Builder.newInstance().id(UUID.randomUUID().toString()).build())
+                .build();
+        var catalog = Catalog.Builder.newInstance().id("id").contractOffers(List.of(contractOffer)).build();
+        var emptyCatalog = Catalog.Builder.newInstance().id("id2").contractOffers(List.of()).build();
+        when(dispatcher.send(any(), any(), any()))
+                .thenReturn(completedFuture(catalog))
+                .thenReturn(completedFuture(emptyCatalog));
+
+        var requestDto = CatalogRequestDto.Builder.newInstance()
+                .limit(29)
+                .offset(13)
+                .sortField("someField")
+                .sortOrder(SortOrder.DESC)
+                .providerUrl("some.provider.url")
+                .filter(List.of(new Criterion("fooProp", "", "bar"), new Criterion("bazProp", "in", List.of("blip", "blup", "blop"))))
+                .build();
+
+        baseRequest()
+                .body(requestDto)
+                .contentType("application/json")
+                .post("/catalog/request")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("id", notNullValue())
+                .body("contractOffers.size()", is(1));
+        var requestCaptor = ArgumentCaptor.forClass(CatalogRequest.class);
+        verify(dispatcher).send(eq(Catalog.class), requestCaptor.capture(), any(MessageContext.class));
+        var rq = requestCaptor.getValue().getQuerySpec();
+        assertThat(rq.getOffset()).isEqualTo(requestDto.getOffset());
+        assertThat(rq.getLimit()).isEqualTo(requestDto.getLimit());
+        assertThat(rq.getSortField()).isEqualTo(requestDto.getSortField());
+        assertThat(rq.getSortOrder()).isEqualTo(requestDto.getSortOrder());
+        assertThat(rq.getFilterExpression()).isEqualTo(requestDto.getFilter());
+    }
+
+    @Test
+    void postCatalogRequest_whenOnlyProviderUrl_shouldUseDefault() {
+        var contractOffer = ContractOffer.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .policy(Policy.Builder.newInstance().build())
+                .asset(Asset.Builder.newInstance().id(UUID.randomUUID().toString()).build())
+                .build();
+        var catalog = Catalog.Builder.newInstance().id("id").contractOffers(List.of(contractOffer)).build();
+        var emptyCatalog = Catalog.Builder.newInstance().id("id2").contractOffers(List.of()).build();
+        when(dispatcher.send(any(), any(), any()))
+                .thenReturn(completedFuture(catalog))
+                .thenReturn(completedFuture(emptyCatalog));
+
+        var requestDto = CatalogRequestDto.Builder.newInstance()
+                .providerUrl("some.provider.url")
+                .build();
+
+
+        baseRequest()
+                .body(requestDto)
+                .contentType("application/json")
+                .post("/catalog/request")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("id", notNullValue())
+                .body("contractOffers.size()", is(1));
+
+        var requestCaptor = ArgumentCaptor.forClass(CatalogRequest.class);
+        verify(dispatcher).send(eq(Catalog.class), requestCaptor.capture(), any(MessageContext.class));
+        var rq = requestCaptor.getValue().getQuerySpec();
+        assertThat(rq.getOffset()).isEqualTo(0);
+        assertThat(rq.getLimit()).isEqualTo(50);
+        assertThat(rq.getSortField()).isNull();
+        assertThat(rq.getSortOrder()).isEqualTo(SortOrder.ASC);
+        assertThat(rq.getFilterExpression()).isNotNull().isEmpty();
+    }
+
+    @Test
+    void postCatalogRequest_whenNoBody_shouldReturn400() {
+        baseRequest()
+                .contentType("application/json")
+                .post("/catalog/request")
+                .then()
+                .statusCode(400);
     }
 
     private RequestSpecification baseRequest() {

--- a/extensions/control-plane/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerTest.java
+++ b/extensions/control-plane/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerTest.java
@@ -22,7 +22,6 @@ import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.result.Result;
@@ -38,6 +37,7 @@ import java.util.UUID;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.CompletableFuture.failedFuture;
+import static org.eclipse.dataspaceconnector.api.datamanagement.catalog.TestFunctions.createCriterionDto;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -98,15 +98,16 @@ class CatalogApiControllerTest {
                 .build();
         var catalog = Catalog.Builder.newInstance().id("any").contractOffers(List.of(offer)).build();
         var url = "test.url";
-        
+
         when(service.getByProviderUrl(eq(url), any())).thenReturn(completedFuture(catalog));
 
         var request = CatalogRequestDto.Builder.newInstance()
                 .providerUrl(url)
                 .sortField("test-field")
                 .sortOrder(SortOrder.DESC)
-                .filter(List.of(new Criterion("foo", "=", "bar")))
+                .filter(List.of(createCriterionDto("foo", "=", "bar")))
                 .build();
+
         controller.requestCatalog(request, response);
 
         verify(response).resume(Mockito.<Catalog>argThat(c -> c.getContractOffers().equals(List.of(offer))));

--- a/extensions/control-plane/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerTest.java
+++ b/extensions/control-plane/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerTest.java
@@ -15,13 +15,16 @@
 package org.eclipse.dataspaceconnector.api.datamanagement.catalog;
 
 import jakarta.ws.rs.container.AsyncResponse;
+import org.eclipse.dataspaceconnector.api.datamanagement.catalog.model.CatalogRequestDto;
 import org.eclipse.dataspaceconnector.api.datamanagement.catalog.service.CatalogService;
 import org.eclipse.dataspaceconnector.api.query.QuerySpecDto;
 import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
@@ -82,5 +85,30 @@ class CatalogApiControllerTest {
         controller.getCatalog(url, new QuerySpecDto(), response);
 
         verify(response).resume(isA(EdcException.class));
+    }
+
+    @Test
+    void shouldPostCatalogRequest() {
+        var controller = new CatalogApiController(service, transformerRegistry, monitor);
+        var response = mock(AsyncResponse.class);
+        var offer = ContractOffer.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .policy(Policy.Builder.newInstance().build())
+                .asset(Asset.Builder.newInstance().id(UUID.randomUUID().toString()).build())
+                .build();
+        var catalog = Catalog.Builder.newInstance().id("any").contractOffers(List.of(offer)).build();
+        var url = "test.url";
+        
+        when(service.getByProviderUrl(eq(url), any())).thenReturn(completedFuture(catalog));
+
+        var request = CatalogRequestDto.Builder.newInstance()
+                .providerUrl(url)
+                .sortField("test-field")
+                .sortOrder(SortOrder.DESC)
+                .filter(List.of(new Criterion("foo", "=", "bar")))
+                .build();
+        controller.requestCatalog(request, response);
+
+        verify(response).resume(Mockito.<Catalog>argThat(c -> c.getContractOffers().equals(List.of(offer))));
     }
 }

--- a/extensions/control-plane/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/TestFunctions.java
+++ b/extensions/control-plane/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/TestFunctions.java
@@ -1,0 +1,10 @@
+package org.eclipse.dataspaceconnector.api.datamanagement.catalog;
+
+import org.eclipse.dataspaceconnector.api.model.CriterionDto;
+
+public class TestFunctions {
+    public static CriterionDto createCriterionDto(String left, String op, Object right) {
+        return CriterionDto.Builder.newInstance().operandLeft(left).operator(op).operandRight(right).build();
+    }
+
+}

--- a/extensions/control-plane/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/model/CatalogRequestDtoTest.java
+++ b/extensions/control-plane/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/model/CatalogRequestDtoTest.java
@@ -16,13 +16,13 @@ package org.eclipse.dataspaceconnector.api.datamanagement.catalog.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.api.datamanagement.catalog.TestFunctions.createCriterionDto;
 
 class CatalogRequestDtoTest {
 
@@ -36,7 +36,7 @@ class CatalogRequestDtoTest {
                 .offset(69)
                 .sortField("someField")
                 .sortOrder(SortOrder.DESC)
-                .filter(List.of(new Criterion("foo", "=", "bar"), new Criterion("bar", "<", "baz")))
+                .filter(List.of(createCriterionDto("foo", "=", "bar"), createCriterionDto("bar", "<", "baz")))
                 .build();
 
         var json = MAPPER.writeValueAsString(dto);

--- a/extensions/control-plane/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/model/CatalogRequestDtoTest.java
+++ b/extensions/control-plane/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/model/CatalogRequestDtoTest.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.datamanagement.catalog.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.dataspaceconnector.spi.query.Criterion;
+import org.eclipse.dataspaceconnector.spi.query.SortOrder;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CatalogRequestDtoTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void verifySerdes() throws JsonProcessingException {
+        var dto = CatalogRequestDto.Builder.newInstance()
+                .providerUrl("https://some.provider/path")
+                .limit(420)
+                .offset(69)
+                .sortField("someField")
+                .sortOrder(SortOrder.DESC)
+                .filter(List.of(new Criterion("foo", "=", "bar"), new Criterion("bar", "<", "baz")))
+                .build();
+
+        var json = MAPPER.writeValueAsString(dto);
+        assertThat(json).isNotNull();
+
+        var deser = MAPPER.readValue(json, CatalogRequestDto.class);
+        assertThat(deser).usingRecursiveComparison().isEqualTo(dto);
+    }
+}

--- a/extensions/control-plane/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/transform/CatalogRequestDtoToQuerySpecTransformerTest.java
+++ b/extensions/control-plane/api/data-management/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/transform/CatalogRequestDtoToQuerySpecTransformerTest.java
@@ -1,0 +1,78 @@
+package org.eclipse.dataspaceconnector.api.datamanagement.catalog.transform;
+
+import org.eclipse.dataspaceconnector.api.datamanagement.catalog.model.CatalogRequestDto;
+import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.spi.query.SortOrder;
+import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.api.datamanagement.catalog.TestFunctions.createCriterionDto;
+import static org.mockito.Mockito.mock;
+
+class CatalogRequestDtoToQuerySpecTransformerTest {
+
+    private CatalogRequestDtoToQuerySpecTransformer transformer;
+
+    @BeforeEach
+    void setup() {
+        transformer = new CatalogRequestDtoToQuerySpecTransformer();
+    }
+
+    @Test
+    void verifyInputType() {
+        assertThat(transformer.getInputType()).isEqualTo(CatalogRequestDto.class);
+    }
+
+    @Test
+    void verifyOutputType() {
+        assertThat(transformer.getOutputType()).isEqualTo(QuerySpec.class);
+    }
+
+    @Test
+    void transform() {
+        var dto = CatalogRequestDto.Builder.newInstance()
+                .providerUrl("test-providerUrl")
+                .sortOrder(SortOrder.ASC)
+                .sortField("test-sortfield")
+                .limit(5)
+                .offset(1)
+                .filter(List.of(createCriterionDto("foo", "=", "bar"), createCriterionDto("bar", "in", Arrays.asList("baz", "boz", "buz"))))
+                .build();
+
+        var ctx = mock(TransformerContext.class);
+        var tf = transformer.transform(dto, ctx);
+
+        assertThat(tf).isNotNull();
+        assertThat(tf.getLimit()).isEqualTo(dto.getLimit());
+        assertThat(tf.getOffset()).isEqualTo(dto.getOffset());
+        assertThat(tf.getFilterExpression()).hasSize(2);
+        assertThat(tf.getSortField()).isEqualTo(dto.getSortField());
+        assertThat(tf.getSortOrder()).isEqualTo(dto.getSortOrder());
+    }
+
+    @Test
+    void transform_withoutFilter() {
+        var dto = CatalogRequestDto.Builder.newInstance()
+                .providerUrl("test-providerUrl")
+                .sortOrder(SortOrder.ASC)
+                .sortField("test-sortfield")
+                .limit(5)
+                .offset(1)
+                .build();
+
+        var ctx = mock(TransformerContext.class);
+        var tf = transformer.transform(dto, ctx);
+
+        assertThat(tf).isNotNull();
+        assertThat(tf.getLimit()).isEqualTo(dto.getLimit());
+        assertThat(tf.getOffset()).isEqualTo(dto.getOffset());
+        assertThat(tf.getFilterExpression()).isNotNull().isEmpty();
+        assertThat(tf.getSortField()).isEqualTo(dto.getSortField());
+        assertThat(tf.getSortOrder()).isEqualTo(dto.getSortOrder());
+    }
+}

--- a/extensions/control-plane/api/data-management/contractdefinition-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiExtension.java
+++ b/extensions/control-plane/api/data-management/contractdefinition-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiExtension.java
@@ -21,8 +21,6 @@ import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.serv
 import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.service.ContractDefinitionServiceImpl;
 import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.transform.ContractDefinitionRequestDtoToContractDefinitionTransformer;
 import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.transform.ContractDefinitionToContractDefinitionResponseDtoTransformer;
-import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.transform.CriterionDtoToCriterionTransformer;
-import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.transform.CriterionToCriterionDtoTransformer;
 import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
@@ -69,8 +67,7 @@ public class ContractDefinitionApiExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        transformerRegistry.register(new CriterionToCriterionDtoTransformer());
-        transformerRegistry.register(new CriterionDtoToCriterionTransformer());
+
         transformerRegistry.register(new ContractDefinitionToContractDefinitionResponseDtoTransformer());
         transformerRegistry.register(new ContractDefinitionRequestDtoToContractDefinitionTransformer());
 

--- a/extensions/control-plane/api/data-management/contractdefinition-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/ContractDefinitionRequestDto.java
+++ b/extensions/control-plane/api/data-management/contractdefinition-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/ContractDefinitionRequestDto.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
+import org.eclipse.dataspaceconnector.api.model.CriterionDto;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/extensions/control-plane/api/data-management/contractdefinition-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/ContractDefinitionResponseDto.java
+++ b/extensions/control-plane/api/data-management/contractdefinition-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/ContractDefinitionResponseDto.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.dataspaceconnector.api.model.BaseResponseDto;
+import org.eclipse.dataspaceconnector.api.model.CriterionDto;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/extensions/control-plane/api/data-management/contractdefinition-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/CriterionDto.java
+++ b/extensions/control-plane/api/data-management/contractdefinition-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/CriterionDto.java
@@ -12,7 +12,6 @@
  *
  */
 
-
 package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/extensions/control-plane/api/data-management/contractdefinition-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/transform/ContractDefinitionToContractDefinitionResponseDtoTransformer.java
+++ b/extensions/control-plane/api/data-management/contractdefinition-api/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/transform/ContractDefinitionToContractDefinitionResponseDtoTransformer.java
@@ -15,7 +15,7 @@
 package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.transform;
 
 import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model.ContractDefinitionResponseDto;
-import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model.CriterionDto;
+import org.eclipse.dataspaceconnector.api.model.CriterionDto;
 import org.eclipse.dataspaceconnector.api.transformer.DtoTransformer;
 import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDefinition;

--- a/extensions/control-plane/api/data-management/contractdefinition-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/data-management/contractdefinition-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiControllerIntegrationTest.java
@@ -17,7 +17,7 @@ package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition;
 
 import io.restassured.specification.RequestSpecification;
 import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model.ContractDefinitionResponseDto;
-import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model.CriterionDto;
+import org.eclipse.dataspaceconnector.api.model.CriterionDto;
 import org.eclipse.dataspaceconnector.junit.extensions.EdcExtension;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;

--- a/extensions/control-plane/api/data-management/contractdefinition-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/ContractDefinitionRequestDtoTest.java
+++ b/extensions/control-plane/api/data-management/contractdefinition-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/ContractDefinitionRequestDtoTest.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.mod
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.dataspaceconnector.api.model.CriterionDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/extensions/control-plane/api/data-management/contractdefinition-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/ContractDefinitionRequestDtoValidationTest.java
+++ b/extensions/control-plane/api/data-management/contractdefinition-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/ContractDefinitionRequestDtoValidationTest.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.mod
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
+import org.eclipse.dataspaceconnector.api.model.CriterionDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/extensions/control-plane/api/data-management/contractdefinition-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/ContractDefinitionResponseDtoTest.java
+++ b/extensions/control-plane/api/data-management/contractdefinition-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/model/ContractDefinitionResponseDtoTest.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.mod
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.dataspaceconnector.api.model.CriterionDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/extensions/control-plane/api/data-management/contractdefinition-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/transform/ContractDefinitionRequestDtoToContractDefinitionTransformerTest.java
+++ b/extensions/control-plane/api/data-management/contractdefinition-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/transform/ContractDefinitionRequestDtoToContractDefinitionTransformerTest.java
@@ -15,7 +15,7 @@
 package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.transform;
 
 import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model.ContractDefinitionRequestDto;
-import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model.CriterionDto;
+import org.eclipse.dataspaceconnector.api.model.CriterionDto;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
 import org.junit.jupiter.api.Test;

--- a/extensions/control-plane/api/data-management/contractdefinition-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/transform/ContractDefinitionToContractDefinitionResponseDtoTransformerTest.java
+++ b/extensions/control-plane/api/data-management/contractdefinition-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/transform/ContractDefinitionToContractDefinitionResponseDtoTransformerTest.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.transform;
 
-import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model.CriterionDto;
+import org.eclipse.dataspaceconnector.api.model.CriterionDto;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;

--- a/extensions/control-plane/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/validation/ExpirationDateValidationRuleTest.java
+++ b/extensions/control-plane/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/validation/ExpirationDateValidationRuleTest.java
@@ -12,7 +12,6 @@
  *
  */
 
-
 package org.eclipse.dataspaceconnector.transfer.dataplane.sync.validation;
 
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -1644,7 +1644,7 @@ components:
         filter:
           type: array
           items:
-            $ref: '#/components/schemas/Criterion'
+            $ref: '#/components/schemas/CriterionDto'
         limit:
           type: integer
           format: int32

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -25,112 +25,6 @@ tags:
     \ path parameters and request body are supported (in the limits fixed by the HTTP\
     \ server) and can also conveyed to the actual data source."
 paths:
-  /callback/{processId}/deprovision:
-    post:
-      tags:
-      - HTTP Provisioner Webhook
-      operationId: callDeprovisionWebhook
-      parameters:
-      - name: processId
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DeprovisionedResource'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /callback/{processId}/provision:
-    post:
-      tags:
-      - HTTP Provisioner Webhook
-      operationId: callProvisionWebhook
-      parameters:
-      - name: processId
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ProvisionerWebhookRequest'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /catalog:
-    get:
-      tags:
-      - Catalog
-      operationId: getCatalog
-      parameters:
-      - name: providerUrl
-        in: query
-        required: true
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: Gets contract offers (=catalog) of a single connector
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Catalog'
   /policydefinitions:
     get:
       tags:
@@ -305,6 +199,424 @@ paths:
         "409":
           description: "The policy definition cannot be deleted, because it is referenced\
             \ by a contract definition"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /instances:
+    get:
+      tags:
+      - Dataplane Selector
+      operationId: getAll
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DataPlaneInstance'
+    post:
+      tags:
+      - Dataplane Selector
+      operationId: addEntry
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataPlaneInstance'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /instances/select:
+    post:
+      tags:
+      - Dataplane Selector
+      operationId: find
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SelectionRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataPlaneInstance'
+  /check/health:
+    get:
+      tags:
+      - Application Observability
+      description: Performs a liveness probe to determine whether the runtime is working
+        properly.
+      operationId: checkHealth
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HealthStatus'
+  /check/liveness:
+    get:
+      tags:
+      - Application Observability
+      description: Performs a liveness probe to determine whether the runtime is working
+        properly.
+      operationId: getLiveness
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HealthStatus'
+  /check/readiness:
+    get:
+      tags:
+      - Application Observability
+      description: Performs a readiness probe to determine whether the runtime is
+        able to accept requests.
+      operationId: getReadiness
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HealthStatus'
+  /check/startup:
+    get:
+      tags:
+      - Application Observability
+      description: Performs a startup probe to determine whether the runtime has completed
+        startup.
+      operationId: getStartup
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HealthStatus'
+  /token:
+    get:
+      tags:
+      - Token Validation
+      description: "Checks that the provided token has been signed by the present\
+        \ entity and asserts its validity. If token is valid, then the data address\
+        \ contained in its claims is decrypted and returned back to the caller."
+      operationId: validate
+      parameters:
+      - name: Authorization
+        in: header
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Token is valid
+        "400":
+          description: Request was malformed
+        "403":
+          description: Token is invalid
+  /contractnegotiations:
+    get:
+      tags:
+      - Contract Negotiation
+      description: Returns all contract negotiations according to a query
+      operationId: getNegotiations
+      parameters:
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractNegotiationDto'
+        "400":
+          description: Request was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+    post:
+      tags:
+      - Contract Negotiation
+      description: "Initiates a contract negotiation for a given offer and with the\
+        \ given counter part. Please note that successfully invoking this endpoint\
+        \ only means that the negotiation was initiated. Clients must poll the /{id}/state\
+        \ endpoint to track the state"
+      operationId: initiateContractNegotiation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NegotiationInitiateRequestDto'
+      responses:
+        "200":
+          description: The negotiation was successfully initiated. Returns the contract
+            negotiation ID and created timestamp
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdResponseDto'
+          links:
+            poll-state:
+              operationId: getNegotiationState
+              parameters:
+                id: $response.body#/id
+        "400":
+          description: Request body was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /contractnegotiations/{id}:
+    get:
+      tags:
+      - Contract Negotiation
+      description: Gets an contract negotiation with the given ID
+      operationId: getNegotiation
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: The contract negotiation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContractNegotiationDto'
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: An contract negotiation with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /contractnegotiations/{id}/agreement:
+    get:
+      tags:
+      - Contract Negotiation
+      description: Gets a contract agreement for a contract negotiation with the given
+        ID
+      operationId: getAgreementForNegotiation
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "The contract agreement that is attached to the negotiation,\
+            \ or null"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContractNegotiationDto'
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: An contract negotiation with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /contractnegotiations/{id}/cancel:
+    post:
+      tags:
+      - Contract Negotiation
+      description: "Requests aborting the contract negotiation. Due to the asynchronous\
+        \ nature of contract negotiations, a successful response only indicates that\
+        \ the request was successfully received. Clients must poll the /{id}/state\
+        \ endpoint to track the state."
+      operationId: cancelNegotiation
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Request to cancel the Contract negotiation was successfully
+            received
+          links:
+            poll-state:
+              operationId: getNegotiationState
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: A contract negotiation with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /contractnegotiations/{id}/decline:
+    post:
+      tags:
+      - Contract Negotiation
+      description: "Requests cancelling the contract negotiation. Due to the asynchronous\
+        \ nature of contract negotiations, a successful response only indicates that\
+        \ the request was successfully received. Clients must poll the /{id}/state\
+        \ endpoint to track the state."
+      operationId: declineNegotiation
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Request to decline the Contract negotiation was successfully
+            received
+          links:
+            poll-state:
+              operationId: getNegotiationState
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: A contract negotiation with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /contractnegotiations/{id}/state:
+    get:
+      tags:
+      - Contract Negotiation
+      description: Gets the state of a contract negotiation with the given ID
+      operationId: getNegotiationState
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: The contract negotiation's state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NegotiationState'
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: An contract negotiation with the given ID does not exist
           content:
             application/json:
               schema:
@@ -693,13 +1005,65 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
-  /assets:
+  /callback/{processId}/deprovision:
+    post:
+      tags:
+      - HTTP Provisioner Webhook
+      operationId: callDeprovisionWebhook
+      parameters:
+      - name: processId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeprovisionedResource'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /callback/{processId}/provision:
+    post:
+      tags:
+      - HTTP Provisioner Webhook
+      operationId: callProvisionWebhook
+      parameters:
+      - name: processId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProvisionerWebhookRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /catalog:
     get:
       tags:
-      - Asset
-      description: Gets all assets according to a particular query
-      operationId: getAllAssets
+      - Catalog
+      operationId: getCatalog
       parameters:
+      - name: providerUrl
+        in: query
+        required: true
+        style: form
+        explode: true
+        schema:
+          type: string
       - name: offset
         in: query
         required: false
@@ -741,243 +1105,31 @@ paths:
         schema:
           type: string
       responses:
-        "200":
+        default:
+          description: Gets contract offers (=catalog) of a single connector
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/AssetResponseDto'
-        "400":
-          description: Request body was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
+                $ref: '#/components/schemas/Catalog'
+      deprecated: true
+  /catalog/request:
     post:
       tags:
-      - Asset
-      description: Creates a new asset together with a data address
-      operationId: createAsset
+      - Catalog
+      operationId: requestCatalog
       requestBody:
         content:
-          application/json:
+          '*/*':
             schema:
-              $ref: '#/components/schemas/AssetEntryDto'
-      responses:
-        "200":
-          description: Asset was created successfully. Returns the asset Id and created
-            timestamp
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IdResponseDto'
-        "400":
-          description: Request body was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "409":
-          description: "Could not create asset, because an asset with that ID already\
-            \ exists"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /assets/{id}:
-    get:
-      tags:
-      - Asset
-      description: Gets an asset with the given ID
-      operationId: getAsset
-      parameters:
-      - name: id
-        in: path
+              $ref: '#/components/schemas/CatalogRequestDto'
         required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: The asset
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AssetResponseDto'
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: An asset with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-    delete:
-      tags:
-      - Asset
-      description: "Removes an asset with the given ID if possible. Deleting an asset\
-        \ is only possible if that asset is not yet referenced by a contract agreement,\
-        \ in which case an error is returned. DANGER ZONE: Note that deleting assets\
-        \ can have unexpected results, especially for contract offers that have been\
-        \ sent out or ongoing or contract negotiations."
-      operationId: removeAsset
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: Asset was deleted successfully
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: An asset with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "409":
-          description: "The asset cannot be deleted, because it is referenced by a\
-            \ contract agreement"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /instances:
-    get:
-      tags:
-      - Dataplane Selector
-      operationId: getAll
       responses:
         default:
-          description: default response
+          description: Gets contract offers (=catalog) of a single connector
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/DataPlaneInstance'
-    post:
-      tags:
-      - Dataplane Selector
-      operationId: addEntry
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DataPlaneInstance'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /instances/select:
-    post:
-      tags:
-      - Dataplane Selector
-      operationId: find
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SelectionRequest'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DataPlaneInstance'
-  /check/health:
-    get:
-      tags:
-      - Application Observability
-      description: Performs a liveness probe to determine whether the runtime is working
-        properly.
-      operationId: checkHealth
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/HealthStatus'
-  /check/liveness:
-    get:
-      tags:
-      - Application Observability
-      description: Performs a liveness probe to determine whether the runtime is working
-        properly.
-      operationId: getLiveness
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/HealthStatus'
-  /check/readiness:
-    get:
-      tags:
-      - Application Observability
-      description: Performs a readiness probe to determine whether the runtime is
-        able to accept requests.
-      operationId: getReadiness
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/HealthStatus'
-  /check/startup:
-    get:
-      tags:
-      - Application Observability
-      description: Performs a startup probe to determine whether the runtime has completed
-        startup.
-      operationId: getStartup
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/HealthStatus'
+                $ref: '#/components/schemas/Catalog'
   /transferprocess:
     get:
       tags:
@@ -1228,35 +1380,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
-  /token:
+  /assets:
     get:
       tags:
-      - Token Validation
-      description: "Checks that the provided token has been signed by the present\
-        \ entity and asserts its validity. If token is valid, then the data address\
-        \ contained in its claims is decrypted and returned back to the caller."
-      operationId: validate
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: Token is valid
-        "400":
-          description: Request was malformed
-        "403":
-          description: Token is invalid
-  /contractnegotiations:
-    get:
-      tags:
-      - Contract Negotiation
-      description: Returns all contract negotiations according to a query
-      operationId: getNegotiations
+      - Asset
+      description: Gets all assets according to a particular query
+      operationId: getAllAssets
       parameters:
       - name: offset
         in: query
@@ -1305,41 +1434,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ContractNegotiationDto'
-        "400":
-          description: Request was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-    post:
-      tags:
-      - Contract Negotiation
-      description: "Initiates a contract negotiation for a given offer and with the\
-        \ given counter part. Please note that successfully invoking this endpoint\
-        \ only means that the negotiation was initiated. Clients must poll the /{id}/state\
-        \ endpoint to track the state"
-      operationId: initiateContractNegotiation
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/NegotiationInitiateRequestDto'
-      responses:
-        "200":
-          description: The negotiation was successfully initiated. Returns the contract
-            negotiation ID and created timestamp
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IdResponseDto'
-          links:
-            poll-state:
-              operationId: getNegotiationState
-              parameters:
-                id: $response.body#/id
+                  $ref: '#/components/schemas/AssetResponseDto'
         "400":
           description: Request body was malformed
           content:
@@ -1348,168 +1443,47 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
-  /contractnegotiations/{id}:
-    get:
-      tags:
-      - Contract Negotiation
-      description: Gets an contract negotiation with the given ID
-      operationId: getNegotiation
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: The contract negotiation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ContractNegotiationDto'
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: An contract negotiation with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /contractnegotiations/{id}/agreement:
-    get:
-      tags:
-      - Contract Negotiation
-      description: Gets a contract agreement for a contract negotiation with the given
-        ID
-      operationId: getAgreementForNegotiation
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: "The contract agreement that is attached to the negotiation,\
-            \ or null"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ContractNegotiationDto'
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: An contract negotiation with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /contractnegotiations/{id}/cancel:
     post:
       tags:
-      - Contract Negotiation
-      description: "Requests aborting the contract negotiation. Due to the asynchronous\
-        \ nature of contract negotiations, a successful response only indicates that\
-        \ the request was successfully received. Clients must poll the /{id}/state\
-        \ endpoint to track the state."
-      operationId: cancelNegotiation
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
+      - Asset
+      description: Creates a new asset together with a data address
+      operationId: createAsset
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssetEntryDto'
       responses:
         "200":
-          description: Request to cancel the Contract negotiation was successfully
-            received
-          links:
-            poll-state:
-              operationId: getNegotiationState
+          description: Asset was created successfully. Returns the asset Id and created
+            timestamp
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdResponseDto'
         "400":
-          description: "Request was malformed, e.g. id was null"
+          description: Request body was malformed
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: A contract negotiation with the given ID does not exist
+        "409":
+          description: "Could not create asset, because an asset with that ID already\
+            \ exists"
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
-  /contractnegotiations/{id}/decline:
-    post:
-      tags:
-      - Contract Negotiation
-      description: "Requests cancelling the contract negotiation. Due to the asynchronous\
-        \ nature of contract negotiations, a successful response only indicates that\
-        \ the request was successfully received. Clients must poll the /{id}/state\
-        \ endpoint to track the state."
-      operationId: declineNegotiation
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: Request to decline the Contract negotiation was successfully
-            received
-          links:
-            poll-state:
-              operationId: getNegotiationState
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: A contract negotiation with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /contractnegotiations/{id}/state:
+  /assets/{id}:
     get:
       tags:
-      - Contract Negotiation
-      description: Gets the state of a contract negotiation with the given ID
-      operationId: getNegotiationState
+      - Asset
+      description: Gets an asset with the given ID
+      operationId: getAsset
       parameters:
       - name: id
         in: path
@@ -1520,11 +1494,11 @@ paths:
           type: string
       responses:
         "200":
-          description: The contract negotiation's state
+          description: The asset
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NegotiationState'
+                $ref: '#/components/schemas/AssetResponseDto'
         "400":
           description: "Request was malformed, e.g. id was null"
           content:
@@ -1534,7 +1508,52 @@ paths:
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
         "404":
-          description: An contract negotiation with the given ID does not exist
+          description: An asset with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+    delete:
+      tags:
+      - Asset
+      description: "Removes an asset with the given ID if possible. Deleting an asset\
+        \ is only possible if that asset is not yet referenced by a contract agreement,\
+        \ in which case an error is returned. DANGER ZONE: Note that deleting assets\
+        \ can have unexpected results, especially for contract offers that have been\
+        \ sent out or ongoing or contract negotiations."
+      operationId: removeAsset
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Asset was deleted successfully
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: An asset with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "409":
+          description: "The asset cannot be deleted, because it is referenced by a\
+            \ contract agreement"
           content:
             application/json:
               schema:
@@ -1617,6 +1636,30 @@ components:
             $ref: '#/components/schemas/ContractOffer'
         id:
           type: string
+    CatalogRequestDto:
+      required:
+      - providerUrl
+      type: object
+      properties:
+        filter:
+          type: array
+          items:
+            $ref: '#/components/schemas/Criterion'
+        limit:
+          type: integer
+          format: int32
+        offset:
+          type: integer
+          format: int32
+        providerUrl:
+          type: string
+        sortField:
+          type: string
+        sortOrder:
+          type: string
+          enum:
+          - ASC
+          - DESC
     Constraint:
       required:
       - edctype

--- a/resources/openapi/yaml/catalog-api.yaml
+++ b/resources/openapi/yaml/catalog-api.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.1
 paths:
   /catalog:
     get:
+      deprecated: true
       operationId: getCatalog
       parameters:
       - in: query
@@ -43,6 +44,24 @@ paths:
           description: Gets contract offers (=catalog) of a single connector
       tags:
       - Catalog
+  /catalog/request:
+    post:
+      operationId: requestCatalog
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/CatalogRequestDto'
+        required: true
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Catalog'
+          description: Gets contract offers (=catalog) of a single connector
+      tags:
+      - Catalog
 components:
   schemas:
     Action:
@@ -75,6 +94,30 @@ components:
             $ref: '#/components/schemas/ContractOffer'
         id:
           type: string
+    CatalogRequestDto:
+      type: object
+      properties:
+        filter:
+          type: array
+          items:
+            $ref: '#/components/schemas/Criterion'
+        limit:
+          type: integer
+          format: int32
+        offset:
+          type: integer
+          format: int32
+        providerUrl:
+          type: string
+        sortField:
+          type: string
+        sortOrder:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      required:
+      - providerUrl
     Constraint:
       type: object
       discriminator:
@@ -111,6 +154,15 @@ components:
         provider:
           type: string
           format: uri
+    Criterion:
+      type: object
+      properties:
+        operandLeft:
+          type: object
+        operandRight:
+          type: object
+        operator:
+          type: string
     Duty:
       type: object
       properties:

--- a/resources/openapi/yaml/catalog-api.yaml
+++ b/resources/openapi/yaml/catalog-api.yaml
@@ -100,7 +100,7 @@ components:
         filter:
           type: array
           items:
-            $ref: '#/components/schemas/Criterion'
+            $ref: '#/components/schemas/CriterionDto'
         limit:
           type: integer
           format: int32
@@ -154,7 +154,7 @@ components:
         provider:
           type: string
           format: uri
-    Criterion:
+    CriterionDto:
       type: object
       properties:
         operandLeft:
@@ -163,6 +163,9 @@ components:
           type: object
         operator:
           type: string
+      required:
+      - operandLeft
+      - operator
     Duty:
       type: object
       properties:

--- a/spi/common/oauth2-spi/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/spi/NoopCredentialsRequestAdditionalParametersProvider.java
+++ b/spi/common/oauth2-spi/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/spi/NoopCredentialsRequestAdditionalParametersProvider.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.iam.oauth2.spi;
 
 import org.eclipse.dataspaceconnector.spi.iam.TokenParameters;

--- a/spi/federated-catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/FederatedCacheNodeFilter.java
+++ b/spi/federated-catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/FederatedCacheNodeFilter.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.dataspaceconnector.catalog.spi;
 
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.ExtensionPoint;


### PR DESCRIPTION
## What this PR changes/adds

This PR adds another endpoint called `POST /catalog/request` to the DMgmtApi, which accepts a `CatalogRequestDto` in the body.

## Why it does that

switching over to `POST` allows to pass a more complex object to the endpoint, in particular an actual request object instead of just a filter string.

## Further notes

- the existing `GET /catalog` endpoint was deprecated
- the body is mandatory, as it also contains the `providerUrl`. 
- moved the `CriterionDto` and its transformers to `api-core`
- using a dedicated request object (or modifying/recycling the `QuerySpecDto`) and `POST`ing instead of `GET`ting in all the other endpoints as well should be done in (a) separate PR(s)
- unrelated: added/fixed some copyright headers

## Linked Issue(s)

Closes #2051 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
