### PR TITLE
chore: set output dir of the autodoc plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -153,6 +153,7 @@ allprojects {
     // configure which version of the annotation processor to use. defaults to the same version as the plugin
     configure<org.eclipse.dataspaceconnector.plugins.autodoc.AutodocExtension> {
         processorVersion.set(annotationProcessorVersion)
+        outputDirectory.set(project.buildDir)
     }
 
     apply(plugin = "org.eclipse.dataspaceconnector.test-summary")


### PR DESCRIPTION
## What this PR changes/adds

Sets the output dir to be the build directory of every project

## Why it does that

so that manifests get cleaned with the rest of the build artefacts


## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
