### PR TITLE
fix(configuration): strip whitespaces in properties and env values

### DIFF
--- a/core/common/util/src/main/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctions.java
+++ b/core/common/util/src/main/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctions.java
@@ -35,7 +35,7 @@ public class ConfigurationFunctions {
         if (!StringUtils.isNullOrBlank(value)) {
             return value.strip();
         }
-        return defaultValue.strip();
+        return defaultValue;
     }
 
 }

--- a/core/common/util/src/main/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctions.java
+++ b/core/common/util/src/main/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctions.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
- *
+ *       SAP SE - Improvements
  */
 
 package org.eclipse.dataspaceconnector.common.configuration;
@@ -28,14 +28,14 @@ public class ConfigurationFunctions {
     public static String propOrEnv(String key, String defaultValue) {
         String value = System.getProperty(key);
         if (!StringUtils.isNullOrBlank(value)) {
-            return value;
+            return value.strip();
         }
         String upperKey = key.toUpperCase().replace('.', '_');
         value = System.getenv(upperKey);
         if (!StringUtils.isNullOrBlank(value)) {
-            return value;
+            return value.strip();
         }
-        return defaultValue;
+        return defaultValue.strip();
     }
 
 }

--- a/core/common/util/src/test/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctionsTest.java
+++ b/core/common/util/src/test/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctionsTest.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       SAP SE - Improvements
  *
  */
 
@@ -34,18 +35,26 @@ class ConfigurationFunctionsTest {
     public static final String ENV_VAR_1 = "EDC_KEY1";
     public static final String ENV_VAR_2 = "EDC_KEY2";
     public static final String EDC_VAR_3 = "EDC_KEY3";
+    public static final String EDC_VAR_4 = "EDC_KEY4";
+
     private static final String SYS_PROP_1 = "edc.key1";
     private static final String SYS_PROP_2 = "edc.key2";
     private static final String SYS_PROP_3 = "edc.key3";
+    private static final String SYS_PROP_4 = "edc.key4";
+
+    public static final String NONEXISTENT = "nonexistent";
+
     public static final String VALUE_1 = "value1";
 
     @AfterEach
     @ClearEnvironmentVariable(key = ENV_VAR_1)
     @ClearEnvironmentVariable(key = ENV_VAR_2)
     @ClearEnvironmentVariable(key = EDC_VAR_3)
+    @ClearEnvironmentVariable(key = EDC_VAR_4)
     @ClearSystemProperty(key = SYS_PROP_1)
     @ClearSystemProperty(key = SYS_PROP_2)
     @ClearSystemProperty(key = SYS_PROP_3)
+    @ClearSystemProperty(key = SYS_PROP_4)
     public void cleanUp() {
         // clear env vars and system properties
     }
@@ -55,6 +64,7 @@ class ConfigurationFunctionsTest {
     @SetSystemProperty(key = SYS_PROP_1, value = VALUE_1)
     @SetSystemProperty(key = SYS_PROP_2, value = "")
     @SetSystemProperty(key = SYS_PROP_3, value = "    ")
+    @SetSystemProperty(key = SYS_PROP_4, value = VALUE_1 + "    ")
     public void returnSystemProperty(String key, String expected) {
         String resultValue = ConfigurationFunctions.propOrEnv(key, DEFAULT);
         assertThat(resultValue).isEqualTo(expected);
@@ -64,23 +74,20 @@ class ConfigurationFunctionsTest {
     @SetEnvironmentVariable(key = ENV_VAR_1, value = VALUE_1)
     @SetEnvironmentVariable(key = ENV_VAR_2, value = "")
     @SetEnvironmentVariable(key = EDC_VAR_3, value = "    ")
+    @SetEnvironmentVariable(key = EDC_VAR_4, value = VALUE_1 + "    ")
     @MethodSource("envVarsSource")
     public void returnEnv(String key, String expected) {
         String resultValue = ConfigurationFunctions.propOrEnv(key, DEFAULT);
         assertThat(resultValue).isEqualTo(expected);
     }
 
-    @Test
-    public void returnDefaultEnv_NullValue() {
-        String resultValue = ConfigurationFunctions.propOrEnv("nonexistent", DEFAULT);
-        assertThat(resultValue).isEqualTo(DEFAULT);
-    }
-
     private static Stream<Arguments> propertiesSource() {
         return Stream.of(
                 Arguments.of(SYS_PROP_1, VALUE_1),
                 Arguments.of(SYS_PROP_2, DEFAULT),
-                Arguments.of(SYS_PROP_3, DEFAULT)
+                Arguments.of(SYS_PROP_3, DEFAULT),
+                Arguments.of(SYS_PROP_4, VALUE_1),
+                Arguments.of(NONEXISTENT, DEFAULT)
         );
     }
 
@@ -89,7 +96,9 @@ class ConfigurationFunctionsTest {
                 Arguments.of(ENV_VAR_1, VALUE_1),
                 Arguments.of(SYS_PROP_1, VALUE_1),
                 Arguments.of(ENV_VAR_2, DEFAULT),
-                Arguments.of(EDC_VAR_3, DEFAULT)
+                Arguments.of(EDC_VAR_3, DEFAULT),
+                Arguments.of(EDC_VAR_4, VALUE_1),
+                Arguments.of(NONEXISTENT, DEFAULT)
         );
     }
 }

--- a/core/common/util/src/test/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctionsTest.java
+++ b/core/common/util/src/test/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctionsTest.java
@@ -16,7 +16,6 @@
 package org.eclipse.dataspaceconnector.common.configuration;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/core/common/util/src/test/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctionsTest.java
+++ b/core/common/util/src/test/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctionsTest.java
@@ -16,6 +16,7 @@
 package org.eclipse.dataspaceconnector.common.configuration;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -80,13 +81,18 @@ class ConfigurationFunctionsTest {
         assertThat(resultValue).isEqualTo(expected);
     }
 
+    @Test
+    public void returnDefault_NullValue() {
+        String resultValue = ConfigurationFunctions.propOrEnv(NONEXISTENT, DEFAULT);
+        assertThat(resultValue).isEqualTo(DEFAULT);
+    }
+
     private static Stream<Arguments> propertiesSource() {
         return Stream.of(
                 Arguments.of(SYS_PROP_1, VALUE_1),
                 Arguments.of(SYS_PROP_2, DEFAULT),
                 Arguments.of(SYS_PROP_3, DEFAULT),
-                Arguments.of(SYS_PROP_4, VALUE_1),
-                Arguments.of(NONEXISTENT, DEFAULT)
+                Arguments.of(SYS_PROP_4, VALUE_1)
         );
     }
 
@@ -96,8 +102,7 @@ class ConfigurationFunctionsTest {
                 Arguments.of(SYS_PROP_1, VALUE_1),
                 Arguments.of(ENV_VAR_2, DEFAULT),
                 Arguments.of(EDC_VAR_3, DEFAULT),
-                Arguments.of(EDC_VAR_4, VALUE_1),
-                Arguments.of(NONEXISTENT, DEFAULT)
+                Arguments.of(EDC_VAR_4, VALUE_1)
         );
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Make sure that properties or env variables not starting or ending with whitespaces.

## Why it does that

Ensure that properties with trailing or ending whitespaces are not crashing the components and extensions or end up in a malfunction. Therefore remove all trailing or ending whitespaces if there are any.

## Linked Issue(s)

Closes #2101 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [notneeded] documented public classes/methods?
- [not needed] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
