### PR TITLE
chore(github): remove checklist from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -22,8 +22,3 @@ _If possible, provide a (brief!) solution proposal._
 
 ## Type of Issue
 _i.e., new feature, improvement, cleanup, etc._
-
-## Checklist
-
-- [ ] assigned appropriate label?
-- [x] **Do NOT select a milestone or an assignee!**


### PR DESCRIPTION
## What this PR changes/adds

Removes checklist from issue template

## Why it does that

Has become misleading for new contributors

## Further notes

-

## Linked Issue(s)

-

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
