### PR TITLE
chore: update multiple GH action versions

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -12,7 +12,7 @@ runs:
       run: ${{ inputs.command }}
 
     - name: Upload Test Results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: always()
       with:
         name: Test Results ${{ github.job }}

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -3,7 +3,7 @@ description: "Setup Gradle"
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-java@v2
+    - uses: actions/setup-java@v3
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -322,7 +322,7 @@ jobs:
           VAULT_TOKEN: test-token
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-build
 
       - name: Hashicorp Vault Integration Tests


### PR DESCRIPTION
## What this PR changes/adds

updates some of the actions we use to their respective latest versions

## Why it does that

some actions seem to use Node 12, which is [out of support](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12) as of April 2022, specifically:
- `actions/setup-java@v2`
- `actions/upload-artifact@v2`
- `actions/checkout@v2`


## Further Notes
- `deepakputhraya/action-pr-title` is also affected, but there is no new version yet (latest is from June 1). I did, however, submit an [issue](https://github.com/deepakputhraya/action-pr-title/issues/24) there asking for the upgrade.


## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
