### PR TITLE
refactor(ContractNegotiationStore): remove ContractNegotiationStore.getAgreementsForDefinitionId

### DIFF
--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/dataspaceconnector/core/controlplane/defaults/negotiationstore/InMemoryContractNegotiationStore.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/dataspaceconnector/core/controlplane/defaults/negotiationstore/InMemoryContractNegotiationStore.java
@@ -92,10 +92,6 @@ public class InMemoryContractNegotiationStore implements ContractNegotiationStor
         return negotiationQueryResolver.query(store.findAll(), querySpec);
     }
 
-    @Override
-    public @NotNull Stream<ContractAgreement> getAgreementsForDefinitionId(String definitionId) {
-        return getAgreements().filter(it -> it.getId().startsWith(definitionId + ":"));
-    }
 
     @Override
     public @NotNull Stream<ContractAgreement> queryAgreements(QuerySpec querySpec) {

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/dataspaceconnector/core/controlplane/defaults/negotiationstore/InMemoryContractNegotiationStoreTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/dataspaceconnector/core/controlplane/defaults/negotiationstore/InMemoryContractNegotiationStoreTest.java
@@ -250,28 +250,6 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
     }
 
     @Test
-    void getAgreementsForDefinitionId() {
-        var contractAgreement = createAgreementBuilder().id(ContractId.createContractId("definitionId")).build();
-        var negotiation = createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
-        store.save(negotiation);
-
-        var result = store.getAgreementsForDefinitionId("definitionId");
-
-        assertThat(result).hasSize(1);
-    }
-
-    @Test
-    void getAgreementsForDefinitionId_notFound() {
-        var contractAgreement = createAgreementBuilder().id(ContractId.createContractId("otherDefinitionId")).build();
-        var negotiation = createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
-        store.save(negotiation);
-
-        var result = store.getAgreementsForDefinitionId("definitionId");
-
-        assertThat(result).isEmpty();
-    }
-
-    @Test
     void queryAgreements_noQuerySpec() {
         IntStream.range(0, 10).forEach(i -> {
             var contractAgreement = createAgreementBuilder().id(ContractId.createContractId(UUID.randomUUID().toString())).build();

--- a/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStore.java
+++ b/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStore.java
@@ -152,17 +152,6 @@ public class CosmosContractNegotiationStore implements ContractNegotiationStore 
     }
 
     @Override
-    public @NotNull Stream<ContractAgreement> getAgreementsForDefinitionId(String definitionId) {
-        var query = "SELECT * FROM c WHERE c.wrappedInstance.contractAgreement.id LIKE @agreementId";
-        var param = new SqlParameter("@agreementId", definitionId + ":%");
-
-        var spec = new SqlQuerySpec(query, param);
-        return with(retryPolicy).get(() -> cosmosDbApi.queryItems(spec))
-                .map(this::toNegotiation)
-                .map(ContractNegotiation::getContractAgreement);
-    }
-
-    @Override
     public @NotNull Stream<ContractAgreement> queryAgreements(QuerySpec querySpec) {
         var criteria = querySpec.getFilterExpression().stream()
                 .map(it -> it.withLeftOperand(op -> "contractAgreement." + op))

--- a/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
+++ b/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
@@ -460,28 +460,6 @@ class CosmosContractNegotiationStoreIntegrationTest extends ContractNegotiationS
     }
 
     @Test
-    void getAgreementsForDefinitionId() {
-        var contractAgreement = createContractBuilder().id(ContractId.createContractId("definitionId")).build();
-        var negotiation = createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
-        store.save(negotiation);
-
-        var result = store.getAgreementsForDefinitionId("definitionId");
-
-        assertThat(result).hasSize(1);
-    }
-
-    @Test
-    void getAgreementsForDefinitionId_notFound() {
-        var contractAgreement = createContractBuilder().id(ContractId.createContractId("otherDefinitionId")).build();
-        var negotiation = createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
-        store.save(negotiation);
-
-        var result = store.getAgreementsForDefinitionId("definitionId");
-
-        assertThat(result).isEmpty();
-    }
-
-    @Test
     void queryAgreements_noQuerySpec() {
         IntStream.range(0, 10).forEach(i -> {
             var contractAgreement = createContractBuilder().id(ContractId.createContractId(UUID.randomUUID().toString())).build();

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -163,18 +163,6 @@ public class SqlContractNegotiationStore implements ContractNegotiationStore {
     }
 
     @Override
-    public @NotNull Stream<ContractAgreement> getAgreementsForDefinitionId(String definitionId) {
-        return transactionContext.execute(() -> {
-            try {
-                var stmt = statements.getFindContractAgreementByDefinitionIdTemplate();
-                return executeQuery(getConnection(), true, this::mapContractAgreement, stmt, definitionId + ":%");
-            } catch (SQLException e) {
-                throw new EdcPersistenceException(e);
-            }
-        });
-    }
-
-    @Override
     public @NotNull Stream<ContractAgreement> queryAgreements(QuerySpec querySpec) {
         return transactionContext.execute(() -> {
             try {

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/BaseSqlDialectStatements.java
@@ -37,11 +37,6 @@ public class BaseSqlDialectStatements implements ContractNegotiationStatements {
     }
 
     @Override
-    public String getFindContractAgreementByDefinitionIdTemplate() {
-        return format("SELECT * FROM %s where %s LIKE ?", getContractAgreementTable(), getContractAgreementIdColumn());
-    }
-
-    @Override
     public String getUpdateNegotiationTemplate() {
         return format("UPDATE %s SET %s=?, %s=?, %s=?, %s=?, %s=?%s, %s=?%s, %s=?, %s=? WHERE id = ?;",
                 getContractNegotiationTable(), getStateColumn(), getStateCountColumn(), getStateTimestampColumn(),

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/ContractNegotiationStatements.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/schema/ContractNegotiationStatements.java
@@ -27,8 +27,6 @@ public interface ContractNegotiationStatements extends LeaseStatements {
 
     String getFindContractAgreementTemplate();
 
-    String getFindContractAgreementByDefinitionIdTemplate();
-
     String getUpdateNegotiationTemplate();
 
     String getInsertNegotiationTemplate();

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/store/ContractNegotiationStore.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/store/ContractNegotiationStore.java
@@ -77,15 +77,6 @@ public interface ContractNegotiationStore extends StateEntityStore<ContractNegot
     @NotNull
     Stream<ContractNegotiation> queryNegotiations(QuerySpec querySpec);
 
-    /**
-     * Finds all contract agreements that are based on a specific contract definition
-     *
-     * @param definitionId the contract definition id
-     * @return a stream of ContractAgreement, cannot be null.
-     */
-    @NotNull
-    Stream<ContractAgreement> getAgreementsForDefinitionId(String definitionId);
-
 
     /**
      * Finds all contract agreement that are covered by a specific {@link QuerySpec}. If no

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/store/ContractNegotiationStoreTestBase.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/dataspaceconnector/spi/contract/negotiation/store/ContractNegotiationStoreTestBase.java
@@ -516,28 +516,6 @@ public abstract class ContractNegotiationStoreTestBase {
     }
 
     @Test
-    void getAgreementsForDefinitionId() {
-        var contractAgreement = TestFunctions.createContract(ContractId.createContractId("definitionId"));
-        var negotiation = TestFunctions.createNegotiation(UUID.randomUUID().toString(), contractAgreement);
-        getContractNegotiationStore().save(negotiation);
-
-        var result = getContractNegotiationStore().getAgreementsForDefinitionId("definitionId");
-
-        assertThat(result).hasSize(1);
-    }
-
-    @Test
-    void getAgreementsForDefinitionId_notFound() {
-        var contractAgreement = TestFunctions.createContract(ContractId.createContractId("otherDefinitionId"));
-        var negotiation = TestFunctions.createNegotiation(UUID.randomUUID().toString(), contractAgreement);
-        getContractNegotiationStore().save(negotiation);
-
-        var result = getContractNegotiationStore().getAgreementsForDefinitionId("definitionId");
-
-        assertThat(result).isEmpty();
-    }
-
-    @Test
     void queryAgreements_noQuerySpec() {
         IntStream.range(0, 10).forEach(i -> {
             var contractAgreement = TestFunctions.createContract(ContractId.createContractId(UUID.randomUUID().toString()));


### PR DESCRIPTION

## What this PR changes/adds

Removes `ContractNegotiationStore.getAgreementsForDefinitionId`

## Why it does that

cleanup since it was not used 

## Linked Issue(s)

Closes #2069 

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
