### PR TITLE
refactor: use `@Setting` and `@SettingContext`

### DIFF
--- a/core/common/connector-core/src/main/java/org/eclipse/dataspaceconnector/core/CoreDefaultServicesExtension.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/dataspaceconnector/core/CoreDefaultServicesExtension.java
@@ -19,10 +19,10 @@ import okhttp3.EventListener;
 import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.core.base.OkHttpClientFactory;
 import org.eclipse.dataspaceconnector.core.event.EventExecutorServiceContainer;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provider;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.security.CertificateResolver;
 import org.eclipse.dataspaceconnector.spi.security.PrivateKeyResolver;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
@@ -46,11 +46,11 @@ import java.util.concurrent.Executors;
  */
 public class CoreDefaultServicesExtension implements ServiceExtension {
 
-    @EdcSetting(value = "Maximum retries for the retry policy before a failure is propagated")
+    @Setting(value = "Maximum retries for the retry policy before a failure is propagated")
     public static final String MAX_RETRIES = "edc.core.retry.retries.max";
-    @EdcSetting(value = "Minimum number of milliseconds for exponential backoff")
+    @Setting(value = "Minimum number of milliseconds for exponential backoff")
     public static final String BACKOFF_MIN_MILLIS = "edc.core.retry.backoff.min";
-    @EdcSetting(value = "Maximum number of milliseconds for exponential backoff. ")
+    @Setting(value = "Maximum number of milliseconds for exponential backoff. ")
     public static final String BACKOFF_MAX_MILLIS = "edc.core.retry.backoff.max";
     public static final String NAME = "Core Default Services";
 

--- a/core/common/connector-core/src/main/java/org/eclipse/dataspaceconnector/core/CoreServicesExtension.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/dataspaceconnector/core/CoreServicesExtension.java
@@ -27,11 +27,11 @@ import org.eclipse.dataspaceconnector.core.policy.engine.ScopeFilter;
 import org.eclipse.dataspaceconnector.core.security.DefaultPrivateKeyParseFunction;
 import org.eclipse.dataspaceconnector.policy.model.PolicyRegistrationTypes;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.BaseExtension;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provider;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgentService;
 import org.eclipse.dataspaceconnector.spi.command.CommandHandlerRegistry;
 import org.eclipse.dataspaceconnector.spi.event.EventRouter;
@@ -63,15 +63,15 @@ import java.time.Duration;
 @Extension(value = CoreServicesExtension.NAME)
 public class CoreServicesExtension implements ServiceExtension {
 
-    @EdcSetting
+    @Setting
     public static final String LIVENESS_PERIOD_SECONDS_SETTING = "edc.core.system.health.check.liveness-period";
-    @EdcSetting
+    @Setting
     public static final String STARTUP_PERIOD_SECONDS_SETTING = "edc.core.system.health.check.startup-period";
-    @EdcSetting
+    @Setting
     public static final String READINESS_PERIOD_SECONDS_SETTING = "edc.core.system.health.check.readiness-period";
-    @EdcSetting
+    @Setting
     public static final String THREADPOOL_SIZE_SETTING = "edc.core.system.health.check.threadpool-size";
-    @EdcSetting
+    @Setting
     public static final String HOSTNAME_SETTING = "edc.hostname";
     public static final String NAME = "Core Services";
     private static final long DEFAULT_DURATION = 60;

--- a/core/common/connector-core/src/main/java/org/eclipse/dataspaceconnector/core/base/OkHttpClientFactory.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/dataspaceconnector/core/base/OkHttpClientFactory.java
@@ -18,7 +18,7 @@ import okhttp3.EventListener;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Response;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.jetbrains.annotations.NotNull;
@@ -31,7 +31,7 @@ import static java.util.Optional.ofNullable;
 
 public class OkHttpClientFactory {
 
-    @EdcSetting(value = "If true, enable HTTPS call enforcement. Default value is 'false'", type = "boolean")
+    @Setting(value = "If true, enable HTTPS call enforcement. Default value is 'false'", type = "boolean")
     public static final String EDC_HTTP_ENFORCE_HTTPS = "edc.http.enforce-https";
 
     /**

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
@@ -28,9 +28,9 @@ import org.eclipse.dataspaceconnector.contract.policy.PolicyArchiveImpl;
 import org.eclipse.dataspaceconnector.contract.policy.PolicyEquality;
 import org.eclipse.dataspaceconnector.contract.validation.ContractValidationServiceImpl;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.CoreExtension;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgentService;
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.command.BoundedCommandQueue;
@@ -72,17 +72,17 @@ import java.time.Clock;
 public class ContractServiceExtension implements ServiceExtension {
 
     private static final long DEFAULT_ITERATION_WAIT = 5000; // millis
-    @EdcSetting
+    @Setting
     private static final String NEGOTIATION_CONSUMER_STATE_MACHINE_BATCH_SIZE = "edc.negotiation.consumer.state-machine.batch-size";
-    @EdcSetting
+    @Setting
     private static final String NEGOTIATION_PROVIDER_STATE_MACHINE_BATCH_SIZE = "edc.negotiation.provider.state-machine.batch-size";
-    @EdcSetting
+    @Setting
     private static final String NEGOTIATION_CONSUMER_SEND_RETRY_LIMIT = "edc.negotiation.consumer.send.retry.limit";
-    @EdcSetting
+    @Setting
     private static final String NEGOTIATION_PROVIDER_SEND_RETRY_LIMIT = "edc.negotiation.provider.send.retry.limit";
-    @EdcSetting
+    @Setting
     private static final String NEGOTIATION_CONSUMER_SEND_RETRY_BASE_DELAY_MS = "edc.negotiation.consumer.send.retry.base-delay.ms";
-    @EdcSetting
+    @Setting
     private static final String NEGOTIATION_PROVIDER_SEND_RETRY_BASE_DELAY_MS = "edc.negotiation.provider.send.retry.base-delay.ms";
 
     private ConsumerContractNegotiationManagerImpl consumerNegotiationManager;

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
@@ -17,10 +17,10 @@ package org.eclipse.dataspaceconnector.transfer.core;
 
 import org.eclipse.dataspaceconnector.common.statemachine.retry.EntitySendRetryManager;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.CoreExtension;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
 import org.eclipse.dataspaceconnector.spi.command.BoundedCommandQueue;
 import org.eclipse.dataspaceconnector.spi.command.CommandHandlerRegistry;
@@ -74,11 +74,11 @@ import java.time.Clock;
 public class CoreTransferExtension implements ServiceExtension {
     public static final String NAME = "Core Transfer";
     private static final long DEFAULT_ITERATION_WAIT = 5000; // millis
-    @EdcSetting
+    @Setting
     private static final String TRANSFER_STATE_MACHINE_BATCH_SIZE = "edc.transfer.state-machine.batch-size";
-    @EdcSetting
+    @Setting
     private static final String TRANSFER_SEND_RETRY_LIMIT = "edc.transfer.send.retry.limit";
-    @EdcSetting
+    @Setting
     private static final String TRANSFER_SEND_RETRY_BASE_DELAY_MS = "edc.transfer.send.retry.base-delay.ms";
     @Inject
     private TransferProcessStore transferProcessStore;

--- a/core/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneFrameworkExtension.java
+++ b/core/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneFrameworkExtension.java
@@ -26,10 +26,10 @@ import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataTransferExecuto
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.PipelineService;
 import org.eclipse.dataspaceconnector.dataplane.spi.registry.TransferServiceRegistry;
 import org.eclipse.dataspaceconnector.dataplane.spi.store.DataPlaneStore;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.system.ExecutorInstrumentation;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
@@ -47,16 +47,16 @@ import java.util.concurrent.Executors;
 public class DataPlaneFrameworkExtension implements ServiceExtension {
     public static final String NAME = "Data Plane Framework";
     private static final int IN_MEMORY_STORE_CAPACITY = 1000;
-    @EdcSetting
+    @Setting
     private static final String QUEUE_CAPACITY = "edc.dataplane.queue.capacity";
     private static final int DEFAULT_QUEUE_CAPACITY = 10000;
-    @EdcSetting
+    @Setting
     private static final String WORKERS = "edc.dataplane.workers";
     private static final int DEFAULT_WORKERS = 10;
-    @EdcSetting
+    @Setting
     private static final String WAIT_TIMEOUT = "edc.dataplane.wait";
     private static final long DEFAULT_WAIT_TIMEOUT = 1000;
-    @EdcSetting
+    @Setting
     private static final String TRANSFER_THREADS = "edc.dataplane.transfer.threads";
     private static final int DEFAULT_TRANSFER_THREADS = 10;
     private DataPlaneManagerImpl dataPlaneManager;

--- a/data-protocols/ids/ids-api-configuration/src/main/java/org/eclipse/dataspaceconnector/ids/api/configuration/IdsApiConfigurationExtension.java
+++ b/data-protocols/ids/ids-api-configuration/src/main/java/org/eclipse/dataspaceconnector/ids/api/configuration/IdsApiConfigurationExtension.java
@@ -15,10 +15,10 @@
 
 package org.eclipse.dataspaceconnector.ids.api.configuration;
 
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.WebServer;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
@@ -31,7 +31,7 @@ import static java.lang.String.format;
 @Provides(IdsApiConfiguration.class)
 @Extension(value = IdsApiConfigurationExtension.NAME)
 public class IdsApiConfigurationExtension implements ServiceExtension {
-    @EdcSetting
+    @Setting
     public static final String IDS_WEBHOOK_ADDRESS = "ids.webhook.address";
     public static final String DEFAULT_IDS_WEBHOOK_ADDRESS = "http://localhost";
 

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/IdsCoreServiceExtension.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/IdsCoreServiceExtension.java
@@ -28,10 +28,10 @@ import org.eclipse.dataspaceconnector.ids.spi.service.DynamicAttributeTokenServi
 import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTransformerRegistry;
 import org.eclipse.dataspaceconnector.ids.spi.types.IdsId;
 import org.eclipse.dataspaceconnector.ids.spi.types.IdsType;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
 import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
@@ -50,7 +50,7 @@ import java.util.List;
 @Extension(value = IdsCoreServiceExtension.NAME)
 public class IdsCoreServiceExtension implements ServiceExtension {
 
-    @EdcSetting
+    @Setting
     public static final String EDC_IDS_CATALOG_ID = "edc.ids.catalog.id";
 
     public static final String DEFAULT_EDC_IDS_CATALOG_ID = "urn:catalog:default";

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceSettings.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceSettings.java
@@ -16,7 +16,7 @@ package org.eclipse.dataspaceconnector.ids.core.service;
 
 import org.eclipse.dataspaceconnector.ids.spi.domain.connector.SecurityProfile;
 import org.eclipse.dataspaceconnector.ids.spi.types.IdsId;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
@@ -32,19 +32,19 @@ import static org.eclipse.dataspaceconnector.ids.core.util.ConnectorIdUtil.resol
 
 public class ConnectorServiceSettings {
 
-    @EdcSetting
+    @Setting
     public static final String EDC_IDS_ID = "edc.ids.id";
-    @EdcSetting
+    @Setting
     public static final String EDC_IDS_TITLE = "edc.ids.title";
-    @EdcSetting
+    @Setting
     public static final String EDC_IDS_DESCRIPTION = "edc.ids.description";
-    @EdcSetting
+    @Setting
     public static final String EDC_IDS_SECURITY_PROFILE = "edc.ids.security.profile";
-    @EdcSetting
+    @Setting
     public static final String EDC_IDS_ENDPOINT = "edc.ids.endpoint";
-    @EdcSetting
+    @Setting
     public static final String EDC_IDS_MAINTAINER = "edc.ids.maintainer";
-    @EdcSetting
+    @Setting
     public static final String EDC_IDS_CURATOR = "edc.ids.curator";
 
     public static final String DEFAULT_EDC_IDS_TITLE = "Eclipse Dataspace Connector";
@@ -60,7 +60,7 @@ public class ConnectorServiceSettings {
 
     private final Monitor monitor;
     private final ServiceExtensionContext serviceExtensionContext;
-    
+
     private IdsId id;
     private String title;
     private String description;

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/util/ConnectorIdUtil.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/util/ConnectorIdUtil.java
@@ -16,7 +16,7 @@ package org.eclipse.dataspaceconnector.ids.core.util;
 
 import org.eclipse.dataspaceconnector.ids.spi.types.IdsId;
 import org.eclipse.dataspaceconnector.ids.spi.types.IdsType;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
@@ -24,13 +24,14 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
  * Utility class for handling the connector's IDS ID.
  */
 public class ConnectorIdUtil {
-    
-    @EdcSetting
+
+    @Setting
     public static final String EDC_IDS_ID = "edc.ids.id";
     public static final String DEFAULT_EDC_IDS_ID = "urn:connector:edc";
-    
-    private ConnectorIdUtil() {}
-    
+
+    private ConnectorIdUtil() {
+    }
+
     /**
      * Returns the connector's ID from its IDS ID. Will use the IDS ID supplied in the configuration,
      * if it is present, else will use a default IDS ID.
@@ -41,7 +42,7 @@ public class ConnectorIdUtil {
      */
     public static IdsId resolveConnectorId(ServiceExtensionContext context) {
         var value = context.getSetting(EDC_IDS_ID, DEFAULT_EDC_IDS_ID);
-    
+
         // Hint: use stringified uri to keep uri path and query
         var result = IdsId.from(value);
         if (result.succeeded()) {
@@ -50,9 +51,9 @@ public class ConnectorIdUtil {
                 return idsId;
             }
         }
-        
+
         var message = "IDS Settings: Expected valid URN for setting '%s', but was %s'. Expected format: 'urn:connector:[id]'";
         throw new EdcException(String.format(message, EDC_IDS_ID, DEFAULT_EDC_IDS_ID));
     }
-    
+
 }

--- a/data-protocols/ids/ids-token-validation/src/main/java/org/eclipse/dataspaceconnector/ids/token/validation/IdsTokenValidationServiceExtension.java
+++ b/data-protocols/ids/ids-token-validation/src/main/java/org/eclipse/dataspaceconnector/ids/token/validation/IdsTokenValidationServiceExtension.java
@@ -16,9 +16,9 @@ package org.eclipse.dataspaceconnector.ids.token.validation;
 
 import org.eclipse.dataspaceconnector.iam.oauth2.spi.Oauth2ValidationRulesRegistry;
 import org.eclipse.dataspaceconnector.ids.token.validation.rule.IdsValidationRule;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
@@ -28,7 +28,7 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 @Extension(value = IdsTokenValidationServiceExtension.NAME)
 public final class IdsTokenValidationServiceExtension implements ServiceExtension {
 
-    @EdcSetting
+    @Setting
     public static final String EDC_IDS_VALIDATION_REFERRINGCONNECTOR = "edc.ids.validation.referringconnector";
     public static final String NAME = "IDS Token Validation";
 

--- a/docs/developer/architecture/architecture-principles.md
+++ b/docs/developer/architecture/architecture-principles.md
@@ -2,61 +2,93 @@
 
 ## I. Fail-fast and Explicit Configuration
 
-1. Configuration should be loaded and validated at extension initialization so that issues are reported immediately. Do not lazy-load configuration unless it is required to do so.
-2. Settings can be pulled from the extension context and placed into configuration objects, which are passed to services via their constructor.
-3. Service configuration requirements should always be explicit; as a general rule, do not pass a single configuration object with many values to multiple services.
+1. Configuration should be loaded and validated at extension initialization so that issues are reported immediately. Do
+   not lazy-load configuration unless it is required to do so.
+2. Settings can be pulled from the extension context and placed into configuration objects, which are passed to services
+   via their constructor.
+3. Service configuration requirements should always be explicit; as a general rule, do not pass a single configuration
+   object with many values to multiple services.
    For example, see `HttpFunctionConfiguration.java`.
-4. Annotate configuration keys with `EdcSetting` so that they may be tracked.
+4. Annotate configuration keys with `@Setting` so that they may be tracked.
 
 ## II. Errors
-1. Do not throw checked exceptions; use unchecked exceptions. If an unchecked exception type needs to be defined, inherit from EdcException.
-2. Do not throw exceptions to signal a validation error; report the error (preferably collated) and return an error response.
-3. Throw an unchecked exception if something unexpected happens (e.g. a backing store connection is down after a number of retries). Note that validation errors are expected.
-   For example, see `Result.java`. 
-4. Only throw an exception when there is no remediation possible, i.e. the exception is fatal. Do not throw an exception if an operation can be retried.  
+
+1. Do not throw checked exceptions; use unchecked exceptions. If an unchecked exception type needs to be defined,
+   inherit from EdcException.
+2. Do not throw exceptions to signal a validation error; report the error (preferably collated) and return an error
+   response.
+3. Throw an unchecked exception if something unexpected happens (e.g. a backing store connection is down after a number
+   of retries). Note that validation errors are expected.
+   For example, see `Result.java`.
+4. Only throw an exception when there is no remediation possible, i.e. the exception is fatal. Do not throw an exception
+   if an operation can be retried.
 
 ## III. Simplicity
+
 1. Avoid layers of indirection when they are not needed (e.g. "pass-through methods").
 
 ### IV. Testing
+
 1. All handlers and services should have dedicated unit tests with mocks used for dependencies.
-2. When appropriate, prefer composing services via the constructor so that dependencies can be mocked as opposed to instantiating dependencies directly, see `ProvisionManagerImpl`. 
-   
+2. When appropriate, prefer composing services via the constructor so that dependencies can be mocked as opposed to
+   instantiating dependencies directly, see `ProvisionManagerImpl`.
+
 ### V. Data Objects
-1. Do not create constructors that take many parameters; instead use the builder pattern. An example is `TransferProcess`.
-2. Note that the motivation behind use of builders is not for immutability (although that may be good in certain circumstances). Rather, it is to make code less error-prone and 
+
+1. Do not create constructors that take many parameters; instead use the builder pattern. An example
+   is `TransferProcess`.
+2. Note that the motivation behind use of builders is not for immutability (although that may be good in certain
+   circumstances). Rather, it is to make code less error-prone and
    simpler given the lack of named arguments and optional parameters in Java.
 
 ### VI. Secrets
+
 1. Only store secrets in the `Vault` and do not hold them in objects that may be persisted to other stores.
 2. Do not log secrets or sensitive information.
 
 ### VII. Extensions and Libraries
-1. Extension modules contribute a feature to the runtime such as a service. 
-2. SPI modules define extensibility points in the runtime. There is a core SPI module that defines extensibility for essential runtime features. There are other SPI modules that 
+
+1. Extension modules contribute a feature to the runtime such as a service.
+2. SPI modules define extensibility points in the runtime. There is a core SPI module that defines extensibility for
+   essential runtime features. There are other SPI modules that
    define extensibility points for optional features such as IDS.
-3. Libraries are utility modules that provide classes which may be used by other modules. They do not directly contribute features to the runtime. 
-4. An SPI module may only reference other SPI modules and library modules. 
+3. Libraries are utility modules that provide classes which may be used by other modules. They do not directly
+   contribute features to the runtime.
+4. An SPI module may only reference other SPI modules and library modules.
 5. An Extension module may only reference other SPI modules and library modules.
 6. A library module may only reference other library modules.
 
 ### VIII. Build
-1. There should only be a root `gradle.properties` that defines dependency versions. Do not create separate gradle.properties files in a module.
-2. For external dependencies, do not reference the version directly. Instead, add an entry in `gradle.properties` so that it may be synchronized across the codebase.
+
+1. There should only be a root `gradle.properties` that defines dependency versions. Do not create separate
+   gradle.properties files in a module.
+2. For external dependencies, do not reference the version directly. Instead, add an entry in `gradle.properties` so
+   that it may be synchronized across the codebase.
 
 ### IX. Handling Null Return Values
-1. In certain situations, `null` may need to be returned from a method, passed as a parameter, or set on a field. Only use `Optional` if a method is part of a fluent API. 
-   Since the runtime will rarely require this, the project standard is to use the `org.jetbrains.annotations.Nullable` and `org.jetbrains.annotations.NotNull` annotations. 
+
+1. In certain situations, `null` may need to be returned from a method, passed as a parameter, or set on a field. Only
+   use `Optional` if a method is part of a fluent API.
+   Since the runtime will rarely require this, the project standard is to use the `org.jetbrains.annotations.Nullable`
+   and `org.jetbrains.annotations.NotNull` annotations.
 
 ### X. Objects Serialization/Deserialization
-1. `TypeManager` is the component responsible for json ser/des, you can also use the `ObjectMapper` inside it, but there should be no other `ObjectMapper` instance.
+
+1. `TypeManager` is the component responsible for json ser/des, you can also use the `ObjectMapper` inside it, but there
+   should be no other `ObjectMapper` instance.
 
 ### XI. Class Naming
+
 1. A single implementor of an interface should be named `<interface name>Impl`.
-2. An implementor who are meant to be the default implementation for an interface but other are/can be defined used instead.
+2. An implementor who are meant to be the default implementation for an interface but other are/can be defined used
+   instead.
 
 ### XII. Observability
-1. Services are [instrumented for collecting essential metrics](../metrics.md), in particular instances of `ExecutorService`.
+
+1. Services are [instrumented for collecting essential metrics](../metrics.md), in particular instances
+   of `ExecutorService`.
 
 ### XIII. Streams
-1. Always close explicitly `Stream` objects that are returned by a service/store, since they could carry a connection, and otherwise it will leak.
+
+1. Always close explicitly `Stream` objects that are returned by a service/store, since they could carry a connection,
+   and otherwise it will leak.

--- a/docs/developer/architecture/configuration/README.md
+++ b/docs/developer/architecture/configuration/README.md
@@ -16,7 +16,7 @@ Settings are retrieved from the ServiceExtensionContext interface.
 
 - setting keys start with _edc_
 - setting keys are defined in _private static final_ fields
-- setting fields are annotated with the _@EdcSetting_ marker interface
+- setting fields are annotated with the _@Setting_ marker interface
 - settings have a valid default value
 
 **Example Setting**
@@ -24,7 +24,7 @@ Settings are retrieved from the ServiceExtensionContext interface.
 ```java
 class ExampleSetting {
 
-    @EdcSetting
+    @Setting
     private final static String EDC_IDS_TITLE = "edc.ids.title";
 
     private final static String DEFAULT_TITLE = "Default Title";

--- a/docs/developer/decision-records/2022-08-04-documentation-automation/README.md
+++ b/docs/developer/decision-records/2022-08-04-documentation-automation/README.md
@@ -166,15 +166,15 @@ public @interface Extension {
 }
 ```
 
-The annotation processor uses the existing `@EdcSetting`, `@Provides`, and `@Inject` annotations.
-An `@EdcSettingContext` provides for `ConfigMap` support:
+The annotation processor uses the existing `@Setting`, `@Provides`, and `@Inject` annotations.
+An `@SettingContext` provides for `ConfigMap` support:
 
 ```java
 
 @Target({ElementType.TYPE, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface EdcSettingContext {
+public @interface SettingContext {
     String value();
 }
 ```
@@ -193,10 +193,10 @@ including the `PREFIX` symbol):
 ```java
 private static final String PREFIX="edc.core.";
 
-@EdcSetting("Specifies the maximum number of retries")
+@Setting("Specifies the maximum number of retries")
 public static final String MAX_RETRIES=PREFIX+"retry.retries.max";
 
-@EdcSetting
+@Setting
 public static final String BACKOFF_MIN_MILLIS="edc.core.retry.backoff.min";
 ```
 

--- a/docs/developer/decision-records/2022-09-23-extract-metamodel-and-autodoc/README.md
+++ b/docs/developer/decision-records/2022-09-23-extract-metamodel-and-autodoc/README.md
@@ -15,7 +15,7 @@ a [new repository](https://github.com/paullatzelsperger/GradlePlugins).
    needs to be built and published _before_ building/publishing EDC.
 
 2) `runtime-metamodel`
-   The `autodoc` feature has compile-time dependencies onto some metamodel annotations, such as `@Inject`, `@EdcSetting`
+   The `autodoc` feature has compile-time dependencies onto some metamodel annotations, such as `@Inject`, `@Setting`
    , `@Extension` etc., which are also referenced by EDC. Thus, to break a cyclic dependency, the `runtime-metamodel` is
    moved out into the plugin repo as well.
 

--- a/extensions/common/auth/auth-basic/src/main/java/org/eclipse/dataspaceconnector/api/auth/BasicAuthenticationExtension.java
+++ b/extensions/common/auth/auth-basic/src/main/java/org/eclipse/dataspaceconnector/api/auth/BasicAuthenticationExtension.java
@@ -14,10 +14,10 @@
 
 package org.eclipse.dataspaceconnector.api.auth;
 
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
@@ -33,7 +33,7 @@ import static java.lang.String.format;
 @Extension(value = "Basic authentication")
 public class BasicAuthenticationExtension implements ServiceExtension {
 
-    @EdcSetting
+    @Setting
     public static final String BASIC_AUTH = "edc.api.auth.basic.vault-keys";
     @Inject
     private Vault vault;

--- a/extensions/common/auth/auth-tokenbased/src/main/java/org/eclipse/dataspaceconnector/api/auth/TokenBasedAuthenticationExtension.java
+++ b/extensions/common/auth/auth-tokenbased/src/main/java/org/eclipse/dataspaceconnector/api/auth/TokenBasedAuthenticationExtension.java
@@ -16,10 +16,10 @@
 
 package org.eclipse.dataspaceconnector.api.auth;
 
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
@@ -34,9 +34,9 @@ import java.util.UUID;
 public class TokenBasedAuthenticationExtension implements ServiceExtension {
 
     public static final String NAME = "Static token API Authentication";
-    @EdcSetting
+    @Setting
     private static final String AUTH_SETTING_APIKEY = "edc.api.auth.key";
-    @EdcSetting
+    @Setting
     private static final String AUTH_SETTING_APIKEY_ALIAS = "edc.api.auth.key.alias";
     @Inject
     private Vault vault;

--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/dataspaceconnector/aws/s3/core/S3CoreExtension.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/dataspaceconnector/aws/s3/core/S3CoreExtension.java
@@ -14,10 +14,10 @@
 
 package org.eclipse.dataspaceconnector.aws.s3.core;
 
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provider;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
@@ -37,13 +37,13 @@ import static org.eclipse.dataspaceconnector.aws.s3.core.AwsClientProviderConfig
 public class S3CoreExtension implements ServiceExtension {
 
     public static final String NAME = "S3";
-    @EdcSetting(value = "The key of the secret where the AWS Access Key Id is stored")
+    @Setting(value = "The key of the secret where the AWS Access Key Id is stored")
     private static final String AWS_ACCESS_KEY = "edc.aws.access.key";
-    @EdcSetting(value = "The key of the secret where the AWS Secret Access Key is stored")
+    @Setting(value = "The key of the secret where the AWS Secret Access Key is stored")
     private static final String AWS_SECRET_KEY = "edc.aws.secret.access.key";
-    @EdcSetting(value = "If valued, the AWS clients will point to the specified endpoint")
+    @Setting(value = "If valued, the AWS clients will point to the specified endpoint")
     private static final String AWS_ENDPOINT_OVERRIDE = "edc.aws.endpoint.override";
-    @EdcSetting(value = "The size of the thread pool used for the async clients")
+    @Setting(value = "The size of the thread pool used for the async clients")
     private static final String AWS_ASYNC_CLIENT_THREAD_POOL_SIZE = "edc.aws.client.async.thread-pool-size";
     @Inject
     private Vault vault;

--- a/extensions/common/azure/azure-blob-core/src/main/java/org/eclipse/dataspaceconnector/azure/blob/core/BlobStoreCoreExtension.java
+++ b/extensions/common/azure/azure-blob-core/src/main/java/org/eclipse/dataspaceconnector/azure/blob/core/BlobStoreCoreExtension.java
@@ -16,10 +16,10 @@ package org.eclipse.dataspaceconnector.azure.blob.core;
 
 import org.eclipse.dataspaceconnector.azure.blob.core.api.BlobStoreApi;
 import org.eclipse.dataspaceconnector.azure.blob.core.api.BlobStoreApiImpl;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
@@ -28,7 +28,7 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 @Extension(value = BlobStoreCoreExtension.NAME)
 public class BlobStoreCoreExtension implements ServiceExtension {
 
-    @EdcSetting
+    @Setting
     public static final String EDC_BLOBSTORE_ENDPOINT_TEMPLATE = "edc.blobstore.endpoint.template";
     public static final String NAME = "Azure BlobStore Core";
 

--- a/extensions/common/azure/azure-cosmos-core/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/AbstractCosmosConfig.java
+++ b/extensions/common/azure/azure-cosmos-core/src/main/java/org/eclipse/dataspaceconnector/azure/cosmos/AbstractCosmosConfig.java
@@ -15,7 +15,7 @@
 package org.eclipse.dataspaceconnector.azure.cosmos;
 
 
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
@@ -28,9 +28,9 @@ import static org.eclipse.dataspaceconnector.common.string.StringUtils.isNullOrB
 public abstract class AbstractCosmosConfig {
 
     public static final String DEFAULT_REGION = "westeurope";
-    @EdcSetting
+    @Setting
     private static final String PARTITION_KEY_SETTING = "edc.cosmos.partition-key";
-    @EdcSetting
+    @Setting
     private static final String QUERY_METRICS_ENABLED_SETTING = "edc.cosmos.query-metrics-enabled";
 
 

--- a/extensions/common/azure/azure-eventgrid/src/main/java/org/eclipse/dataspaceconnector/events/azure/AzureEventGridConfig.java
+++ b/extensions/common/azure/azure-eventgrid/src/main/java/org/eclipse/dataspaceconnector/events/azure/AzureEventGridConfig.java
@@ -14,16 +14,16 @@
 
 package org.eclipse.dataspaceconnector.events.azure;
 
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
 public class AzureEventGridConfig {
     public static final String DEFAULT_SYSTEM_TOPIC_NAME = "connector-events";
     public static final String DEFAULT_ENDPOINT_NAME_TEMPLATE = "https://%s.westeurope-1.eventgrid.azure.net/api/events";
 
-    @EdcSetting
+    @Setting
     public static final String TOPIC_NAME_SETTING = "edc.events.topic.name";
-    @EdcSetting
+    @Setting
     public static final String TOPIC_ENDPOINT_SETTING = "edc.events.topic.endpoint";
     private final ServiceExtensionContext context;
 

--- a/extensions/common/configuration/configuration-filesystem/src/main/java/org/eclipse/dataspaceconnector/configuration/fs/FsConfigurationExtension.java
+++ b/extensions/common/configuration/configuration-filesystem/src/main/java/org/eclipse/dataspaceconnector/configuration/fs/FsConfigurationExtension.java
@@ -14,8 +14,8 @@
 
 package org.eclipse.dataspaceconnector.configuration.fs;
 
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.system.ConfigurationExtension;
@@ -39,7 +39,7 @@ import static org.eclipse.dataspaceconnector.common.configuration.ConfigurationF
 public class FsConfigurationExtension implements ConfigurationExtension {
 
     public static final String NAME = "FS Configuration";
-    @EdcSetting
+    @Setting
     private static final String FS_CONFIG = "edc.fs.config";
     private Config config;
     private Path configFile;

--- a/extensions/common/events/events-cloud-http/src/main/java/org/eclipse/dataspaceconnector/events/cloudevents/http/CloudEventsHttpExtension.java
+++ b/extensions/common/events/events-cloud-http/src/main/java/org/eclipse/dataspaceconnector/events/cloudevents/http/CloudEventsHttpExtension.java
@@ -16,9 +16,9 @@ package org.eclipse.dataspaceconnector.events.cloudevents.http;
 
 import dev.failsafe.RetryPolicy;
 import okhttp3.OkHttpClient;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.event.EventRouter;
 import org.eclipse.dataspaceconnector.spi.system.Hostname;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
@@ -30,7 +30,7 @@ import java.time.Clock;
 @Extension(value = "Cloud events HTTP")
 public class CloudEventsHttpExtension implements ServiceExtension {
 
-    @EdcSetting(required = true)
+    @Setting(required = true)
     static final String EDC_EVENTS_CLOUDEVENTS_ENDPOINT = "edc.events.cloudevents.endpoint";
 
     @Inject

--- a/extensions/common/http/jersey-core/src/main/java/org/eclipse/dataspaceconnector/extension/jersey/JerseyConfiguration.java
+++ b/extensions/common/http/jersey-core/src/main/java/org/eclipse/dataspaceconnector/extension/jersey/JerseyConfiguration.java
@@ -14,20 +14,20 @@
 
 package org.eclipse.dataspaceconnector.extension.jersey;
 
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
 /**
  * Jersey extension configuration class
  */
 public class JerseyConfiguration {
-    @EdcSetting
+    @Setting
     public static final String CORS_CONFIG_ORIGINS_SETTING = "edc.web.rest.cors.origins";
-    @EdcSetting
+    @Setting
     public static final String CORS_CONFIG_ENABLED_SETTING = "edc.web.rest.cors.enabled";
-    @EdcSetting
+    @Setting
     public static final String CORS_CONFIG_HEADERS_SETTING = "edc.web.rest.cors.headers";
-    @EdcSetting
+    @Setting
     public static final String CORS_CONFIG_METHODS_SETTING = "edc.web.rest.cors.methods";
     private String allowedOrigins;
     private String allowedHeaders;

--- a/extensions/common/http/jersey-micrometer/src/main/java/org/eclipse/dataspaceconnector/extension/jersey/JerseyMicrometerExtension.java
+++ b/extensions/common/http/jersey-micrometer/src/main/java/org/eclipse/dataspaceconnector/extension/jersey/JerseyMicrometerExtension.java
@@ -17,8 +17,8 @@ package org.eclipse.dataspaceconnector.extension.jersey;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.jersey.server.DefaultJerseyTagsProvider;
 import io.micrometer.core.instrument.binder.jersey.server.MetricsApplicationEventListener;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.WebService;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
@@ -29,9 +29,9 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
  */
 public class JerseyMicrometerExtension implements ServiceExtension {
 
-    @EdcSetting
+    @Setting
     public static final String ENABLE_METRICS = "edc.metrics.enabled";
-    @EdcSetting
+    @Setting
     public static final String ENABLE_JERSEY_METRICS = "edc.metrics.jersey.enabled";
 
     @Inject

--- a/extensions/common/http/jetty-core/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyConfiguration.java
+++ b/extensions/common/http/jetty-core/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyConfiguration.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.dataspaceconnector.extension.jetty;
 
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.system.configuration.Config;
 
 import java.util.AbstractMap;
@@ -30,7 +30,7 @@ public class JettyConfiguration {
     public static final String DEFAULT_PATH = "/api";
     public static final String DEFAULT_CONTEXT_NAME = "default";
     public static final int DEFAULT_PORT = 8181;
-    @EdcSetting
+    @Setting
     private static final String HTTP_PORT = "web.http.port";
     private final String keystorePassword;
     private final String keymanagerPassword;

--- a/extensions/common/http/jetty-core/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyExtension.java
+++ b/extensions/common/http/jetty-core/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyExtension.java
@@ -14,8 +14,8 @@
 
 package org.eclipse.dataspaceconnector.extension.jetty;
 
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.WebServer;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
@@ -32,13 +32,13 @@ import java.security.cert.CertificateException;
 public class JettyExtension implements ServiceExtension {
 
 
-    @EdcSetting
+    @Setting
     private static final String KEYSTORE_PASSWORD = "edc.web.https.keystore.password";
-    @EdcSetting
+    @Setting
     private static final String KEYMANAGER_PASSWORD = "edc.web.https.keymanager.password";
-    @EdcSetting
+    @Setting
     private static final String KEYSTORE_PATH_SETTING = "edc.web.https.keystore.path";
-    @EdcSetting
+    @Setting
     private static final String KEYSTORE_TYPE_SETTING = "edc.web.https.keystore.type";
 
     private JettyService jettyService;

--- a/extensions/common/http/jetty-micrometer/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyMicrometerExtension.java
+++ b/extensions/common/http/jetty-micrometer/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyMicrometerExtension.java
@@ -16,9 +16,9 @@ package org.eclipse.dataspaceconnector.extension.jetty;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.jetty.JettyConnectionMetrics;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
@@ -29,9 +29,9 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 @Extension(value = JettyMicrometerExtension.NAME)
 public class JettyMicrometerExtension implements ServiceExtension {
 
-    @EdcSetting
+    @Setting
     public static final String ENABLE_METRICS = "edc.metrics.enabled";
-    @EdcSetting
+    @Setting
     public static final String ENABLE_JETTY_METRICS = "edc.metrics.jetty.enabled";
     public static final String NAME = "Jetty Micrometer Metrics";
 

--- a/extensions/common/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/dataspaceconnector/iam/did/web/ConfigurationKeys.java
+++ b/extensions/common/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/dataspaceconnector/iam/did/web/ConfigurationKeys.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.dataspaceconnector.iam.did.web;
 
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 
 /**
  * Defines configuration keys used by the Web DID extension.
@@ -24,7 +24,7 @@ public interface ConfigurationKeys {
     /**
      * If set, the resolver will use the endpoint to resolve DIDs using DNS over HTTPS.
      */
-    @EdcSetting
+    @Setting
     String DNS_OVER_HTTPS = "edc.webdid.doh.url";
 
 }

--- a/extensions/common/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/dataspaceconnector/iam/did/web/WebDidExtension.java
+++ b/extensions/common/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/dataspaceconnector/iam/did/web/WebDidExtension.java
@@ -20,9 +20,9 @@ import okhttp3.dnsoverhttps.DnsOverHttps;
 import org.eclipse.dataspaceconnector.common.string.StringUtils;
 import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidResolverRegistry;
 import org.eclipse.dataspaceconnector.iam.did.web.resolution.WebDidResolver;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
@@ -43,7 +43,7 @@ public class WebDidExtension implements ServiceExtension {
      * <p>
      * This setting can be used by EDC downstream projects, e.g. for testing with docker compose
      */
-    @EdcSetting
+    @Setting
     private static final String USE_HTTPS_SCHEME = "edc.iam.did.web.use.https";
     @Inject
     private DidResolverRegistry resolverRegistry;

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/Oauth2Extension.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/Oauth2Extension.java
@@ -27,10 +27,10 @@ import org.eclipse.dataspaceconnector.iam.oauth2.core.rule.Oauth2ValidationRules
 import org.eclipse.dataspaceconnector.iam.oauth2.spi.CredentialsRequestAdditionalParametersProvider;
 import org.eclipse.dataspaceconnector.iam.oauth2.spi.Oauth2JwtDecoratorRegistry;
 import org.eclipse.dataspaceconnector.iam.oauth2.spi.Oauth2ValidationRulesRegistry;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
 import org.eclipse.dataspaceconnector.spi.security.CertificateResolver;
@@ -52,23 +52,23 @@ public class Oauth2Extension implements ServiceExtension {
 
     public static final String NAME = "OAuth2";
     private static final long TOKEN_EXPIRATION = TimeUnit.MINUTES.toSeconds(5);
-    @EdcSetting
+    @Setting
     private static final String PROVIDER_JWKS_URL = "edc.oauth.provider.jwks.url";
-    @EdcSetting(value = "outgoing tokens 'aud' claim value, by default it's the connector id")
+    @Setting(value = "outgoing tokens 'aud' claim value, by default it's the connector id")
     private static final String PROVIDER_AUDIENCE = "edc.oauth.provider.audience";
-    @EdcSetting(value = "incoming tokens 'aud' claim required value, by default it's the provider audience value")
+    @Setting(value = "incoming tokens 'aud' claim required value, by default it's the provider audience value")
     private static final String ENDPOINT_AUDIENCE = "edc.oauth.endpoint.audience";
-    @EdcSetting
+    @Setting
     private static final String PUBLIC_KEY_ALIAS = "edc.oauth.public.key.alias";
-    @EdcSetting
+    @Setting
     private static final String PRIVATE_KEY_ALIAS = "edc.oauth.private.key.alias";
-    @EdcSetting
+    @Setting
     private static final String PROVIDER_JWKS_REFRESH = "edc.oauth.provider.jwks.refresh"; // in minutes
-    @EdcSetting
+    @Setting
     private static final String TOKEN_URL = "edc.oauth.token.url";
-    @EdcSetting
+    @Setting
     private static final String CLIENT_ID = "edc.oauth.client.id";
-    @EdcSetting
+    @Setting
     private static final String NOT_BEFORE_LEEWAY = "edc.oauth.validation.nbf.leeway";
     private IdentityProviderKeyResolver providerKeyResolver;
 

--- a/extensions/common/micrometer/micrometer-core/src/main/java/org/eclipse/dataspaceconnector/metrics/micrometer/MicrometerExtension.java
+++ b/extensions/common/micrometer/micrometer-core/src/main/java/org/eclipse/dataspaceconnector/metrics/micrometer/MicrometerExtension.java
@@ -24,9 +24,9 @@ import io.micrometer.core.instrument.binder.okhttp3.OkHttpMetricsEventListener;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import okhttp3.EventListener;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.BaseExtension;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.system.ExecutorInstrumentation;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
@@ -36,13 +36,13 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 @Extension(value = MicrometerExtension.NAME)
 public class MicrometerExtension implements ServiceExtension {
 
-    @EdcSetting
+    @Setting
     public static final String ENABLE_METRICS = "edc.metrics.enabled";
-    @EdcSetting
+    @Setting
     public static final String ENABLE_SYSTEM_METRICS = "edc.metrics.system.enabled";
-    @EdcSetting
+    @Setting
     public static final String ENABLE_OKHTTP_METRICS = "edc.metrics.okhttp.enabled";
-    @EdcSetting
+    @Setting
     public static final String ENABLE_EXECUTOR_METRICS = "edc.metrics.executor.enabled";
     public static final String NAME = "Micrometer Metrics";
     private static final String OKHTTP_REQUESTS_METRIC_NAME = "okhttp.requests";

--- a/extensions/common/sql/sql-pool/sql-pool-apache-commons/src/main/java/org/eclipse/dataspaceconnector/sql/pool/commons/CommonsConnectionPoolConfigKeys.java
+++ b/extensions/common/sql/sql-pool/sql-pool-apache-commons/src/main/java/org/eclipse/dataspaceconnector/sql/pool/commons/CommonsConnectionPoolConfigKeys.java
@@ -14,34 +14,34 @@
 
 package org.eclipse.dataspaceconnector.sql.pool.commons;
 
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 
 interface CommonsConnectionPoolConfigKeys {
 
-    @EdcSetting(required = false)
+    @Setting(required = false)
     String POOL_MAX_IDLE_CONNECTIONS = "pool.maxIdleConnections";
 
-    @EdcSetting(required = false)
+    @Setting(required = false)
     String POOL_MAX_TOTAL_CONNECTIONS = "pool.maxTotalConnections";
 
-    @EdcSetting(required = false)
+    @Setting(required = false)
     String POOL_MIN_IDLE_CONNECTIONS = "pool.minIdleConnections";
 
-    @EdcSetting(required = false)
+    @Setting(required = false)
     String POOL_TEST_CONNECTION_ON_BORROW = "pool.testConnectionOnBorrow";
 
-    @EdcSetting(required = false)
+    @Setting(required = false)
     String POOL_TEST_CONNECTION_ON_CREATE = "pool.testConnectionOnCreate";
 
-    @EdcSetting(required = false)
+    @Setting(required = false)
     String POOL_TEST_CONNECTION_ON_RETURN = "pool.testConnectionOnReturn";
 
-    @EdcSetting(required = false)
+    @Setting(required = false)
     String POOL_TEST_CONNECTION_WHILE_IDLE = "pool.testConnectionWhileIdle";
 
-    @EdcSetting(required = false)
+    @Setting(required = false)
     String POOL_TEST_QUERY = "pool.testQuery";
 
-    @EdcSetting(required = true)
+    @Setting(required = true)
     String URL = "url";
 }

--- a/extensions/common/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/DataSourceConfigurationKeys.java
+++ b/extensions/common/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/DataSourceConfigurationKeys.java
@@ -14,56 +14,56 @@
 
 package org.eclipse.dataspaceconnector.transaction.atomikos;
 
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 
 /**
  * Defines EDC data source configuration keys. All keys are prefixed by: edc.datasource.[ds name].[key]
  */
 public interface DataSourceConfigurationKeys {
 
-    @EdcSetting(required = true)
+    @Setting(required = true)
     String DRIVER_CLASS = "driver.class";
 
-    @EdcSetting(required = true)
+    @Setting(required = true)
     String URL = "url";
 
-    @EdcSetting
+    @Setting
     String DS_TYPE = "type";
 
-    @EdcSetting
+    @Setting
     String USERNAME = "username";
 
-    @EdcSetting
+    @Setting
     String PASSWORD = "password";
 
-    @EdcSetting
+    @Setting
     String POOL_SIZE = "pool.size";
 
-    @EdcSetting
+    @Setting
     String MAX_POOL_SIZE = "max.pool.size";
 
-    @EdcSetting
+    @Setting
     String MIN_POOL_SIZE = "min.pool.size";
 
-    @EdcSetting
+    @Setting
     String CONNECTION_TIMEOUT = "connection.timeout";
 
-    @EdcSetting
+    @Setting
     String LOGIN_TIMEOUT = "login.timeout";
 
-    @EdcSetting
+    @Setting
     String MAINTENANCE_INTERVAL = "maintenance.interval";
 
-    @EdcSetting
+    @Setting
     String MAX_IDLE = "max.idle";
 
-    @EdcSetting
+    @Setting
     String REAP = "reap";
 
-    @EdcSetting
+    @Setting
     String QUERY = "query";
 
-    @EdcSetting
+    @Setting
     String DRIVER_PROPERTIES = "properties";
 
 

--- a/extensions/common/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/TransactionManagerConfigurationKeys.java
+++ b/extensions/common/transaction/transaction-atomikos/src/main/java/org/eclipse/dataspaceconnector/transaction/atomikos/TransactionManagerConfigurationKeys.java
@@ -14,26 +14,26 @@
 
 package org.eclipse.dataspaceconnector.transaction.atomikos;
 
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 
 /**
  * Atomikos configuration keys. For details, see https://www.atomikos.com/Documentation/JtaProperties.
  */
 public interface TransactionManagerConfigurationKeys {
 
-    @EdcSetting(required = false)
+    @Setting(required = false)
     String TIMEOUT = "edc.atomikos.timeout";
 
-    @EdcSetting(required = false)
+    @Setting(required = false)
     String DATA_DIR = "edc.atomikos.directory";
 
-    @EdcSetting(required = false)
+    @Setting(required = false)
     String THREADED2PC = "edc.atomikos.threaded2pc";
 
-    @EdcSetting(required = false)
+    @Setting(required = false)
     String LOGGING = "edc.atomikos.logging";
 
-    @EdcSetting(required = false)
+    @Setting(required = false)
     String CHECKPOINT_INTERVAL = "edc.atomikos.checkpoint.interval";
 
     int DEFAULT_VALUE = -1;

--- a/extensions/common/vault/vault-azure/src/main/java/org/eclipse/dataspaceconnector/core/security/azure/AzureVaultExtension.java
+++ b/extensions/common/vault/vault-azure/src/main/java/org/eclipse/dataspaceconnector/core/security/azure/AzureVaultExtension.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.dataspaceconnector.core.security.azure;
 
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.security.CertificateResolver;
 import org.eclipse.dataspaceconnector.spi.security.PrivateKeyResolver;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
@@ -32,15 +32,15 @@ import static org.eclipse.dataspaceconnector.common.string.StringUtils.isNullOrE
 public class AzureVaultExtension implements ServiceExtension {
 
     public static final String NAME = "Azure Vault";
-    @EdcSetting
+    @Setting
     private static final String VAULT_CLIENT_ID = "edc.vault.clientid";
-    @EdcSetting
+    @Setting
     private static final String VAULT_TENANT_ID = "edc.vault.tenantid";
-    @EdcSetting
+    @Setting
     private static final String VAULT_NAME = "edc.vault.name";
-    @EdcSetting
+    @Setting
     private static final String VAULT_CLIENT_SECRET = "edc.vault.clientsecret";
-    @EdcSetting
+    @Setting
     private static final String VAULT_CERTIFICATE = "edc.vault.certificate";
 
     @Override

--- a/extensions/common/vault/vault-filesystem/src/main/java/org/eclipse/dataspaceconnector/core/security/fs/FsConfiguration.java
+++ b/extensions/common/vault/vault-filesystem/src/main/java/org/eclipse/dataspaceconnector/core/security/fs/FsConfiguration.java
@@ -14,20 +14,20 @@
 
 package org.eclipse.dataspaceconnector.core.security.fs;
 
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 
 public final class FsConfiguration {
 
-    @EdcSetting
+    @Setting
     static final String VAULT_LOCATION = "edc.vault";
 
-    @EdcSetting
+    @Setting
     static final String KEYSTORE_LOCATION = "edc.keystore";
 
-    @EdcSetting
+    @Setting
     static final String KEYSTORE_PASSWORD = "edc.keystore.password";
 
-    @EdcSetting
+    @Setting
     static final String PERSISTENT_VAULT = "edc.vault.persistent";
 
 

--- a/extensions/common/vault/vault-hashicorp/src/main/java/org/eclipse/dataspaceconnector/core/security/hashicorpvault/HashicorpVaultExtension.java
+++ b/extensions/common/vault/vault-hashicorp/src/main/java/org/eclipse/dataspaceconnector/core/security/hashicorpvault/HashicorpVaultExtension.java
@@ -16,11 +16,11 @@ package org.eclipse.dataspaceconnector.core.security.hashicorpvault;
 
 import dev.failsafe.RetryPolicy;
 import okhttp3.OkHttpClient;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provider;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.security.CertificateResolver;
 import org.eclipse.dataspaceconnector.spi.security.PrivateKeyResolver;
@@ -34,10 +34,10 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 @Extension(value = HashicorpVaultExtension.NAME)
 public class HashicorpVaultExtension implements ServiceExtension {
 
-    @EdcSetting(value = "The URL of the Hashicorp Vault", required = true)
+    @Setting(value = "The URL of the Hashicorp Vault", required = true)
     public static final String VAULT_URL = "edc.vault.hashicorp.url";
 
-    @EdcSetting(value = "The token used to access the Hashicorp Vault", required = true)
+    @Setting(value = "The token used to access the Hashicorp Vault", required = true)
     public static final String VAULT_TOKEN = "edc.vault.hashicorp.token";
     public static final String NAME = "Hashicorp Vault";
 

--- a/extensions/control-plane/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/DataPlaneTransferClientExtension.java
+++ b/extensions/control-plane/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/DataPlaneTransferClientExtension.java
@@ -18,9 +18,9 @@ import dev.failsafe.RetryPolicy;
 import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.dataplane.selector.client.DataPlaneSelectorClient;
 import org.eclipse.dataspaceconnector.dataplane.spi.manager.DataPlaneManager;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
@@ -39,7 +39,7 @@ import java.util.Objects;
 public class DataPlaneTransferClientExtension implements ServiceExtension {
 
     public static final String NAME = "Data Plane Transfer Client";
-    @EdcSetting
+    @Setting
     private static final String DPF_SELECTOR_STRATEGY = "edc.transfer.client.selector.strategy";
     @Inject(required = false)
     private DataPlaneSelectorClient selectorClient;

--- a/extensions/control-plane/data-plane-transfer/data-plane-transfer-sync/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/DataPlaneTransferSyncConfig.java
+++ b/extensions/control-plane/data-plane-transfer/data-plane-transfer-sync/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/DataPlaneTransferSyncConfig.java
@@ -14,19 +14,19 @@
 
 package org.eclipse.dataspaceconnector.transfer.dataplane.sync;
 
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 
 import java.util.concurrent.TimeUnit;
 
 public interface DataPlaneTransferSyncConfig {
 
-    @EdcSetting
+    @Setting
     String DATA_PROXY_TOKEN_VALIDITY_SECONDS = "edc.transfer.proxy.token.validity.seconds";
     long DEFAULT_DATA_PROXY_TOKEN_VALIDITY_SECONDS = TimeUnit.MINUTES.toSeconds(10);
 
-    @EdcSetting
+    @Setting
     String TOKEN_SIGNER_PRIVATE_KEY_ALIAS = "edc.transfer.proxy.token.signer.privatekey.alias";
 
-    @EdcSetting
+    @Setting
     String TOKEN_VERIFIER_PUBLIC_KEY_ALIAS = "edc.transfer.proxy.token.verifier.publickey.alias";
 }

--- a/extensions/control-plane/data-plane-transfer/data-plane-transfer-sync/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/DataPlaneTransferSyncExtension.java
+++ b/extensions/control-plane/data-plane-transfer/data-plane-transfer-sync/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/DataPlaneTransferSyncExtension.java
@@ -19,9 +19,9 @@ import org.eclipse.dataspaceconnector.core.jwt.TokenGenerationServiceImpl;
 import org.eclipse.dataspaceconnector.core.jwt.TokenValidationRulesRegistryImpl;
 import org.eclipse.dataspaceconnector.core.jwt.TokenValidationServiceImpl;
 import org.eclipse.dataspaceconnector.dataplane.selector.client.DataPlaneSelectorClient;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.WebService;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
@@ -58,7 +58,7 @@ import static org.eclipse.dataspaceconnector.transfer.dataplane.sync.DataPlaneTr
 public class DataPlaneTransferSyncExtension implements ServiceExtension {
 
     public static final String NAME = "Data Plane Transfer Sync";
-    @EdcSetting
+    @Setting
     private static final String DPF_SELECTOR_STRATEGY = "edc.transfer.client.selector.strategy";
     private static final String API_CONTEXT_ALIAS = "validation";
     @Inject

--- a/extensions/control-plane/http-receiver/src/main/java/org/eclipse/dataspaceconnector/receiver/http/HttpEndpointDataReferenceReceiverExtension.java
+++ b/extensions/control-plane/http-receiver/src/main/java/org/eclipse/dataspaceconnector/receiver/http/HttpEndpointDataReferenceReceiverExtension.java
@@ -17,9 +17,9 @@ package org.eclipse.dataspaceconnector.receiver.http;
 import dev.failsafe.RetryPolicy;
 import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.common.string.StringUtils;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
@@ -29,11 +29,11 @@ import org.eclipse.dataspaceconnector.spi.transfer.edr.EndpointDataReferenceRece
 public class HttpEndpointDataReferenceReceiverExtension implements ServiceExtension {
 
     public static final String NAME = "Http Endpoint Data Reference Receiver";
-    @EdcSetting
+    @Setting
     private static final String HTTP_RECEIVER_ENDPOINT = "edc.receiver.http.endpoint";
-    @EdcSetting
+    @Setting
     private static final String HTTP_RECEIVER_AUTH_KEY = "edc.receiver.http.auth-key";
-    @EdcSetting
+    @Setting
     private static final String HTTP_RECEIVER_AUTH_CODE = "edc.receiver.http.auth-code";
     @Inject
     private EndpointDataReferenceReceiverRegistry receiverRegistry;

--- a/extensions/control-plane/provision/gcs-provision/src/main/java/org/eclipse/dataspaceconnector/gcp/storage/provision/GcsProvisionExtension.java
+++ b/extensions/control-plane/provision/gcs-provision/src/main/java/org/eclipse/dataspaceconnector/gcp/storage/provision/GcsProvisionExtension.java
@@ -18,8 +18,8 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import org.eclipse.dataspaceconnector.gcp.core.iam.IamServiceImpl;
 import org.eclipse.dataspaceconnector.gcp.core.storage.StorageServiceImpl;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ProvisionManager;
@@ -28,7 +28,7 @@ import org.eclipse.dataspaceconnector.spi.transfer.provision.ResourceManifestGen
 
 public class GcsProvisionExtension implements ServiceExtension {
 
-    @EdcSetting(value = "The GCP project ID", required = true)
+    @Setting(value = "The GCP project ID", required = true)
     private static final String GCP_PROJECT_ID = "edc.gcp.projectId";
 
     @Inject

--- a/extensions/control-plane/provision/http-provision/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpWebhookExtension.java
+++ b/extensions/control-plane/provision/http-provision/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/HttpWebhookExtension.java
@@ -34,7 +34,7 @@ import static java.lang.String.format;
 
 @Provides(HttpProvisionerWebhookUrl.class)
 public class HttpWebhookExtension implements ServiceExtension {
-    //not an EdcSetting, because it is only the first part of the config path
+    //not a Setting, because it is only the first part of the config path
     public static final String PROVISIONER_WEBHOOK_CONFIG = "web.http.provisioner";
     public static final String PROVISIONER_CONTEXT_ALIAS = "provisioner";
 

--- a/extensions/control-plane/provision/http-provision/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/config/ConfigParser.java
+++ b/extensions/control-plane/provision/http-provision/src/main/java/org/eclipse/dataspaceconnector/transfer/provision/http/config/ConfigParser.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.dataspaceconnector.transfer.provision.http.config;
 
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.system.configuration.Config;
 import org.eclipse.dataspaceconnector.transfer.provision.http.config.ProvisionerConfiguration.ProvisionerType;
@@ -38,16 +38,16 @@ public class ConfigParser {
 
     private static final String HTTP_PROVISIONER_ENTRIES = CONFIG_PREFIX + ".entries";
 
-    @EdcSetting(required = true)
+    @Setting(required = true)
     private static final String PROVISIONER_TYPE = "provisioner.type";
 
-    @EdcSetting(required = true)
+    @Setting(required = true)
     private static final String DATA_ADDRESS_TYPE = "data.address.type";
 
-    @EdcSetting(required = true)
+    @Setting(required = true)
     private static final String ENDPOINT_URL = "endpoint";
 
-    @EdcSetting
+    @Setting
     private static final String POLICY_SCOPE = "policy.scope";
 
     private ConfigParser() {

--- a/extensions/control-plane/provision/s3-provision/src/main/java/org/eclipse/dataspaceconnector/aws/s3/provision/AwsProvisionExtension.java
+++ b/extensions/control-plane/provision/s3-provision/src/main/java/org/eclipse/dataspaceconnector/aws/s3/provision/AwsProvisionExtension.java
@@ -18,9 +18,9 @@ import dev.failsafe.RetryPolicy;
 import org.eclipse.dataspaceconnector.aws.s3.core.AwsClientProvider;
 import org.eclipse.dataspaceconnector.aws.s3.core.AwsTemporarySecretToken;
 import org.eclipse.dataspaceconnector.aws.s3.core.S3BucketSchema;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
@@ -37,9 +37,9 @@ import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 public class AwsProvisionExtension implements ServiceExtension {
 
     public static final String NAME = "AWS Provision";
-    @EdcSetting
+    @Setting
     private static final String PROVISION_MAX_RETRY = "edc.aws.provision.retry.retries.max";
-    @EdcSetting
+    @Setting
     private static final String PROVISION_MAX_ROLE_SESSION_DURATION = "edc.aws.provision.role.duration.session.max";
     @Inject
     private Vault vault;

--- a/extensions/control-plane/store/cosmos/asset-index-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/AssetIndexCosmosConfig.java
+++ b/extensions/control-plane/store/cosmos/asset-index-cosmos/src/main/java/org/eclipse/dataspaceconnector/assetindex/azure/AssetIndexCosmosConfig.java
@@ -15,18 +15,18 @@
 package org.eclipse.dataspaceconnector.assetindex.azure;
 
 import org.eclipse.dataspaceconnector.azure.cosmos.AbstractCosmosConfig;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
 public class AssetIndexCosmosConfig extends AbstractCosmosConfig {
 
-    @EdcSetting
+    @Setting
     private static final String COSMOS_ACCOUNTNAME_SETTING = "edc.assetindex.cosmos.account-name";
-    @EdcSetting
+    @Setting
     private static final String COSMOS_DBNAME_SETTING = "edc.assetindex.cosmos.database-name";
-    @EdcSetting
+    @Setting
     private static final String COSMOS_PREFERRED_REGION_SETTING = "edc.assetindex.cosmos.preferred-region";
-    @EdcSetting
+    @Setting
     private static final String COSMOS_CONTAINER_NAME_SETTING = "edc.assetindex.cosmos.container-name";
 
     /**

--- a/extensions/control-plane/store/cosmos/transfer-process-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/TransferProcessStoreCosmosConfig.java
+++ b/extensions/control-plane/store/cosmos/transfer-process-store-cosmos/src/main/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/TransferProcessStoreCosmosConfig.java
@@ -15,21 +15,21 @@
 package org.eclipse.dataspaceconnector.transfer.store.cosmos;
 
 import org.eclipse.dataspaceconnector.azure.cosmos.AbstractCosmosConfig;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
 public class TransferProcessStoreCosmosConfig extends AbstractCosmosConfig {
 
-    @EdcSetting
+    @Setting
     private static final String COSMOS_ACCOUNTNAME_SETTING = "edc.transfer-process-store.cosmos.account.name";
 
-    @EdcSetting
+    @Setting
     private static final String COSMOS_DBNAME_SETTING = "edc.transfer-process-store.database.name";
 
-    @EdcSetting
+    @Setting
     private static final String COSMOS_PREFERRED_REGION_SETTING = "edc.transfer-process-store.cosmos.preferred-region";
 
-    @EdcSetting
+    @Setting
     private static final String COSMOS_CONTAINER_NAME_SETTING = "edc.transfer-process-store.cosmos.container-name";
 
     /**

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/dataspaceconnector/sql/assetindex/ConfigurationKeys.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/dataspaceconnector/sql/assetindex/ConfigurationKeys.java
@@ -15,7 +15,7 @@
 
 package org.eclipse.dataspaceconnector.sql.assetindex;
 
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 
 /**
  * Defines configuration keys used by the SqlAssetIndexServiceExtension.
@@ -25,7 +25,7 @@ public interface ConfigurationKeys {
     /**
      * Name of the datasource to use for accessing assets.
      */
-    @EdcSetting(required = true)
+    @Setting(required = true)
     String DATASOURCE_SETTING_NAME = "edc.datasource.asset.name";
 
 }

--- a/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionStoreExtension.java
+++ b/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionStoreExtension.java
@@ -16,10 +16,10 @@
 package org.eclipse.dataspaceconnector.sql.contractdefinition.store;
 
 
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
@@ -35,7 +35,7 @@ public class SqlContractDefinitionStoreExtension implements ServiceExtension {
     /**
      * Name of the datasource to use for accessing contract definitions.
      */
-    @EdcSetting(required = true)
+    @Setting(required = true)
     private static final String DATASOURCE_SETTING_NAME = "edc.datasource.contractdefinition.name";
 
     @Inject

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/policy/SqlPolicyStoreExtension.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/policy/SqlPolicyStoreExtension.java
@@ -14,10 +14,10 @@
 
 package org.eclipse.dataspaceconnector.sql.policy;
 
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyDefinitionStore;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
@@ -31,7 +31,7 @@ import org.eclipse.dataspaceconnector.sql.policy.store.schema.postgres.PostgresD
 @Extension("SQL policy store")
 public class SqlPolicyStoreExtension implements ServiceExtension {
 
-    @EdcSetting(required = true)
+    @Setting(required = true)
     private static final String DATASOURCE_SETTING_NAME = "edc.datasource.policy.name";
 
     @Inject

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/SqlTransferProcessStoreExtension.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/SqlTransferProcessStoreExtension.java
@@ -14,10 +14,10 @@
 
 package org.eclipse.dataspaceconnector.sql.transferprocess;
 
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
@@ -33,7 +33,7 @@ import java.time.Clock;
 @Extension(value = "SQL transfer process store")
 public class SqlTransferProcessStoreExtension implements ServiceExtension {
 
-    @EdcSetting
+    @Setting
     private static final String DATASOURCE_NAME_SETTING = "edc.datasource.transferprocess.name";
     private static final String DEFAULT_DATASOURCE_NAME = "transferprocess";
 

--- a/extensions/data-plane-selector/data-plane-selector-client/src/main/java/org/eclipse/dataspaceconnector/dataplane/selector/DataPlaneInstanceClientExtension.java
+++ b/extensions/data-plane-selector/data-plane-selector-client/src/main/java/org/eclipse/dataspaceconnector/dataplane/selector/DataPlaneInstanceClientExtension.java
@@ -20,10 +20,10 @@ import org.eclipse.dataspaceconnector.common.string.StringUtils;
 import org.eclipse.dataspaceconnector.dataplane.selector.client.DataPlaneSelectorClient;
 import org.eclipse.dataspaceconnector.dataplane.selector.client.EmbeddedDataPlaneSelectorClient;
 import org.eclipse.dataspaceconnector.dataplane.selector.client.RemoteDataPlaneSelectorClient;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
@@ -35,7 +35,7 @@ import static java.lang.String.format;
 @Extension(value = "DataPlane instance client")
 public class DataPlaneInstanceClientExtension implements ServiceExtension {
 
-    @EdcSetting
+    @Setting
     private static final String DPF_SELECTOR_URL_SETTING = "edc.dpf.selector.url";
 
     @Inject(required = false)

--- a/extensions/data-plane/data-plane-api/src/main/java/org/eclipse/dataspaceconnector/dataplane/api/DataPlaneApiExtension.java
+++ b/extensions/data-plane/data-plane-api/src/main/java/org/eclipse/dataspaceconnector/dataplane/api/DataPlaneApiExtension.java
@@ -19,9 +19,9 @@ import org.eclipse.dataspaceconnector.dataplane.api.controller.DataPlaneControlA
 import org.eclipse.dataspaceconnector.dataplane.api.controller.DataPlanePublicApiController;
 import org.eclipse.dataspaceconnector.dataplane.api.validation.TokenValidationClientImpl;
 import org.eclipse.dataspaceconnector.dataplane.spi.manager.DataPlaneManager;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.WebService;
 import org.eclipse.dataspaceconnector.spi.system.ExecutorInstrumentation;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
@@ -37,7 +37,7 @@ import java.util.concurrent.Executors;
 @Extension(value = DataPlaneApiExtension.NAME)
 public class DataPlaneApiExtension implements ServiceExtension {
     public static final String NAME = "Data Plane API";
-    @EdcSetting
+    @Setting
     private static final String CONTROL_PLANE_VALIDATION_ENDPOINT = "edc.dataplane.token.validation.endpoint";
     private static final String CONTROL = "control";
     private static final String PUBLIC = "public";

--- a/extensions/data-plane/data-plane-azure-data-factory/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azuredatafactory/DataPlaneAzureDataFactoryExtension.java
+++ b/extensions/data-plane/data-plane-azure-data-factory/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azuredatafactory/DataPlaneAzureDataFactoryExtension.java
@@ -23,9 +23,9 @@ import com.azure.security.keyvault.secrets.SecretClientBuilder;
 import org.eclipse.dataspaceconnector.azure.blob.core.api.BlobStoreApi;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.TransferService;
 import org.eclipse.dataspaceconnector.dataplane.spi.registry.TransferServiceRegistry;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.system.SettingResolver;
@@ -41,13 +41,13 @@ import java.util.Objects;
 public class DataPlaneAzureDataFactoryExtension implements ServiceExtension {
 
     public static final String NAME = "Data Plane Azure Data Factory";
-    @EdcSetting
+    @Setting
     private static final String KEY_VAULT_LINKED_SERVICE_NAME = "edc.data.factory.key.vault.linkedservicename";
-    @EdcSetting
+    @Setting
     private static final String RESOURCE_ID = "edc.data.factory.resource.id";
-    @EdcSetting
+    @Setting
     private static final String KEY_VAULT_RESOURCE_ID = "edc.data.factory.key.vault.resource.id";
-    @EdcSetting
+    @Setting
     private static final String DATA_FACTORY_POLL_DELAY = "edc.data.factory.poll.delay.ms";
     @Inject
     private TransferServiceRegistry registry;

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/dataspaceconnector/dataplane/http/DataPlaneHttpExtension.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/dataspaceconnector/dataplane/http/DataPlaneHttpExtension.java
@@ -23,9 +23,9 @@ import org.eclipse.dataspaceconnector.dataplane.http.pipeline.HttpSinkRequestPar
 import org.eclipse.dataspaceconnector.dataplane.http.pipeline.HttpSourceRequestParamsSupplier;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataTransferExecutorServiceContainer;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.PipelineService;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
@@ -37,7 +37,7 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 public class DataPlaneHttpExtension implements ServiceExtension {
     public static final String NAME = "Data Plane HTTP";
     private static final int DEFAULT_PART_SIZE = 5;
-    @EdcSetting
+    @Setting
     private static final String EDC_DATAPLANE_HTTP_SINK_PARTITION_SIZE = "edc.dataplane.http.sink.partition.size";
     @Inject
     private OkHttpClient httpClient;

--- a/extensions/federated-catalog/store/fcc-node-directory-cosmos/src/main/java/org/eclipse/dataspaceconnector/catalog/node/directory/azure/FederatedCacheNodeDirectoryCosmosConfig.java
+++ b/extensions/federated-catalog/store/fcc-node-directory-cosmos/src/main/java/org/eclipse/dataspaceconnector/catalog/node/directory/azure/FederatedCacheNodeDirectoryCosmosConfig.java
@@ -15,18 +15,18 @@
 package org.eclipse.dataspaceconnector.catalog.node.directory.azure;
 
 import org.eclipse.dataspaceconnector.azure.cosmos.AbstractCosmosConfig;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
 public class FederatedCacheNodeDirectoryCosmosConfig extends AbstractCosmosConfig {
 
-    @EdcSetting
+    @Setting
     private static final String COSMOS_ACCOUNTNAME_SETTING = "edc.node.directory.cosmos.account.name";
-    @EdcSetting
+    @Setting
     private static final String COSMOS_DBNAME_SETTING = "edc.node.directory.cosmos.database.name";
-    @EdcSetting
+    @Setting
     private static final String COSMOS_PREFERRED_REGION_SETTING = "edc.node.directory.cosmos.preferred.region";
-    @EdcSetting
+    @Setting
     private static final String COSMOS_CONTAINER_NAME_SETTING = "edc.node.directory.cosmos.container.name";
 
     /**

--- a/spi/common/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/document/DidConstants.java
+++ b/spi/common/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/document/DidConstants.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.dataspaceconnector.iam.did.spi.document;
 
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 
 import java.util.Arrays;
 import java.util.List;
@@ -28,7 +28,7 @@ public interface DidConstants {
             DidConstants.JSON_WEB_KEY_2020,
             DidConstants.RSA_VERIFICATION_KEY_2018,
             DidConstants.ED_25519_VERIFICATION_KEY_2018);
-    @EdcSetting
+    @Setting
     String DID_URL_SETTING = "edc.identity.did.url";
 
 }

--- a/spi/federated-catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/CacheConfiguration.java
+++ b/spi/federated-catalog/federated-catalog-spi/src/main/java/org/eclipse/dataspaceconnector/catalog/spi/CacheConfiguration.java
@@ -16,7 +16,7 @@ package org.eclipse.dataspaceconnector.catalog.spi;
 
 import org.eclipse.dataspaceconnector.catalog.spi.model.ExecutionPlan;
 import org.eclipse.dataspaceconnector.catalog.spi.model.RecurringExecutionPlan;
-import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
 import java.time.Duration;
@@ -31,11 +31,11 @@ import static java.lang.String.format;
  */
 public class CacheConfiguration {
 
-    @EdcSetting("The time to elapse between two crawl runs")
+    @Setting("The time to elapse between two crawl runs")
     static final String EXECUTION_PLAN_PERIOD_SECONDS = "edc.catalog.cache.execution.period.seconds";
-    @EdcSetting("The number of crawlers (execution threads) that should be used. The engine will re-use crawlers when necessary.")
+    @Setting("The number of crawlers (execution threads) that should be used. The engine will re-use crawlers when necessary.")
     static final String NUM_CRAWLER_SETTING = "edc.catalog.cache.partition.num.crawlers";
-    @EdcSetting("The initial delay for the cache crawler engine")
+    @Setting("The initial delay for the cache crawler engine")
     static final String EXECUTION_PLAN_DELAY_SECONDS = "edc.catalog.cache.execution.delay.seconds";
     private static final int DEFAULT_EXECUTION_PERIOD_SECONDS = 60;
     private static final int LOW_EXECUTION_PERIOD_SECONDS_THRESHOLD = 10;


### PR DESCRIPTION
## What this PR changes/adds

Issue https://github.com/eclipse-dataspaceconnector/GradlePlugins/issues/19 deprecates `@EdcSetting` and `@EdcSettingContext` in favor of `@Setting` and `@SettingContext`, which are now used everywhere.


## Why it does that

To keep the naming consistent with the other runtime metamodel annotations.

## Further notes

- ~~this PR should be merged **AFTER this one** https://github.com/eclipse-dataspaceconnector/GradlePlugins/pull/27~~
- ~~Actions will fail until https://github.com/eclipse-dataspaceconnector/GradlePlugins/pull/27 is merged and published~~
- removed the `modules.md` file and its generation, as it sometimes caused problems. If needed, we can make it a separate gradle task.


## Linked Issue(s)

Closes https://github.com/eclipse-dataspaceconnector/GradlePlugins/issues/19

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
