### PR TITLE
fix(tests): change IntegrationTest annotation target from TYPE to ANNOTATION_TYPE

### DIFF
--- a/extensions/common/vault/hashicorp-vault/src/test/java/org/eclipse/dataspaceconnector/core/security/hashicorpvault/HashicorpVaultIntegrationTest.java
+++ b/extensions/common/vault/hashicorp-vault/src/test/java/org/eclipse/dataspaceconnector/core/security/hashicorpvault/HashicorpVaultIntegrationTest.java
@@ -14,12 +14,11 @@
 
 package org.eclipse.dataspaceconnector.core.security.hashicorpvault;
 
-import org.eclipse.dataspaceconnector.common.util.junit.annotations.IntegrationTest;
+import org.eclipse.dataspaceconnector.core.security.hashicorpvault.annotations.HashicorpVaultTest;
 import org.eclipse.dataspaceconnector.junit.extensions.EdcExtension;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -30,8 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.core.security.hashicorpvault.HashicorpVaultExtension.VAULT_TOKEN;
 import static org.eclipse.dataspaceconnector.core.security.hashicorpvault.HashicorpVaultExtension.VAULT_URL;
 
-@IntegrationTest
-@Tag("HashicorpVaultIntegrationTest")
+@HashicorpVaultTest
 @ExtendWith(EdcExtension.class)
 class HashicorpVaultIntegrationTest {
     private static final String VAULT_TEST_URL = "http://127.0.0.1:8200";

--- a/extensions/common/vault/hashicorp-vault/src/test/java/org/eclipse/dataspaceconnector/core/security/hashicorpvault/annotations/HashicorpVaultTest.java
+++ b/extensions/common/vault/hashicorp-vault/src/test/java/org/eclipse/dataspaceconnector/core/security/hashicorpvault/annotations/HashicorpVaultTest.java
@@ -8,14 +8,14 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Microsoft Corporation - initial API and implementation
+ *        Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
  *
  */
 
-package org.eclipse.dataspaceconnector.common.util.junit.annotations;
+package org.eclipse.dataspaceconnector.core.security.hashicorpvault.annotations;
 
+import org.eclipse.dataspaceconnector.common.util.junit.annotations.IntegrationTest;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -23,11 +23,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Common annotation for integration testing.  It applies integration-test Junit Tag.
+ * Composite annotation for HashicorpVault integration testing. It applies specific Junit Tag.
  */
-@Target({ElementType.ANNOTATION_TYPE})
+@Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
-@Test
-@Tag("IntegrationTest")
-public @interface IntegrationTest {
+@IntegrationTest
+@Tag("HashicorpVaultTest")
+public @interface HashicorpVaultTest {
 }

--- a/system-tests/minikube/minikube-test.sh
+++ b/system-tests/minikube/minikube-test.sh
@@ -32,7 +32,7 @@ export PROVIDER_URL="http://provider-dataspace-connector:8282"
 export DESTINATION_PATH="/tmp/destination-file-$RANDOM"
 export API_KEY="password"
 
-./gradlew :system-tests:tests:test -DincludeTags="IntegrationTest" --tests org.eclipse.dataspaceconnector.system.tests.remote.FileTransferAsClientIntegrationTest
+./gradlew :system-tests:tests:test -DincludeTags="MinikubeIntegrationTest"
 
 kubectl exec deployment/provider-dataspace-connector -- wc -l $DESTINATION_PATH
 echo "Test succeeded."

--- a/system-tests/tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/remote/FileTransferAsClientIntegrationTest.java
+++ b/system-tests/tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/remote/FileTransferAsClientIntegrationTest.java
@@ -14,16 +14,17 @@
 
 package org.eclipse.dataspaceconnector.system.tests.remote;
 
-import org.eclipse.dataspaceconnector.common.util.junit.annotations.IntegrationTest;
+import org.eclipse.dataspaceconnector.system.tests.remote.annotations.MinikubeIntegrationTest;
 import org.eclipse.dataspaceconnector.system.tests.utils.TransferSimulationUtils;
 import org.junit.jupiter.api.Test;
 
 import static org.eclipse.dataspaceconnector.system.tests.utils.GatlingUtils.runGatling;
 
+
 /**
  * Runs {@see FileTransferAsClientSimulation}.
  */
-@IntegrationTest
+@MinikubeIntegrationTest
 public class FileTransferAsClientIntegrationTest {
 
     @Test

--- a/system-tests/tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/remote/annotations/MinikubeIntegrationTest.java
+++ b/system-tests/tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/remote/annotations/MinikubeIntegrationTest.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.system.tests.remote.annotations;
+
+
+import org.eclipse.dataspaceconnector.common.util.junit.annotations.IntegrationTest;
+import org.junit.jupiter.api.Tag;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for End to End integration testing based on Minikube.
+ * It applies a specific Junit Tag.
+ */
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@IntegrationTest
+@Tag("MinikubeIntegrationTest")
+public @interface MinikubeIntegrationTest {
+}


### PR DESCRIPTION
…ANNOTATION_TYPE

Closes #1949

## What this PR changes/adds

This pr change the target of IntegrationTest annotation to block its direct use on test classes.
Also add a MinikubeIntegrationTest annotaton for End to End integration testing based on Minikube.
Then change the minikube-test.sh file to support the MinikubeIntegrationTest annotation.

## Why it does that

## Further notes

## Linked Issue(s)

Closes #1949

## Checklist

- [ ] added appropriate tests?
- [ ] performed Checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
