### PR TITLE
deps: bump jackson dependency version to 2.14.0-rc2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,17 +1,19 @@
 groupId=org.eclipse.dataspaceconnector
-defaultVersion=0.0.1-SNAPSHOT
 javaVersion=11
+defaultVersion=0.0.1-SNAPSHOT
+# for now, we're using the same version for the autodoc plugin, the processor and the runtime-metamodel lib, but that could
+# change in the future
+annotationProcessorVersion=0.0.1-SNAPSHOT
+edcGradlePluginsVersion=0.0.1-SNAPSHOT
+metaModelVersion=0.0.1-SNAPSHOT
+
 edcDeveloperId=mspiekermann
 edcDeveloperName=Markus Spiekermann
 edcDeveloperEmail=markus.spiekermann@isst.fraunhofer.de
 edcScmConnection=scm:git:git@github.com:eclipse-dataspaceconnector/DataSpaceConnector.git
 edcWebsiteUrl=https://github.com/eclipse-dataspaceconnector/DataSpaceConnector.git
 edcScmUrl=https://github.com/eclipse-dataspaceconnector/DataSpaceConnector.git
-# for now, we're using the same version for the autodoc plugin, the processor and the runtime-metamodel lib, but that could
-# change in the future
-metaModelVersion=0.0.1-SNAPSHOT
-edcGradlePluginsVersion=0.0.1-SNAPSHOT
-annotationProcessorVersion=0.0.1-SNAPSHOT
+
 apacheCommonsPool2Version=2.11.1
 assertj=3.22.0
 atomikosVersion=5.0.8
@@ -33,7 +35,7 @@ googleCloudStorageVersion=2.12.0
 h2Version=2.1.210
 httpMockServer=5.14.0
 infoModelVersion=4.1.3
-jacksonVersion=2.13.3
+jacksonVersion=2.14.0-rc2
 jakartaValidationApi=3.0.2
 jerseyVersion=3.0.8
 jetBrainsAnnotationsVersion=15.0


### PR DESCRIPTION
## What this PR changes/adds

Bump `jackson` dependency version to 2.14.0-rc2

## Why it does that

To avoid vulnerabilities:
https://avd.aquasec.com/nvd/2022/cve-2022-42003/
https://avd.aquasec.com/nvd/2022/cve-2022-42004/

## Further notes

-

## Linked Issue(s)

Closes #2106 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
