### PR TITLE
docs: add decision record for naming conventions

### DIFF
--- a/docs/developer/decision-records/2022-10-10-naming-conventions/README.md
+++ b/docs/developer/decision-records/2022-10-10-naming-conventions/README.md
@@ -3,9 +3,7 @@
 ## Decision
 
 The naming of existing and future Java packages, Gradle modules, Maven artifacts, and configuration
-properties should follow defined naming conventions that align the project's structure. Changes in the
-connector repository will affect downstream repositories, in addition, conventions should also be implemented
-there.
+properties should follow defined naming conventions that align the project's structure. 
 
 Related decision records:
 - [2022-08-09 Project structure review](../2022-08-09-project-structure-review/)
@@ -13,99 +11,112 @@ Related decision records:
 
 ## Rationale
 
-Since the developed framework components of the EDC project are designed to be adopted in other projects,
-their usages must be as simple and developer-friendly as possible. This is supported, for instance,
-by a consistent naming following clearly defined conventions and established standards.
+A software project's structure should be designed as developer-friendly as possible, by following precisely
+defined rules based on established standards.
 
 Our goals by introducing naming conventions are:
-- Easy navigation of Gradle modules, Maven artifacts and imported Java packages.
+- Easy navigation of either Gradle modules, Maven artifacts or the Java package structure.
 - Unique naming of config properties (especially with regard to custom properties introduced by extensions).
 - Accordance to the Eclipse Foundation's guidelines and release processes.
 - Elimination of split packages.
 
 ## Approach
 
-Existing standards that are considered in the following are listed below.
-- Apache Maven's [guide to naming conventions on groupId, artifactId, and version](https://maven.apache.org/guides/mini/guide-naming-conventions.html)
-- Oracle's [Java package naming conventions](https://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html)
+### Gradle module name
 
-### Naming Conventions
-
-#### Gradle Module
-
-All core components of the EDC project are implemented as Gradle multi-module projects. A Gradle module
-is referenced in the `settings.gradle`, e.g.:
+Gradle modules must have unique names across the entire build classpath, even if they are located in
+different module paths. This is because of a bug in Gradle itself where Gradle will erroneously report
+a "cyclic dependency" if this rule is violated. The following hypothetical example would constitute
+such a violation:
 
 ```kotlin
-include(":core:data-plane:data-plane-framework")
+// settings.gradle.kts
+include(":core:common:transfer-process")
+include(":extensions:sql:transfer-process")
 ```
 
-In this example, the _moduleId_ is `data-plane-framework`. This module implements the "data plane framework"
-that is part of the "data plane" without naming the `core` module. With this, the _moduleId_ is a unique
-concatenation of its location, without preventing the moving and a restructuring of the package.
+The EDC project has checks in place to make sure module IDs are unique.
 
+> Rule 1: Modules must have unique names.
 
-#### Maven Artifact
+In addition, the _module name_ should give a hint what is in the module, without being too verbose. The
+earlier example would be a bad one, because "transfer-process" does not indicate what the contents could
+be. This is especially important because Maven's _artifactId_ must be equal to module names.
 
-A Maven artifact is composed of the following components:
-```
-<groupId>.<artifactId>.<version>
-```
+Here are some bad examples:
+- `:core:common:transfer-process:validation`: bad because "validation" is likely to be not unique and isolated it only indicates that it has to do with validation, but not in _what context_.
+- `:core:dataplane:framework`: again, "framework" is liable to cause conflicts, and in addition, it's a very generic, unspecific term
 
-The _groupId_ uniquely identifies our project: `org.eclipse.edc.*`. All EDC core components (as of 10.10.2022:
-[connector](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector),
-[identity hub](https://github.com/eclipse-dataspaceconnector/IdentityHub),
-[registration service](https://github.com/eclipse-dataspaceconnector/RegistrationService),
-and [federated catalog](https://github.com/eclipse-dataspaceconnector/FederatedCatalog))
-are published with the same version under this same _groupId_.
+Refactoring these bad examples, we could arrive at these:
+- `:core:common:transfer-process:transfer-process-validation`: could contain validation functions
+- `:core:dataplane:dataplane-framework`: would contain default impls and platform code for the dataplane
 
-The _artifactId_ is the name of the jar without a version. In the EDC project, the _artifactId_ is identical
-to the _moduleId_. For example:
+> Rule 2: Module names should indicate what the contents are.
 
-```kotlin
-publishing {
-    publications {
-        create<MavenPublication>("data-plane-framework") {
-            artifactId = "data-plane-framework"
-            from(components["java"])
-        }
-    }
-}
-```
+> Rule 3: Module names must be identical to the Maven artifactId (published one).
 
-For versioning, see [here](../2022-07-06-release-automation/).
+### Maven artifactId
 
-#### Java Package
+The EDC project uses the same `groupId = "org.eclipse.edc"` across all sub-projects, which means all
+_artifactIds_ must be unique across multiple software components to avoid conflicts.
+
+> Rule 4: A Maven artifactId must be unique within the groupId.
+
+> Rule 5: A Maven artifactId must be identical to the module name (cf. [Rule 3](#gradle-module-name)).
+
+### Java package name
 
 Following Oracle's [Java package naming conventions](https://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html),
-package names are written in all lower case. In addition, package names use the reversed domain name,
-for example, `com.example.mypackage` for a package named `mypackage` created by a programmer at `example.com`.
+EDC's base package name is `org.eclipse.edc`, followed by domain and then function. For example, the
+Policy SPI should be located at `org.eclipse.edc.policy.spi` rather than `org.eclipse.edc.spi.policy`.
+Here, `policy` is the "domain", i.e. the thematic context, and `spi` would be the "function", i.e. what
+kind of package it is or: what purpose it serves.
 
-Accordingly, in the EDC project, aligned with the _groupId_, Java packages start with `org.eclipse.edc.*`.
-Corresponding to the _moduleId_, this is followed by a unique path. To remain with our example, the
-class `DataPlaneFrameworkExtension` is located at:
+The module name could be a helpful reference for the package name, replacing dashes with dots.
 
-```java
-package org.eclipse.dataspaceconnector.dataplane.framework;
-```
+Other positive examples would be:
+- `org.eclipse.edc.transferprocess.validation`: domain is `transferprocess`, and it's a package that deals with validation
+- `org.eclipse.edc.dataplane.framework.manager`: here the domain is `dataplane.framework`, so all code should be beneath that directory.
 
-In this context, everything after `org.eclipse.edc` is sorted first by field/discipline and then by scope.
-For example, a policy spi will not be located at `org.eclipse.edc.spi.policy` but at `org.eclipse.edc.policy.spi`.
+This helps to avoid split packages.
 
-#### Configuration Property
+> Rule 6: Package names should first contain the domain, and then the function.
 
-Following the [policy scopes](../2022-03-15-policy-scopes/), configuration properties are using a hierarchical
-dot notation. They do **not** start with an `edc` or similar Eclipse related prefix.
+### Configuration properties
 
-Configuration properties should fit to related _moduleIds_ or package names and be grouped by scope.
+Configuration properties should have a unique prefix `edc` to avoid clashes, when EDC gets embedded
+in other Java frameworks such as Spring. Further, the config property should contain the component for
+which it is valid, and a section in hierarchical structure (dot notation) indicating what the value is about.
 
-### Implementation
+Bad:
+- `edc.retry.backoff.min`: does not contain the component, i.e. _which_ retry backoff min value is configured
+- `edc.retry.backoff`: does not contain the component nor does it indicate, _which_ value is configured, i.e. what data type is expected
+- `edc.core.retryBackoffMin`: is not hierarchically structured
+- `edc.core.system.threadpool-size`: missing part of the component and is therefore misleading, because it does not indicate _what_ threadpool we're configuring
+- `edc.dataplane.wait`: does not indicate which value is configured
+- `web.http.port`: not prefixed with `edc`, can lead to conflicts
 
-Renaming according to the defined [naming conventions](#naming-conventions).
-- Check if _moduleId_ and _artifactId_ are unique and represent a concatenation in the correct order.
+Better:
+- `edc.core.retry.backoff.min`
+- `edc.core.system.health.check.threadpool-size`
+- `edc.dataplane.queue.poll-timeout`
+- `edc.web.http.port`
+
+> Rule 7: Configuration properties are prefixed with `edc.`.
+
+> Rule 8: Configuration properties must contain the component in dotted notation to which they belong.
+
+> Rule 9: Configuration properties must indicate the value and datatype that they configure.
+
+
+## Implementation
+
+Renaming according to the defined [rules](#approach).
+- Check if _module name_ and _artifactId_ are unique and represent a concatenation in the correct order.
 - Modify release process to use `org.eclipse.edc` as _groupId_.
 - Check every Java package and move classes if necessary.
 - Detect and resolve split packages.
-- Remove `edc` prefix from any configuration property.
-- Align existing configuration properties in the EDC project. Add a clear warning to extensions that
-  fail to load a (new) value.
+- Align existing configuration properties in the EDC project. Add a clear warning to extensions that fail to load a (new) value.
+
+Changes in the connector repository will affect downstream repositories, in addition, conventions should
+also be implemented there.

--- a/docs/developer/decision-records/2022-10-10-naming-conventions/README.md
+++ b/docs/developer/decision-records/2022-10-10-naming-conventions/README.md
@@ -1,0 +1,111 @@
+# EDC Naming Conventions
+
+## Decision
+
+The naming of existing and future Java packages, Gradle modules, Maven artifacts, and configuration
+properties should follow defined naming conventions that align the project's structure. Changes in the
+connector repository will affect downstream repositories, in addition, conventions should also be implemented
+there.
+
+Related decision records:
+- [2022-08-09 Project structure review](../2022-08-09-project-structure-review/)
+- [2022-08-11 Versioning and Artifacts](../2022-08-11-versioning_and_artifacts/)
+
+## Rationale
+
+Since the developed framework components of the EDC project are designed to be adopted in other projects,
+their usages must be as simple and developer-friendly as possible. This is supported, for instance,
+by a consistent naming following clearly defined conventions and established standards.
+
+Our goals by introducing naming conventions are:
+- Easy navigation of Gradle modules, Maven artifacts and imported Java packages.
+- Unique naming of config properties (especially with regard to custom properties introduced by extensions).
+- Accordance to the Eclipse Foundation's guidelines and release processes.
+- Elimination of split packages.
+
+## Approach
+
+Existing standards that are considered in the following are listed below.
+- Apache Maven's [guide to naming conventions on groupId, artifactId, and version](https://maven.apache.org/guides/mini/guide-naming-conventions.html)
+- Oracle's [Java package naming conventions](https://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html)
+
+### Naming Conventions
+
+#### Gradle Module
+
+All core components of the EDC project are implemented as Gradle multi-module projects. A Gradle module
+is referenced in the `settings.gradle`, e.g.:
+
+```kotlin
+include(":core:data-plane:data-plane-framework")
+```
+
+In this example, the _moduleId_ is `data-plane-framework`. This module implements the "data plane framework"
+that is part of the "data plane" without naming the `core` module. With this, the _moduleId_ is a unique
+concatenation of its location, without preventing the moving and a restructuring of the package.
+
+
+#### Maven Artifact
+
+A Maven artifact is composed of the following components:
+```
+<groupId>.<artifactId>.<version>
+```
+
+The _groupId_ uniquely identifies our project: `org.eclipse.edc.*`. All EDC core components (as of 10.10.2022:
+[connector](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector),
+[identity hub](https://github.com/eclipse-dataspaceconnector/IdentityHub),
+[registration service](https://github.com/eclipse-dataspaceconnector/RegistrationService),
+and [federated catalog](https://github.com/eclipse-dataspaceconnector/FederatedCatalog))
+are published with the same version under this same _groupId_.
+
+The _artifactId_ is the name of the jar without a version. In the EDC project, the _artifactId_ is identical
+to the _moduleId_. For example:
+
+```kotlin
+publishing {
+    publications {
+        create<MavenPublication>("data-plane-framework") {
+            artifactId = "data-plane-framework"
+            from(components["java"])
+        }
+    }
+}
+```
+
+For versioning, see [here](../2022-07-06-release-automation/).
+
+#### Java Package
+
+Following Oracle's [Java package naming conventions](https://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html),
+package names are written in all lower case. In addition, package names use the reversed domain name,
+for example, `com.example.mypackage` for a package named `mypackage` created by a programmer at `example.com`.
+
+Accordingly, in the EDC project, aligned with the _groupId_, Java packages start with `org.eclipse.edc.*`.
+Corresponding to the _moduleId_, this is followed by a unique path. To remain with our example, the
+class `DataPlaneFrameworkExtension` is located at:
+
+```java
+package org.eclipse.dataspaceconnector.dataplane.framework;
+```
+
+In this context, everything after `org.eclipse.edc` is sorted first by field/discipline and then by scope.
+For example, a policy spi will not be located at `org.eclipse.edc.spi.policy` but at `org.eclipse.edc.policy.spi`.
+
+#### Configuration Property
+
+Following the [policy scopes](../2022-03-15-policy-scopes/), configuration properties are using a hierarchical
+dot notation. They do **not** start with an `edc` or similar Eclipse related prefix.
+
+Configuration properties should fit to related _moduleIds_ or package names and be grouped by scope.
+
+### Implementation
+
+Renaming according to the defined [naming conventions](#naming-conventions).
+- Check if _moduleId_ and _artifactId_ are unique and represent a concatenation in the correct order.
+- Modify release process to use `org.eclipse.edc` as _groupId_.
+- Check every Java package and move classes if necessary.
+- Detect and resolve split packages.
+- Remove `edc` prefix from any configuration property.
+- Align existing configuration properties in the EDC project. Add a clear warning to extensions that
+  fail to load a (new) value.

--- a/docs/developer/decision-records/2022-10-10-naming-conventions/README.md
+++ b/docs/developer/decision-records/2022-10-10-naming-conventions/README.md
@@ -41,7 +41,7 @@ The EDC project has checks in place to make sure module IDs are unique.
 
 In addition, the _module name_ should give a hint what is in the module, without being too verbose. The
 earlier example would be a bad one, because "transfer-process" does not indicate what the contents could
-be. This is especially important because Maven's _artifactId_ must be equal to module names.
+be. This is especially important because we require the Maven's _artifactId_ to be equal to module names.
 
 Here are some bad examples:
 - `:core:common:transfer-process:validation`: bad because "validation" is likely to be not unique and isolated it only indicates that it has to do with validation, but not in _what context_.
@@ -53,7 +53,7 @@ Refactoring these bad examples, we could arrive at these:
 
 > Rule 2: Module names should indicate what the contents are.
 
-> Rule 3: Module names must be identical to the Maven artifactId (published one).
+> Rule 3: Module names must be identical to the Maven artifactId (if one is published).
 
 ### Maven artifactId
 
@@ -70,7 +70,7 @@ Following Oracle's [Java package naming conventions](https://docs.oracle.com/jav
 EDC's base package name is `org.eclipse.edc`, followed by domain and then function. For example, the
 Policy SPI should be located at `org.eclipse.edc.policy.spi` rather than `org.eclipse.edc.spi.policy`.
 Here, `policy` is the "domain", i.e. the thematic context, and `spi` would be the "function", i.e. what
-kind of package it is or: what purpose it serves.
+kind of package it is or what purpose it serves.
 
 The module name could be a helpful reference for the package name, replacing dashes with dots.
 

--- a/docs/developer/decision-records/README.md
+++ b/docs/developer/decision-records/README.md
@@ -38,4 +38,5 @@
 - [2022-08-17 Remove H2 Database Tests](2022-08-17-remove_h2_database_tests/)
 - [2022-09-18 IDS catalog request filtering](2022-09-18-ids-catalog-request-filtering/)
 - [2022-09-23 Extract metamodel and autodoc](2022-09-23-extract-metamodel-and-autodoc/)
-- [2022-09-29 Sql Query Streaming](2022-09-29-sql-query-streaming)
+- [2022-09-29 Sql Query Streaming](2022-09-29-sql-query-streaming/)
+- [2022-10-10 EDC Naming Conventions](2022-10-10-naming-conventions/)


### PR DESCRIPTION
## What this PR changes/adds

Describes naming patterns for moduleIds, groupId, artifactIds, packages, and config properties.

## Why it does that

To align the project's code structure.

## Further notes

Do you have a more concrete idea for the config naming, and an example?

## Linked Issue(s)

Closes #1956

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
