### PR TITLE
fix(validation): avoid policy evaluation on consumer side after agreement

### DIFF
--- a/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -187,7 +187,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
             return StatusResult.failure(FATAL_ERROR);
         }
 
-        var result = validationService.validate(token, agreement, latestOffer);
+        var result = validationService.validateConfirmed(token, agreement, latestOffer);
         if (!result) {
             // TODO Add contract offer possibility.
             monitor.debug("[Consumer] Contract agreement received. Validation failed.");

--- a/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -44,8 +44,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import static java.lang.String.format;
-import static org.eclipse.dataspaceconnector.spi.contract.ContractId.DEFINITION_PART;
-import static org.eclipse.dataspaceconnector.spi.contract.ContractId.parseContractId;
 import static org.eclipse.dataspaceconnector.spi.response.ResponseStatus.FATAL_ERROR;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation.Type.CONSUMER;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONFIRMED;
@@ -352,12 +350,12 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
         //TODO this is a dummy agreement used to approve the provider's offer, real agreement will be created and sent by provider
         var lastOffer = negotiation.getLastContractOffer();
 
-        var contractIdTokens = parseContractId(lastOffer.getId());
-        if (contractIdTokens.length != 2) {
+        var contractId = ContractId.parse(lastOffer.getId());
+        if (!contractId.isValid()) {
             monitor.severe("ConsumerContractNegotiationManagerImpl.approveContractOffers(): Offer Id not correctly formatted.");
             return false;
         }
-        var definitionId = contractIdTokens[DEFINITION_PART];
+        var definitionId = contractId.definitionPart();
 
         var policy = lastOffer.getPolicy();
         var agreement = ContractAgreement.Builder.newInstance()

--- a/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -186,10 +186,11 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
         }
 
         var result = validationService.validateConfirmed(token, agreement, latestOffer);
-        if (!result) {
+        if (result.failed()) {
             // TODO Add contract offer possibility.
-            monitor.debug("[Consumer] Contract agreement received. Validation failed.");
-            negotiation.setErrorDetail("Contract rejected."); //TODO set error detail
+            var message = "Contract agreement received. Validation failed: " + result.getFailureDetail();
+            monitor.debug("[Consumer] " + message);
+            negotiation.setErrorDetail(message);
             negotiation.transitionDeclining();
             negotiationStore.save(negotiation);
             monitor.debug(String.format("[Consumer] ContractNegotiation %s is now in state %s.",

--- a/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -185,7 +185,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
             return StatusResult.failure(FATAL_ERROR);
         }
 
-        var result = validationService.validateConfirmed(token, agreement, latestOffer);
+        var result = validationService.validateConfirmed(agreement, latestOffer);
         if (result.failed()) {
             // TODO Add contract offer possibility.
             var message = "Contract agreement received. Validation failed: " + result.getFailureDetail();

--- a/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -41,8 +41,6 @@ import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
-import static org.eclipse.dataspaceconnector.spi.contract.ContractId.DEFINITION_PART;
-import static org.eclipse.dataspaceconnector.spi.contract.ContractId.parseContractId;
 import static org.eclipse.dataspaceconnector.spi.response.ResponseStatus.FATAL_ERROR;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation.Type.PROVIDER;
 import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates.CONFIRMING;
@@ -341,12 +339,12 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
         if (retrievedAgreement == null) {
             var lastOffer = negotiation.getLastContractOffer();
 
-            var contractIdTokens = parseContractId(lastOffer.getId());
-            if (contractIdTokens.length != 2) {
+            var contractId = ContractId.parse(lastOffer.getId());
+            if (!contractId.isValid()) {
                 monitor.severe("ProviderContractNegotiationManagerImpl.checkConfirming(): Offer Id not correctly formatted.");
                 return false;
             }
-            var definitionId = contractIdTokens[DEFINITION_PART];
+            var definitionId = contractId.definitionPart();
 
             policy = lastOffer.getPolicy();
             //TODO move to own service

--- a/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImpl.java
+++ b/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImpl.java
@@ -149,7 +149,7 @@ public class ContractValidationServiceImpl implements ContractValidationService 
     }
 
     @Override
-    public Result<Void> validateConfirmed(ClaimToken token, ContractAgreement agreement, ContractOffer latestOffer) {
+    public Result<Void> validateConfirmed(ContractAgreement agreement, ContractOffer latestOffer) {
         var contractId = ContractId.parse(agreement.getId());
         if (!contractId.isValid()) {
             return Result.failure(format("ContractId %s does not follow the expected schema.", agreement.getId()));

--- a/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImpl.java
+++ b/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImpl.java
@@ -149,13 +149,17 @@ public class ContractValidationServiceImpl implements ContractValidationService 
     }
 
     @Override
-    public boolean validateConfirmed(ClaimToken token, ContractAgreement agreement, ContractOffer latestOffer) {
+    public Result<Void> validateConfirmed(ClaimToken token, ContractAgreement agreement, ContractOffer latestOffer) {
         var contractId = ContractId.parse(agreement.getId());
         if (!contractId.isValid()) {
-            return false;
+            return Result.failure(format("ContractId %s does not follow the expected schema.", agreement.getId()));
         }
 
-        return policyEquality.test(agreement.getPolicy(), latestOffer.getPolicy());
+        if (!policyEquality.test(agreement.getPolicy(), latestOffer.getPolicy())) {
+            return Result.failure("Policy in the contract agreement is not equal to the one in the contract offer");
+        }
+
+        return Result.success();
     }
 
     private boolean isExpired(ContractAgreement contractAgreement) {

--- a/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImpl.java
+++ b/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImpl.java
@@ -150,15 +150,13 @@ public class ContractValidationServiceImpl implements ContractValidationService 
     }
 
     @Override
-    public boolean validate(ClaimToken token, ContractAgreement agreement, ContractOffer latestOffer) {
-        // TODO implement validation against latest offer within the negotiation
+    public boolean validateConfirmed(ClaimToken token, ContractAgreement agreement, ContractOffer latestOffer) {
         var contractIdTokens = parseContractId(agreement.getId());
         if (contractIdTokens.length != 2) {
             return false; // not a valid id
         }
 
-        var agent = agentService.createFor(token);
-        return policyEngine.evaluate(NEGOTIATION_SCOPE, agreement.getPolicy(), agent).succeeded();
+        return policyEquality.test(agreement.getPolicy(), latestOffer.getPolicy());
     }
 
     private boolean isExpired(ContractAgreement contractAgreement) {

--- a/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImpl.java
+++ b/core/control-plane/contract/src/main/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImpl.java
@@ -19,6 +19,7 @@ package org.eclipse.dataspaceconnector.contract.validation;
 import org.eclipse.dataspaceconnector.contract.policy.PolicyEquality;
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgentService;
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
+import org.eclipse.dataspaceconnector.spi.contract.ContractId;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractDefinitionService;
 import org.eclipse.dataspaceconnector.spi.contract.validation.ContractValidationService;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
@@ -32,8 +33,6 @@ import org.jetbrains.annotations.NotNull;
 import java.time.Clock;
 
 import static java.lang.String.format;
-import static org.eclipse.dataspaceconnector.spi.contract.ContractId.DEFINITION_PART;
-import static org.eclipse.dataspaceconnector.spi.contract.ContractId.parseContractId;
 
 /**
  * Implementation of the {@link ContractValidationService}.
@@ -67,13 +66,13 @@ public class ContractValidationServiceImpl implements ContractValidationService 
             return Result.failure("Mandatory attributes are missing.");
         }
 
-        var contractIdTokens = parseContractId(offer.getId());
-        if (contractIdTokens.length != 2) {
+        var contractId = ContractId.parse(offer.getId());
+        if (!contractId.isValid()) {
             return Result.failure("Invalid id: " + offer.getId());
         }
 
         var agent = agentService.createFor(token);
-        var contractDefinition = contractDefinitionService.definitionFor(agent, contractIdTokens[DEFINITION_PART]);
+        var contractDefinition = contractDefinitionService.definitionFor(agent, contractId.definitionPart());
         if (contractDefinition == null) {
             return Result.failure("The ContractDefinition with id %s either does not exist or the access to it is not granted.");
         }
@@ -112,8 +111,8 @@ public class ContractValidationServiceImpl implements ContractValidationService 
             return Result.failure("Mandatory attributes are missing.");
         }
 
-        var contractIdTokens = parseContractId(offer.getId());
-        if (contractIdTokens.length != 2) {
+        var contractId = ContractId.parse(offer.getId());
+        if (!contractId.isValid()) {
             return Result.failure("Invalid id: " + offer.getId());
         }
 
@@ -130,9 +129,9 @@ public class ContractValidationServiceImpl implements ContractValidationService 
 
     @Override
     public boolean validate(ClaimToken token, ContractAgreement agreement) {
-        var contractIdTokens = parseContractId(agreement.getId());
-        if (contractIdTokens.length != 2) {
-            return false; // not a valid id
+        var contractId = ContractId.parse(agreement.getId());
+        if (!contractId.isValid()) {
+            return false;
         }
 
         if (!isStarted(agreement) || isExpired(agreement)) {
@@ -140,7 +139,7 @@ public class ContractValidationServiceImpl implements ContractValidationService 
         }
 
         var agent = agentService.createFor(token);
-        var contractDefinition = contractDefinitionService.definitionFor(agent, contractIdTokens[DEFINITION_PART]);
+        var contractDefinition = contractDefinitionService.definitionFor(agent, contractId.definitionPart());
         if (contractDefinition == null) {
             return false;
         }
@@ -151,9 +150,9 @@ public class ContractValidationServiceImpl implements ContractValidationService 
 
     @Override
     public boolean validateConfirmed(ClaimToken token, ContractAgreement agreement, ContractOffer latestOffer) {
-        var contractIdTokens = parseContractId(agreement.getId());
-        if (contractIdTokens.length != 2) {
-            return false; // not a valid id
+        var contractId = ContractId.parse(agreement.getId());
+        if (!contractId.isValid()) {
+            return false;
         }
 
         return policyEquality.test(agreement.getPolicy(), latestOffer.getPolicy());

--- a/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -202,7 +202,7 @@ class ConsumerContractNegotiationManagerImplTest {
         var contractAgreement = mock(ContractAgreement.class);
         var def = PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build();
         when(store.find(negotiationConsumerOffered.getId())).thenReturn(negotiationConsumerOffered);
-        when(validationService.validateConfirmed(eq(token), eq(contractAgreement), any(ContractOffer.class))).thenReturn(true);
+        when(validationService.validateConfirmed(eq(token), eq(contractAgreement), any(ContractOffer.class))).thenReturn(Result.success());
 
         var result = negotiationManager.confirmed(token, negotiationConsumerOffered.getId(), contractAgreement, def.getPolicy());
 
@@ -222,7 +222,7 @@ class ConsumerContractNegotiationManagerImplTest {
         var contractAgreement = mock(ContractAgreement.class);
         var policy = Policy.Builder.newInstance().build();
         when(store.find(negotiationConsumerOffered.getId())).thenReturn(negotiationConsumerOffered);
-        when(validationService.validateConfirmed(eq(token), eq(contractAgreement), any(ContractOffer.class))).thenReturn(false);
+        when(validationService.validateConfirmed(eq(token), eq(contractAgreement), any(ContractOffer.class))).thenReturn(Result.failure("error"));
 
         var result = negotiationManager.confirmed(token, negotiationConsumerOffered.getId(), contractAgreement, policy);
 

--- a/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -202,7 +202,7 @@ class ConsumerContractNegotiationManagerImplTest {
         var contractAgreement = mock(ContractAgreement.class);
         var def = PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build();
         when(store.find(negotiationConsumerOffered.getId())).thenReturn(negotiationConsumerOffered);
-        when(validationService.validate(eq(token), eq(contractAgreement), any(ContractOffer.class))).thenReturn(true);
+        when(validationService.validateConfirmed(eq(token), eq(contractAgreement), any(ContractOffer.class))).thenReturn(true);
 
         var result = negotiationManager.confirmed(token, negotiationConsumerOffered.getId(), contractAgreement, def.getPolicy());
 
@@ -211,7 +211,7 @@ class ConsumerContractNegotiationManagerImplTest {
                 negotiation.getState() == CONFIRMED.code() &&
                         negotiation.getContractAgreement() == contractAgreement
         ));
-        verify(validationService).validate(eq(token), eq(contractAgreement), any(ContractOffer.class));
+        verify(validationService).validateConfirmed(eq(token), eq(contractAgreement), any(ContractOffer.class));
         verify(listener).confirmed(any());
     }
 
@@ -222,7 +222,7 @@ class ConsumerContractNegotiationManagerImplTest {
         var contractAgreement = mock(ContractAgreement.class);
         var policy = Policy.Builder.newInstance().build();
         when(store.find(negotiationConsumerOffered.getId())).thenReturn(negotiationConsumerOffered);
-        when(validationService.validate(eq(token), eq(contractAgreement), any(ContractOffer.class))).thenReturn(false);
+        when(validationService.validateConfirmed(eq(token), eq(contractAgreement), any(ContractOffer.class))).thenReturn(false);
 
         var result = negotiationManager.confirmed(token, negotiationConsumerOffered.getId(), contractAgreement, policy);
 
@@ -231,7 +231,7 @@ class ConsumerContractNegotiationManagerImplTest {
                 negotiation.getState() == DECLINING.code() &&
                         negotiation.getContractAgreement() == null
         ));
-        verify(validationService).validate(eq(token), eq(contractAgreement), any(ContractOffer.class));
+        verify(validationService).validateConfirmed(eq(token), eq(contractAgreement), any(ContractOffer.class));
     }
 
     @Test

--- a/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -202,7 +202,7 @@ class ConsumerContractNegotiationManagerImplTest {
         var contractAgreement = mock(ContractAgreement.class);
         var def = PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build();
         when(store.find(negotiationConsumerOffered.getId())).thenReturn(negotiationConsumerOffered);
-        when(validationService.validateConfirmed(eq(token), eq(contractAgreement), any(ContractOffer.class))).thenReturn(Result.success());
+        when(validationService.validateConfirmed(eq(contractAgreement), any(ContractOffer.class))).thenReturn(Result.success());
 
         var result = negotiationManager.confirmed(token, negotiationConsumerOffered.getId(), contractAgreement, def.getPolicy());
 
@@ -211,7 +211,7 @@ class ConsumerContractNegotiationManagerImplTest {
                 negotiation.getState() == CONFIRMED.code() &&
                         negotiation.getContractAgreement() == contractAgreement
         ));
-        verify(validationService).validateConfirmed(eq(token), eq(contractAgreement), any(ContractOffer.class));
+        verify(validationService).validateConfirmed(eq(contractAgreement), any(ContractOffer.class));
         verify(listener).confirmed(any());
     }
 
@@ -222,7 +222,7 @@ class ConsumerContractNegotiationManagerImplTest {
         var contractAgreement = mock(ContractAgreement.class);
         var policy = Policy.Builder.newInstance().build();
         when(store.find(negotiationConsumerOffered.getId())).thenReturn(negotiationConsumerOffered);
-        when(validationService.validateConfirmed(eq(token), eq(contractAgreement), any(ContractOffer.class))).thenReturn(Result.failure("error"));
+        when(validationService.validateConfirmed(eq(contractAgreement), any(ContractOffer.class))).thenReturn(Result.failure("error"));
 
         var result = negotiationManager.confirmed(token, negotiationConsumerOffered.getId(), contractAgreement, policy);
 
@@ -231,7 +231,7 @@ class ConsumerContractNegotiationManagerImplTest {
                 negotiation.getState() == DECLINING.code() &&
                         negotiation.getContractAgreement() == null
         ));
-        verify(validationService).validateConfirmed(eq(token), eq(contractAgreement), any(ContractOffer.class));
+        verify(validationService).validateConfirmed(eq(contractAgreement), any(ContractOffer.class));
     }
 
     @Test

--- a/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -137,7 +137,7 @@ class ContractNegotiationIntegrationTest {
         consumerNegotiationId = "consumerNegotiationId";
         ContractOffer offer = getContractOffer();
         when(validationService.validate(token, offer)).thenReturn(Result.success(offer));
-        when(validationService.validate(eq(token), any(ContractAgreement.class),
+        when(validationService.validateConfirmed(eq(token), any(ContractAgreement.class),
                 any(ContractOffer.class))).thenReturn(true);
 
         // Start provider and consumer negotiation managers
@@ -169,7 +169,7 @@ class ContractNegotiationIntegrationTest {
 
 
                     verify(validationService, atLeastOnce()).validate(token, offer);
-                    verify(validationService, atLeastOnce()).validate(eq(token), any(ContractAgreement.class), any(ContractOffer.class));
+                    verify(validationService, atLeastOnce()).validateConfirmed(eq(token), any(ContractAgreement.class), any(ContractOffer.class));
                 });
     }
 
@@ -222,7 +222,7 @@ class ContractNegotiationIntegrationTest {
         var offer = getContractOffer();
 
         when(validationService.validate(token, offer)).thenReturn(Result.success(offer));
-        when(validationService.validate(eq(token), any(ContractAgreement.class),
+        when(validationService.validateConfirmed(eq(token), any(ContractAgreement.class),
                 any(ContractOffer.class))).thenReturn(false);
 
         // Start provider and consumer negotiation managers
@@ -254,7 +254,7 @@ class ContractNegotiationIntegrationTest {
                     assertThat(providerNegotiation.getContractAgreement()).isNull();
 
                     verify(validationService, atLeastOnce()).validate(token, offer);
-                    verify(validationService, atLeastOnce()).validate(eq(token), any(ContractAgreement.class), any(ContractOffer.class));
+                    verify(validationService, atLeastOnce()).validateConfirmed(eq(token), any(ContractAgreement.class), any(ContractOffer.class));
                 });
     }
 
@@ -267,7 +267,7 @@ class ContractNegotiationIntegrationTest {
 
         when(validationService.validate(token, initialOffer)).thenReturn(Result.success(null));
         when(validationService.validate(token, counterOffer, initialOffer)).thenReturn(Result.success(null));
-        when(validationService.validate(eq(token), any(ContractAgreement.class),
+        when(validationService.validateConfirmed(eq(token), any(ContractAgreement.class),
                 eq(counterOffer))).thenReturn(true);
 
         // Start provider and consumer negotiation managers
@@ -305,7 +305,7 @@ class ContractNegotiationIntegrationTest {
 
                     verify(validationService, atLeastOnce()).validate(token, initialOffer);
                     verify(validationService, atLeastOnce()).validate(token, counterOffer, initialOffer);
-                    verify(validationService, atLeastOnce()).validate(eq(token), any(ContractAgreement.class), any(ContractOffer.class));
+                    verify(validationService, atLeastOnce()).validateConfirmed(eq(token), any(ContractAgreement.class), any(ContractOffer.class));
                 });
     }
 
@@ -355,7 +355,7 @@ class ContractNegotiationIntegrationTest {
                     assertThat(providerNegotiation.getContractAgreement()).isNull();
                     verify(validationService, atLeastOnce()).validate(token, initialOffer);
                     verify(validationService, atLeastOnce()).validate(token, counterOffer, initialOffer);
-                    verify(validationService, atLeastOnce()).validate(eq(token), any(ContractAgreement.class), any(ContractOffer.class));
+                    verify(validationService, atLeastOnce()).validateConfirmed(eq(token), any(ContractAgreement.class), any(ContractOffer.class));
                 });
     }
 
@@ -379,7 +379,7 @@ class ContractNegotiationIntegrationTest {
         when(validationService.validate(token, consumerCounterOffer, counterOffer)).thenReturn(Result.success(null));
 
         // Mock validation of agreement on consumer side
-        when(validationService.validate(eq(token), any(ContractAgreement.class),
+        when(validationService.validateConfirmed(eq(token), any(ContractAgreement.class),
                 eq(consumerCounterOffer))).thenReturn(true);
 
         // Start provider and consumer negotiation managers
@@ -422,7 +422,7 @@ class ContractNegotiationIntegrationTest {
                     verify(validationService, atLeastOnce()).validate(token, initialOffer);
                     verify(validationService, atLeastOnce()).validate(token, counterOffer, initialOffer);
                     verify(validationService, atLeastOnce()).validate(token, consumerCounterOffer, counterOffer);
-                    verify(validationService, atLeastOnce()).validate(eq(token), any(ContractAgreement.class), eq(consumerCounterOffer));
+                    verify(validationService, atLeastOnce()).validateConfirmed(eq(token), any(ContractAgreement.class), eq(consumerCounterOffer));
                 });
     }
 

--- a/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -137,8 +137,8 @@ class ContractNegotiationIntegrationTest {
         consumerNegotiationId = "consumerNegotiationId";
         ContractOffer offer = getContractOffer();
         when(validationService.validate(token, offer)).thenReturn(Result.success(offer));
-        when(validationService.validateConfirmed(eq(token), any(ContractAgreement.class),
-                any(ContractOffer.class))).thenReturn(Result.success());
+        when(validationService.validateConfirmed(any(ContractAgreement.class), any(ContractOffer.class)))
+                .thenReturn(Result.success());
 
         // Start provider and consumer negotiation managers
         providerManager.start();
@@ -169,7 +169,7 @@ class ContractNegotiationIntegrationTest {
 
 
                     verify(validationService, atLeastOnce()).validate(token, offer);
-                    verify(validationService, atLeastOnce()).validateConfirmed(eq(token), any(ContractAgreement.class), any(ContractOffer.class));
+                    verify(validationService, atLeastOnce()).validateConfirmed(any(ContractAgreement.class), any(ContractOffer.class));
                 });
     }
 
@@ -222,8 +222,8 @@ class ContractNegotiationIntegrationTest {
         var offer = getContractOffer();
 
         when(validationService.validate(token, offer)).thenReturn(Result.success(offer));
-        when(validationService.validateConfirmed(eq(token), any(ContractAgreement.class),
-                any(ContractOffer.class))).thenReturn(Result.failure("error"));
+        when(validationService.validateConfirmed(any(ContractAgreement.class), any(ContractOffer.class)))
+                .thenReturn(Result.failure("error"));
 
         // Start provider and consumer negotiation managers
         providerManager.start();
@@ -254,7 +254,7 @@ class ContractNegotiationIntegrationTest {
                     assertThat(providerNegotiation.getContractAgreement()).isNull();
 
                     verify(validationService, atLeastOnce()).validate(token, offer);
-                    verify(validationService, atLeastOnce()).validateConfirmed(eq(token), any(ContractAgreement.class), any(ContractOffer.class));
+                    verify(validationService, atLeastOnce()).validateConfirmed(any(ContractAgreement.class), any(ContractOffer.class));
                 });
     }
 
@@ -267,8 +267,8 @@ class ContractNegotiationIntegrationTest {
 
         when(validationService.validate(token, initialOffer)).thenReturn(Result.success(null));
         when(validationService.validate(token, counterOffer, initialOffer)).thenReturn(Result.success(null));
-        when(validationService.validateConfirmed(eq(token), any(ContractAgreement.class),
-                eq(counterOffer))).thenReturn(Result.success());
+        when(validationService.validateConfirmed(any(ContractAgreement.class), eq(counterOffer)))
+                .thenReturn(Result.success());
 
         // Start provider and consumer negotiation managers
         providerManager.start();
@@ -305,7 +305,7 @@ class ContractNegotiationIntegrationTest {
 
                     verify(validationService, atLeastOnce()).validate(token, initialOffer);
                     verify(validationService, atLeastOnce()).validate(token, counterOffer, initialOffer);
-                    verify(validationService, atLeastOnce()).validateConfirmed(eq(token), any(ContractAgreement.class), any(ContractOffer.class));
+                    verify(validationService, atLeastOnce()).validateConfirmed(any(ContractAgreement.class), any(ContractOffer.class));
                 });
     }
 
@@ -355,7 +355,7 @@ class ContractNegotiationIntegrationTest {
                     assertThat(providerNegotiation.getContractAgreement()).isNull();
                     verify(validationService, atLeastOnce()).validate(token, initialOffer);
                     verify(validationService, atLeastOnce()).validate(token, counterOffer, initialOffer);
-                    verify(validationService, atLeastOnce()).validateConfirmed(eq(token), any(ContractAgreement.class), any(ContractOffer.class));
+                    verify(validationService, atLeastOnce()).validateConfirmed(any(ContractAgreement.class), any(ContractOffer.class));
                 });
     }
 
@@ -379,8 +379,8 @@ class ContractNegotiationIntegrationTest {
         when(validationService.validate(token, consumerCounterOffer, counterOffer)).thenReturn(Result.success(null));
 
         // Mock validation of agreement on consumer side
-        when(validationService.validateConfirmed(eq(token), any(ContractAgreement.class),
-                eq(consumerCounterOffer))).thenReturn(Result.success());
+        when(validationService.validateConfirmed(any(ContractAgreement.class), eq(consumerCounterOffer)))
+                .thenReturn(Result.success());
 
         // Start provider and consumer negotiation managers
         providerManager.start();
@@ -422,7 +422,7 @@ class ContractNegotiationIntegrationTest {
                     verify(validationService, atLeastOnce()).validate(token, initialOffer);
                     verify(validationService, atLeastOnce()).validate(token, counterOffer, initialOffer);
                     verify(validationService, atLeastOnce()).validate(token, consumerCounterOffer, counterOffer);
-                    verify(validationService, atLeastOnce()).validateConfirmed(eq(token), any(ContractAgreement.class), eq(consumerCounterOffer));
+                    verify(validationService, atLeastOnce()).validateConfirmed(any(ContractAgreement.class), eq(consumerCounterOffer));
                 });
     }
 

--- a/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -138,7 +138,7 @@ class ContractNegotiationIntegrationTest {
         ContractOffer offer = getContractOffer();
         when(validationService.validate(token, offer)).thenReturn(Result.success(offer));
         when(validationService.validateConfirmed(eq(token), any(ContractAgreement.class),
-                any(ContractOffer.class))).thenReturn(true);
+                any(ContractOffer.class))).thenReturn(Result.success());
 
         // Start provider and consumer negotiation managers
         providerManager.start();
@@ -223,7 +223,7 @@ class ContractNegotiationIntegrationTest {
 
         when(validationService.validate(token, offer)).thenReturn(Result.success(offer));
         when(validationService.validateConfirmed(eq(token), any(ContractAgreement.class),
-                any(ContractOffer.class))).thenReturn(false);
+                any(ContractOffer.class))).thenReturn(Result.failure("error"));
 
         // Start provider and consumer negotiation managers
         providerManager.start();
@@ -268,7 +268,7 @@ class ContractNegotiationIntegrationTest {
         when(validationService.validate(token, initialOffer)).thenReturn(Result.success(null));
         when(validationService.validate(token, counterOffer, initialOffer)).thenReturn(Result.success(null));
         when(validationService.validateConfirmed(eq(token), any(ContractAgreement.class),
-                eq(counterOffer))).thenReturn(true);
+                eq(counterOffer))).thenReturn(Result.success());
 
         // Start provider and consumer negotiation managers
         providerManager.start();
@@ -380,7 +380,7 @@ class ContractNegotiationIntegrationTest {
 
         // Mock validation of agreement on consumer side
         when(validationService.validateConfirmed(eq(token), any(ContractAgreement.class),
-                eq(consumerCounterOffer))).thenReturn(true);
+                eq(consumerCounterOffer))).thenReturn(Result.success());
 
         // Start provider and consumer negotiation managers
         providerManager.start();

--- a/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImplTest.java
+++ b/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImplTest.java
@@ -211,35 +211,32 @@ class ContractValidationServiceImplTest {
 
     @Test
     void validateConfirmed_succeed() {
-        var claimToken = ClaimToken.Builder.newInstance().build();
         var agreement = createContractAgreement().id("1:2").build();
         var offer = createContractOffer().build();
         when(policyEquality.test(any(), any())).thenReturn(true);
 
-        var result = validationService.validateConfirmed(claimToken, agreement, offer);
+        var result = validationService.validateConfirmed(agreement, offer);
 
         assertThat(result.succeeded()).isTrue();
     }
 
     @Test
     void validateConfirmed_failsIfIdIsNotValid() {
-        var claimToken = ClaimToken.Builder.newInstance().build();
         var agreement = createContractAgreement().id("not a valid id").build();
         var offer = createContractOffer().build();
 
-        var result = validationService.validateConfirmed(claimToken, agreement, offer);
+        var result = validationService.validateConfirmed(agreement, offer);
 
         assertThat(result.failed()).isTrue();
     }
 
     @Test
     void validateConfirmed_failsIfPoliciesAreNotEqual() {
-        var claimToken = ClaimToken.Builder.newInstance().build();
         var agreement = createContractAgreement().id("1:2").build();
         var offer = createContractOffer().build();
         when(policyEquality.test(any(), any())).thenReturn(false);
 
-        var result = validationService.validateConfirmed(claimToken, agreement, offer);
+        var result = validationService.validateConfirmed(agreement, offer);
 
         assertThat(result.failed()).isTrue();
     }

--- a/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImplTest.java
+++ b/core/control-plane/contract/src/test/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImplTest.java
@@ -216,9 +216,9 @@ class ContractValidationServiceImplTest {
         var offer = createContractOffer().build();
         when(policyEquality.test(any(), any())).thenReturn(true);
 
-        boolean result = validationService.validateConfirmed(claimToken, agreement, offer);
+        var result = validationService.validateConfirmed(claimToken, agreement, offer);
 
-        assertThat(result).isTrue();
+        assertThat(result.succeeded()).isTrue();
     }
 
     @Test
@@ -227,9 +227,9 @@ class ContractValidationServiceImplTest {
         var agreement = createContractAgreement().id("not a valid id").build();
         var offer = createContractOffer().build();
 
-        boolean result = validationService.validateConfirmed(claimToken, agreement, offer);
+        var result = validationService.validateConfirmed(claimToken, agreement, offer);
 
-        assertThat(result).isFalse();
+        assertThat(result.failed()).isTrue();
     }
 
     @Test
@@ -239,9 +239,9 @@ class ContractValidationServiceImplTest {
         var offer = createContractOffer().build();
         when(policyEquality.test(any(), any())).thenReturn(false);
 
-        boolean result = validationService.validateConfirmed(claimToken, agreement, offer);
+        var result = validationService.validateConfirmed(claimToken, agreement, offer);
 
-        assertThat(result).isFalse();
+        assertThat(result.failed()).isTrue();
     }
 
     @NotNull

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/ContractId.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/ContractId.java
@@ -41,7 +41,8 @@ public final class ContractId {
     }
 
     /**
-     * Return a {@link ContractId} instance parsed from the passed string
+     * Return a {@link ContractId} instance parsed from the passed string, that should be in the
+     * <code>[definition-id]:UUID</code> format
      *
      * @param id the string representation of the id
      * @return the {@link ContractId} instance that represent the id

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/ContractId.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/ContractId.java
@@ -20,15 +20,20 @@ import java.util.UUID;
 
 /**
  * Handles contract ID generation for contract offers and agreements originating in an EDC runtime.
- *
- * Ids are architected to allow the contract definition which generated the contract to be de-referenced. The id format follows the following scheme: [definition-id]:UUID.
+ * Ids are architected to allow the contract definition which generated the contract to be de-referenced.
+ * The id format follows the following scheme: <code>[definition-id]:UUID</code>
  */
 public final class ContractId {
-    public static final int DEFINITION_PART = 0;
+
+    private static final int DEFINITION_PART = 0;
     private static final String DELIMITER = ":";
+    private final String value;
 
     /**
-     * Returns a UUID that references the definition id.
+     * Returns a new id given the definition part
+     *
+     * @param definitionPart the part that will be used as prefix of the id
+     * @return a {@link String} that represent the contract id
      */
     @NotNull
     public static String createContractId(String definitionPart) {
@@ -36,12 +41,40 @@ public final class ContractId {
     }
 
     /**
-     * Parses a contract id into its definition and sub-identifier parts. Use {@link #DEFINITION_PART} to access the definition part.
+     * Return a {@link ContractId} instance parsed from the passed string
+     *
+     * @param id the string representation of the id
+     * @return the {@link ContractId} instance that represent the id
      */
-    public static String[] parseContractId(@NotNull String id) {
-        return id.split(DELIMITER);
+    public static ContractId parse(String id) {
+        return new ContractId(id);
     }
 
-    private ContractId() {
+    private ContractId(String value) {
+        this.value = value;
+    }
+
+    /**
+     * The id is valid if it follows the following scheme: [definition-id]:UUID
+     *
+     * @return true if it is valid, false otherwise
+     */
+    public boolean isValid() {
+        var parts = parseContractId(value);
+        return parts.length == 2;
+    }
+
+    /**
+     * The definition part of the id
+     *
+     * @return The definition part of the id
+     */
+    public String definitionPart() {
+        var parts = parseContractId(value);
+        return parts[DEFINITION_PART];
+    }
+
+    private String[] parseContractId(@NotNull String id) {
+        return id.split(DELIMITER);
     }
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/validation/ContractValidationService.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/validation/ContractValidationService.java
@@ -55,5 +55,5 @@ public interface ContractValidationService {
      * When the negotiation has been confirmed by the provider, needs to be validated to ensure that is the same of the
      * one that was required in the offer
      */
-    boolean validateConfirmed(ClaimToken token, ContractAgreement agreement, ContractOffer latestOffer);
+    Result<Void> validateConfirmed(ClaimToken token, ContractAgreement agreement, ContractOffer latestOffer);
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/validation/ContractValidationService.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/validation/ContractValidationService.java
@@ -55,5 +55,5 @@ public interface ContractValidationService {
      * When the negotiation has been confirmed by the provider, needs to be validated to ensure that is the same of the
      * one that was required in the offer
      */
-    Result<Void> validateConfirmed(ClaimToken token, ContractAgreement agreement, ContractOffer latestOffer);
+    Result<Void> validateConfirmed(ContractAgreement agreement, ContractOffer latestOffer);
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/validation/ContractValidationService.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/validation/ContractValidationService.java
@@ -52,8 +52,8 @@ public interface ContractValidationService {
     boolean validate(ClaimToken token, ContractAgreement agreement);
 
     /**
-     * When the negotiation has been confirmed by the provider, needs to be validated to ensure that is the same of the
-     * one that was required in the offer
+     * When the negotiation has been confirmed by the provider, the consumer must validate it ensuring that is the same
+     * one that was sent in the offer
      */
     Result<Void> validateConfirmed(ContractAgreement agreement, ContractOffer latestOffer);
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/validation/ContractValidationService.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/validation/ContractValidationService.java
@@ -52,7 +52,8 @@ public interface ContractValidationService {
     boolean validate(ClaimToken token, ContractAgreement agreement);
 
     /**
-     * During the negotiation process, it may be necessary to validate a contract agreement against an offer that is only persisted by the contract negotiation and not known to the ContractDefinitionService.
+     * When the negotiation has been confirmed by the provider, needs to be validated to ensure that is the same of the
+     * one that was required in the offer
      */
-    boolean validate(ClaimToken token, ContractAgreement agreement, ContractOffer latestOffer);
+    boolean validateConfirmed(ClaimToken token, ContractAgreement agreement, ContractOffer latestOffer);
 }

--- a/spi/control-plane/contract-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/ContractIdTest.java
+++ b/spi/control-plane/contract-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/ContractIdTest.java
@@ -22,7 +22,30 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ContractIdTest {
 
     @Test
-    void verifyIdGeneration() {
-        assertThat(ContractId.parseContractId(ContractId.createContractId("foo"))[ContractId.DEFINITION_PART]).isEqualTo("foo");
+    void isValid() {
+        var id = ContractId.parse("thisis:avalidid");
+
+        assertThat(id.isValid()).isTrue();
+    }
+
+    @Test
+    void isValid_falseIfNoColonPresent() {
+        var id = ContractId.parse("thisisaninvalidid");
+
+        assertThat(id.isValid()).isFalse();
+    }
+
+    @Test
+    void isValid_falseIfTooManyColonsPresent() {
+        var id = ContractId.parse("thisis:an:invalidid");
+
+        assertThat(id.isValid()).isFalse();
+    }
+
+    @Test
+    void definitionPart_returnsTheFirstPartOfTheId() {
+        var id = ContractId.parse("definitionPart:agreementPart");
+
+        assertThat(id.definitionPart()).isEqualTo("definitionPart");
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Changes contract validation on consumer side when it receives the "confirmed" message from the provider, at this point the agreement is already reached and there should be only a formal validation of the id and the policy, no need to evaluate the latter.

## Why it does that

It was an unnecessary evaluation.

## Further notes

- renamed the `validate` method to `validateConfirmed` to have a clear distinction on what's the purpose of the method avoiding confusion with the others.
- refactored `ContractId` to a more object oriented one.
- made `validateConfirmed` returns a `Result`, so the caller can obtain a detail on what was the problem.

## Linked Issue(s)

Closes #1975

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
