### PR TITLE
feat(DataPlaneInstanceStore): add SQL store implementation

### DIFF
--- a/core/data-plane-selector/data-plane-selector-core/build.gradle.kts
+++ b/core/data-plane-selector/data-plane-selector-core/build.gradle.kts
@@ -23,6 +23,9 @@ dependencies {
     api(project(":core:common:base"))
     api(project(":core:common:boot"))
     implementation(project(":core:common:util"))
+
+    testImplementation(testFixtures(project(":spi:data-plane-selector:data-plane-selector-spi")))
+
 }
 
 publishing {

--- a/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/dataspaceconnector/dataplane/selector/core/DataPlaneSelectorDefaultServicesExtension.java
+++ b/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/dataspaceconnector/dataplane/selector/core/DataPlaneSelectorDefaultServicesExtension.java
@@ -15,7 +15,7 @@
 package org.eclipse.dataspaceconnector.dataplane.selector.core;
 
 import org.eclipse.dataspaceconnector.dataplane.selector.store.DataPlaneInstanceStore;
-import org.eclipse.dataspaceconnector.dataplane.selector.store.DefaultDataPlaneInstanceStore;
+import org.eclipse.dataspaceconnector.dataplane.selector.store.InMemoryDataPlaneInstanceStore;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provider;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
@@ -35,6 +35,6 @@ public class DataPlaneSelectorDefaultServicesExtension implements ServiceExtensi
 
     @Provider(isDefault = true)
     public DataPlaneInstanceStore instanceStore() {
-        return new DefaultDataPlaneInstanceStore();
+        return new InMemoryDataPlaneInstanceStore();
     }
 }

--- a/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/dataspaceconnector/dataplane/selector/store/InMemoryDataPlaneInstanceStore.java
+++ b/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/dataspaceconnector/dataplane/selector/store/InMemoryDataPlaneInstanceStore.java
@@ -27,12 +27,12 @@ import java.util.stream.Stream;
 /**
  * Default (=in-memory) implementation for the {@link DataPlaneInstanceStore}. All r/w access is secured with a {@link LockManager}.
  */
-public class DefaultDataPlaneInstanceStore implements DataPlaneInstanceStore {
+public class InMemoryDataPlaneInstanceStore implements DataPlaneInstanceStore {
 
     private final LockManager lockManager;
     private final List<DataPlaneInstance> list;
 
-    public DefaultDataPlaneInstanceStore() {
+    public InMemoryDataPlaneInstanceStore() {
         lockManager = new LockManager(new ReentrantReadWriteLock(true));
         list = new ArrayList<>();
     }

--- a/core/data-plane-selector/data-plane-selector-core/src/test/java/org/eclipse/dataspaceconnector/dataplane/selector/store/InMemoryDataPlaneInstanceStoreTest.java
+++ b/core/data-plane-selector/data-plane-selector-core/src/test/java/org/eclipse/dataspaceconnector/dataplane/selector/store/InMemoryDataPlaneInstanceStoreTest.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.dataplane.selector.store;
+
+import org.junit.jupiter.api.BeforeEach;
+
+class InMemoryDataPlaneInstanceStoreTest extends DataPlaneInstanceStoreTestBase {
+
+    private InMemoryDataPlaneInstanceStore store;
+
+    @BeforeEach
+    void setup() {
+        store = new InMemoryDataPlaneInstanceStore();
+    }
+
+
+    @Override
+    public InMemoryDataPlaneInstanceStore getStore() {
+        return store;
+    }
+}

--- a/docs/developer/modules.md
+++ b/docs/developer/modules.md
@@ -120,3 +120,4 @@ org.eclipse.dataspaceconnector:contractnegotiation-store-sql:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:control-plane-sql:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:policy-store-sql:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:transfer-process-store-sql:0.0.1-SNAPSHOT
+org.eclipse.dataspaceconnector:data-plane-instance-store-sql:0.0.1-SNAPSHOT

--- a/extensions/data-plane-selector/selector-api/src/test/java/org/eclipse/dataspaceconnector/dataplane/selector/api/DataplaneSelectorApiControllerIntegrationTest.java
+++ b/extensions/data-plane-selector/selector-api/src/test/java/org/eclipse/dataspaceconnector/dataplane/selector/api/DataplaneSelectorApiControllerIntegrationTest.java
@@ -25,7 +25,7 @@ import org.eclipse.dataspaceconnector.dataplane.selector.DataPlaneSelectorServic
 import org.eclipse.dataspaceconnector.dataplane.selector.core.DataPlaneSelectorImpl;
 import org.eclipse.dataspaceconnector.dataplane.selector.instance.DataPlaneInstance;
 import org.eclipse.dataspaceconnector.dataplane.selector.instance.DataPlaneInstanceImpl;
-import org.eclipse.dataspaceconnector.dataplane.selector.store.DefaultDataPlaneInstanceStore;
+import org.eclipse.dataspaceconnector.dataplane.selector.store.InMemoryDataPlaneInstanceStore;
 import org.eclipse.dataspaceconnector.dataplane.selector.strategy.DefaultSelectionStrategyRegistry;
 import org.eclipse.dataspaceconnector.dataplane.selector.strategy.SelectionStrategy;
 import org.eclipse.dataspaceconnector.dataplane.selector.strategy.SelectionStrategyRegistry;
@@ -58,7 +58,7 @@ class DataplaneSelectorApiControllerIntegrationTest {
     public static final MediaType JSON_TYPE = MediaType.parse("application/json");
     private static int port;
     private static DataplaneSelectorApiController controller;
-    private static DefaultDataPlaneInstanceStore store;
+    private static InMemoryDataPlaneInstanceStore store;
     private static JettyConfiguration config;
     private static Monitor monitor;
     private final TypeReference<List<DataPlaneInstance>> listTypeRef = new TypeReference<>() {
@@ -82,7 +82,7 @@ class DataplaneSelectorApiControllerIntegrationTest {
 
         selectionStrategyRegistry = new DefaultSelectionStrategyRegistry(); //in-memory
 
-        store = new DefaultDataPlaneInstanceStore();
+        store = new InMemoryDataPlaneInstanceStore();
         var selector = new DataPlaneSelectorImpl(store);
         var service = new DataPlaneSelectorServiceImpl(selector, store, selectionStrategyRegistry);
         controller = new DataplaneSelectorApiController(service);

--- a/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/build.gradle.kts
+++ b/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    `java-library`
+    `maven-publish`
+}
+
+
+dependencies {
+    api(project(":spi:common:transaction-spi"))
+    api(project(":spi:data-plane-selector:data-plane-selector-spi"))
+
+    implementation(project(":spi:common:transaction-datasource-spi"))
+    implementation(project(":extensions:common:sql:common-sql"))
+
+    testImplementation(testFixtures(project(":core:common:util")))
+    testImplementation(testFixtures(project(":spi:data-plane-selector:data-plane-selector-spi")))
+    testImplementation(testFixtures(project(":extensions:common:sql:common-sql")))
+
+
+}
+
+
+publishing {
+    publications {
+        create<MavenPublication>("data-plane-instance-store-sql") {
+            artifactId = "data-plane-instance-store-sql"
+            from(components["java"])
+        }
+    }
+}

--- a/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/docs/schema.sql
+++ b/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/docs/schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS edc_data_plane_instance
+(
+    id                   VARCHAR NOT NULL PRIMARY KEY,
+    data                 JSON
+);

--- a/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/main/java/org/eclipse/dataspaceconnector/dataplane/selector/store/sql/SqlDataPlaneInstanceStore.java
+++ b/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/main/java/org/eclipse/dataspaceconnector/dataplane/selector/store/sql/SqlDataPlaneInstanceStore.java
@@ -1,0 +1,154 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.dataplane.selector.store.sql;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.dataspaceconnector.dataplane.selector.instance.DataPlaneInstance;
+import org.eclipse.dataspaceconnector.dataplane.selector.store.DataPlaneInstanceStore;
+import org.eclipse.dataspaceconnector.dataplane.selector.store.sql.schema.DataPlaneInstanceStatements;
+import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.persistence.EdcPersistenceException;
+import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
+import org.eclipse.dataspaceconnector.spi.transaction.datasource.DataSourceRegistry;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Stream;
+import javax.sql.DataSource;
+
+import static java.lang.String.format;
+import static org.eclipse.dataspaceconnector.sql.SqlQueryExecutor.executeQuery;
+import static org.eclipse.dataspaceconnector.sql.SqlQueryExecutor.executeQuerySingle;
+
+/**
+ * SQL store implementation of {@link DataPlaneInstanceStore}
+ */
+public class SqlDataPlaneInstanceStore implements DataPlaneInstanceStore {
+    private final DataSourceRegistry dataSourceRegistry;
+    private final String dataSourceName;
+    private final TransactionContext transactionContext;
+    private final DataPlaneInstanceStatements statements;
+    private final ObjectMapper objectMapper;
+
+    public SqlDataPlaneInstanceStore(DataSourceRegistry dataSourceRegistry, String dataSourceName, TransactionContext transactionContext, DataPlaneInstanceStatements statements, ObjectMapper objectMapper) {
+        this.dataSourceRegistry = Objects.requireNonNull(dataSourceRegistry);
+        this.dataSourceName = Objects.requireNonNull(dataSourceName);
+        this.transactionContext = Objects.requireNonNull(transactionContext);
+        this.statements = Objects.requireNonNull(statements);
+        this.objectMapper = Objects.requireNonNull(objectMapper);
+    }
+
+    @Override
+    public void save(DataPlaneInstance instance) {
+
+        transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+
+                if (findByIdInternal(connection, instance.getId()) == null) {
+                    insert(connection, instance);
+                } else {
+                    update(connection, instance);
+                }
+
+            } catch (Exception exception) {
+                throw new EdcPersistenceException(exception);
+            }
+        });
+    }
+
+    @Override
+    public void saveAll(Collection<DataPlaneInstance> instances) {
+        transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                for (var instance : instances) {
+                    if (findByIdInternal(connection, instance.getId()) == null) {
+                        insert(connection, instance);
+                    } else {
+                        update(connection, instance);
+                    }
+                }
+            } catch (Exception exception) {
+                throw new EdcPersistenceException(exception);
+            }
+        });
+    }
+
+    @Override
+    public DataPlaneInstance findById(String id) {
+        Objects.requireNonNull(id);
+        return transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                return findByIdInternal(connection, id);
+
+            } catch (Exception exception) {
+                throw new EdcPersistenceException(exception);
+            }
+        });
+    }
+
+    @Override
+    public Stream<DataPlaneInstance> getAll() {
+        try {
+            var sql = statements.getAllTemplate();
+            return executeQuery(getConnection(), true, this::mapResultSet, sql);
+        } catch (SQLException exception) {
+            throw new EdcPersistenceException(exception);
+        }
+    }
+
+
+    private DataPlaneInstance findByIdInternal(Connection connection, String id) {
+        var sql = statements.getFindByIdTemplate();
+        return executeQuerySingle(connection, false, this::mapResultSet, sql, id);
+    }
+
+    private void insert(Connection connection, DataPlaneInstance instance) {
+        var sql = statements.getInsertTemplate();
+        executeQuery(connection, sql, instance.getId(), toJson(instance));
+    }
+
+    private void update(Connection connection, DataPlaneInstance instance) {
+        var sql = statements.getUpdateTemplate();
+        executeQuery(connection, sql, toJson(instance), instance.getId());
+    }
+
+
+    private DataPlaneInstance mapResultSet(ResultSet resultSet) throws Exception {
+
+        var json = resultSet.getString(statements.getDataColumn());
+        return objectMapper.readValue(json, DataPlaneInstance.class);
+    }
+
+    private String toJson(Object object) {
+        try {
+            return objectMapper.writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            throw new EdcException(e);
+        }
+    }
+
+    private DataSource getDataSource() {
+        return Objects.requireNonNull(dataSourceRegistry.resolve(dataSourceName), format("DataSource %s could not be resolved", dataSourceName));
+    }
+
+    private Connection getConnection() throws SQLException {
+        return getDataSource().getConnection();
+    }
+
+}

--- a/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/main/java/org/eclipse/dataspaceconnector/dataplane/selector/store/sql/SqlDataPlaneInstanceStoreExtension.java
+++ b/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/main/java/org/eclipse/dataspaceconnector/dataplane/selector/store/sql/SqlDataPlaneInstanceStoreExtension.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.dataplane.selector.store.sql;
+
+import org.eclipse.dataspaceconnector.dataplane.selector.store.DataPlaneInstanceStore;
+import org.eclipse.dataspaceconnector.dataplane.selector.store.sql.schema.DataPlaneInstanceStatements;
+import org.eclipse.dataspaceconnector.dataplane.selector.store.sql.schema.postgres.PostgresDataPlaneInstanceStatements;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provider;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
+import org.eclipse.dataspaceconnector.spi.transaction.datasource.DataSourceRegistry;
+
+/**
+ * Extensions that expose an implementation of {@link DataPlaneInstanceStore} that uses SQL as backend storage
+ */
+@Provides(DataPlaneInstanceStore.class)
+@Extension(value = SqlDataPlaneInstanceStoreExtension.NAME)
+public class SqlDataPlaneInstanceStoreExtension implements ServiceExtension {
+    public static final String NAME = "Sql Data Plane Instance Store";
+    
+    @EdcSetting(value = "Name of the datasource to use for accessing data plane instances")
+    private static final String DATASOURCE_SETTING_NAME = "edc.datasource.dataplaneinstance.name";
+    private static final String DEFAULT_DATASOURCE_NAME = "dataplaneinstance";
+    @Inject
+    private DataSourceRegistry dataSourceRegistry;
+
+    @Inject
+    private TransactionContext transactionContext;
+
+    @Inject(required = false)
+    private DataPlaneInstanceStatements statements;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+
+    @Provider
+    public DataPlaneInstanceStore dataPlaneInstanceStore(ServiceExtensionContext context) {
+        return new SqlDataPlaneInstanceStore(dataSourceRegistry, getDataSourceName(context), transactionContext, statements, context.getTypeManager().getMapper());
+    }
+
+    /**
+     * returns an externally-provided sql statement dialect, or postgres as a default
+     */
+    private DataPlaneInstanceStatements getStatementImpl() {
+        return statements != null ? statements : new PostgresDataPlaneInstanceStatements();
+    }
+
+    private String getDataSourceName(ServiceExtensionContext context) {
+        return context.getConfig().getString(DATASOURCE_SETTING_NAME, DEFAULT_DATASOURCE_NAME);
+    }
+}

--- a/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/main/java/org/eclipse/dataspaceconnector/dataplane/selector/store/sql/schema/BaseSqlDataPlaneInstanceStatements.java
+++ b/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/main/java/org/eclipse/dataspaceconnector/dataplane/selector/store/sql/schema/BaseSqlDataPlaneInstanceStatements.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.dataplane.selector.store.sql.schema;
+
+public class BaseSqlDataPlaneInstanceStatements implements DataPlaneInstanceStatements {
+
+
+    @Override
+    public String getFindByIdTemplate() {
+        return String.format("SELECT * FROM %s WHERE %s = ?", getDataPlaneInstanceTable(), getIdColumn());
+    }
+
+    @Override
+    public String getAllTemplate() {
+        return String.format("SELECT * FROM %s", getDataPlaneInstanceTable());
+    }
+
+    @Override
+    public String getInsertTemplate() {
+        return String.format("INSERT INTO %s (%s, %s) VALUES (?, ?%s)",
+                getDataPlaneInstanceTable(),
+                getIdColumn(),
+                getDataColumn(),
+                getFormatAsJsonOperator()
+        );
+    }
+
+    @Override
+    public String getUpdateTemplate() {
+        return String.format("UPDATE %s SET %s = ?%s WHERE %s = ?",
+                getDataPlaneInstanceTable(),
+                getDataColumn(),
+                getFormatAsJsonOperator(),
+                getIdColumn());
+    }
+}

--- a/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/main/java/org/eclipse/dataspaceconnector/dataplane/selector/store/sql/schema/DataPlaneInstanceStatements.java
+++ b/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/main/java/org/eclipse/dataspaceconnector/dataplane/selector/store/sql/schema/DataPlaneInstanceStatements.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.dataplane.selector.store.sql.schema;
+
+import org.eclipse.dataspaceconnector.sql.dialect.BaseSqlDialect;
+
+public interface DataPlaneInstanceStatements {
+
+
+    default String getDataPlaneInstanceTable() {
+        return "edc_data_plane_instance";
+    }
+
+    default String getIdColumn() {
+        return "id";
+    }
+
+    default String getDataColumn() {
+        return "data";
+    }
+
+    String getFindByIdTemplate();
+
+    String getAllTemplate();
+
+    String getInsertTemplate();
+
+    String getUpdateTemplate();
+
+
+    default String getFormatAsJsonOperator() {
+        return BaseSqlDialect.getJsonCastOperator();
+    }
+
+}
+

--- a/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/main/java/org/eclipse/dataspaceconnector/dataplane/selector/store/sql/schema/postgres/PostgresDataPlaneInstanceStatements.java
+++ b/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/main/java/org/eclipse/dataspaceconnector/dataplane/selector/store/sql/schema/postgres/PostgresDataPlaneInstanceStatements.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.dataplane.selector.store.sql.schema.postgres;
+
+import org.eclipse.dataspaceconnector.dataplane.selector.store.sql.schema.BaseSqlDataPlaneInstanceStatements;
+import org.eclipse.dataspaceconnector.sql.dialect.PostgresDialect;
+
+public class PostgresDataPlaneInstanceStatements extends BaseSqlDataPlaneInstanceStatements {
+
+
+    @Override
+    public String getFormatAsJsonOperator() {
+        return PostgresDialect.getJsonCastOperator();
+    }
+}

--- a/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
+++ b/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
@@ -1,0 +1,16 @@
+#
+#  Copyright (c) 2020 - 2022 Microsoft Corporation
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Microsoft Corporation - initial API and implementation
+#
+#
+
+org.eclipse.dataspaceconnector.dataplane.selector.store.sql.SqlDataPlaneInstanceStoreExtension
+

--- a/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/test/java/org/eclipse/dataspaceconnector/dataplane/selector/store/sql/PostgresDataPlaneInstanceStoreTest.java
+++ b/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/test/java/org/eclipse/dataspaceconnector/dataplane/selector/store/sql/PostgresDataPlaneInstanceStoreTest.java
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.dataplane.selector.store.sql;
+
+import org.eclipse.dataspaceconnector.common.util.junit.annotations.PostgresqlDbIntegrationTest;
+import org.eclipse.dataspaceconnector.dataplane.selector.TestDataPlaneInstance;
+import org.eclipse.dataspaceconnector.dataplane.selector.instance.DataPlaneInstanceImpl;
+import org.eclipse.dataspaceconnector.dataplane.selector.store.DataPlaneInstanceStore;
+import org.eclipse.dataspaceconnector.dataplane.selector.store.DataPlaneInstanceStoreTestBase;
+import org.eclipse.dataspaceconnector.dataplane.selector.store.sql.schema.DataPlaneInstanceStatements;
+import org.eclipse.dataspaceconnector.dataplane.selector.store.sql.schema.postgres.PostgresDataPlaneInstanceStatements;
+import org.eclipse.dataspaceconnector.spi.transaction.NoopTransactionContext;
+import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
+import org.eclipse.dataspaceconnector.spi.transaction.datasource.DataSourceRegistry;
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
+import org.eclipse.dataspaceconnector.sql.PostgresqlLocalInstance;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+
+import static org.eclipse.dataspaceconnector.sql.SqlQueryExecutor.executeQuery;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+
+@PostgresqlDbIntegrationTest
+public class PostgresDataPlaneInstanceStoreTest extends DataPlaneInstanceStoreTestBase {
+
+    private static final String DATASOURCE_NAME = "dataplaneinstance";
+
+    private final TransactionContext transactionContext = new NoopTransactionContext();
+    private final DataSourceRegistry dataSourceRegistry = mock(DataSourceRegistry.class);
+    private final DataPlaneInstanceStatements statements = new PostgresDataPlaneInstanceStatements();
+    private final DataSource dataSource = mock(DataSource.class);
+    private final Connection connection = spy(PostgresqlLocalInstance.getTestConnection());
+
+    SqlDataPlaneInstanceStore store;
+
+    @BeforeAll
+    static void prepare() {
+        PostgresqlLocalInstance.createTestDatabase();
+    }
+
+    @BeforeEach
+    void setUp() throws IOException, SQLException {
+        when(dataSourceRegistry.resolve(DATASOURCE_NAME)).thenReturn(dataSource);
+        when(dataSource.getConnection()).thenReturn(connection);
+        doNothing().when(connection).close();
+
+        var typeManager = new TypeManager();
+        typeManager.registerTypes(DataPlaneInstanceImpl.class);
+        typeManager.registerTypes(TestDataPlaneInstance.class);
+
+
+        store = new SqlDataPlaneInstanceStore(dataSourceRegistry, DATASOURCE_NAME, transactionContext, statements, typeManager.getMapper());
+        var schema = Files.readString(Paths.get("./docs/schema.sql"));
+        transactionContext.execute(() -> executeQuery(connection, schema));
+    }
+
+    @AfterEach
+    void tearDown() throws SQLException {
+        transactionContext.execute(() -> executeQuery(connection, "DROP TABLE " + statements.getDataPlaneInstanceTable() + " CASCADE"));
+        doCallRealMethod().when(connection).close();
+        connection.close();
+    }
+
+    @Override
+    protected DataPlaneInstanceStore getStore() {
+        return store;
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -140,6 +140,7 @@ include(":extensions:data-plane:integration-tests")
 
 include(":extensions:data-plane-selector:selector-api")
 include(":extensions:data-plane-selector:selector-client")
+include(":extensions:data-plane-selector:store:sql:data-plane-instance-store-sql")
 
 include(":extensions:federated-catalog:store:fcc-node-directory-cosmos")
 

--- a/spi/data-plane-selector/data-plane-selector-spi/build.gradle.kts
+++ b/spi/data-plane-selector/data-plane-selector-spi/build.gradle.kts
@@ -13,12 +13,24 @@
  */
 
 val mockitoVersion: String by project
+val jupiterVersion: String by project
+val assertj: String by project
 
 plugins {
     `java-library`
+    `java-test-fixtures`
 }
 dependencies {
     api(project(":spi:common:core-spi"))
+    implementation(project(":core:common:util"))
+
+
+    // needed by the abstract test spec located in testFixtures
+    testFixturesImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
+    testFixturesImplementation("org.junit.jupiter:junit-jupiter-params:${jupiterVersion}")
+    testFixturesImplementation("org.mockito:mockito-core:${mockitoVersion}")
+    testFixturesImplementation("org.assertj:assertj-core:${assertj}")
+    testFixturesRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")
 }
 
 

--- a/spi/data-plane-selector/data-plane-selector-spi/src/testFixtures/java/org/eclipse/dataspaceconnector/dataplane/selector/TestDataPlaneInstance.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/testFixtures/java/org/eclipse/dataspaceconnector/dataplane/selector/TestDataPlaneInstance.java
@@ -1,0 +1,155 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.dataplane.selector;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.dataspaceconnector.dataplane.selector.instance.DataPlaneInstance;
+import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+
+@JsonDeserialize(builder = TestDataPlaneInstance.Builder.class)
+@JsonTypeName("dataspaceconnector:testdataplaneinstance")
+public class TestDataPlaneInstance implements DataPlaneInstance {
+
+    private Map<String, Object> properties;
+    private int turnCount;
+    private long lastActive;
+    private URL url;
+    private String id;
+
+    private String name;
+
+    private TestDataPlaneInstance() {
+        turnCount = 0;
+        lastActive = Instant.now().toEpochMilli();
+        properties = new HashMap<>();
+    }
+
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public boolean canHandle(DataAddress sourceAddress, DataAddress destinationAddress) {
+        return true;
+    }
+
+    @Override
+    public URL getUrl() {
+        return url;
+    }
+
+    @Override
+    public int getTurnCount() {
+        return turnCount;
+    }
+
+    @Override
+    public long getLastActive() {
+        return lastActive;
+    }
+
+    @Override
+    public Map<String, Object> getProperties() {
+        return properties;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder {
+        private final TestDataPlaneInstance instance;
+
+        private Builder() {
+            instance = new TestDataPlaneInstance();
+        }
+
+        @JsonCreator
+        public static TestDataPlaneInstance.Builder newInstance() {
+            return new TestDataPlaneInstance.Builder();
+        }
+
+        public TestDataPlaneInstance.Builder turnCount(int turnCount) {
+            instance.turnCount = turnCount;
+            return this;
+        }
+
+        public TestDataPlaneInstance.Builder lastActive(long lastActive) {
+            instance.lastActive = lastActive;
+            return this;
+        }
+
+        public TestDataPlaneInstance.Builder id(String id) {
+            instance.id = id;
+            return this;
+        }
+
+
+        public TestDataPlaneInstance.Builder url(URL url) {
+            instance.url = url;
+            return this;
+        }
+
+        public TestDataPlaneInstance.Builder url(String url) {
+            try {
+                instance.url = new URL(url);
+            } catch (MalformedURLException e) {
+                throw new EdcException(e);
+            }
+            return this;
+        }
+
+        public TestDataPlaneInstance build() {
+            if (instance.id == null) {
+                instance.id = UUID.randomUUID().toString();
+            }
+            Objects.requireNonNull(instance.url, "DataPlaneInstance must have an URL");
+
+            return instance;
+        }
+
+        public TestDataPlaneInstance.Builder property(String key, Object value) {
+            instance.properties.put(key, value);
+            return this;
+        }
+
+        public TestDataPlaneInstance.Builder name(String name) {
+            instance.name = name;
+            return this;
+        }
+
+
+        private TestDataPlaneInstance.Builder properties(Map<String, Object> properties) {
+            instance.properties = properties;
+            return this;
+        }
+    }
+}

--- a/spi/data-plane-selector/data-plane-selector-spi/src/testFixtures/java/org/eclipse/dataspaceconnector/dataplane/selector/TestFunctions.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/testFixtures/java/org/eclipse/dataspaceconnector/dataplane/selector/TestFunctions.java
@@ -35,4 +35,12 @@ public class TestFunctions {
                 .build();
     }
 
+    public static TestDataPlaneInstance createCustomInstance(String id, String name) {
+        return TestDataPlaneInstance.Builder.newInstance()
+                .id(id)
+                .url("http://somewhere.com:1234/api/v1")
+                .name(name)
+                .build();
+    }
+
 }


### PR DESCRIPTION
## What this PR changes/adds

Add SQL store implementation for DataPlaneInstanceStore

## Why it does that

Durability of Data Plane Instances


## Linked Issue(s)

Closes #2074 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
