### PR TITLE
feat(transferprocess): introduced a comunication channel from data-plane to control-plane

### DIFF
--- a/core/control-plane/control-plane-api-client/build.gradle.kts
+++ b/core/control-plane/control-plane-api-client/build.gradle.kts
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2020, 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+val failsafeVersion: String by project
+val okHttpVersion: String by project
+val awaitility: String by project
+
+
+
+dependencies {
+    api(project(":spi:control-plane:control-plane-api-client-spi"))
+
+    implementation("dev.failsafe:failsafe:${failsafeVersion}")
+    implementation("com.squareup.okhttp3:okhttp:${okHttpVersion}")
+
+    testImplementation(project(":extensions:common:junit"))
+    testImplementation(project(":core:control-plane:control-plane-core"))
+    testImplementation(project(":core:data-plane:data-plane-core"))
+    testImplementation(project(":core:control-plane:control-plane-api"))
+    testImplementation(project(":extensions:common:auth:auth-tokenbased"))
+    testImplementation("org.awaitility:awaitility:${awaitility}")
+
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("control-plane-api-client") {
+            artifactId = "control-plane-api-client"
+            from(components["java"])
+        }
+    }
+}

--- a/core/control-plane/control-plane-api-client/src/main/java/org/eclipse/dataspaceconnector/controlplane/api/client/ControlPlaneApiClientExtension.java
+++ b/core/control-plane/control-plane-api-client/src/main/java/org/eclipse/dataspaceconnector/controlplane/api/client/ControlPlaneApiClientExtension.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2020, 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.controlplane.api.client;
+
+import dev.failsafe.RetryPolicy;
+import okhttp3.OkHttpClient;
+import org.eclipse.dataspaceconnector.controlplane.api.client.transferprocess.TransferProcessHttpClient;
+import org.eclipse.dataspaceconnector.controlplane.api.client.transferprocess.model.TransferProcessFailRequest;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provider;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
+import org.eclipse.dataspaceconnector.spi.controlplane.api.client.transferprocess.TransferProcessApiClient;
+import org.eclipse.dataspaceconnector.spi.security.Vault;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+
+
+/**
+ * Extensions that contains clients for Control Plane HTTP APIs
+ */
+@Extension(value = ControlPlaneApiClientExtension.NAME)
+@Provides(TransferProcessApiClient.class)
+public class ControlPlaneApiClientExtension implements ServiceExtension {
+
+
+    public static final String NAME = "Control Plane HTTP API client";
+
+
+    @Inject
+    private Vault vault;
+
+    @Inject
+    private OkHttpClient okHttpClient;
+
+    @Inject
+    private RetryPolicy<Object> retryPolicy;
+
+
+    @Provider
+    public TransferProcessApiClient transferProcessApiClient(ServiceExtensionContext context) {
+
+        context.getTypeManager().registerTypes(TransferProcessFailRequest.class);
+
+        return new TransferProcessHttpClient(okHttpClient, retryPolicy, context.getTypeManager().getMapper(), context.getMonitor());
+    }
+
+}

--- a/core/control-plane/control-plane-api-client/src/main/java/org/eclipse/dataspaceconnector/controlplane/api/client/transferprocess/TransferProcessHttpClient.java
+++ b/core/control-plane/control-plane-api-client/src/main/java/org/eclipse/dataspaceconnector/controlplane/api/client/transferprocess/TransferProcessHttpClient.java
@@ -1,0 +1,111 @@
+/*
+ *  Copyright (c) 2020, 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.controlplane.api.client.transferprocess;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.failsafe.Failsafe;
+import dev.failsafe.RetryPolicy;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.eclipse.dataspaceconnector.controlplane.api.client.transferprocess.model.TransferProcessFailRequest;
+import org.eclipse.dataspaceconnector.spi.controlplane.api.client.transferprocess.TransferProcessApiClient;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
+import org.jetbrains.annotations.NotNull;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Implementation of {@link TransferProcessApiClient} which talks to the Control Plane Transfer Process via HTTP APIs
+ */
+public class TransferProcessHttpClient implements TransferProcessApiClient {
+
+    public static final MediaType TYPE_JSON = MediaType.parse("application/json");
+
+    private final RetryPolicy<Object> retryPolicy;
+    private final OkHttpClient okHttpClient;
+
+    private final ObjectMapper mapper;
+    private final Monitor monitor;
+
+    public TransferProcessHttpClient(OkHttpClient okHttpClient, RetryPolicy<Object> retryPolicy, ObjectMapper mapper, Monitor monitor) {
+        this.okHttpClient = okHttpClient;
+        this.retryPolicy = retryPolicy;
+        this.mapper = mapper;
+        this.monitor = monitor;
+    }
+
+
+    @Override
+    public void completed(DataFlowRequest dataFlowRequest) {
+        sendRequest(dataFlowRequest, "complete", null);
+    }
+
+    @Override
+    public void failed(DataFlowRequest dataFlowRequest, String reason) {
+        sendRequest(dataFlowRequest, "fail", TransferProcessFailRequest.Builder.newInstance().errorMessage(reason).build());
+    }
+
+
+    private void sendRequest(DataFlowRequest dataFlowRequest, String action, Object body) {
+
+        if (dataFlowRequest.getCallbackAddress() != null) {
+            try {
+                var rq = createRequest(buildUrl(dataFlowRequest, action), body);
+                try (var response = executeRequest(rq)) {
+                    if (!response.isSuccessful()) {
+                        monitor.severe(String.format("Failed to send callback request: received %s from the TransferProcess API", response.code()));
+                    }
+                }
+
+            } catch (Exception e) {
+                monitor.severe("Failed to send callback request", e);
+            }
+        } else {
+            monitor.warning(String.format("Missing callback address in DataFlowRequest %s", dataFlowRequest.getId()));
+        }
+    }
+
+    @NotNull
+    private String buildUrl(DataFlowRequest dataFlowRequest, String action) throws URISyntaxException {
+        var url = new URI(dataFlowRequest.getCallbackAddress().toString() + "/").resolve(String.format("./transferprocess/%s/%s", dataFlowRequest.getProcessId(), action)).normalize();
+        return url.toString();
+    }
+
+    @NotNull
+    private Response executeRequest(Request rq) {
+        return Failsafe.with(retryPolicy).get(() -> okHttpClient.newCall(rq).execute());
+    }
+
+
+    private Request createRequest(String url, Object body) throws JsonProcessingException {
+        RequestBody requestBody = null;
+        if (body != null) {
+            requestBody =
+                    RequestBody.create(mapper.writeValueAsString(body), TYPE_JSON);
+        } else {
+            requestBody = RequestBody.create("", null);
+        }
+        return new Request.Builder()
+                .url(url)
+                .post(requestBody)
+                .build();
+    }
+}

--- a/core/control-plane/control-plane-api-client/src/main/java/org/eclipse/dataspaceconnector/controlplane/api/client/transferprocess/model/TransferProcessFailRequest.java
+++ b/core/control-plane/control-plane-api-client/src/main/java/org/eclipse/dataspaceconnector/controlplane/api/client/transferprocess/model/TransferProcessFailRequest.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2020, 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.controlplane.api.client.transferprocess.model;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+/**
+ * Payload for notifying a failed transfer
+ */
+@JsonDeserialize(builder = TransferProcessFailRequest.Builder.class)
+public class TransferProcessFailRequest {
+    private String errorMessage;
+
+    private TransferProcessFailRequest() {
+
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder {
+        private final TransferProcessFailRequest request;
+
+        private Builder() {
+            request = new TransferProcessFailRequest();
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder errorMessage(String errorMessage) {
+            request.errorMessage = errorMessage;
+            return this;
+        }
+
+        public TransferProcessFailRequest build() {
+            return request;
+        }
+    }
+}

--- a/core/control-plane/control-plane-api-client/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
+++ b/core/control-plane/control-plane-api-client/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2020 - 2022 Microsoft Corporation
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Microsoft Corporation - initial API and implementation
+#
+#
+
+org.eclipse.dataspaceconnector.controlplane.api.client.ControlPlaneApiClientExtension

--- a/core/control-plane/control-plane-api-client/src/test/java/org/eclipse/dataspaceconnector/controlplane/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
+++ b/core/control-plane/control-plane-api-client/src/test/java/org/eclipse/dataspaceconnector/controlplane/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
@@ -1,0 +1,162 @@
+/*
+ *  Copyright (c) 2020, 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.controlplane.api.client.transferprocess;
+
+import org.eclipse.dataspaceconnector.controlplane.api.ControlPlaneApiExtension;
+import org.eclipse.dataspaceconnector.dataplane.spi.manager.DataPlaneManager;
+import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.TransferService;
+import org.eclipse.dataspaceconnector.dataplane.spi.registry.TransferServiceRegistry;
+import org.eclipse.dataspaceconnector.junit.extensions.EdcExtension;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
+import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.entity.StatefulEntity;
+import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
+import org.eclipse.dataspaceconnector.spi.response.StatusResult;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.transfer.callback.ControlPlaneApiUrl;
+import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.net.URL;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.eclipse.dataspaceconnector.junit.testfixtures.TestUtils.getFreePort;
+import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.COMPLETED;
+import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.ERROR;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(EdcExtension.class)
+public class TransferProcessHttpClientIntegrationTest {
+
+    private final String authKey = "123456";
+    private final int port = getFreePort();
+
+    private TransferService service;
+
+    @BeforeEach
+    void setUp(EdcExtension extension) {
+
+        service = mock(TransferService.class);
+        when(service.canHandle(any())).thenReturn(true);
+
+
+        extension.setConfiguration(Map.of(
+                "web.http.port", String.valueOf(getFreePort()),
+                "web.http.path", "/api",
+                "web.http.controlplane.port", String.valueOf(port),
+                "web.http.controlplane.path", ControlPlaneApiExtension.DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH
+        ));
+
+        extension.registerSystemExtension(ServiceExtension.class, new TransferServiceMockExtension(service));
+    }
+
+    @Test
+    void shouldCallTransferProcessApiWithComplete(TransferProcessStore store, DataPlaneManager manager, ControlPlaneApiUrl callbackUrl) {
+        when(service.transfer(any())).thenReturn(CompletableFuture.completedFuture(StatusResult.success()));
+        var id = "tp-id";
+        store.create(createTransferProcess(id));
+        manager.initiateTransfer(createDataFlowRequest(id, callbackUrl.get()));
+
+        await().untilAsserted(() -> {
+            var transferProcess = store.find("tp-id");
+            assertThat(transferProcess).isNotNull()
+                    .extracting(StatefulEntity::getState).isEqualTo(COMPLETED.code());
+        });
+    }
+
+
+    @Test
+    void shouldCallTransferProcessApiWithFailed(TransferProcessStore store, DataPlaneManager manager, ControlPlaneApiUrl callbackUrl) {
+        when(service.transfer(any())).thenReturn(CompletableFuture.completedFuture(StatusResult.failure(ResponseStatus.FATAL_ERROR, "error")));
+        var id = "tp-id";
+        store.create(createTransferProcess(id));
+        manager.initiateTransfer(createDataFlowRequest(id, callbackUrl.get()));
+
+        await().untilAsserted(() -> {
+            var transferProcess = store.find("tp-id");
+            assertThat(transferProcess).isNotNull().satisfies(process -> {
+                assertThat(process.getState()).isEqualTo(ERROR.code());
+                assertThat(process.getErrorDetail()).isEqualTo("error");
+            });
+        });
+    }
+
+    @Test
+    void shouldCallTransferProcessApiWithException(TransferProcessStore store, DataPlaneManager manager, ControlPlaneApiUrl callbackUrl) {
+        when(service.transfer(any())).thenReturn(CompletableFuture.failedFuture(new EdcException("error")));
+        var id = "tp-id";
+        store.create(createTransferProcess(id));
+        manager.initiateTransfer(createDataFlowRequest(id, callbackUrl.get()));
+
+        await().untilAsserted(() -> {
+            var transferProcess = store.find("tp-id");
+            assertThat(transferProcess).isNotNull().satisfies(process -> {
+                assertThat(process.getState()).isEqualTo(ERROR.code());
+                assertThat(process.getErrorDetail()).isEqualTo("error");
+            });
+        });
+    }
+
+    private TransferProcess createTransferProcess(String id) {
+        return TransferProcess.Builder.newInstance()
+                .id(id)
+                .state(TransferProcessStates.IN_PROGRESS.code())
+                .type(TransferProcess.Type.PROVIDER)
+                .dataRequest(DataRequest.Builder.newInstance()
+                        .destinationType("file")
+                        .build())
+                .build();
+    }
+
+    private DataFlowRequest createDataFlowRequest(String processId, URL callbackAddress) {
+        return DataFlowRequest.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .processId(processId)
+                .callbackAddress(callbackAddress)
+                .sourceDataAddress(DataAddress.Builder.newInstance().type("file").build())
+                .destinationDataAddress(DataAddress.Builder.newInstance().type("file").build())
+                .build();
+    }
+
+    private static class TransferServiceMockExtension implements ServiceExtension {
+
+        private final TransferService transferService;
+        @Inject
+        private TransferServiceRegistry registry;
+
+        private TransferServiceMockExtension(TransferService transferService) {
+            this.transferService = transferService;
+        }
+
+        @Override
+        public void initialize(ServiceExtensionContext context) {
+            registry.registerTransferService(transferService);
+        }
+    }
+}

--- a/core/control-plane/control-plane-api/build.gradle.kts
+++ b/core/control-plane/control-plane-api/build.gradle.kts
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2020, 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    id("io.swagger.core.v3.swagger-gradle-plugin")
+}
+
+
+val restAssured: String by project
+val rsApi: String by project
+val awaitility: String by project
+val jakartaValidationApi: String by project
+val jerseyVersion: String by project
+
+
+dependencies {
+
+    api(project(":spi:control-plane:control-plane-spi"))
+    api(project(":spi:control-plane:control-plane-api-client-spi"))
+    api(project(":spi:common:web-spi"))
+    api(project(":spi:common:auth-spi"))
+
+
+    implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
+    implementation("jakarta.validation:jakarta.validation-api:${jakartaValidationApi}")
+    implementation("org.glassfish.jersey.ext:jersey-bean-validation:${jerseyVersion}") //for validation
+
+
+    testImplementation(project(":core:control-plane:control-plane-core"))
+    testImplementation(project(":extensions:common:http"))
+    testImplementation(project(":extensions:common:junit"))
+    testImplementation(project(":extensions:common:auth:auth-tokenbased"))
+    testImplementation("io.rest-assured:rest-assured:${restAssured}")
+    testImplementation("org.awaitility:awaitility:${awaitility}")
+
+}
+
+
+publishing {
+    publications {
+        create<MavenPublication>("control-plane-api") {
+            artifactId = "control-plane-api"
+            from(components["java"])
+        }
+    }
+}

--- a/core/control-plane/control-plane-api/src/main/java/org/eclipse/dataspaceconnector/controlplane/api/ControlPlaneApiExtension.java
+++ b/core/control-plane/control-plane-api/src/main/java/org/eclipse/dataspaceconnector/controlplane/api/ControlPlaneApiExtension.java
@@ -1,0 +1,109 @@
+/*
+ *  Copyright (c) 2020, 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.controlplane.api;
+
+import org.eclipse.dataspaceconnector.controlplane.api.transferprocess.TransferProcessControlApiController;
+import org.eclipse.dataspaceconnector.controlplane.api.transferprocess.model.TransferProcessFailStateDto;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provider;
+import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.WebServer;
+import org.eclipse.dataspaceconnector.spi.WebService;
+import org.eclipse.dataspaceconnector.spi.system.Hostname;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
+import org.eclipse.dataspaceconnector.spi.transfer.callback.ControlPlaneApiUrl;
+import org.jetbrains.annotations.NotNull;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static java.lang.String.format;
+
+/**
+ * {@link ControlPlaneApiExtension } exposes HTTP endpoints for internal interaction with the Control Plane
+ */
+@Extension(value = ControlPlaneApiExtension.NAME)
+public class ControlPlaneApiExtension implements ServiceExtension {
+
+    public static final String NAME = "Control Plane API";
+
+    public static final String CONTROL_PLANE_API_CONFIG = "web.http.controlplane";
+    public static final String CONTROL_PLANE_CONTEXT_ALIAS = "controlplane";
+
+    public static final int DEFAULT_CONTROL_PLANE_API_PORT = 8384;
+    public static final String DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH = "/api/v1/controlplane";
+
+    private int port = DEFAULT_CONTROL_PLANE_API_PORT;
+    private String path = DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH;
+
+    @Inject
+    private WebServer webServer;
+    @Inject
+    private WebService webService;
+    @Inject
+    private TransferProcessManager transferProcessManager;
+    @Inject
+    private Hostname hostname;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var monitor = context.getMonitor();
+        var alias = CONTROL_PLANE_CONTEXT_ALIAS;
+
+        var config = context.getConfig(CONTROL_PLANE_API_CONFIG);
+        if (config.getEntries().isEmpty()) {
+            monitor.warning(format("Settings for [%s] and/or [%s] were not provided. Using default" +
+                    " value(s) instead.", CONTROL_PLANE_API_CONFIG + ".path", CONTROL_PLANE_API_CONFIG + ".path"));
+            webServer.addPortMapping(alias, port, path);
+        } else {
+            path = config.getString("path", path);
+            port = config.getInteger("port", port);
+        }
+
+        context.getTypeManager().registerTypes(TransferProcessFailStateDto.class);
+
+        monitor.info(format("Control Plane API will be available at [path=%s], [port=%s].", path, port));
+
+        webService.registerResource(alias, new TransferProcessControlApiController(transferProcessManager));
+    }
+
+
+    @Provider
+    public ControlPlaneApiUrl controlPlaneApiUrl(ServiceExtensionContext context) {
+        var s = getApiUrl();
+        try {
+            var url = new URL(s);
+            return () -> url;
+        } catch (MalformedURLException e) {
+            context.getMonitor().severe("Error creating callback endpoint", e);
+            throw new EdcException(e);
+        }
+    }
+
+    @NotNull
+    private String getApiUrl() {
+        return String.format("http://%s:%s%s", hostname.get(), port, path);
+    }
+
+
+}

--- a/core/control-plane/control-plane-api/src/main/java/org/eclipse/dataspaceconnector/controlplane/api/transferprocess/TransferProcessControlApi.java
+++ b/core/control-plane/control-plane-api/src/main/java/org/eclipse/dataspaceconnector/controlplane/api/transferprocess/TransferProcessControlApi.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2020, 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.controlplane.api.transferprocess;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import org.eclipse.dataspaceconnector.controlplane.api.transferprocess.model.TransferProcessFailStateDto;
+import org.eclipse.dataspaceconnector.spi.ApiErrorDetail;
+
+
+@OpenAPIDefinition
+@Tag(name = "Transfer Process Control Api")
+public interface TransferProcessControlApi {
+
+    @Operation(description = "Requests completion of the transfer process. Due to the asynchronous nature of transfers, a successful response " +
+            "only indicates that the request was successfully received",
+            responses = {
+                    @ApiResponse(responseCode = "204"),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
+            })
+    void complete(String processId);
+
+    @Operation(description = "Requests completion of the transfer process. Due to the asynchronous nature of transfers, a successful response " +
+            "only indicates that the request was successfully received",
+            responses = {
+                    @ApiResponse(responseCode = "204"),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
+            })
+    void fail(String processId, @NotNull @Valid TransferProcessFailStateDto request);
+
+
+}

--- a/core/control-plane/control-plane-api/src/main/java/org/eclipse/dataspaceconnector/controlplane/api/transferprocess/TransferProcessControlApiController.java
+++ b/core/control-plane/control-plane-api/src/main/java/org/eclipse/dataspaceconnector/controlplane/api/transferprocess/TransferProcessControlApiController.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2020, 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.controlplane.api.transferprocess;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.dataspaceconnector.controlplane.api.transferprocess.model.TransferProcessFailStateDto;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.command.CompleteTransferCommand;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.command.FailTransferCommand;
+
+
+@Consumes({ MediaType.APPLICATION_JSON })
+@Produces({ MediaType.APPLICATION_JSON })
+@Path(TransferProcessControlApiController.PATH)
+public class TransferProcessControlApiController implements TransferProcessControlApi {
+
+    public static final String PATH = "/transferprocess";
+    private final TransferProcessManager transferProcessManager;
+
+
+    public TransferProcessControlApiController(TransferProcessManager transferProcessManager) {
+        this.transferProcessManager = transferProcessManager;
+    }
+
+
+    @POST
+    @Path("/{processId}/complete")
+    @Override
+    public void complete(@PathParam("processId") String processId) {
+        transferProcessManager.enqueueCommand(new CompleteTransferCommand(processId));
+    }
+
+    @POST
+    @Path("/{processId}/fail")
+    @Override
+    public void fail(@PathParam("processId") String processId, @NotNull @Valid TransferProcessFailStateDto request) {
+        transferProcessManager.enqueueCommand(new FailTransferCommand(processId, request.getErrorMessage()));
+    }
+}

--- a/core/control-plane/control-plane-api/src/main/java/org/eclipse/dataspaceconnector/controlplane/api/transferprocess/model/TransferProcessFailStateDto.java
+++ b/core/control-plane/control-plane-api/src/main/java/org/eclipse/dataspaceconnector/controlplane/api/transferprocess/model/TransferProcessFailStateDto.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2020, 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.controlplane.api.transferprocess.model;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import jakarta.validation.constraints.NotNull;
+
+@JsonDeserialize(builder = TransferProcessFailStateDto.Builder.class)
+public class TransferProcessFailStateDto {
+    @NotNull
+    private String errorMessage;
+
+    private TransferProcessFailStateDto() {
+
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder {
+        private final TransferProcessFailStateDto request;
+
+        private Builder() {
+            request = new TransferProcessFailStateDto();
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder errorMessage(String errorMessage) {
+            request.errorMessage = errorMessage;
+            return this;
+        }
+
+        public TransferProcessFailStateDto build() {
+            return request;
+        }
+    }
+}

--- a/core/control-plane/control-plane-api/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
+++ b/core/control-plane/control-plane-api/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2020 - 2022 Microsoft Corporation
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Microsoft Corporation - initial API and implementation
+#
+#
+
+org.eclipse.dataspaceconnector.controlplane.api.ControlPlaneApiExtension

--- a/core/control-plane/control-plane-api/src/test/java/org/eclipse/dataspaceconnector/controlplane/api/TransferProcessControlApiControllerIntegrationTest.java
+++ b/core/control-plane/control-plane-api/src/test/java/org/eclipse/dataspaceconnector/controlplane/api/TransferProcessControlApiControllerIntegrationTest.java
@@ -1,0 +1,142 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.controlplane.api;
+
+import io.restassured.specification.RequestSpecification;
+import org.eclipse.dataspaceconnector.controlplane.api.transferprocess.model.TransferProcessFailStateDto;
+import org.eclipse.dataspaceconnector.junit.extensions.EdcExtension;
+import org.eclipse.dataspaceconnector.spi.entity.StatefulEntity;
+import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.eclipse.dataspaceconnector.junit.testfixtures.TestUtils.getFreePort;
+import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.COMPLETED;
+import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.ERROR;
+import static org.hamcrest.Matchers.is;
+
+@ExtendWith(EdcExtension.class)
+class TransferProcessControlApiControllerIntegrationTest {
+
+    private final int port = getFreePort();
+
+    @BeforeEach
+    void setUp(EdcExtension extension) {
+        extension.setConfiguration(Map.of(
+                "web.http.port", String.valueOf(getFreePort()),
+                "web.http.path", "/api",
+                "web.http.controlplane.port", String.valueOf(port),
+                "web.http.controlplane.path", ControlPlaneApiExtension.DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH
+        ));
+    }
+
+    @Test
+    void callTransferProcessHookWithComplete(TransferProcessStore store) {
+
+        store.create(createTransferProcess());
+
+
+        baseRequest()
+                .contentType("application/json")
+                .post("/transferprocess/{processId}/complete", "tp-id")
+                .then()
+                .body(is(""))
+                .statusCode(is(204));
+
+
+        await().untilAsserted(() -> {
+            var transferProcess = store.find("tp-id");
+            assertThat(transferProcess).isNotNull()
+                    .extracting(StatefulEntity::getState).isEqualTo(COMPLETED.code());
+        });
+    }
+
+    @Test
+    void callTransferProcessHookWithError(TransferProcessStore store) {
+
+        store.create(createTransferProcess());
+
+        var rq = TransferProcessFailStateDto.Builder.newInstance()
+                .errorMessage("error")
+                .build();
+
+        baseRequest()
+                .body(rq)
+                .contentType("application/json")
+                .post("/transferprocess/{processId}/fail", "tp-id")
+                .then()
+                .body(is(""))
+                .statusCode(is(204));
+
+
+        await().untilAsserted(() -> {
+            var transferProcess = store.find("tp-id");
+            assertThat(transferProcess).isNotNull().satisfies((process) -> {
+                assertThat(process.getState()).isEqualTo(ERROR.code());
+                assertThat(process.getErrorDetail()).isEqualTo("error");
+            });
+        });
+    }
+
+    @Test
+    void callTransferProcessHookWithErrorFailWithNoErrorMessageBody(TransferProcessStore store) {
+        baseRequest()
+                .body("{}")
+                .contentType("application/json")
+                .post("/transferprocess/{processId}/fail", "tp-id")
+                .then()
+                .statusCode(is(400));
+
+    }
+
+    @Test
+    void callTransferProcessHookWithErrorFailWithNoBody(TransferProcessStore store) {
+        baseRequest()
+                .contentType("application/json")
+                .post("/transferprocess/{processId}/fail", "tp-id")
+                .then()
+                .statusCode(is(400));
+
+    }
+
+    private TransferProcess createTransferProcess() {
+        return TransferProcess.Builder.newInstance()
+                .id("tp-id")
+                .state(TransferProcessStates.IN_PROGRESS.code())
+                .type(TransferProcess.Type.PROVIDER)
+                .dataRequest(DataRequest.Builder.newInstance()
+                        .destinationType("file")
+                        .build())
+                .build();
+    }
+
+    private RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + port)
+                .basePath(ControlPlaneApiExtension.DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH)
+                .when();
+    }
+
+
+}

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/TransferProcessCommandExtension.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/TransferProcessCommandExtension.java
@@ -22,7 +22,9 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.transfer.observe.TransferProcessObservable;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 import org.eclipse.dataspaceconnector.transfer.core.command.handlers.CancelTransferCommandHandler;
+import org.eclipse.dataspaceconnector.transfer.core.command.handlers.CompleteTransferCommandHandler;
 import org.eclipse.dataspaceconnector.transfer.core.command.handlers.DeprovisionRequestHandler;
+import org.eclipse.dataspaceconnector.transfer.core.command.handlers.FailTransferCommandHandler;
 
 /**
  * Registers command handlers that the core provides
@@ -42,6 +44,8 @@ public class TransferProcessCommandExtension implements ServiceExtension {
 
         registry.register(new CancelTransferCommandHandler(store, observable));
         registry.register(new DeprovisionRequestHandler(store));
+        registry.register(new CompleteTransferCommandHandler(store, observable));
+        registry.register(new FailTransferCommandHandler(store, observable));
     }
 
 }

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/CancelTransferCommandHandler.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/CancelTransferCommandHandler.java
@@ -39,7 +39,7 @@ public class CancelTransferCommandHandler extends SingleTransferProcessCommandHa
     }
 
     @Override
-    protected boolean modify(TransferProcess process) {
+    protected boolean modify(TransferProcess process, CancelTransferCommand command) {
         var state = process.getState();
         if (state == TransferProcessStates.COMPLETED.code() ||
                 state == TransferProcessStates.ERROR.code() ||

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/CompleteTransferCommandHandler.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/CompleteTransferCommandHandler.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - refactored
+ *
+ */
+
+package org.eclipse.dataspaceconnector.transfer.core.command.handlers;
+
+import org.eclipse.dataspaceconnector.spi.transfer.observe.TransferProcessObservable;
+import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.command.CompleteTransferCommand;
+
+/**
+ * Completes a transfer process and sends it to the {@link TransferProcessStates#COMPLETED} state.
+ */
+public class CompleteTransferCommandHandler extends SingleTransferProcessCommandHandler<CompleteTransferCommand> {
+
+    private final TransferProcessObservable observable;
+
+    public CompleteTransferCommandHandler(TransferProcessStore store, TransferProcessObservable observable) {
+        super(store);
+        this.observable = observable;
+    }
+
+    @Override
+    public Class<CompleteTransferCommand> getType() {
+        return CompleteTransferCommand.class;
+    }
+
+    @Override
+    protected boolean modify(TransferProcess process, CompleteTransferCommand command) {
+        if (process.getState() == TransferProcessStates.IN_PROGRESS.code()) {
+            process.transitionCompleted();
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    protected void postAction(TransferProcess process) {
+        observable.invokeForEach(l -> l.completed(process));
+    }
+}

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/DeprovisionRequestHandler.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/DeprovisionRequestHandler.java
@@ -35,7 +35,7 @@ public class DeprovisionRequestHandler extends SingleTransferProcessCommandHandl
     }
 
     @Override
-    protected boolean modify(TransferProcess process) {
+    protected boolean modify(TransferProcess process, DeprovisionRequest command) {
         process.transitionDeprovisioning();
         return true;
     }

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/FailTransferCommandHandler.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/FailTransferCommandHandler.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - refactored
+ *
+ */
+
+package org.eclipse.dataspaceconnector.transfer.core.command.handlers;
+
+import org.eclipse.dataspaceconnector.spi.transfer.observe.TransferProcessObservable;
+import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.command.FailTransferCommand;
+
+/**
+ * Fails a transfer process and sends it to the {@link TransferProcessStates#ERROR} state.
+ */
+public class FailTransferCommandHandler extends SingleTransferProcessCommandHandler<FailTransferCommand> {
+
+    private final TransferProcessObservable observable;
+
+    public FailTransferCommandHandler(TransferProcessStore store, TransferProcessObservable observable) {
+        super(store);
+        this.observable = observable;
+    }
+
+    @Override
+    public Class<FailTransferCommand> getType() {
+        return FailTransferCommand.class;
+    }
+
+    @Override
+    protected boolean modify(TransferProcess process, FailTransferCommand command) {
+        if (process.getState() == TransferProcessStates.IN_PROGRESS.code()) {
+            process.transitionError(command.getErrorMessage());
+            return true;
+        }
+        return false;
+    }
+
+
+    @Override
+    protected void postAction(TransferProcess process) {
+        observable.invokeForEach(l -> l.failed(process));
+    }
+}

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/SingleTransferProcessCommandHandler.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/SingleTransferProcessCommandHandler.java
@@ -36,13 +36,13 @@ public abstract class SingleTransferProcessCommandHandler<T extends SingleTransf
     }
 
     @Override
-    public void handle(SingleTransferProcessCommand command) {
+    public void handle(T command) {
         var transferProcessId = command.getTransferProcessId();
         var transferProcess = store.find(transferProcessId);
         if (transferProcess == null) {
             throw new EdcException(format("Could not find TransferProcess with ID [%s]", transferProcessId));
         } else {
-            if (modify(transferProcess)) {
+            if (modify(transferProcess, command)) {
                 transferProcess.setModified();
                 store.update(transferProcess);
                 postAction(transferProcess);
@@ -56,9 +56,10 @@ public abstract class SingleTransferProcessCommandHandler<T extends SingleTransf
      * If the {@link TransferProcess} was indeed modified, implementors should return {@code true}, otherwise {@code false}
      *
      * @param process The {@link TransferProcess}
+     * @param command The {@link SingleTransferProcessCommand}
      * @return true if the process was actually modified, false otherwise.
      */
-    protected abstract boolean modify(TransferProcess process);
+    protected abstract boolean modify(TransferProcess process, T command);
 
     /**
      * Method that would be called after the entity update has been persisted.

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/CompleteTransferCommandHandlerTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/CompleteTransferCommandHandlerTest.java
@@ -1,0 +1,104 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.transfer.core.command.handlers;
+
+import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.transfer.observe.TransferProcessListener;
+import org.eclipse.dataspaceconnector.spi.transfer.observe.TransferProcessObservable;
+import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.command.CompleteTransferCommand;
+import org.eclipse.dataspaceconnector.transfer.core.observe.TransferProcessObservableImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+class CompleteTransferCommandHandlerTest {
+
+    private final TransferProcessStore store = mock(TransferProcessStore.class);
+    private final TransferProcessObservable observable = new TransferProcessObservableImpl();
+    private final TransferProcessListener listener = mock(TransferProcessListener.class);
+    private CompleteTransferCommandHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        observable.registerListener(listener);
+        handler = new CompleteTransferCommandHandler(store, observable);
+    }
+
+    @Test
+    void handle() {
+        var cmd = new CompleteTransferCommand("test-id");
+        var tp = TransferProcess.Builder.newInstance().id("test-id").state(TransferProcessStates.IN_PROGRESS.code())
+                .updatedAt(124123) //some invalid time
+                .type(TransferProcess.Type.CONSUMER).build();
+        var originalDate = tp.getUpdatedAt();
+
+        when(store.find(anyString())).thenReturn(tp);
+        handler.handle(cmd);
+
+        assertThat(tp.getState()).isEqualTo(TransferProcessStates.COMPLETED.code());
+        assertThat(tp.getErrorDetail()).isNull();
+        assertThat(tp.getUpdatedAt()).isNotEqualTo(originalDate);
+
+        verify(store).find(anyString());
+        verify(store).update(tp);
+        verifyNoMoreInteractions(store);
+        verify(listener).completed(tp);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = TransferProcessStates.class, names = { "COMPLETED", "ENDED", "ERROR", "CANCELLED" })
+    void handle_illegalState(TransferProcessStates targetState) {
+        var tp = TransferProcess.Builder.newInstance().id("test-id").state(targetState.code())
+                .type(TransferProcess.Type.CONSUMER).build();
+        var originalDate = tp.getUpdatedAt();
+        var cmd = new CompleteTransferCommand("test-id");
+
+        when(store.find(anyString())).thenReturn(tp);
+        handler.handle(cmd);
+
+        assertThat(tp.getUpdatedAt()).isEqualTo(originalDate);
+
+        verify(store).find(anyString());
+        verifyNoMoreInteractions(store);
+        verifyNoInteractions(listener);
+    }
+
+    @Test
+    void handle_notFound() {
+        var cmd = new CompleteTransferCommand("test-id");
+
+        when(store.find(anyString())).thenReturn(null);
+        assertThatThrownBy(() -> handler.handle(cmd)).isInstanceOf(EdcException.class).hasMessageStartingWith("Could not find TransferProcess with ID [test-id]");
+        verifyNoInteractions(listener);
+    }
+
+    @Test
+    void verifyCorrectType() {
+        assertThat(handler.getType()).isEqualTo(CompleteTransferCommand.class);
+    }
+}

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/FailTransferCommandHandlerTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/dataspaceconnector/transfer/core/command/handlers/FailTransferCommandHandlerTest.java
@@ -1,0 +1,104 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.transfer.core.command.handlers;
+
+import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.transfer.observe.TransferProcessListener;
+import org.eclipse.dataspaceconnector.spi.transfer.observe.TransferProcessObservable;
+import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.command.FailTransferCommand;
+import org.eclipse.dataspaceconnector.transfer.core.observe.TransferProcessObservableImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+class FailTransferCommandHandlerTest {
+
+    private final TransferProcessStore store = mock(TransferProcessStore.class);
+    private final TransferProcessObservable observable = new TransferProcessObservableImpl();
+    private final TransferProcessListener listener = mock(TransferProcessListener.class);
+    private FailTransferCommandHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        observable.registerListener(listener);
+        handler = new FailTransferCommandHandler(store, observable);
+    }
+
+    @Test
+    void handle() {
+        var cmd = new FailTransferCommand("test-id", "error");
+        var tp = TransferProcess.Builder.newInstance().id("test-id").state(TransferProcessStates.IN_PROGRESS.code())
+                .updatedAt(124123) //some invalid time
+                .type(TransferProcess.Type.CONSUMER).build();
+        var originalDate = tp.getUpdatedAt();
+
+        when(store.find(anyString())).thenReturn(tp);
+        handler.handle(cmd);
+
+        assertThat(tp.getState()).isEqualTo(TransferProcessStates.ERROR.code());
+        assertThat(tp.getErrorDetail()).isEqualTo("error");
+        assertThat(tp.getUpdatedAt()).isNotEqualTo(originalDate);
+
+        verify(store).find(anyString());
+        verify(store).update(tp);
+        verifyNoMoreInteractions(store);
+        verify(listener).failed(tp);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = TransferProcessStates.class, names = { "COMPLETED", "ENDED", "ERROR", "CANCELLED" })
+    void handle_illegalState(TransferProcessStates targetState) {
+        var tp = TransferProcess.Builder.newInstance().id("test-id").state(targetState.code())
+                .type(TransferProcess.Type.CONSUMER).build();
+        var originalDate = tp.getUpdatedAt();
+        var cmd = new FailTransferCommand("test-id", "error");
+
+        when(store.find(anyString())).thenReturn(tp);
+        handler.handle(cmd);
+
+        assertThat(tp.getUpdatedAt()).isEqualTo(originalDate);
+
+        verify(store).find(anyString());
+        verifyNoMoreInteractions(store);
+        verifyNoInteractions(listener);
+    }
+
+    @Test
+    void handle_notFound() {
+        var cmd = new FailTransferCommand("test-id", "error");
+
+        when(store.find(anyString())).thenReturn(null);
+        assertThatThrownBy(() -> handler.handle(cmd)).isInstanceOf(EdcException.class).hasMessageStartingWith("Could not find TransferProcess with ID [test-id]");
+        verifyNoInteractions(listener);
+    }
+
+    @Test
+    void verifyCorrectType() {
+        assertThat(handler.getType()).isEqualTo(FailTransferCommand.class);
+    }
+}

--- a/core/data-plane/data-plane-framework/build.gradle.kts
+++ b/core/data-plane/data-plane-framework/build.gradle.kts
@@ -23,6 +23,8 @@ plugins {
 dependencies {
     api(project(":spi:common:core-spi"))
     api(project(":spi:data-plane:data-plane-spi"))
+    api(project(":spi:control-plane:control-plane-api-client-spi"))
+
     implementation(project(":core:data-plane:data-plane-util"))
     implementation(project(":core:common:util"))
 

--- a/core/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneDefaultServicesExtension.java
+++ b/core/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneDefaultServicesExtension.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2020, 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.dataplane.framework;
+
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provider;
+import org.eclipse.dataspaceconnector.spi.controlplane.api.client.transferprocess.NoopTransferProcessClient;
+import org.eclipse.dataspaceconnector.spi.controlplane.api.client.transferprocess.TransferProcessApiClient;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
+
+@Extension(value = DataPlaneDefaultServicesExtension.NAME)
+public class DataPlaneDefaultServicesExtension implements ServiceExtension {
+
+    public static final String NAME = "Data Plane Framework Default Services";
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+
+    @Provider(isDefault = true)
+    public TransferProcessApiClient transferProcessApiClient() {
+        return new NoopTransferProcessClient();
+    }
+}

--- a/core/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneFrameworkExtension.java
+++ b/core/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneFrameworkExtension.java
@@ -30,6 +30,7 @@ import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Extension;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provides;
 import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
+import org.eclipse.dataspaceconnector.spi.controlplane.api.client.transferprocess.TransferProcessApiClient;
 import org.eclipse.dataspaceconnector.spi.system.ExecutorInstrumentation;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
@@ -67,6 +68,9 @@ public class DataPlaneFrameworkExtension implements ServiceExtension {
 
     @Inject(required = false)
     private DataPlaneStore store;
+
+    @Inject
+    private TransferProcessApiClient transferProcessApiClient;
 
     @Inject
     private ExecutorInstrumentation executorInstrumentation;
@@ -110,6 +114,7 @@ public class DataPlaneFrameworkExtension implements ServiceExtension {
                 .pipelineService(pipelineService)
                 .transferServiceRegistry(transferServiceRegistry)
                 .store(registerStore(context))
+                .transferProcessClient(transferProcessApiClient)
                 .monitor(monitor)
                 .telemetry(telemetry)
                 .build();
@@ -128,7 +133,7 @@ public class DataPlaneFrameworkExtension implements ServiceExtension {
             dataPlaneManager.forceStop();
         }
     }
-
+    
     @NotNull
     private DataPlaneStore registerStore(ServiceExtensionContext context) {
         var monitor = context.getMonitor();

--- a/core/data-plane/data-plane-framework/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
+++ b/core/data-plane/data-plane-framework/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
@@ -1,1 +1,2 @@
 org.eclipse.dataspaceconnector.dataplane.framework.DataPlaneFrameworkExtension
+org.eclipse.dataspaceconnector.dataplane.framework.DataPlaneDefaultServicesExtension

--- a/core/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneFrameworkExtensionTest.java
+++ b/core/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneFrameworkExtensionTest.java
@@ -21,6 +21,8 @@ import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.PipelineService;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.TransferService;
 import org.eclipse.dataspaceconnector.dataplane.spi.registry.TransferServiceRegistry;
 import org.eclipse.dataspaceconnector.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.dataspaceconnector.spi.controlplane.api.client.transferprocess.NoopTransferProcessClient;
+import org.eclipse.dataspaceconnector.spi.controlplane.api.client.transferprocess.TransferProcessApiClient;
 import org.eclipse.dataspaceconnector.spi.system.ExecutorInstrumentation;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.system.injection.ObjectFactory;
@@ -48,6 +50,7 @@ class DataPlaneFrameworkExtensionTest {
         when(transferService1.canHandle(request)).thenReturn(true);
         when(transferService2.canHandle(request)).thenReturn(true);
         context.registerService(ExecutorInstrumentation.class, ExecutorInstrumentation.noop());
+        context.registerService(TransferProcessApiClient.class, new NoopTransferProcessClient());
     }
 
     @Test

--- a/core/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/e2e/EndToEndTest.java
+++ b/core/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/e2e/EndToEndTest.java
@@ -20,6 +20,7 @@ import org.eclipse.dataspaceconnector.dataplane.framework.pipeline.PipelineServi
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSink;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSinkFactory;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.InputStreamDataSource;
+import org.eclipse.dataspaceconnector.spi.controlplane.api.client.transferprocess.NoopTransferProcessClient;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.system.ExecutorInstrumentation;
@@ -36,6 +37,14 @@ import static org.mockito.Mockito.mock;
 
 public class EndToEndTest {
 
+    public static DataFlowRequest.Builder createRequest(String type) {
+        return DataFlowRequest.Builder.newInstance()
+                .id("1")
+                .processId("1")
+                .sourceDataAddress(DataAddress.Builder.newInstance().type(type).build())
+                .destinationDataAddress(DataAddress.Builder.newInstance().type(type).build());
+    }
+
     @Test
     void testEndToEnd() throws Exception {
         var monitor = mock(Monitor.class);
@@ -48,6 +57,7 @@ public class EndToEndTest {
                 .monitor(monitor)
                 .pipelineService(pipelineService)
                 .executorInstrumentation(ExecutorInstrumentation.noop())
+                .transferProcessClient(new NoopTransferProcessClient())
                 .build();
         manager.start();
         manager.transfer(new InputStreamDataSource("test", new ByteArrayInputStream("bytes".getBytes())), createRequest("1").build()).get();
@@ -80,14 +90,6 @@ public class EndToEndTest {
         public DataSink createSink(DataFlowRequest request) {
             return sink;
         }
-    }
-
-    public static DataFlowRequest.Builder createRequest(String type) {
-        return DataFlowRequest.Builder.newInstance()
-                .id("1")
-                .processId("1")
-                .sourceDataAddress(DataAddress.Builder.newInstance().type(type).build())
-                .destinationDataAddress(DataAddress.Builder.newInstance().type(type).build());
     }
 
 }

--- a/core/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/manager/DataPlaneManagerImplTest.java
+++ b/core/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/manager/DataPlaneManagerImplTest.java
@@ -18,6 +18,7 @@ import org.eclipse.dataspaceconnector.dataplane.framework.store.InMemoryDataPlan
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.TransferService;
 import org.eclipse.dataspaceconnector.dataplane.spi.registry.TransferServiceRegistry;
 import org.eclipse.dataspaceconnector.dataplane.spi.store.DataPlaneStore;
+import org.eclipse.dataspaceconnector.spi.controlplane.api.client.transferprocess.NoopTransferProcessClient;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.system.ExecutorInstrumentation;
@@ -121,6 +122,15 @@ class DataPlaneManagerImplTest {
         });
     }
 
+    DataFlowRequest createRequest() {
+        return DataFlowRequest.Builder.newInstance()
+                .id("1")
+                .processId("1")
+                .sourceDataAddress(DataAddress.Builder.newInstance().type("type").build())
+                .destinationDataAddress(DataAddress.Builder.newInstance().type("type").build())
+                .build();
+    }
+
     private DataPlaneManagerImpl createDataPlaneManager() {
         return DataPlaneManagerImpl.Builder.newInstance()
                 .queueCapacity(100)
@@ -129,16 +139,8 @@ class DataPlaneManagerImplTest {
                 .waitTimeout(10)
                 .transferServiceRegistry(registry)
                 .store(store)
+                .transferProcessClient(new NoopTransferProcessClient())
                 .monitor(mock(Monitor.class))
-                .build();
-    }
-
-    DataFlowRequest createRequest() {
-        return DataFlowRequest.Builder.newInstance()
-                .id("1")
-                .processId("1")
-                .sourceDataAddress(DataAddress.Builder.newInstance().type("type").build())
-                .destinationDataAddress(DataAddress.Builder.newInstance().type("type").build())
                 .build();
     }
 

--- a/docs/swaggerui/swagger-spec.js
+++ b/docs/swaggerui/swagger-spec.js
@@ -20,192 +20,12 @@ window.swaggerSpec={
     "description" : "The public API of the Data Plane is a data proxy enabling a data consumer to actively querydata from the provider data source (e.g. backend Rest API, internal database...) through its Data Planeinstance. Thus the Data Plane is the only entry/output door for the data, which avoids the provider to exposedirectly its data externally.The Data Plane public API being a proxy, it supports all verbs (i.e. GET, POST, PUT, PATCH, DELETE), whichcan then conveyed until the data source is required. This is especially useful when the actual data sourceis a Rest API itself.In the same manner, any set of arbitrary query parameters, path parameters and request body are supported (in the limits fixed by the HTTP server) and can also conveyed to the actual data source."
   } ],
   "paths" : {
-    "/contractdefinitions" : {
-      "get" : {
-        "tags" : [ "Contract Definition" ],
-        "description" : "Returns all contract definitions according to a query",
-        "operationId" : "getAllContractDefinitions",
-        "parameters" : [ {
-          "name" : "offset",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int32"
-          }
-        }, {
-          "name" : "limit",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int32"
-          }
-        }, {
-          "name" : "filter",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "sort",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "ASC", "DESC" ]
-          }
-        }, {
-          "name" : "sortField",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ContractDefinitionResponseDto"
-                  }
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request was malformed",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "deprecated" : true
-      },
+    "/callback/{processId}/deprovision" : {
       "post" : {
-        "tags" : [ "Contract Definition" ],
-        "description" : "Creates a new contract definition",
-        "operationId" : "createContractDefinition",
-        "requestBody" : {
-          "content" : {
-            "*/*" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/ContractDefinitionRequestDto"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "200" : {
-            "description" : "contract definition was created successfully. Returns the Contract Definition Id and created timestamp",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/IdResponseDto"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request body was malformed",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Could not create contract definition, because a contract definition with that ID already exists",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/contractdefinitions/request" : {
-      "post" : {
-        "tags" : [ "Contract Definition" ],
-        "description" : "Returns all contract definitions according to a query",
-        "operationId" : "queryAllContractDefinitions",
-        "requestBody" : {
-          "content" : {
-            "*/*" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/QuerySpecDto"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ContractDefinitionResponseDto"
-                  }
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request was malformed",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/contractdefinitions/{id}" : {
-      "get" : {
-        "tags" : [ "Contract Definition" ],
-        "description" : "Gets an contract definition with the given ID",
-        "operationId" : "getContractDefinition",
+        "tags" : [ "HTTP Provisioner Webhook" ],
+        "operationId" : "callDeprovisionWebhook",
         "parameters" : [ {
-          "name" : "id",
+          "name" : "processId",
           "in" : "path",
           "required" : true,
           "style" : "simple",
@@ -214,51 +34,31 @@ window.swaggerSpec={
             "type" : "string"
           }
         } ],
-        "responses" : {
-          "200" : {
-            "description" : "The contract definition",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ContractDefinitionResponseDto"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request was malformed, e.g. id was null",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "An contract agreement with the given ID does not exist",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/DeprovisionedResource"
               }
             }
           }
+        },
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "application/json" : { }
+            }
+          }
         }
-      },
-      "delete" : {
-        "tags" : [ "Contract Definition" ],
-        "description" : "Removes a contract definition with the given ID if possible. DANGER ZONE: Note that deleting contract definitions can have unexpected results, especially for contract offers that have been sent out or ongoing or contract negotiations.",
-        "operationId" : "deleteContractDefinition",
+      }
+    },
+    "/callback/{processId}/provision" : {
+      "post" : {
+        "tags" : [ "HTTP Provisioner Webhook" ],
+        "operationId" : "callProvisionWebhook",
         "parameters" : [ {
-          "name" : "id",
+          "name" : "processId",
           "in" : "path",
           "required" : true,
           "style" : "simple",
@@ -267,34 +67,20 @@ window.swaggerSpec={
             "type" : "string"
           }
         } ],
-        "responses" : {
-          "200" : {
-            "description" : "Contract definition was deleted successfully"
-          },
-          "400" : {
-            "description" : "Request was malformed, e.g. id was null",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ProvisionerWebhookRequest"
               }
             }
-          },
-          "404" : {
-            "description" : "A contract definition with the given ID does not exist",
+          }
+        },
+        "responses" : {
+          "default" : {
+            "description" : "default response",
             "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
+              "application/json" : { }
             }
           }
         }
@@ -401,369 +187,6 @@ window.swaggerSpec={
                 }
               }
             }
-          }
-        }
-      }
-    },
-    "/check/health" : {
-      "get" : {
-        "tags" : [ "Application Observability" ],
-        "description" : "Performs a liveness probe to determine whether the runtime is working properly.",
-        "operationId" : "checkHealth",
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/HealthStatus"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/check/liveness" : {
-      "get" : {
-        "tags" : [ "Application Observability" ],
-        "description" : "Performs a liveness probe to determine whether the runtime is working properly.",
-        "operationId" : "getLiveness",
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/HealthStatus"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/check/readiness" : {
-      "get" : {
-        "tags" : [ "Application Observability" ],
-        "description" : "Performs a readiness probe to determine whether the runtime is able to accept requests.",
-        "operationId" : "getReadiness",
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/HealthStatus"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/check/startup" : {
-      "get" : {
-        "tags" : [ "Application Observability" ],
-        "description" : "Performs a startup probe to determine whether the runtime has completed startup.",
-        "operationId" : "getStartup",
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/HealthStatus"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/contractagreements" : {
-      "get" : {
-        "tags" : [ "Contract Agreement" ],
-        "description" : "Gets all contract agreements according to a particular query",
-        "operationId" : "getAllAgreements",
-        "parameters" : [ {
-          "name" : "offset",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int32"
-          }
-        }, {
-          "name" : "limit",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int32"
-          }
-        }, {
-          "name" : "filter",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "sort",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "ASC", "DESC" ]
-          }
-        }, {
-          "name" : "sortField",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ContractAgreementDto"
-                  }
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request body was malformed",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "deprecated" : true
-      }
-    },
-    "/contractagreements/request" : {
-      "post" : {
-        "tags" : [ "Contract Agreement" ],
-        "description" : "Gets all contract agreements according to a particular query",
-        "operationId" : "queryAllAgreements",
-        "requestBody" : {
-          "content" : {
-            "*/*" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/QuerySpecDto"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ContractAgreementDto"
-                  }
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request body was malformed",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/contractagreements/{id}" : {
-      "get" : {
-        "tags" : [ "Contract Agreement" ],
-        "description" : "Gets an contract agreement with the given ID",
-        "operationId" : "getContractAgreement",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "The contract agreement",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ContractAgreementDto"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request was malformed, e.g. id was null",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "An contract agreement with the given ID does not exist",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/instances" : {
-      "get" : {
-        "tags" : [ "Dataplane Selector" ],
-        "operationId" : "getAll",
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/DataPlaneInstance"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "post" : {
-        "tags" : [ "Dataplane Selector" ],
-        "operationId" : "addEntry",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/DataPlaneInstance"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "application/json" : { }
-            }
-          }
-        }
-      }
-    },
-    "/instances/select" : {
-      "post" : {
-        "tags" : [ "Dataplane Selector" ],
-        "operationId" : "find",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/SelectionRequest"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/DataPlaneInstance"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/token" : {
-      "get" : {
-        "tags" : [ "Token Validation" ],
-        "description" : "Checks that the provided token has been signed by the present entity and asserts its validity. If token is valid, then the data address contained in its claims is decrypted and returned back to the caller.",
-        "operationId" : "validate",
-        "parameters" : [ {
-          "name" : "Authorization",
-          "in" : "header",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Token is valid"
-          },
-          "400" : {
-            "description" : "Request was malformed"
-          },
-          "403" : {
-            "description" : "Token is invalid"
           }
         }
       }
@@ -1061,25 +484,14 @@ window.swaggerSpec={
         }
       }
     },
-    "/callback/{processId}/deprovision" : {
+    "/federatedcatalog" : {
       "post" : {
-        "tags" : [ "HTTP Provisioner Webhook" ],
-        "operationId" : "callDeprovisionWebhook",
-        "parameters" : [ {
-          "name" : "processId",
-          "in" : "path",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
+        "operationId" : "getCachedCatalog",
         "requestBody" : {
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/DeprovisionedResource"
+                "$ref" : "#/components/schemas/FederatedCatalogCacheQuery"
               }
             }
           }
@@ -1088,40 +500,14 @@ window.swaggerSpec={
           "default" : {
             "description" : "default response",
             "content" : {
-              "application/json" : { }
-            }
-          }
-        }
-      }
-    },
-    "/callback/{processId}/provision" : {
-      "post" : {
-        "tags" : [ "HTTP Provisioner Webhook" ],
-        "operationId" : "callProvisionWebhook",
-        "parameters" : [ {
-          "name" : "processId",
-          "in" : "path",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/ProvisionerWebhookRequest"
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ContractOffer"
+                  }
+                }
               }
-            }
-          }
-        },
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "application/json" : { }
             }
           }
         }
@@ -1251,6 +637,468 @@ window.swaggerSpec={
           },
           "500" : {
             "description" : "Failed to transfer data"
+          }
+        }
+      }
+    },
+    "/contractagreements" : {
+      "get" : {
+        "tags" : [ "Contract Agreement" ],
+        "description" : "Gets all contract agreements according to a particular query",
+        "operationId" : "getAllAgreements",
+        "parameters" : [ {
+          "name" : "offset",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "filter",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "sort",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "ASC", "DESC" ]
+          }
+        }, {
+          "name" : "sortField",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ContractAgreementDto"
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request body was malformed",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated" : true
+      }
+    },
+    "/contractagreements/request" : {
+      "post" : {
+        "tags" : [ "Contract Agreement" ],
+        "description" : "Gets all contract agreements according to a particular query",
+        "operationId" : "queryAllAgreements",
+        "requestBody" : {
+          "content" : {
+            "*/*" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/QuerySpecDto"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ContractAgreementDto"
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request body was malformed",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/contractagreements/{id}" : {
+      "get" : {
+        "tags" : [ "Contract Agreement" ],
+        "description" : "Gets an contract agreement with the given ID",
+        "operationId" : "getContractAgreement",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The contract agreement",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ContractAgreementDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request was malformed, e.g. id was null",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "An contract agreement with the given ID does not exist",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/contractdefinitions" : {
+      "get" : {
+        "tags" : [ "Contract Definition" ],
+        "description" : "Returns all contract definitions according to a query",
+        "operationId" : "getAllContractDefinitions",
+        "parameters" : [ {
+          "name" : "offset",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "filter",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "sort",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "ASC", "DESC" ]
+          }
+        }, {
+          "name" : "sortField",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ContractDefinitionResponseDto"
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request was malformed",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated" : true
+      },
+      "post" : {
+        "tags" : [ "Contract Definition" ],
+        "description" : "Creates a new contract definition",
+        "operationId" : "createContractDefinition",
+        "requestBody" : {
+          "content" : {
+            "*/*" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ContractDefinitionRequestDto"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "contract definition was created successfully. Returns the Contract Definition Id and created timestamp",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/IdResponseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request body was malformed",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Could not create contract definition, because a contract definition with that ID already exists",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/contractdefinitions/request" : {
+      "post" : {
+        "tags" : [ "Contract Definition" ],
+        "description" : "Returns all contract definitions according to a query",
+        "operationId" : "queryAllContractDefinitions",
+        "requestBody" : {
+          "content" : {
+            "*/*" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/QuerySpecDto"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ContractDefinitionResponseDto"
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request was malformed",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/contractdefinitions/{id}" : {
+      "get" : {
+        "tags" : [ "Contract Definition" ],
+        "description" : "Gets an contract definition with the given ID",
+        "operationId" : "getContractDefinition",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The contract definition",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ContractDefinitionResponseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request was malformed, e.g. id was null",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "An contract agreement with the given ID does not exist",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "Contract Definition" ],
+        "description" : "Removes a contract definition with the given ID if possible. DANGER ZONE: Note that deleting contract definitions can have unexpected results, especially for contract offers that have been sent out or ongoing or contract negotiations.",
+        "operationId" : "deleteContractDefinition",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Contract definition was deleted successfully"
+          },
+          "400" : {
+            "description" : "Request was malformed, e.g. id was null",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "A contract definition with the given ID does not exist",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -1544,6 +1392,651 @@ window.swaggerSpec={
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/transferprocess/{processId}/complete" : {
+      "post" : {
+        "tags" : [ "Transfer Process Control Api" ],
+        "description" : "Requests completion of the transfer process. Due to the asynchronous nature of transfers, a successful response only indicates that the request was successfully received",
+        "operationId" : "complete",
+        "parameters" : [ {
+          "name" : "processId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Request was malformed, e.g. id was null",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/transferprocess/{processId}/fail" : {
+      "post" : {
+        "tags" : [ "Transfer Process Control Api" ],
+        "description" : "Requests completion of the transfer process. Due to the asynchronous nature of transfers, a successful response only indicates that the request was successfully received",
+        "operationId" : "fail",
+        "parameters" : [ {
+          "name" : "processId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/TransferProcessFailStateDto"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "400" : {
+            "description" : "Request was malformed, e.g. id was null",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/instances" : {
+      "get" : {
+        "tags" : [ "Dataplane Selector" ],
+        "operationId" : "getAll",
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/DataPlaneInstance"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "Dataplane Selector" ],
+        "operationId" : "addEntry",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/DataPlaneInstance"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "application/json" : { }
+            }
+          }
+        }
+      }
+    },
+    "/instances/select" : {
+      "post" : {
+        "tags" : [ "Dataplane Selector" ],
+        "operationId" : "find",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SelectionRequest"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/DataPlaneInstance"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/check/health" : {
+      "get" : {
+        "tags" : [ "Application Observability" ],
+        "description" : "Performs a liveness probe to determine whether the runtime is working properly.",
+        "operationId" : "checkHealth",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/HealthStatus"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/check/liveness" : {
+      "get" : {
+        "tags" : [ "Application Observability" ],
+        "description" : "Performs a liveness probe to determine whether the runtime is working properly.",
+        "operationId" : "getLiveness",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/HealthStatus"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/check/readiness" : {
+      "get" : {
+        "tags" : [ "Application Observability" ],
+        "description" : "Performs a readiness probe to determine whether the runtime is able to accept requests.",
+        "operationId" : "getReadiness",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/HealthStatus"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/check/startup" : {
+      "get" : {
+        "tags" : [ "Application Observability" ],
+        "description" : "Performs a startup probe to determine whether the runtime has completed startup.",
+        "operationId" : "getStartup",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/HealthStatus"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/transferprocess" : {
+      "get" : {
+        "tags" : [ "Transfer Process" ],
+        "description" : "Returns all transfer process according to a query",
+        "operationId" : "getAllTransferProcesses",
+        "parameters" : [ {
+          "name" : "offset",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "filter",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "sort",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "ASC", "DESC" ]
+          }
+        }, {
+          "name" : "sortField",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/TransferProcessDto"
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request was malformed",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated" : true
+      },
+      "post" : {
+        "tags" : [ "Transfer Process" ],
+        "description" : "Initiates a data transfer with the given parameters. Please note that successfully invoking this endpoint only means that the transfer was initiated. Clients must poll the /{id}/state endpoint to track the state",
+        "operationId" : "initiateTransfer",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/TransferRequestDto"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "The transfer was successfully initiated. Returns the transfer process ID and created timestamp",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/IdResponseDto"
+                }
+              }
+            },
+            "links" : {
+              "poll-state" : {
+                "operationId" : "getTransferProcessState",
+                "parameters" : {
+                  "id" : "$response.body#/id"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request body was malformed",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/transferprocess/request" : {
+      "post" : {
+        "tags" : [ "Transfer Process" ],
+        "description" : "Returns all transfer process according to a query",
+        "operationId" : "queryAllTransferProcesses",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/QuerySpecDto"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/TransferProcessDto"
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request was malformed",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/transferprocess/{id}" : {
+      "get" : {
+        "tags" : [ "Transfer Process" ],
+        "description" : "Gets an transfer process with the given ID",
+        "operationId" : "getTransferProcess",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The transfer process",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/TransferProcessDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request was malformed, e.g. id was null",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "A transfer process with the given ID does not exist",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/transferprocess/{id}/cancel" : {
+      "post" : {
+        "tags" : [ "Transfer Process" ],
+        "description" : "Requests aborting the transfer process. Due to the asynchronous nature of transfers, a successful response only indicates that the request was successfully received. Clients must poll the /{id}/state endpoint to track the state.",
+        "operationId" : "cancelTransferProcess",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Request to cancel the transfer process was successfully received",
+            "links" : {
+              "poll-state" : {
+                "operationId" : "getTransferProcessState"
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request was malformed, e.g. id was null",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "A contract negotiation with the given ID does not exist",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/transferprocess/{id}/deprovision" : {
+      "post" : {
+        "tags" : [ "Transfer Process" ],
+        "description" : "Requests the deprovisioning of resources associated with a transfer process. Due to the asynchronous nature of transfers, a successful response only indicates that the request was successfully received. This may take a long time, so clients must poll the /{id}/state endpoint to track the state.",
+        "operationId" : "deprovisionTransferProcess",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Request to deprovision the transfer process was successfully received",
+            "links" : {
+              "poll-state" : {
+                "operationId" : "getTransferProcessState"
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request was malformed, e.g. id was null",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "A contract negotiation with the given ID does not exist",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/transferprocess/{id}/state" : {
+      "get" : {
+        "tags" : [ "Transfer Process" ],
+        "description" : "Gets the state of a transfer process with the given ID",
+        "operationId" : "getTransferProcessState",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The  transfer process's state",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/TransferState"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Request was malformed, e.g. id was null",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "An  transfer process with the given ID does not exist",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiErrorDetail"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/token" : {
+      "get" : {
+        "tags" : [ "Token Validation" ],
+        "description" : "Checks that the provided token has been signed by the present entity and asserts its validity. If token is valid, then the data address contained in its claims is decrypted and returned back to the caller.",
+        "operationId" : "validate",
+        "parameters" : [ {
+          "name" : "Authorization",
+          "in" : "header",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Token is valid"
+          },
+          "400" : {
+            "description" : "Request was malformed"
+          },
+          "403" : {
+            "description" : "Token is invalid"
           }
         }
       }
@@ -1992,425 +2485,6 @@ window.swaggerSpec={
           }
         }
       }
-    },
-    "/federatedcatalog" : {
-      "post" : {
-        "operationId" : "getCachedCatalog",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/FederatedCatalogCacheQuery"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ContractOffer"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/transferprocess" : {
-      "get" : {
-        "tags" : [ "Transfer Process" ],
-        "description" : "Returns all transfer process according to a query",
-        "operationId" : "getAllTransferProcesses",
-        "parameters" : [ {
-          "name" : "offset",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int32"
-          }
-        }, {
-          "name" : "limit",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int32"
-          }
-        }, {
-          "name" : "filter",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "sort",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "ASC", "DESC" ]
-          }
-        }, {
-          "name" : "sortField",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/TransferProcessDto"
-                  }
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request was malformed",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "deprecated" : true
-      },
-      "post" : {
-        "tags" : [ "Transfer Process" ],
-        "description" : "Initiates a data transfer with the given parameters. Please note that successfully invoking this endpoint only means that the transfer was initiated. Clients must poll the /{id}/state endpoint to track the state",
-        "operationId" : "initiateTransfer",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/TransferRequestDto"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "200" : {
-            "description" : "The transfer was successfully initiated. Returns the transfer process ID and created timestamp",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/IdResponseDto"
-                }
-              }
-            },
-            "links" : {
-              "poll-state" : {
-                "operationId" : "getTransferProcessState",
-                "parameters" : {
-                  "id" : "$response.body#/id"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request body was malformed",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/transferprocess/request" : {
-      "post" : {
-        "tags" : [ "Transfer Process" ],
-        "description" : "Returns all transfer process according to a query",
-        "operationId" : "queryAllTransferProcesses",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/QuerySpecDto"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/TransferProcessDto"
-                  }
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request was malformed",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/transferprocess/{id}" : {
-      "get" : {
-        "tags" : [ "Transfer Process" ],
-        "description" : "Gets an transfer process with the given ID",
-        "operationId" : "getTransferProcess",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "The transfer process",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/TransferProcessDto"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request was malformed, e.g. id was null",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "A transfer process with the given ID does not exist",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/transferprocess/{id}/cancel" : {
-      "post" : {
-        "tags" : [ "Transfer Process" ],
-        "description" : "Requests aborting the transfer process. Due to the asynchronous nature of transfers, a successful response only indicates that the request was successfully received. Clients must poll the /{id}/state endpoint to track the state.",
-        "operationId" : "cancelTransferProcess",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Request to cancel the transfer process was successfully received",
-            "links" : {
-              "poll-state" : {
-                "operationId" : "getTransferProcessState"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request was malformed, e.g. id was null",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "A contract negotiation with the given ID does not exist",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/transferprocess/{id}/deprovision" : {
-      "post" : {
-        "tags" : [ "Transfer Process" ],
-        "description" : "Requests the deprovisioning of resources associated with a transfer process. Due to the asynchronous nature of transfers, a successful response only indicates that the request was successfully received. This may take a long time, so clients must poll the /{id}/state endpoint to track the state.",
-        "operationId" : "deprovisionTransferProcess",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Request to deprovision the transfer process was successfully received",
-            "links" : {
-              "poll-state" : {
-                "operationId" : "getTransferProcessState"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request was malformed, e.g. id was null",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "A contract negotiation with the given ID does not exist",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/transferprocess/{id}/state" : {
-      "get" : {
-        "tags" : [ "Transfer Process" ],
-        "description" : "Gets the state of a transfer process with the given ID",
-        "operationId" : "getTransferProcessState",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "required" : true,
-          "style" : "simple",
-          "explode" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "The  transfer process's state",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/TransferState"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Request was malformed, e.g. id was null",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "An  transfer process with the given ID does not exist",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ApiErrorDetail"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
     }
   },
   "components" : {
@@ -2779,6 +2853,10 @@ window.swaggerSpec={
       "DataFlowRequest" : {
         "type" : "object",
         "properties" : {
+          "callbackAddress" : {
+            "type" : "string",
+            "format" : "url"
+          },
           "destinationDataAddress" : {
             "$ref" : "#/components/schemas/DataAddress"
           },
@@ -3218,6 +3296,15 @@ window.swaggerSpec={
           "updatedAt" : {
             "type" : "integer",
             "format" : "int64"
+          }
+        }
+      },
+      "TransferProcessFailStateDto" : {
+        "required" : [ "errorMessage" ],
+        "type" : "object",
+        "properties" : {
+          "errorMessage" : {
+            "type" : "string"
           }
         }
       },

--- a/extensions/control-plane/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/DataPlaneTransferClientExtension.java
+++ b/extensions/control-plane/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/DataPlaneTransferClientExtension.java
@@ -24,6 +24,7 @@ import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Setting;
 import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.transfer.callback.ControlPlaneApiUrl;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowManager;
 import org.eclipse.dataspaceconnector.transfer.dataplane.client.EmbeddedDataPlaneTransferClient;
 import org.eclipse.dataspaceconnector.transfer.dataplane.client.RemoteDataPlaneTransferClient;
@@ -61,6 +62,9 @@ public class DataPlaneTransferClientExtension implements ServiceExtension {
     @Inject
     private DataFlowManager flowManager;
 
+    @Inject(required = false)
+    private ControlPlaneApiUrl callbackUrl;
+
     @Override
     public String name() {
         return NAME;
@@ -84,7 +88,7 @@ public class DataPlaneTransferClientExtension implements ServiceExtension {
             monitor.debug(() -> format("Using remote Data Plane with selectionStratey=%s.", selectionStrategy));
         }
 
-        var flowController = new DataPlaneTransferFlowController(client);
+        var flowController = new DataPlaneTransferFlowController(client, callbackUrl);
         flowManager.register(flowController);
     }
 }

--- a/extensions/control-plane/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/flow/DataPlaneTransferFlowController.java
+++ b/extensions/control-plane/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/flow/DataPlaneTransferFlowController.java
@@ -18,6 +18,7 @@ import org.eclipse.dataspaceconnector.common.string.StringUtils;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
 import org.eclipse.dataspaceconnector.spi.response.StatusResult;
+import org.eclipse.dataspaceconnector.spi.transfer.callback.ControlPlaneApiUrl;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowController;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
@@ -38,9 +39,11 @@ import static org.eclipse.dataspaceconnector.transfer.dataplane.spi.DataPlaneTra
  */
 public class DataPlaneTransferFlowController implements DataFlowController {
     private final DataPlaneTransferClient client;
+    private final ControlPlaneApiUrl callbackUrl;
 
-    public DataPlaneTransferFlowController(DataPlaneTransferClient client) {
+    public DataPlaneTransferFlowController(DataPlaneTransferClient client, ControlPlaneApiUrl callbackUrl) {
         this.client = client;
+        this.callbackUrl = callbackUrl;
     }
 
     @Override
@@ -71,6 +74,7 @@ public class DataPlaneTransferFlowController implements DataFlowController {
                 .sourceDataAddress(sourceAddress)
                 .destinationType(dataRequest.getDestinationType())
                 .destinationDataAddress(dataRequest.getDataDestination())
+                .callbackAddress(callbackUrl != null ? callbackUrl.get() : null)
                 .properties(dataRequest.getProperties())
                 .build();
     }

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -25,204 +25,52 @@ tags:
     \ path parameters and request body are supported (in the limits fixed by the HTTP\
     \ server) and can also conveyed to the actual data source."
 paths:
-  /contractdefinitions:
-    get:
-      tags:
-      - Contract Definition
-      description: Returns all contract definitions according to a query
-      operationId: getAllContractDefinitions
-      parameters:
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ContractDefinitionResponseDto'
-        "400":
-          description: Request was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-      deprecated: true
+  /callback/{processId}/deprovision:
     post:
       tags:
-      - Contract Definition
-      description: Creates a new contract definition
-      operationId: createContractDefinition
-      requestBody:
-        content:
-          '*/*':
-            schema:
-              $ref: '#/components/schemas/ContractDefinitionRequestDto'
-      responses:
-        "200":
-          description: contract definition was created successfully. Returns the Contract
-            Definition Id and created timestamp
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IdResponseDto'
-        "400":
-          description: Request body was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "409":
-          description: "Could not create contract definition, because a contract definition\
-            \ with that ID already exists"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /contractdefinitions/request:
-    post:
-      tags:
-      - Contract Definition
-      description: Returns all contract definitions according to a query
-      operationId: queryAllContractDefinitions
-      requestBody:
-        content:
-          '*/*':
-            schema:
-              $ref: '#/components/schemas/QuerySpecDto'
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ContractDefinitionResponseDto'
-        "400":
-          description: Request was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /contractdefinitions/{id}:
-    get:
-      tags:
-      - Contract Definition
-      description: Gets an contract definition with the given ID
-      operationId: getContractDefinition
+      - HTTP Provisioner Webhook
+      operationId: callDeprovisionWebhook
       parameters:
-      - name: id
+      - name: processId
         in: path
         required: true
         style: simple
         explode: false
         schema:
           type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeprovisionedResource'
       responses:
-        "200":
-          description: The contract definition
+        default:
+          description: default response
           content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ContractDefinitionResponseDto'
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: An contract agreement with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-    delete:
+            application/json: {}
+  /callback/{processId}/provision:
+    post:
       tags:
-      - Contract Definition
-      description: "Removes a contract definition with the given ID if possible. DANGER\
-        \ ZONE: Note that deleting contract definitions can have unexpected results,\
-        \ especially for contract offers that have been sent out or ongoing or contract\
-        \ negotiations."
-      operationId: deleteContractDefinition
+      - HTTP Provisioner Webhook
+      operationId: callProvisionWebhook
       parameters:
-      - name: id
+      - name: processId
         in: path
         required: true
         style: simple
         explode: false
         schema:
           type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProvisionerWebhookRequest'
       responses:
-        "200":
-          description: Contract definition was deleted successfully
-        "400":
-          description: "Request was malformed, e.g. id was null"
+        default:
+          description: default response
           content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: A contract definition with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
+            application/json: {}
   /catalog:
     get:
       tags:
@@ -302,262 +150,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Catalog'
-  /check/health:
-    get:
-      tags:
-      - Application Observability
-      description: Performs a liveness probe to determine whether the runtime is working
-        properly.
-      operationId: checkHealth
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/HealthStatus'
-  /check/liveness:
-    get:
-      tags:
-      - Application Observability
-      description: Performs a liveness probe to determine whether the runtime is working
-        properly.
-      operationId: getLiveness
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/HealthStatus'
-  /check/readiness:
-    get:
-      tags:
-      - Application Observability
-      description: Performs a readiness probe to determine whether the runtime is
-        able to accept requests.
-      operationId: getReadiness
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/HealthStatus'
-  /check/startup:
-    get:
-      tags:
-      - Application Observability
-      description: Performs a startup probe to determine whether the runtime has completed
-        startup.
-      operationId: getStartup
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/HealthStatus'
-  /contractagreements:
-    get:
-      tags:
-      - Contract Agreement
-      description: Gets all contract agreements according to a particular query
-      operationId: getAllAgreements
-      parameters:
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ContractAgreementDto'
-        "400":
-          description: Request body was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-      deprecated: true
-  /contractagreements/request:
-    post:
-      tags:
-      - Contract Agreement
-      description: Gets all contract agreements according to a particular query
-      operationId: queryAllAgreements
-      requestBody:
-        content:
-          '*/*':
-            schema:
-              $ref: '#/components/schemas/QuerySpecDto'
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ContractAgreementDto'
-        "400":
-          description: Request body was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /contractagreements/{id}:
-    get:
-      tags:
-      - Contract Agreement
-      description: Gets an contract agreement with the given ID
-      operationId: getContractAgreement
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: The contract agreement
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ContractAgreementDto'
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: An contract agreement with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /instances:
-    get:
-      tags:
-      - Dataplane Selector
-      operationId: getAll
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/DataPlaneInstance'
-    post:
-      tags:
-      - Dataplane Selector
-      operationId: addEntry
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DataPlaneInstance'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /instances/select:
-    post:
-      tags:
-      - Dataplane Selector
-      operationId: find
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SelectionRequest'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DataPlaneInstance'
-  /token:
-    get:
-      tags:
-      - Token Validation
-      description: "Checks that the provided token has been signed by the present\
-        \ entity and asserts its validity. If token is valid, then the data address\
-        \ contained in its claims is decrypted and returned back to the caller."
-      operationId: validate
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: Token is valid
-        "400":
-          description: Request was malformed
-        "403":
-          description: Token is invalid
   /policydefinitions:
     get:
       tags:
@@ -766,52 +358,23 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
-  /callback/{processId}/deprovision:
+  /federatedcatalog:
     post:
-      tags:
-      - HTTP Provisioner Webhook
-      operationId: callDeprovisionWebhook
-      parameters:
-      - name: processId
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
+      operationId: getCachedCatalog
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeprovisionedResource'
+              $ref: '#/components/schemas/FederatedCatalogCacheQuery'
       responses:
         default:
           description: default response
           content:
-            application/json: {}
-  /callback/{processId}/provision:
-    post:
-      tags:
-      - HTTP Provisioner Webhook
-      operationId: callProvisionWebhook
-      parameters:
-      - name: processId
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ProvisionerWebhookRequest'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractOffer'
   /transfer:
     post:
       tags:
@@ -907,6 +470,332 @@ paths:
           description: Access token is expired or invalid
         "500":
           description: Failed to transfer data
+  /contractagreements:
+    get:
+      tags:
+      - Contract Agreement
+      description: Gets all contract agreements according to a particular query
+      operationId: getAllAgreements
+      parameters:
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractAgreementDto'
+        "400":
+          description: Request body was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+      deprecated: true
+  /contractagreements/request:
+    post:
+      tags:
+      - Contract Agreement
+      description: Gets all contract agreements according to a particular query
+      operationId: queryAllAgreements
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/QuerySpecDto'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractAgreementDto'
+        "400":
+          description: Request body was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /contractagreements/{id}:
+    get:
+      tags:
+      - Contract Agreement
+      description: Gets an contract agreement with the given ID
+      operationId: getContractAgreement
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: The contract agreement
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContractAgreementDto'
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: An contract agreement with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /contractdefinitions:
+    get:
+      tags:
+      - Contract Definition
+      description: Returns all contract definitions according to a query
+      operationId: getAllContractDefinitions
+      parameters:
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractDefinitionResponseDto'
+        "400":
+          description: Request was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+      deprecated: true
+    post:
+      tags:
+      - Contract Definition
+      description: Creates a new contract definition
+      operationId: createContractDefinition
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/ContractDefinitionRequestDto'
+      responses:
+        "200":
+          description: contract definition was created successfully. Returns the Contract
+            Definition Id and created timestamp
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdResponseDto'
+        "400":
+          description: Request body was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "409":
+          description: "Could not create contract definition, because a contract definition\
+            \ with that ID already exists"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /contractdefinitions/request:
+    post:
+      tags:
+      - Contract Definition
+      description: Returns all contract definitions according to a query
+      operationId: queryAllContractDefinitions
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/QuerySpecDto'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractDefinitionResponseDto'
+        "400":
+          description: Request was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /contractdefinitions/{id}:
+    get:
+      tags:
+      - Contract Definition
+      description: Gets an contract definition with the given ID
+      operationId: getContractDefinition
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: The contract definition
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContractDefinitionResponseDto'
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: An contract agreement with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+    delete:
+      tags:
+      - Contract Definition
+      description: "Removes a contract definition with the given ID if possible. DANGER\
+        \ ZONE: Note that deleting contract definitions can have unexpected results,\
+        \ especially for contract offers that have been sent out or ongoing or contract\
+        \ negotiations."
+      operationId: deleteContractDefinition
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Contract definition was deleted successfully
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: A contract definition with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
   /assets:
     get:
       tags:
@@ -1115,6 +1004,468 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
+  /transferprocess/{processId}/complete:
+    post:
+      tags:
+      - Transfer Process Control Api
+      description: "Requests completion of the transfer process. Due to the asynchronous\
+        \ nature of transfers, a successful response only indicates that the request\
+        \ was successfully received"
+      operationId: complete
+      parameters:
+      - name: processId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /transferprocess/{processId}/fail:
+    post:
+      tags:
+      - Transfer Process Control Api
+      description: "Requests completion of the transfer process. Due to the asynchronous\
+        \ nature of transfers, a successful response only indicates that the request\
+        \ was successfully received"
+      operationId: fail
+      parameters:
+      - name: processId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransferProcessFailStateDto'
+        required: true
+      responses:
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /instances:
+    get:
+      tags:
+      - Dataplane Selector
+      operationId: getAll
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DataPlaneInstance'
+    post:
+      tags:
+      - Dataplane Selector
+      operationId: addEntry
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataPlaneInstance'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /instances/select:
+    post:
+      tags:
+      - Dataplane Selector
+      operationId: find
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SelectionRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataPlaneInstance'
+  /check/health:
+    get:
+      tags:
+      - Application Observability
+      description: Performs a liveness probe to determine whether the runtime is working
+        properly.
+      operationId: checkHealth
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HealthStatus'
+  /check/liveness:
+    get:
+      tags:
+      - Application Observability
+      description: Performs a liveness probe to determine whether the runtime is working
+        properly.
+      operationId: getLiveness
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HealthStatus'
+  /check/readiness:
+    get:
+      tags:
+      - Application Observability
+      description: Performs a readiness probe to determine whether the runtime is
+        able to accept requests.
+      operationId: getReadiness
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HealthStatus'
+  /check/startup:
+    get:
+      tags:
+      - Application Observability
+      description: Performs a startup probe to determine whether the runtime has completed
+        startup.
+      operationId: getStartup
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HealthStatus'
+  /transferprocess:
+    get:
+      tags:
+      - Transfer Process
+      description: Returns all transfer process according to a query
+      operationId: getAllTransferProcesses
+      parameters:
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TransferProcessDto'
+        "400":
+          description: Request was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+      deprecated: true
+    post:
+      tags:
+      - Transfer Process
+      description: "Initiates a data transfer with the given parameters. Please note\
+        \ that successfully invoking this endpoint only means that the transfer was\
+        \ initiated. Clients must poll the /{id}/state endpoint to track the state"
+      operationId: initiateTransfer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransferRequestDto'
+      responses:
+        "200":
+          description: The transfer was successfully initiated. Returns the transfer
+            process ID and created timestamp
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdResponseDto'
+          links:
+            poll-state:
+              operationId: getTransferProcessState
+              parameters:
+                id: $response.body#/id
+        "400":
+          description: Request body was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /transferprocess/request:
+    post:
+      tags:
+      - Transfer Process
+      description: Returns all transfer process according to a query
+      operationId: queryAllTransferProcesses
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuerySpecDto'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TransferProcessDto'
+        "400":
+          description: Request was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /transferprocess/{id}:
+    get:
+      tags:
+      - Transfer Process
+      description: Gets an transfer process with the given ID
+      operationId: getTransferProcess
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: The transfer process
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransferProcessDto'
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: A transfer process with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /transferprocess/{id}/cancel:
+    post:
+      tags:
+      - Transfer Process
+      description: "Requests aborting the transfer process. Due to the asynchronous\
+        \ nature of transfers, a successful response only indicates that the request\
+        \ was successfully received. Clients must poll the /{id}/state endpoint to\
+        \ track the state."
+      operationId: cancelTransferProcess
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Request to cancel the transfer process was successfully received
+          links:
+            poll-state:
+              operationId: getTransferProcessState
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: A contract negotiation with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /transferprocess/{id}/deprovision:
+    post:
+      tags:
+      - Transfer Process
+      description: "Requests the deprovisioning of resources associated with a transfer\
+        \ process. Due to the asynchronous nature of transfers, a successful response\
+        \ only indicates that the request was successfully received. This may take\
+        \ a long time, so clients must poll the /{id}/state endpoint to track the\
+        \ state."
+      operationId: deprovisionTransferProcess
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Request to deprovision the transfer process was successfully
+            received
+          links:
+            poll-state:
+              operationId: getTransferProcessState
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: A contract negotiation with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /transferprocess/{id}/state:
+    get:
+      tags:
+      - Transfer Process
+      description: Gets the state of a transfer process with the given ID
+      operationId: getTransferProcessState
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: The  transfer process's state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransferState'
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: An  transfer process with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /token:
+    get:
+      tags:
+      - Token Validation
+      description: "Checks that the provided token has been signed by the present\
+        \ entity and asserts its validity. If token is valid, then the data address\
+        \ contained in its claims is decrypted and returned back to the caller."
+      operationId: validate
+      parameters:
+      - name: Authorization
+        in: header
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Token is valid
+        "400":
+          description: Request was malformed
+        "403":
+          description: Token is invalid
   /contractnegotiations:
     get:
       tags:
@@ -1433,301 +1784,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
-  /federatedcatalog:
-    post:
-      operationId: getCachedCatalog
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/FederatedCatalogCacheQuery'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ContractOffer'
-  /transferprocess:
-    get:
-      tags:
-      - Transfer Process
-      description: Returns all transfer process according to a query
-      operationId: getAllTransferProcesses
-      parameters:
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/TransferProcessDto'
-        "400":
-          description: Request was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-      deprecated: true
-    post:
-      tags:
-      - Transfer Process
-      description: "Initiates a data transfer with the given parameters. Please note\
-        \ that successfully invoking this endpoint only means that the transfer was\
-        \ initiated. Clients must poll the /{id}/state endpoint to track the state"
-      operationId: initiateTransfer
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TransferRequestDto'
-      responses:
-        "200":
-          description: The transfer was successfully initiated. Returns the transfer
-            process ID and created timestamp
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IdResponseDto'
-          links:
-            poll-state:
-              operationId: getTransferProcessState
-              parameters:
-                id: $response.body#/id
-        "400":
-          description: Request body was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /transferprocess/request:
-    post:
-      tags:
-      - Transfer Process
-      description: Returns all transfer process according to a query
-      operationId: queryAllTransferProcesses
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/QuerySpecDto'
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/TransferProcessDto'
-        "400":
-          description: Request was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /transferprocess/{id}:
-    get:
-      tags:
-      - Transfer Process
-      description: Gets an transfer process with the given ID
-      operationId: getTransferProcess
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: The transfer process
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TransferProcessDto'
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: A transfer process with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /transferprocess/{id}/cancel:
-    post:
-      tags:
-      - Transfer Process
-      description: "Requests aborting the transfer process. Due to the asynchronous\
-        \ nature of transfers, a successful response only indicates that the request\
-        \ was successfully received. Clients must poll the /{id}/state endpoint to\
-        \ track the state."
-      operationId: cancelTransferProcess
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: Request to cancel the transfer process was successfully received
-          links:
-            poll-state:
-              operationId: getTransferProcessState
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: A contract negotiation with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /transferprocess/{id}/deprovision:
-    post:
-      tags:
-      - Transfer Process
-      description: "Requests the deprovisioning of resources associated with a transfer\
-        \ process. Due to the asynchronous nature of transfers, a successful response\
-        \ only indicates that the request was successfully received. This may take\
-        \ a long time, so clients must poll the /{id}/state endpoint to track the\
-        \ state."
-      operationId: deprovisionTransferProcess
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: Request to deprovision the transfer process was successfully
-            received
-          links:
-            poll-state:
-              operationId: getTransferProcessState
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: A contract negotiation with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /transferprocess/{id}/state:
-    get:
-      tags:
-      - Transfer Process
-      description: Gets the state of a transfer process with the given ID
-      operationId: getTransferProcessState
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: The  transfer process's state
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TransferState'
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: An  transfer process with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
 components:
   schemas:
     Action:
@@ -1996,6 +2052,9 @@ components:
     DataFlowRequest:
       type: object
       properties:
+        callbackAddress:
+          type: string
+          format: url
         destinationDataAddress:
           $ref: '#/components/schemas/DataAddress'
         id:
@@ -2304,6 +2363,13 @@ components:
         updatedAt:
           type: integer
           format: int64
+    TransferProcessFailStateDto:
+      required:
+      - errorMessage
+      type: object
+      properties:
+        errorMessage:
+          type: string
     TransferRequestDto:
       required:
       - assetId

--- a/resources/openapi/yaml/control-plane-api.yaml
+++ b/resources/openapi/yaml/control-plane-api.yaml
@@ -1,0 +1,85 @@
+openapi: 3.0.1
+paths:
+  /transferprocess/{processId}/complete:
+    post:
+      description: "Requests completion of the transfer process. Due to the asynchronous\
+        \ nature of transfers, a successful response only indicates that the request\
+        \ was successfully received"
+      operationId: complete
+      parameters:
+      - in: path
+        name: processId
+        required: true
+        schema:
+          type: string
+          example: null
+      responses:
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "Request was malformed, e.g. id was null"
+      tags:
+      - Transfer Process Control Api
+  /transferprocess/{processId}/fail:
+    post:
+      description: "Requests completion of the transfer process. Due to the asynchronous\
+        \ nature of transfers, a successful response only indicates that the request\
+        \ was successfully received"
+      operationId: fail
+      parameters:
+      - in: path
+        name: processId
+        required: true
+        schema:
+          type: string
+          example: null
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransferProcessFailStateDto'
+        required: true
+      responses:
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "Request was malformed, e.g. id was null"
+      tags:
+      - Transfer Process Control Api
+components:
+  schemas:
+    ApiErrorDetail:
+      type: object
+      example: null
+      properties:
+        invalidValue:
+          type: string
+          example: null
+        message:
+          type: string
+          example: null
+        path:
+          type: string
+          example: null
+        type:
+          type: string
+          example: null
+    TransferProcessFailStateDto:
+      type: object
+      example: null
+      properties:
+        errorMessage:
+          type: string
+          example: null
+      required:
+      - errorMessage

--- a/resources/openapi/yaml/data-plane-api.yaml
+++ b/resources/openapi/yaml/data-plane-api.yaml
@@ -121,6 +121,9 @@ components:
     DataFlowRequest:
       type: object
       properties:
+        callbackAddress:
+          type: string
+          format: url
         destinationDataAddress:
           $ref: '#/components/schemas/DataAddress'
         id:

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,6 +41,9 @@ include(":core:common:util")
 include(":core:control-plane:contract-core")
 include(":core:control-plane:control-plane-core")
 include(":core:control-plane:transfer-core")
+include(":core:control-plane:control-plane-api")
+include(":core:control-plane:control-plane-api-client")
+
 
 include(":core:data-plane:data-plane-util")
 include(":core:data-plane:data-plane-core")
@@ -199,6 +202,8 @@ include(":spi:control-plane:control-plane-spi")
 include(":spi:control-plane:data-plane-transfer-spi")
 include(":spi:control-plane:policy-spi")
 include(":spi:control-plane:transfer-spi")
+include(":spi:control-plane:control-plane-api-client-spi")
+
 
 include(":spi:data-plane:data-plane-spi")
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataFlowRequest.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataFlowRequest.java
@@ -22,6 +22,7 @@ import org.eclipse.dataspaceconnector.spi.telemetry.TraceCarrier;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.Polymorphic;
 
+import java.net.URL;
 import java.util.Map;
 import java.util.Objects;
 
@@ -37,6 +38,7 @@ public class DataFlowRequest implements Polymorphic, TraceCarrier {
     private DataAddress sourceDataAddress;
     private DataAddress destinationDataAddress;
 
+    private URL callbackAddress;
     private boolean trackable;
 
     private Map<String, String> properties = Map.of();
@@ -93,6 +95,13 @@ public class DataFlowRequest implements Polymorphic, TraceCarrier {
     @Override
     public Map<String, String> getTraceContext() {
         return traceContext;
+    }
+
+    /**
+     * Callback address for this request once it has completed
+     */
+    public URL getCallbackAddress() {
+        return callbackAddress;
     }
 
     /**
@@ -160,6 +169,11 @@ public class DataFlowRequest implements Polymorphic, TraceCarrier {
 
         public Builder traceContext(Map<String, String> value) {
             request.traceContext = value;
+            return this;
+        }
+
+        public Builder callbackAddress(URL callbackAddress) {
+            request.callbackAddress = callbackAddress;
             return this;
         }
 

--- a/spi/common/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataFlowRequestTest.java
+++ b/spi/common/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataFlowRequestTest.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.junit.jupiter.api.Test;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Map;
 import java.util.UUID;
 
@@ -27,7 +29,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 class DataFlowRequestTest {
 
     @Test
-    void verifySerializeDeserialize() throws JsonProcessingException {
+    void verifySerializeDeserialize() throws JsonProcessingException, MalformedURLException {
+
+        var url = new URL("http://test");
         ObjectMapper mapper = new ObjectMapper();
         var request = DataFlowRequest.Builder.newInstance()
                 .sourceDataAddress(DataAddress.Builder.newInstance().type("foo").build())
@@ -35,6 +39,7 @@ class DataFlowRequestTest {
                 .id(UUID.randomUUID().toString())
                 .processId(UUID.randomUUID().toString())
                 .destinationType("test")
+                .callbackAddress(url)
                 .properties(Map.of("key", "value"))
                 .traceContext(Map.of("key2", "value2"))
                 .build();
@@ -44,5 +49,6 @@ class DataFlowRequestTest {
         assertThat(deserialized).isNotNull();
         assertThat(deserialized.getProperties().get("key")).isEqualTo("value");
         assertThat(deserialized.getTraceContext().get("key2")).isEqualTo("value2");
+        assertThat(deserialized.getCallbackAddress()).isEqualTo(url);
     }
 }

--- a/spi/control-plane/control-plane-api-client-spi/build.gradle.kts
+++ b/spi/control-plane/control-plane-api-client-spi/build.gradle.kts
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2020, 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+
+dependencies {
+    api(project(":spi:common:core-spi"))
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("control-plane-api-client-spi") {
+            artifactId = "control-plane-api-client-spi"
+            from(components["java"])
+        }
+    }
+}

--- a/spi/control-plane/control-plane-api-client-spi/src/main/java/org/eclipse/dataspaceconnector/spi/controlplane/api/client/package-info.java
+++ b/spi/control-plane/control-plane-api-client-spi/src/main/java/org/eclipse/dataspaceconnector/spi/controlplane/api/client/package-info.java
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2020, 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+@Spi("Control Plane API Services")
+package org.eclipse.dataspaceconnector.spi.controlplane.api.client;
+
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Spi;

--- a/spi/control-plane/control-plane-api-client-spi/src/main/java/org/eclipse/dataspaceconnector/spi/controlplane/api/client/transferprocess/NoopTransferProcessClient.java
+++ b/spi/control-plane/control-plane-api-client-spi/src/main/java/org/eclipse/dataspaceconnector/spi/controlplane/api/client/transferprocess/NoopTransferProcessClient.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2020, 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.controlplane.api.client.transferprocess;
+
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
+
+/**
+ * Noop Transfer process client
+ */
+public class NoopTransferProcessClient implements TransferProcessApiClient {
+    @Override
+    public void completed(DataFlowRequest request) {
+
+    }
+
+    @Override
+    public void failed(DataFlowRequest request, String reason) {
+
+    }
+}

--- a/spi/control-plane/control-plane-api-client-spi/src/main/java/org/eclipse/dataspaceconnector/spi/controlplane/api/client/transferprocess/TransferProcessApiClient.java
+++ b/spi/control-plane/control-plane-api-client-spi/src/main/java/org/eclipse/dataspaceconnector/spi/controlplane/api/client/transferprocess/TransferProcessApiClient.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2020, 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.controlplane.api.client.transferprocess;
+
+
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
+
+/**
+ * {@link TransferProcessApiClient} is an abstraction for talking with Control Plane, in this case for signaling back
+ * that the transfer at Data Plane level has been completed or failed. Implementors should call the Transfer Process Manager
+ * for altering the state of the Transfer Process with the chosen protocol/implementation. The default implementation will use the HTTP APIs
+ * of the Control Plane.
+ */
+@ExtensionPoint
+public interface TransferProcessApiClient {
+
+    /**
+     * Mark the TransferProcess referenced by {@link DataFlowRequest#getProcessId()} as completed
+     *
+     * @param request The completed {@link DataFlowRequest}
+     */
+    void completed(DataFlowRequest request);
+
+    /**
+     * Mark the TransferProcess referenced by {@link DataFlowRequest#getProcessId()} as failed
+     *
+     * @param request The failed {@link DataFlowRequest}
+     */
+    void failed(DataFlowRequest request, String reason);
+
+}

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/callback/ControlPlaneApiUrl.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/callback/ControlPlaneApiUrl.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2020, 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.transfer.callback;
+
+
+import java.net.URL;
+
+@FunctionalInterface
+public interface ControlPlaneApiUrl {
+
+    /**
+     * gets the URL which the HTTP Control Plane API provides for out-of-process systems to call back into.
+     */
+    URL get();
+}

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/command/CompleteTransferCommand.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/command/CompleteTransferCommand.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - refactored
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.types.domain.transfer.command;
+
+/**
+ * Completes a transfer process by sending it to the COMPLETED state
+ */
+public class CompleteTransferCommand extends SingleTransferProcessCommand {
+
+    public CompleteTransferCommand(String transferProcessId) {
+        super(transferProcessId);
+    }
+
+}

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/command/FailTransferCommand.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/command/FailTransferCommand.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - refactored
+ *
+ */
+
+package org.eclipse.dataspaceconnector.spi.types.domain.transfer.command;
+
+/**
+ * Fail a transfer process by sending it to the ERROR state
+ */
+public class FailTransferCommand extends SingleTransferProcessCommand {
+
+    private String errorMessage;
+
+    public FailTransferCommand(String transferProcessId, String errorMessage) {
+        super(transferProcessId);
+        this.errorMessage = errorMessage;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+}


### PR DESCRIPTION


## What this PR changes/adds

Adds a way to callback the control-plane from the data-plane once the transfer has finished (success or failed)

## Why it does that

Enable two-way communication between DP and CP to enable status updates. In
this particular implementation it will allow to mark the TransferProcess as completed instead
of being stuck in `InProgress` forever in the provider side

## Further notes

- `FailTransferCommand` and `CompleteTransferCommand` has been added as command with their handler in order to mark a transfer process failed or completed.
- `ControlPlaneApiUrl` interface has been added in `transfer-spi` for attaching the callback URL to the `DataFlowRequest`
- `control-plane-api`  module provides the `ControlPlaneApiUrl` and exposes the Rest API for sending the `FailTransferCommand` and `CompleteTransferCommand` to the TPM
- `control-plane-api-client-spi` module provides an interface for calling back the Control Plane
- `control-plane-api-client`  module provides an HTTP implementation for calling the Control Plane Rest API
- The client is then injected into the DPMImpl for calling back the CP when the transfer at DP level has finished (success or failed)

For now it's backward compatible since the injected `ControlPlaneApiUrl` and the client in the DPMimpl are not required by default. If they are not provided the behavior will be the same as today.

## Linked Issue(s)

Closes #2082 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
