### PR TITLE
refactor(SqlStore): create a base class for all SQL stores

### DIFF
--- a/extensions/common/sql/sql-core/build.gradle.kts
+++ b/extensions/common/sql/sql-core/build.gradle.kts
@@ -20,13 +20,24 @@ plugins {
 
 val h2Version: String by project
 val postgresVersion: String by project
+val jupiterVersion: String by project
+val mockitoVersion: String by project
+
+
 
 dependencies {
     api(project(":spi:common:core-spi"))
+    api(project(":spi:common:transaction-spi"))
     implementation(project(":core:common:util"))
+    implementation(project(":spi:common:transaction-datasource-spi"))
+
 
     testImplementation("com.h2database:h2:${h2Version}")
     testFixturesImplementation("org.postgresql:postgresql:${postgresVersion}")
+    testFixturesImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
+    testFixturesImplementation(project(":spi:common:transaction-datasource-spi"))
+    testFixturesImplementation("org.mockito:mockito-core:${mockitoVersion}")
+
 }
 
 publishing {

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/dataspaceconnector/sql/store/AbstractSqlStore.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/dataspaceconnector/sql/store/AbstractSqlStore.java
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (c) 2020, 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.sql.store;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.dataspaceconnector.spi.persistence.EdcPersistenceException;
+import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
+import org.eclipse.dataspaceconnector.spi.transaction.datasource.DataSourceRegistry;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Objects;
+import javax.sql.DataSource;
+
+import static java.lang.String.format;
+
+public abstract class AbstractSqlStore {
+    protected final TransactionContext transactionContext;
+    private final DataSourceRegistry dataSourceRegistry;
+    private final String dataSourceName;
+
+    private final ObjectMapper objectMapper;
+
+
+    public AbstractSqlStore(DataSourceRegistry dataSourceRegistry, String dataSourceName, TransactionContext transactionContext, ObjectMapper objectMapper) {
+        this.dataSourceRegistry = Objects.requireNonNull(dataSourceRegistry);
+        this.dataSourceName = Objects.requireNonNull(dataSourceName);
+        this.transactionContext = Objects.requireNonNull(transactionContext);
+        this.objectMapper = Objects.requireNonNull(objectMapper);
+    }
+
+    protected Connection getConnection() throws SQLException {
+        return getDataSource().getConnection();
+    }
+
+    protected String toJson(Object object) {
+        if (object == null) {
+            return null;
+        }
+        try {
+            return object instanceof String ? object.toString() : objectMapper.writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            throw new EdcPersistenceException(e);
+        }
+    }
+
+    protected <T> String toJson(Object object, TypeReference<T> typeReference) {
+        if (object == null) {
+            return null;
+        }
+        try {
+            return object instanceof String ? object.toString() : objectMapper.writerFor(typeReference).writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            throw new EdcPersistenceException(e);
+        }
+    }
+
+    protected <T> T fromJson(String json, TypeReference<T> typeReference) {
+        if (json == null) {
+            return null;
+        }
+        try {
+            return objectMapper.readValue(json, typeReference);
+        } catch (JsonProcessingException e) {
+            throw new EdcPersistenceException(e);
+        }
+    }
+
+    protected <T> T fromJson(String json, Class<T> type) {
+
+        if (json == null) {
+            return null;
+        }
+
+        try {
+            return objectMapper.readValue(json, type);
+        } catch (JsonProcessingException e) {
+            throw new EdcPersistenceException(e);
+        }
+    }
+
+    private DataSource getDataSource() {
+        return Objects.requireNonNull(dataSourceRegistry.resolve(dataSourceName), format("DataSource %s could not be resolved", dataSourceName));
+    }
+}

--- a/extensions/common/sql/sql-core/src/testFixtures/java/org/eclipse/dataspaceconnector/sql/PostgresqlStoreSetupExtension.java
+++ b/extensions/common/sql/sql-core/src/testFixtures/java/org/eclipse/dataspaceconnector/sql/PostgresqlStoreSetupExtension.java
@@ -1,0 +1,124 @@
+/*
+ *  Copyright (c) 2020, 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.sql;
+
+import org.eclipse.dataspaceconnector.spi.transaction.NoopTransactionContext;
+import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
+import org.eclipse.dataspaceconnector.spi.transaction.datasource.DataSourceRegistry;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+import java.sql.Connection;
+import java.util.UUID;
+import javax.sql.DataSource;
+
+import static org.eclipse.dataspaceconnector.sql.SqlQueryExecutor.executeQuery;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * Extension for running PG SQL store implementation. It automatically creates a test database and provided all the base data structure
+ * for a SQL store to run such as {@link DataSourceRegistry}, {@link TransactionContext} and data source name which is automatically generated
+ */
+public class PostgresqlStoreSetupExtension implements BeforeEachCallback, AfterEachCallback, BeforeAllCallback, ParameterResolver {
+
+
+    private final String datasourceName;
+    private DataSourceRegistry dataSourceRegistry = null;
+    private DataSource dataSource = null;
+    private Connection connection = null;
+    private TransactionContext transactionContext = null;
+
+    public PostgresqlStoreSetupExtension(String datasourceName) {
+        this.datasourceName = datasourceName;
+    }
+
+    public PostgresqlStoreSetupExtension() {
+        this(UUID.randomUUID().toString());
+    }
+
+
+    public DataSource getDataSource() {
+        return dataSource;
+    }
+
+    public String getDatasourceName() {
+        return datasourceName;
+    }
+
+    public Connection getConnection() {
+        return connection;
+    }
+
+    public int runQuery(String query) {
+        return transactionContext.execute(() -> executeQuery(connection, query));
+    }
+
+
+    public TransactionContext getTransactionContext() {
+        return transactionContext;
+    }
+
+    public DataSourceRegistry getDataSourceRegistry() {
+        return dataSourceRegistry;
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        transactionContext = new NoopTransactionContext();
+        dataSourceRegistry = mock(DataSourceRegistry.class);
+        dataSource = mock(DataSource.class);
+        connection = spy(PostgresqlLocalInstance.getTestConnection());
+
+        when(dataSourceRegistry.resolve(datasourceName)).thenReturn(dataSource);
+        when(dataSource.getConnection()).thenReturn(connection);
+        doNothing().when(connection).close();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        doCallRealMethod().when(connection).close();
+        connection.close();
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        PostgresqlLocalInstance.createTestDatabase();
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        var type = parameterContext.getParameter().getParameterizedType();
+        return type.equals(PostgresqlStoreSetupExtension.class);
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws
+            ParameterResolutionException {
+        var type = parameterContext.getParameter().getParameterizedType();
+        if (type.equals(PostgresqlStoreSetupExtension.class)) {
+            return this;
+        }
+        return null;
+    }
+}

--- a/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionStoreExtension.java
+++ b/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionStoreExtension.java
@@ -51,7 +51,7 @@ public class SqlContractDefinitionStoreExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         var dataSourceName = context.getConfig().getString(DATASOURCE_SETTING_NAME);
 
-        var sqlContractDefinitionStore = new SqlContractDefinitionStore(dataSourceRegistry, dataSourceName, transactionContext, getStatementImpl(), context.getTypeManager());
+        var sqlContractDefinitionStore = new SqlContractDefinitionStore(dataSourceRegistry, dataSourceName, transactionContext, getStatementImpl(), context.getTypeManager().getMapper());
 
         context.registerService(ContractDefinitionStore.class, sqlContractDefinitionStore);
     }

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/build.gradle.kts
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
     testImplementation("org.assertj:assertj-core:${assertj}")
     testImplementation(testFixtures(project(":core:common:util")))
     testImplementation(testFixtures(project(":spi:control-plane:contract-spi")))
-
+    testImplementation(testFixtures(project(":extensions:common:sql:sql-core")))
     testImplementation("org.postgresql:postgresql:${postgresVersion}")
 }
 

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/SqlContractNegotiationStoreExtension.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/SqlContractNegotiationStoreExtension.java
@@ -49,7 +49,7 @@ public class SqlContractNegotiationStoreExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var sqlStore = new SqlContractNegotiationStore(dataSourceRegistry, getDataSourceName(context), trxContext, context.getTypeManager(), getStatementImpl(), context.getConnectorId(), clock);
+        var sqlStore = new SqlContractNegotiationStore(dataSourceRegistry, getDataSourceName(context), trxContext, context.getTypeManager().getMapper(), getStatementImpl(), context.getConnectorId(), clock);
         context.registerService(ContractNegotiationStore.class, sqlStore);
     }
 

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/policy/SqlPolicyStoreExtension.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/policy/SqlPolicyStoreExtension.java
@@ -46,7 +46,7 @@ public class SqlPolicyStoreExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
 
-        var sqlPolicyStore = new SqlPolicyDefinitionStore(dataSourceRegistry, getDataSourceName(context), transactionContext, context.getTypeManager(), getStatementImpl());
+        var sqlPolicyStore = new SqlPolicyDefinitionStore(dataSourceRegistry, getDataSourceName(context), transactionContext, context.getTypeManager().getMapper(), getStatementImpl());
 
         context.registerService(PolicyDefinitionStore.class, sqlPolicyStore);
     }

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/policy/store/PostgresPolicyDefinitionStoreTest.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/policy/store/PostgresPolicyDefinitionStoreTest.java
@@ -20,76 +20,52 @@ import org.eclipse.dataspaceconnector.spi.policy.PolicyDefinition;
 import org.eclipse.dataspaceconnector.spi.policy.store.PolicyDefinitionStoreTestBase;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
-import org.eclipse.dataspaceconnector.spi.transaction.NoopTransactionContext;
-import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
-import org.eclipse.dataspaceconnector.spi.transaction.datasource.DataSourceRegistry;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
-import org.eclipse.dataspaceconnector.sql.PostgresqlLocalInstance;
+import org.eclipse.dataspaceconnector.sql.PostgresqlStoreSetupExtension;
 import org.eclipse.dataspaceconnector.sql.policy.store.schema.postgres.PostgresDialectStatements;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.stream.IntStream;
-import javax.sql.DataSource;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.dataspaceconnector.spi.policy.TestFunctions.createPolicy;
 import static org.eclipse.dataspaceconnector.spi.policy.TestFunctions.createPolicyBuilder;
 import static org.eclipse.dataspaceconnector.spi.policy.TestFunctions.createQuery;
-import static org.eclipse.dataspaceconnector.sql.SqlQueryExecutor.executeQuery;
-import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 /**
  * This test aims to verify those parts of the policy definition store, that are specific to Postgres, e.g. JSON query
  * operators.
  */
 @PostgresqlDbIntegrationTest
+@ExtendWith(PostgresqlStoreSetupExtension.class)
 class PostgresPolicyDefinitionStoreTest extends PolicyDefinitionStoreTestBase {
-    private static final String DATASOURCE_NAME = "policydefinition";
 
-    private final DataSourceRegistry dataSourceRegistry = mock(DataSourceRegistry.class);
-    private final TransactionContext txManager = new NoopTransactionContext();
     private final PostgresDialectStatements statements = new PostgresDialectStatements();
-    private final DataSource dataSource = mock(DataSource.class);
-    private final Connection connection = spy(PostgresqlLocalInstance.getTestConnection());
     private SqlPolicyDefinitionStore sqlPolicyStore;
 
-    @BeforeAll
-    static void prepare() {
-        PostgresqlLocalInstance.createTestDatabase();
-    }
 
     @BeforeEach
-    void setUp() throws IOException, SQLException {
-        when(dataSourceRegistry.resolve(DATASOURCE_NAME)).thenReturn(dataSource);
-        when(dataSource.getConnection()).thenReturn(connection);
-        doNothing().when(connection).close();
+    void setUp(PostgresqlStoreSetupExtension extension) throws IOException, SQLException {
 
         var typeManager = new TypeManager();
         typeManager.registerTypes(PolicyRegistrationTypes.TYPES.toArray(Class<?>[]::new));
 
-        sqlPolicyStore = new SqlPolicyDefinitionStore(dataSourceRegistry, DATASOURCE_NAME, txManager, typeManager, statements);
+        sqlPolicyStore = new SqlPolicyDefinitionStore(extension.getDataSourceRegistry(), extension.getDatasourceName(), extension.getTransactionContext(), typeManager.getMapper(), statements);
 
         var schema = Files.readString(Paths.get("./docs/schema.sql"));
-        txManager.execute(() -> executeQuery(connection, schema));
+        extension.runQuery(schema);
     }
 
     @AfterEach
-    void tearDown() throws SQLException {
-        txManager.execute(() -> executeQuery(connection, "DROP TABLE " + statements.getPolicyTable() + " CASCADE"));
-        doCallRealMethod().when(connection).close();
-        connection.close();
+    void tearDown(PostgresqlStoreSetupExtension extension) throws SQLException {
+        extension.runQuery("DROP TABLE " + statements.getPolicyTable() + " CASCADE");
     }
 
     @Test

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/PostgresTransferProcessStoreTest.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/PostgresTransferProcessStoreTest.java
@@ -19,90 +19,63 @@ import org.eclipse.dataspaceconnector.policy.model.PolicyRegistrationTypes;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
-import org.eclipse.dataspaceconnector.spi.transaction.NoopTransactionContext;
-import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
-import org.eclipse.dataspaceconnector.spi.transaction.datasource.DataSourceRegistry;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedResourceSet;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ResourceManifest;
-import org.eclipse.dataspaceconnector.sql.PostgresqlLocalInstance;
+import org.eclipse.dataspaceconnector.sql.PostgresqlStoreSetupExtension;
 import org.eclipse.dataspaceconnector.sql.lease.LeaseUtil;
 import org.eclipse.dataspaceconnector.sql.transferprocess.store.schema.postgres.PostgresDialectStatements;
 import org.eclipse.dataspaceconnector.transfer.store.TestFunctions;
 import org.eclipse.dataspaceconnector.transfer.store.TransferProcessStoreTestBase;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.List;
 import java.util.stream.IntStream;
-import javax.sql.DataSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.eclipse.dataspaceconnector.sql.SqlQueryExecutor.executeQuery;
 import static org.eclipse.dataspaceconnector.transfer.store.TestFunctions.createDataRequest;
 import static org.eclipse.dataspaceconnector.transfer.store.TestFunctions.createTransferProcess;
 import static org.eclipse.dataspaceconnector.transfer.store.TestFunctions.createTransferProcessBuilder;
-import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 @PostgresqlDbIntegrationTest
+@ExtendWith(PostgresqlStoreSetupExtension.class)
 class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
-    private static final String DATASOURCE_NAME = "transferprocess";
 
     private final Clock clock = Clock.systemUTC();
-    private final TransactionContext transactionContext = new NoopTransactionContext();
     private final PostgresDialectStatements statements = new PostgresDialectStatements();
-    private final DataSource dataSource = mock(DataSource.class);
-    private final DataSourceRegistry dataSourceRegistry = mock(DataSourceRegistry.class);
-    private final Connection connection = spy(PostgresqlLocalInstance.getTestConnection());
     private LeaseUtil leaseUtil;
     private SqlTransferProcessStore store;
 
-    @BeforeAll
-    static void prepare() {
-        PostgresqlLocalInstance.createTestDatabase();
-    }
-
     @BeforeEach
-    void setUp() throws IOException, SQLException {
-        when(dataSourceRegistry.resolve(DATASOURCE_NAME)).thenReturn(dataSource);
-        when(dataSource.getConnection()).thenReturn(connection);
-        doNothing().when(connection).close();
+    void setUp(PostgresqlStoreSetupExtension extension) throws IOException, SQLException {
 
         var typeManager = new TypeManager();
         typeManager.registerTypes(TestFunctions.TestResourceDef.class, TestFunctions.TestProvisionedResource.class);
         typeManager.registerTypes(PolicyRegistrationTypes.TYPES.toArray(Class<?>[]::new));
 
-        leaseUtil = new LeaseUtil(transactionContext, () -> connection, statements, clock);
-        store = new SqlTransferProcessStore(dataSourceRegistry, DATASOURCE_NAME, transactionContext, typeManager.getMapper(), statements, "test-connector", clock);
+        leaseUtil = new LeaseUtil(extension.getTransactionContext(), extension::getConnection, statements, clock);
+        store = new SqlTransferProcessStore(extension.getDataSourceRegistry(), extension.getDatasourceName(), extension.getTransactionContext(), typeManager.getMapper(), statements, "test-connector", clock);
 
         var schema = Files.readString(Paths.get("./docs/schema.sql"));
-        transactionContext.execute(() -> executeQuery(connection, schema));
+        extension.runQuery(schema);
     }
 
     @AfterEach
-    void tearDown() throws SQLException {
-        transactionContext.execute(() -> {
-            executeQuery(connection, "DROP TABLE " + statements.getTransferProcessTableName() + " CASCADE");
-            executeQuery(connection, "DROP TABLE " + statements.getDataRequestTable() + " CASCADE");
-            executeQuery(connection, "DROP TABLE " + statements.getLeaseTableName() + " CASCADE");
-        });
-        doCallRealMethod().when(connection).close();
-        connection.close();
+    void tearDown(PostgresqlStoreSetupExtension extension) throws SQLException {
+        extension.runQuery("DROP TABLE " + statements.getTransferProcessTableName() + " CASCADE");
+        extension.runQuery("DROP TABLE " + statements.getDataRequestTable() + " CASCADE");
+        extension.runQuery("DROP TABLE " + statements.getLeaseTableName() + " CASCADE");
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

Adds a Base class for all SQL store which handle data source registry and JSON mapping.
It also introduces a custom extension for testing PG stores. 

## Why it does that

Reduce duplicated code when implementing an SQL based store. 

## Further notes

All SQL store tests can be extended with `PostgresqlStoreSetupExtension` JUnit Extension which eliminates the boilerplate code of the test setup.

## Linked Issue(s)

Closes #2114 

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
