### PR TITLE
docs: add description about rule of PR title (fixes #2124)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,4 +22,4 @@ Closes # <-- _insert Issue number if one exists_
 - [ ] documented public classes/methods?
 - [ ] added/updated relevant documentation?
 - [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
-- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
+- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)

--- a/pr_etiquette.md
+++ b/pr_etiquette.md
@@ -30,6 +30,9 @@ Submitting pull requests in EDC should be done while adhering to a couple of sim
 - If you disagree with a committer's remarks, feel free to object and argue, but if no agreement is reached, you'll have
   to either accept the decision or withdraw your PR.
 - Be civil and objective. No foul language, insulting or otherwise abusive language will be tolerated.
+- The title of the PR must follow the format like `<prefix>(<scope>): <description>`.
+  The allowed `prefix` pattern is (build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test).
+  The length of the PR title must be kept under 80 characters.
 
 ## As a reviewer
 

--- a/pr_etiquette.md
+++ b/pr_etiquette.md
@@ -30,9 +30,10 @@ Submitting pull requests in EDC should be done while adhering to a couple of sim
 - If you disagree with a committer's remarks, feel free to object and argue, but if no agreement is reached, you'll have
   to either accept the decision or withdraw your PR.
 - Be civil and objective. No foul language, insulting or otherwise abusive language will be tolerated.
-- The title of the PR must follow the format like `<prefix>(<scope>): <description>`.
-  The allowed `prefix` pattern is (build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test).
-  The length of the PR title must be kept under 80 characters.
+- The PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
+  - The title must follow the format as `<type>(<optional scope>): <description>`.
+    `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test` are allowed for the `<type>`.
+  - The length must be kept under 80 characters.
 
 ## As a reviewer
 

--- a/pr_etiquette.md
+++ b/pr_etiquette.md
@@ -34,6 +34,7 @@ Submitting pull requests in EDC should be done while adhering to a couple of sim
   - The title must follow the format as `<type>(<optional scope>): <description>`.
     `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test` are allowed for the `<type>`.
   - The length must be kept under 80 characters.
+  - See [check-pull-request-title job of GitHub workflow](https://github.com/iwasakims/DataSpaceConnector/blob/describe-pr-prefix/.github/workflows/scan-pull-request.yaml) for checking details.
 
 ## As a reviewer
 

--- a/pr_etiquette.md
+++ b/pr_etiquette.md
@@ -34,7 +34,7 @@ Submitting pull requests in EDC should be done while adhering to a couple of sim
   - The title must follow the format as `<type>(<optional scope>): <description>`.
     `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test` are allowed for the `<type>`.
   - The length must be kept under 80 characters.
-  - See [check-pull-request-title job of GitHub workflow](https://github.com/iwasakims/DataSpaceConnector/blob/describe-pr-prefix/.github/workflows/scan-pull-request.yaml) for checking details.
+  - See [check-pull-request-title job of GitHub workflow](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/.github/workflows/scan-pull-request.yaml) for checking details.
 
 ## As a reviewer
 


### PR DESCRIPTION
## What this PR changes/adds

This PR adds description about the rule of PR title to contributor documentation.

## Why it does that

Contributor can conform to the rule without seeing the result of GitHub job checking the title.

## Linked Issue(s)

Closes # 2124

## Checklist

- [n/a] added appropriate tests?
- [x] performed checkstyle check locally?
- [n/a] added/updated copyright headers?
- [n/a] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
