### PR TITLE
chore: rename ContractOfferService to ContractOfferResolver

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
@@ -23,7 +23,7 @@ import org.eclipse.dataspaceconnector.contract.negotiation.ConsumerContractNegot
 import org.eclipse.dataspaceconnector.contract.negotiation.ProviderContractNegotiationManagerImpl;
 import org.eclipse.dataspaceconnector.contract.observe.ContractNegotiationObservableImpl;
 import org.eclipse.dataspaceconnector.contract.offer.ContractDefinitionServiceImpl;
-import org.eclipse.dataspaceconnector.contract.offer.ContractOfferServiceImpl;
+import org.eclipse.dataspaceconnector.contract.offer.ContractOfferResolverImpl;
 import org.eclipse.dataspaceconnector.contract.policy.PolicyArchiveImpl;
 import org.eclipse.dataspaceconnector.contract.policy.PolicyEquality;
 import org.eclipse.dataspaceconnector.contract.validation.ContractValidationServiceImpl;
@@ -43,7 +43,7 @@ import org.eclipse.dataspaceconnector.spi.contract.negotiation.ProviderContractN
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.observe.ContractNegotiationObservable;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractDefinitionService;
-import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
+import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferResolver;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
 import org.eclipse.dataspaceconnector.spi.contract.validation.ContractValidationService;
 import org.eclipse.dataspaceconnector.spi.event.EventRouter;
@@ -64,7 +64,7 @@ import org.jetbrains.annotations.NotNull;
 import java.time.Clock;
 
 @Provides({
-        ContractOfferService.class, ContractValidationService.class, ConsumerContractNegotiationManager.class,
+        ContractOfferResolver.class, ContractValidationService.class, ConsumerContractNegotiationManager.class,
         PolicyArchive.class, ProviderContractNegotiationManager.class, ContractNegotiationObservable.class,
         ContractDefinitionService.class
 })
@@ -155,8 +155,8 @@ public class ContractServiceExtension implements ServiceExtension {
         var definitionService = new ContractDefinitionServiceImpl(monitor, contractDefinitionStore, policyEngine, policyStore);
         context.registerService(ContractDefinitionService.class, definitionService);
 
-        var contractOfferService = new ContractOfferServiceImpl(agentService, definitionService, assetIndex, policyStore);
-        context.registerService(ContractOfferService.class, contractOfferService);
+        var contractOfferService = new ContractOfferResolverImpl(agentService, definitionService, assetIndex, policyStore);
+        context.registerService(ContractOfferResolver.class, contractOfferService);
 
         var policyEquality = new PolicyEquality(context.getTypeManager());
         var validationService = new ContractValidationServiceImpl(agentService, definitionService, assetIndex, policyStore, clock, policyEngine, policyEquality);

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferResolverImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferResolverImpl.java
@@ -24,7 +24,7 @@ import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.contract.ContractId;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractDefinitionService;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferQuery;
-import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
+import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferResolver;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyDefinitionStore;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
@@ -41,15 +41,15 @@ import java.util.stream.Stream;
 import static java.util.stream.Stream.concat;
 
 /**
- * Implementation of the {@link ContractOfferService}.
+ * Implementation of the {@link ContractOfferResolver}.
  */
-public class ContractOfferServiceImpl implements ContractOfferService {
+public class ContractOfferResolverImpl implements ContractOfferResolver {
     private final ParticipantAgentService agentService;
     private final ContractDefinitionService definitionService;
     private final AssetIndex assetIndex;
     private final PolicyDefinitionStore policyStore;
 
-    public ContractOfferServiceImpl(ParticipantAgentService agentService, ContractDefinitionService definitionService, AssetIndex assetIndex, PolicyDefinitionStore policyStore) {
+    public ContractOfferResolverImpl(ParticipantAgentService agentService, ContractDefinitionService definitionService, AssetIndex assetIndex, PolicyDefinitionStore policyStore) {
         this.agentService = agentService;
         this.definitionService = definitionService;
         this.assetIndex = assetIndex;

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferResolverImplIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferResolverImplIntegrationTest.java
@@ -23,7 +23,7 @@ import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractDefinitionService;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferQuery;
-import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
+import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferResolver;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.policy.PolicyDefinition;
@@ -56,18 +56,18 @@ import static org.mockito.Mockito.when;
 /**
  * This could be seen as se second part of the {@code ContractOfferServiceImplTest}, using the in-mem asset index
  */
-class ContractOfferServiceImplIntegrationTest {
+class ContractOfferResolverImplIntegrationTest {
 
     private final ContractDefinitionService contractDefinitionService = mock(ContractDefinitionService.class);
     private final ParticipantAgentService agentService = mock(ParticipantAgentService.class);
     private final PolicyDefinitionStore policyStore = mock(PolicyDefinitionStore.class);
     private AssetIndex assetIndex;
-    private ContractOfferService contractOfferService;
+    private ContractOfferResolver contractOfferResolver;
 
     @BeforeEach
     void setUp() {
         assetIndex = new InMemoryAssetIndex();
-        contractOfferService = new ContractOfferServiceImpl(agentService, contractDefinitionService, assetIndex, policyStore);
+        contractOfferResolver = new ContractOfferResolverImpl(agentService, contractDefinitionService, assetIndex, policyStore);
     }
 
     @Test
@@ -94,7 +94,7 @@ class ContractOfferServiceImplIntegrationTest {
         var to = 50;
         var query = ContractOfferQuery.builder().range(new Range(from, to)).claimToken(ClaimToken.Builder.newInstance().build()).build();
 
-        assertThat(contractOfferService.queryContractOffers(query)).hasSize(to - from);
+        assertThat(contractOfferResolver.queryContractOffers(query)).hasSize(to - from);
         verify(agentService).createFor(isA(ClaimToken.class));
         verify(contractDefinitionService, times(1)).definitionsFor(isA(ParticipantAgent.class));
         verify(policyStore).findById("contract");
@@ -120,7 +120,7 @@ class ContractOfferServiceImplIntegrationTest {
         var query = ContractOfferQuery.builder().range(new Range(from, to)).claimToken(ClaimToken.Builder.newInstance().build()).build();
 
         // 4 definitions, 10 assets each = 40 offers total -> offset 20 ==> result = 20
-        assertThat(contractOfferService.queryContractOffers(query)).hasSize(4);
+        assertThat(contractOfferResolver.queryContractOffers(query)).hasSize(4);
         verify(agentService).createFor(isA(ClaimToken.class));
         verify(contractDefinitionService).definitionsFor(isA(ParticipantAgent.class));
         verify(policyStore, atLeastOnce()).findById("contract");
@@ -141,7 +141,7 @@ class ContractOfferServiceImplIntegrationTest {
         var query = ContractOfferQuery.builder().range(new Range(from, to)).claimToken(ClaimToken.Builder.newInstance().build()).build();
 
         // 2 definitions, 10 assets each = 20 offers total -> offset of 25 is outside
-        assertThat(contractOfferService.queryContractOffers(query)).isEmpty();
+        assertThat(contractOfferResolver.queryContractOffers(query)).isEmpty();
         verify(agentService).createFor(isA(ClaimToken.class));
         verify(contractDefinitionService).definitionsFor(isA(ParticipantAgent.class));
         verify(policyStore, never()).findById("contract");

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferResolverImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/dataspaceconnector/contract/offer/ContractOfferResolverImplTest.java
@@ -22,7 +22,7 @@ import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractDefinitionService;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferQuery;
-import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
+import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferResolver;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.message.Range;
 import org.eclipse.dataspaceconnector.spi.policy.PolicyDefinition;
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-class ContractOfferServiceImplTest {
+class ContractOfferResolverImplTest {
 
     private static final Range DEFAULT_RANGE = new Range(0, 10);
     private final ContractDefinitionService contractDefinitionService = mock(ContractDefinitionService.class);
@@ -62,11 +62,11 @@ class ContractOfferServiceImplTest {
     private final ParticipantAgentService agentService = mock(ParticipantAgentService.class);
     private final PolicyDefinitionStore policyStore = mock(PolicyDefinitionStore.class);
 
-    private ContractOfferService contractOfferService;
+    private ContractOfferResolver contractOfferResolver;
 
     @BeforeEach
     void setUp() {
-        contractOfferService = new ContractOfferServiceImpl(agentService, contractDefinitionService, assetIndex, policyStore);
+        contractOfferResolver = new ContractOfferResolverImpl(agentService, contractDefinitionService, assetIndex, policyStore);
     }
 
     @Test
@@ -81,7 +81,7 @@ class ContractOfferServiceImplTest {
         when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(assetStream);
         when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
 
-        var offers = contractOfferService.queryContractOffers(getQuery());
+        var offers = contractOfferResolver.queryContractOffers(getQuery());
 
         assertThat(offers).hasSize(2);
         verify(agentService).createFor(isA(ClaimToken.class));
@@ -99,7 +99,7 @@ class ContractOfferServiceImplTest {
         when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(Stream.of(Asset.Builder.newInstance().build()));
         when(policyStore.findById(any())).thenReturn(null);
 
-        var result = contractOfferService.queryContractOffers(getQuery());
+        var result = contractOfferResolver.queryContractOffers(getQuery());
 
         assertThat(result).hasSize(0);
     }
@@ -118,7 +118,7 @@ class ContractOfferServiceImplTest {
         var from = 20;
         var to = 50;
 
-        var offers = contractOfferService.queryContractOffers(getQuery(from, to));
+        var offers = contractOfferResolver.queryContractOffers(getQuery(from, to));
 
         assertThat(offers).hasSize(to - from)
                 .extracting(ContractOffer::getAsset)
@@ -147,7 +147,7 @@ class ContractOfferServiceImplTest {
         var from = 20;
         var to = 50;
 
-        var offers = contractOfferService.queryContractOffers(getQuery(from, to));
+        var offers = contractOfferResolver.queryContractOffers(getQuery(from, to));
 
         // 4 definitions, 10 assets each = 40 offers total -> offset 20 ==> result = 20
         assertThat(offers).hasSize(20);
@@ -171,7 +171,7 @@ class ContractOfferServiceImplTest {
         var from = 25;
         var to = 50;
 
-        var offers = contractOfferService.queryContractOffers(getQuery(from, to));
+        var offers = contractOfferResolver.queryContractOffers(getQuery(from, to));
 
         // 2 definitions, 10 assets each = 20 offers total -> offset of 25 is outside
         assertThat(offers).isEmpty();
@@ -195,7 +195,7 @@ class ContractOfferServiceImplTest {
         var from = 20;
         var to = 50;
 
-        var offers = contractOfferService.queryContractOffers(getQuery(from, to));
+        var offers = contractOfferResolver.queryContractOffers(getQuery(from, to));
 
         assertThat(offers).hasSize(to - from);
         verify(contractDefinitionService).definitionsFor(isA(ParticipantAgent.class));
@@ -225,7 +225,7 @@ class ContractOfferServiceImplTest {
                 .assetsCriteria(List.of(new Criterion(Asset.PROPERTY_ID, "=", "2")))
                 .build();
 
-        var offers = contractOfferService.queryContractOffers(query);
+        var offers = contractOfferResolver.queryContractOffers(query);
 
         assertThat(offers).hasSize(2);
         verify(agentService).createFor(isA(ClaimToken.class));

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsMultipartApiServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/IdsMultipartApiServiceExtension.java
@@ -38,7 +38,7 @@ import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.ConsumerContractNegotiationManager;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.ProviderContractNegotiationManager;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
-import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
+import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferResolver;
 import org.eclipse.dataspaceconnector.spi.contract.validation.ContractValidationService;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
@@ -81,7 +81,7 @@ public final class IdsMultipartApiServiceExtension implements ServiceExtension {
     private IdsTransformerRegistry transformerRegistry;
 
     @Inject
-    private ContractOfferService contractOfferService;
+    private ContractOfferResolver contractOfferResolver;
 
     @Inject
     private ContractNegotiationStore contractNegotiationStore;
@@ -127,7 +127,7 @@ public final class IdsMultipartApiServiceExtension implements ServiceExtension {
 
         // create request handlers
         var handlers = new LinkedList<Handler>();
-        handlers.add(new DescriptionRequestHandler(monitor, connectorId, transformerRegistry, assetIndex, dataCatalogService, contractOfferService, connectorService, objectMapper));
+        handlers.add(new DescriptionRequestHandler(monitor, connectorId, transformerRegistry, assetIndex, dataCatalogService, contractOfferResolver, connectorService, objectMapper));
         handlers.add(new ArtifactRequestHandler(monitor, connectorId, objectMapper, contractNegotiationStore, contractValidationService, transferProcessManager, vault));
         handlers.add(new EndpointDataReferenceHandler(monitor, connectorId, endpointDataReferenceReceiverRegistry, endpointDataReferenceTransformerRegistry, context.getTypeManager()));
         handlers.add(new ContractRequestHandler(monitor, connectorId, objectMapper, providerNegotiationManager, transformerRegistry, assetIndex));

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/DescriptionRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/DescriptionRequestHandler.java
@@ -33,7 +33,7 @@ import org.eclipse.dataspaceconnector.ids.spi.types.IdsType;
 import org.eclipse.dataspaceconnector.ids.spi.types.container.OfferedAsset;
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferQuery;
-import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
+import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferResolver;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
@@ -56,7 +56,7 @@ public class DescriptionRequestHandler implements Handler {
     private final IdsTransformerRegistry transformerRegistry;
     private final AssetIndex assetIndex;
     private final CatalogService catalogService;
-    private final ContractOfferService contractOfferService;
+    private final ContractOfferResolver contractOfferResolver;
     private final ConnectorService connectorService;
     private final ObjectMapper objectMapper;
 
@@ -66,7 +66,7 @@ public class DescriptionRequestHandler implements Handler {
             @NotNull IdsTransformerRegistry transformerRegistry,
             @NotNull AssetIndex assetIndex,
             @NotNull CatalogService catalogService,
-            @NotNull ContractOfferService contractOfferService,
+            @NotNull ContractOfferResolver contractOfferResolver,
             @NotNull ConnectorService connectorService,
             @NotNull ObjectMapper objectMapper) {
         this.monitor = monitor;
@@ -74,7 +74,7 @@ public class DescriptionRequestHandler implements Handler {
         this.transformerRegistry = transformerRegistry;
         this.assetIndex = assetIndex;
         this.catalogService = catalogService;
-        this.contractOfferService = contractOfferService;
+        this.contractOfferResolver = contractOfferResolver;
         this.connectorService = connectorService;
         this.objectMapper = objectMapper;
     }
@@ -151,7 +151,7 @@ public class DescriptionRequestHandler implements Handler {
                         .assetsCriterion(new Criterion(Asset.PROPERTY_ID, "=", assetId))
                         .build();
 
-                try (var stream = contractOfferService.queryContractOffers(contractOfferQuery)) {
+                try (var stream = contractOfferResolver.queryContractOffers(contractOfferQuery)) {
                     var targetingContractOffers = stream.collect(toList());
 
                     return new OfferedAsset(asset, targetingContractOffers);

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/MultipartControllerIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/MultipartControllerIntegrationTest.java
@@ -58,7 +58,7 @@ import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provider;
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.ConsumerContractNegotiationManager;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.ProviderContractNegotiationManager;
-import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
+import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferResolver;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
 import org.eclipse.dataspaceconnector.spi.iam.TokenRepresentation;
@@ -103,7 +103,7 @@ public class MultipartControllerIntegrationTest {
     private static final String INFOMODEL_VERSION = "4.1.3";
     private final ObjectMapper objectMapper = getCustomizedObjectMapper();
 
-    private final ContractOfferService contractOfferService = mock(ContractOfferService.class);
+    private final ContractOfferResolver contractOfferResolver = mock(ContractOfferResolver.class);
     private final ConsumerContractNegotiationManager consumerContractNegotiationManager = mock(ConsumerContractNegotiationManager.class);
     private final ProviderContractNegotiationManager providerContractNegotiationManager = mock(ProviderContractNegotiationManager.class);
 
@@ -119,7 +119,7 @@ public class MultipartControllerIntegrationTest {
         ));
 
         extension.registerSystemExtension(ServiceExtension.class, new TestExtension());
-        extension.registerServiceMock(ContractOfferService.class, contractOfferService);
+        extension.registerServiceMock(ContractOfferResolver.class, contractOfferResolver);
         extension.registerServiceMock(ProviderContractNegotiationManager.class, providerContractNegotiationManager);
         extension.registerServiceMock(ConsumerContractNegotiationManager.class, consumerContractNegotiationManager);
     }
@@ -253,7 +253,7 @@ public class MultipartControllerIntegrationTest {
                 .asset(asset)
                 .policy(createEverythingAllowedPolicy())
                 .build();
-        when(contractOfferService.queryContractOffers(any())).thenReturn(Stream.of(contractOffer));
+        when(contractOfferResolver.queryContractOffers(any())).thenReturn(Stream.of(contractOffer));
 
         var request = createRequest(getDescriptionRequestMessage(
                 IdsId.Builder.newInstance().value(CATALOG_ID).type(IdsType.CATALOG).build()
@@ -496,7 +496,7 @@ public class MultipartControllerIntegrationTest {
                 .asset(asset)
                 .policy(createEverythingAllowedPolicy())
                 .build();
-        when(contractOfferService.queryContractOffers(any())).thenReturn(Stream.of(contractOffer));
+        when(contractOfferResolver.queryContractOffers(any())).thenReturn(Stream.of(contractOffer));
 
         var request = createRequest(getDescriptionRequestMessage(
                 IdsId.Builder.newInstance().value(assetId).type(IdsType.RESOURCE).build()

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/DescriptionRequestHandlerTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/DescriptionRequestHandlerTest.java
@@ -40,7 +40,7 @@ import org.eclipse.dataspaceconnector.ids.spi.types.IdsId;
 import org.eclipse.dataspaceconnector.ids.spi.types.IdsType;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
-import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
+import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferResolver;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
@@ -86,7 +86,7 @@ class DescriptionRequestHandlerTest {
     private IdsTransformerRegistry transformerRegistry;
     private AssetIndex assetIndex;
     private CatalogService catalogService;
-    private ContractOfferService contractOfferService;
+    private ContractOfferResolver contractOfferResolver;
     private ConnectorService connectorService;
 
     @BeforeEach
@@ -96,11 +96,11 @@ class DescriptionRequestHandlerTest {
         transformerRegistry = mock(IdsTransformerRegistry.class);
         assetIndex = mock(AssetIndex.class);
         catalogService = mock(CatalogService.class);
-        contractOfferService = mock(ContractOfferService.class);
+        contractOfferResolver = mock(ContractOfferResolver.class);
         connectorService = mock(ConnectorService.class);
 
         handler = new DescriptionRequestHandler(mock(Monitor.class), connectorId, transformerRegistry,
-                assetIndex, catalogService, contractOfferService, connectorService, new ObjectMapper());
+                assetIndex, catalogService, contractOfferResolver, connectorService, new ObjectMapper());
     }
 
     @Test
@@ -143,7 +143,7 @@ class DescriptionRequestHandlerTest {
         verify(connectorService, times(1))
                 .getConnector(any(), argThat(query -> query.getRange().getFrom() == rangeFrom && query.getRange().getTo() == rangeTo));
         verifyNoMoreInteractions(connectorService);
-        verifyNoInteractions(catalogService, contractOfferService, assetIndex);
+        verifyNoInteractions(catalogService, contractOfferResolver, assetIndex);
     }
 
     @Test
@@ -170,7 +170,7 @@ class DescriptionRequestHandlerTest {
                                 query.getFilterExpression().get(0).getOperandRight().equals(VALUE) &&
                                 query.getFilterExpression().get(0).getOperator().equals(EQUALS_SIGN)));
         verifyNoMoreInteractions(catalogService);
-        verifyNoInteractions(connectorService, contractOfferService, assetIndex);
+        verifyNoInteractions(connectorService, contractOfferResolver, assetIndex);
     }
 
     @Test
@@ -190,7 +190,7 @@ class DescriptionRequestHandlerTest {
                 .build();
 
         when(assetIndex.findById(any())).thenReturn(asset);
-        when(contractOfferService.queryContractOffers(any())).thenReturn(Stream.of(contractOffer));
+        when(contractOfferResolver.queryContractOffers(any())).thenReturn(Stream.of(contractOffer));
         when(transformerRegistry.transform(any(), eq(Resource.class))).thenReturn(Result.success(idsResource));
 
         var response = handler.handleRequest(request);
@@ -200,8 +200,8 @@ class DescriptionRequestHandlerTest {
 
         verify(assetIndex, times(1)).findById(assetId);
         verifyNoMoreInteractions(assetIndex);
-        verify(contractOfferService, times(1)).queryContractOffers(any());
-        verifyNoMoreInteractions(contractOfferService);
+        verify(contractOfferResolver, times(1)).queryContractOffers(any());
+        verifyNoMoreInteractions(contractOfferResolver);
         verifyNoMoreInteractions(connectorService, catalogService);
     }
 
@@ -231,7 +231,7 @@ class DescriptionRequestHandlerTest {
 
         verify(assetIndex, times(1)).findById(assetId);
         verifyNoMoreInteractions(assetIndex);
-        verifyNoInteractions(connectorService, catalogService, contractOfferService);
+        verifyNoInteractions(connectorService, catalogService, contractOfferResolver);
     }
 
     @Test
@@ -260,7 +260,7 @@ class DescriptionRequestHandlerTest {
 
         verify(assetIndex, times(1)).findById(assetId);
         verifyNoMoreInteractions(assetIndex);
-        verifyNoInteractions(connectorService, catalogService, contractOfferService);
+        verifyNoInteractions(connectorService, catalogService, contractOfferResolver);
     }
 
     private DescriptionRequestMessage descriptionRequestMessage(URI requestedElement) {

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/IdsCoreServiceExtension.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/IdsCoreServiceExtension.java
@@ -33,7 +33,7 @@ import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
 import org.eclipse.dataspaceconnector.spi.EdcException;
-import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
+import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferResolver;
 import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
@@ -60,7 +60,7 @@ public class IdsCoreServiceExtension implements ServiceExtension {
     private Monitor monitor;
 
     @Inject
-    private ContractOfferService contractOfferService;
+    private ContractOfferResolver contractOfferResolver;
 
     @Inject
     private IdentityService identityService;
@@ -101,7 +101,7 @@ public class IdsCoreServiceExtension implements ServiceExtension {
 
         context.registerService(IdsTransformerRegistry.class, new IdsTransformerRegistryImpl());
 
-        var dataCatalogService = new CatalogServiceImpl(dataCatalogId, contractOfferService);
+        var dataCatalogService = new CatalogServiceImpl(dataCatalogId, contractOfferResolver);
         context.registerService(CatalogService.class, dataCatalogService);
 
         var connectorService = new ConnectorServiceImpl(monitor, connectorServiceSettings, dataCatalogService);

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImpl.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImpl.java
@@ -18,7 +18,7 @@ package org.eclipse.dataspaceconnector.ids.core.service;
 
 import org.eclipse.dataspaceconnector.ids.spi.service.CatalogService;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferQuery;
-import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
+import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferResolver;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
@@ -30,13 +30,13 @@ import static java.util.stream.Collectors.toList;
 
 public class CatalogServiceImpl implements CatalogService {
     private final String dataCatalogId;
-    private final ContractOfferService contractOfferService;
+    private final ContractOfferResolver contractOfferResolver;
 
     public CatalogServiceImpl(
             @NotNull String dataCatalogId,
-            @NotNull ContractOfferService contractOfferService) {
+            @NotNull ContractOfferResolver contractOfferResolver) {
         this.dataCatalogId = Objects.requireNonNull(dataCatalogId);
-        this.contractOfferService = Objects.requireNonNull(contractOfferService);
+        this.contractOfferResolver = Objects.requireNonNull(contractOfferResolver);
     }
 
     /**
@@ -53,7 +53,7 @@ public class CatalogServiceImpl implements CatalogService {
                 .assetsCriteria(querySpec.getFilterExpression())
                 .range(querySpec.getRange()).build();
 
-        try (var offers = contractOfferService.queryContractOffers(query)) {
+        try (var offers = contractOfferResolver.queryContractOffers(query)) {
             return Catalog.Builder.newInstance()
                     .id(dataCatalogId)
                     .contractOffers(offers.collect(toList()))

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImplTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImplTest.java
@@ -16,7 +16,7 @@ package org.eclipse.dataspaceconnector.ids.core.service;
 
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferQuery;
-import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
+import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferResolver;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
@@ -35,12 +35,12 @@ import static org.mockito.Mockito.when;
 class CatalogServiceImplTest {
     private static final String CATALOG_ID = "catalogId";
 
-    private final ContractOfferService contractOfferService = mock(ContractOfferService.class);
+    private final ContractOfferResolver contractOfferResolver = mock(ContractOfferResolver.class);
     private CatalogServiceImpl dataCatalogService;
 
     @BeforeEach
     void setUp() {
-        dataCatalogService = new CatalogServiceImpl(CATALOG_ID, contractOfferService);
+        dataCatalogService = new CatalogServiceImpl(CATALOG_ID, contractOfferResolver);
     }
 
     @Test
@@ -58,14 +58,14 @@ class CatalogServiceImplTest {
                         .asset(Asset.Builder.newInstance().id("test-asset").build())
                         .id("1")
                         .build());
-        when(contractOfferService.queryContractOffers(any(ContractOfferQuery.class))).thenReturn(offers.stream());
+        when(contractOfferResolver.queryContractOffers(any(ContractOfferQuery.class))).thenReturn(offers.stream());
 
         var result = dataCatalogService.getDataCatalog(claimToken, QuerySpec.none());
 
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(CATALOG_ID);
         assertThat(result.getContractOffers()).hasSameElementsAs(offers);
-        verify(contractOfferService).queryContractOffers(any(ContractOfferQuery.class));
+        verify(contractOfferResolver).queryContractOffers(any(ContractOfferQuery.class));
     }
 
 }

--- a/extensions/control-plane/api/data-management-api/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/data-management-api/catalog-api/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/catalog/CatalogApiControllerIntegrationTest.java
@@ -21,7 +21,7 @@ import org.eclipse.dataspaceconnector.junit.extensions.EdcExtension;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
-import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
+import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferResolver;
 import org.eclipse.dataspaceconnector.spi.message.MessageContext;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcher;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
@@ -220,7 +220,7 @@ public class CatalogApiControllerIntegrationTest {
                 .when();
     }
 
-    @Provides(ContractOfferService.class)
+    @Provides(ContractOfferResolver.class)
     private class TestExtension implements ServiceExtension {
 
         @Inject
@@ -228,7 +228,7 @@ public class CatalogApiControllerIntegrationTest {
 
         @Override
         public void initialize(ServiceExtensionContext context) {
-            context.registerService(ContractOfferService.class, mock(ContractOfferService.class));
+            context.registerService(ContractOfferResolver.class, mock(ContractOfferResolver.class));
 
             registry.register(dispatcher);
         }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/ContractOfferResolver.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/contract/offer/ContractOfferResolver.java
@@ -25,7 +25,7 @@ import java.util.stream.Stream;
  */
 
 @ExtensionPoint
-public interface ContractOfferService {
+public interface ContractOfferResolver {
 
     /**
      * Resolves contract offers.


### PR DESCRIPTION
## What this PR changes/adds

Rename one of the `ContractOfferService`s to `ContractOfferResolver`

## Why it does that

To avoid duplicated class names and let the class be more self-explainatory

## Further notes

-

## Linked Issue(s)

Closes #1248 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
