### PR TITLE
feat(api): adds @ApiTest tag for controller integration tests

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -361,6 +361,20 @@ jobs:
         with:
           command: ./gradlew test jacocoTestReport -DincludeTags="ComponentTest"
 
+  API-Tests:
+    env:
+      JACOCO: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-build
+
+      - name: Component Tests
+        uses: ./.github/actions/run-tests
+        with:
+          command: ./gradlew test jacocoTestReport -DincludeTags="ApiTest"
+
+
   OpenTelemetry-Integration-Tests:
     runs-on: ubuntu-latest
     steps:
@@ -475,6 +489,7 @@ jobs:
     needs:
       - Unit-Tests
       - Component-Tests
+      - API-Tests
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/core/common/util/src/testFixtures/java/org/eclipse/edc/util/testfixtures/annotations/ApiTest.java
+++ b/core/common/util/src/testFixtures/java/org/eclipse/edc/util/testfixtures/annotations/ApiTest.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.util.testfixtures.annotations;
+
+import org.junit.jupiter.api.Tag;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Common annotation for integration testing.  It applies integration-test Junit Tag.
+ */
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@IntegrationTest
+@Tag("ApiTest")
+public @interface ApiTest {
+}

--- a/core/federated-catalog/federated-catalog-core/build.gradle.kts
+++ b/core/federated-catalog/federated-catalog-core/build.gradle.kts
@@ -38,8 +38,8 @@ dependencies {
 
     // required for integration test
     testImplementation(project(":extensions:common:junit"))
-
     testImplementation(project(":extensions:common:http"))
+    testImplementation(testFixtures(project(":core:common:util")))
     testImplementation(project(":data-protocols:ids:ids-spi"))
     testImplementation("org.awaitility:awaitility:${awaitility}")
 

--- a/core/federated-catalog/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/cache/FederatedCatalogCacheEndToEndTest.java
+++ b/core/federated-catalog/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/cache/FederatedCatalogCacheEndToEndTest.java
@@ -23,6 +23,7 @@ import okhttp3.Response;
 import org.eclipse.edc.catalog.spi.FederatedCacheStore;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.junit.extensions.EdcExtension;
+import org.eclipse.edc.util.testfixtures.annotations.ApiTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,7 +41,7 @@ import static org.eclipse.edc.catalog.cache.TestUtil.createOffer;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.testOkHttpClient;
 
-
+@ApiTest
 @ExtendWith(EdcExtension.class)
 class FederatedCatalogCacheEndToEndTest {
 

--- a/extensions/common/http/jersey-core/build.gradle.kts
+++ b/extensions/common/http/jersey-core/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     testImplementation("com.squareup.okhttp3:okhttp:${okHttpVersion}")
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
     testImplementation("org.glassfish.jersey.ext:jersey-bean-validation:${jerseyVersion}") //for validation
+    testImplementation(testFixtures(project(":core:common:util")))
 }
 
 publishing {

--- a/extensions/common/http/jersey-core/src/test/java/org/eclipse/edc/web/jersey/mapper/ExceptionMappersIntegrationTest.java
+++ b/extensions/common/http/jersey-core/src/test/java/org/eclipse/edc/web/jersey/mapper/ExceptionMappersIntegrationTest.java
@@ -30,6 +30,7 @@ import org.eclipse.edc.junit.extensions.EdcExtension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.util.testfixtures.annotations.ApiTest;
 import org.eclipse.edc.web.spi.WebService;
 import org.eclipse.edc.web.spi.exception.ObjectNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,6 +50,7 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
+@ApiTest
 @ExtendWith(EdcExtension.class)
 public class ExceptionMappersIntegrationTest {
 

--- a/extensions/common/http/jersey-core/src/test/java/org/eclipse/edc/web/jersey/validation/integrationtest/ValidationIntegrationTest.java
+++ b/extensions/common/http/jersey-core/src/test/java/org/eclipse/edc/web/jersey/validation/integrationtest/ValidationIntegrationTest.java
@@ -19,6 +19,7 @@ import io.restassured.specification.RequestSpecification;
 import org.eclipse.edc.junit.extensions.EdcExtension;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.util.testfixtures.annotations.ApiTest;
 import org.eclipse.edc.web.spi.validation.InterceptorFunction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,6 +44,7 @@ import static org.mockito.Mockito.when;
  * <p>
  * Please note that the focus of this test is on demonstration rather than full coverage
  */
+@ApiTest
 @ExtendWith({ EdcExtension.class })
 class ValidationIntegrationTest {
 

--- a/extensions/control-plane/api/data-management-api/asset-api/build.gradle.kts
+++ b/extensions/control-plane/api/data-management-api/asset-api/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     testImplementation(project(":core:control-plane:control-plane-core"))
     testImplementation(project(":extensions:common:http"))
     testImplementation(project(":extensions:common:junit"))
+    testImplementation(testFixtures(project(":core:common:util")))
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
     testImplementation("org.awaitility:awaitility:${awaitility}")
 

--- a/extensions/control-plane/api/data-management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/datamanagement/asset/AssetApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/data-management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/datamanagement/asset/AssetApiControllerIntegrationTest.java
@@ -30,6 +30,7 @@ import org.eclipse.edc.spi.asset.AssetIndex;
 import org.eclipse.edc.spi.query.SortOrder;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
+import org.eclipse.edc.util.testfixtures.annotations.ApiTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,6 +48,8 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
+
+@ApiTest
 @ExtendWith(EdcExtension.class)
 public class AssetApiControllerIntegrationTest {
 

--- a/extensions/control-plane/api/data-management-api/catalog-api/build.gradle.kts
+++ b/extensions/control-plane/api/data-management-api/catalog-api/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     testImplementation(project(":extensions:common:iam:iam-mock"))
 
     testImplementation(project(":extensions:common:junit"))
+    testImplementation(testFixtures(project(":core:common:util")))
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
 }
 

--- a/extensions/control-plane/api/data-management-api/catalog-api/src/test/java/org/eclipse/edc/connector/api/datamanagement/catalog/CatalogApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/data-management-api/catalog-api/src/test/java/org/eclipse/edc/connector/api/datamanagement/catalog/CatalogApiControllerIntegrationTest.java
@@ -32,6 +32,7 @@ import org.eclipse.edc.spi.query.SortOrder;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
+import org.eclipse.edc.util.testfixtures.annotations.ApiTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -55,6 +56,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@ApiTest
 @ExtendWith(EdcExtension.class)
 public class CatalogApiControllerIntegrationTest {
 

--- a/extensions/control-plane/api/data-management-api/contract-agreement-api/build.gradle.kts
+++ b/extensions/control-plane/api/data-management-api/contract-agreement-api/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     testImplementation(project(":core:control-plane:control-plane-core"))
     testImplementation(project(":extensions:common:http"))
     testImplementation(project(":extensions:common:junit"))
+    testImplementation(testFixtures(project(":core:common:util")))
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
 }
 

--- a/extensions/control-plane/api/data-management-api/contract-agreement-api/src/test/java/org/eclipse/edc/connector/api/datamanagement/contractagreement/ContractAgreementApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/data-management-api/contract-agreement-api/src/test/java/org/eclipse/edc/connector/api/datamanagement/contractagreement/ContractAgreementApiControllerIntegrationTest.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.junit.extensions.EdcExtension;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.util.testfixtures.annotations.ApiTest;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,6 +39,7 @@ import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
 import static org.eclipse.edc.spi.query.SortOrder.ASC;
 import static org.hamcrest.CoreMatchers.is;
 
+@ApiTest
 @ExtendWith(EdcExtension.class)
 public class ContractAgreementApiControllerIntegrationTest {
 

--- a/extensions/control-plane/api/data-management-api/contract-definition-api/build.gradle.kts
+++ b/extensions/control-plane/api/data-management-api/contract-definition-api/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     testImplementation(project(":core:control-plane:control-plane-core"))
     testImplementation(project(":extensions:common:http"))
     testImplementation(project(":extensions:common:junit"))
+    testImplementation(testFixtures(project(":core:common:util")))
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
     testImplementation("org.awaitility:awaitility:${awaitility}")
 }

--- a/extensions/control-plane/api/data-management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/datamanagement/contractdefinition/ContractDefinitionApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/data-management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/datamanagement/contractdefinition/ContractDefinitionApiControllerIntegrationTest.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.junit.extensions.EdcExtension;
 import org.eclipse.edc.spi.asset.AssetSelectorExpression;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.query.SortOrder;
+import org.eclipse.edc.util.testfixtures.annotations.ApiTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,6 +41,7 @@ import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
+@ApiTest
 @ExtendWith(EdcExtension.class)
 public class ContractDefinitionApiControllerIntegrationTest {
 

--- a/extensions/control-plane/api/data-management-api/contract-negotiation-api/build.gradle.kts
+++ b/extensions/control-plane/api/data-management-api/contract-negotiation-api/build.gradle.kts
@@ -33,7 +33,8 @@ dependencies {
     testImplementation(project(":core:control-plane:control-plane-core"))
     testImplementation(project(":extensions:common:http"))
     testImplementation(project(":extensions:common:junit"))
-
+    testImplementation(testFixtures(project(":core:common:util")))
+    
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
     testImplementation("org.awaitility:awaitility:${awaitility}")
 }

--- a/extensions/control-plane/api/data-management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/data-management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
@@ -29,6 +29,7 @@ import org.eclipse.edc.spi.message.RemoteMessageDispatcher;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.query.SortOrder;
 import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
+import org.eclipse.edc.util.testfixtures.annotations.ApiTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,6 +49,7 @@ import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
+@ApiTest
 @ExtendWith(EdcExtension.class)
 class ContractNegotiationApiControllerIntegrationTest {
 

--- a/extensions/control-plane/api/data-management-api/policy-definition-api/build.gradle.kts
+++ b/extensions/control-plane/api/data-management-api/policy-definition-api/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     testImplementation(project(":extensions:common:http"))
     testImplementation(project(":extensions:common:transaction:transaction-local"))
     testImplementation(project(":extensions:common:junit"))
+    testImplementation(testFixtures(project(":core:common:util")))
     testImplementation("org.awaitility:awaitility:${awaitility}")
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
 }

--- a/extensions/control-plane/api/data-management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/datamanagement/policy/PolicyDefinitionApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/data-management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/datamanagement/policy/PolicyDefinitionApiControllerIntegrationTest.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.junit.extensions.EdcExtension;
 import org.eclipse.edc.spi.query.SortOrder;
+import org.eclipse.edc.util.testfixtures.annotations.ApiTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,6 +41,7 @@ import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
+@ApiTest
 @ExtendWith(EdcExtension.class)
 public class PolicyDefinitionApiControllerIntegrationTest {
 

--- a/extensions/control-plane/api/data-management-api/transfer-process-api/build.gradle.kts
+++ b/extensions/control-plane/api/data-management-api/transfer-process-api/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     testImplementation(project(":core:control-plane:control-plane-core"))
     testImplementation(project(":extensions:common:http"))
     testImplementation(project(":extensions:common:junit"))
+    testImplementation(testFixtures(project(":core:common:util")))
 
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
     testImplementation("org.awaitility:awaitility:${awaitility}")

--- a/extensions/control-plane/api/data-management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/datamanagement/transferprocess/TransferProcessApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/data-management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/datamanagement/transferprocess/TransferProcessApiControllerIntegrationTest.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.junit.extensions.EdcExtension;
 import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.util.testfixtures.annotations.ApiTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,7 +45,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
-
+@ApiTest
 @ExtendWith(EdcExtension.class)
 class TransferProcessApiControllerIntegrationTest {
 

--- a/extensions/control-plane/provision/provision-http/build.gradle.kts
+++ b/extensions/control-plane/provision/provision-http/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     testImplementation(project(":core:control-plane:control-plane-core"))
     testImplementation(project(":extensions:common:http"))
     testImplementation(project(":extensions:common:junit"))
+    testImplementation(testFixtures(project(":core:common:util")))
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
 
     testImplementation("org.awaitility:awaitility:${awaitility}")

--- a/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/webhook/HttpProvisionerWebhookApiControllerIntegrationTest.java
+++ b/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/webhook/HttpProvisionerWebhookApiControllerIntegrationTest.java
@@ -18,6 +18,7 @@ import io.restassured.specification.RequestSpecification;
 import org.eclipse.edc.connector.transfer.spi.types.DeprovisionedResource;
 import org.eclipse.edc.junit.extensions.EdcExtension;
 import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.util.testfixtures.annotations.ApiTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,6 +40,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThan;
 
+@ApiTest
 @ExtendWith(EdcExtension.class)
 class HttpProvisionerWebhookApiControllerIntegrationTest {
 

--- a/extensions/data-plane-selector/data-plane-selector-api/build.gradle.kts
+++ b/extensions/data-plane-selector/data-plane-selector-api/build.gradle.kts
@@ -37,9 +37,8 @@ dependencies {
 
     testImplementation("com.squareup.okhttp3:okhttp:${okHttpVersion}")
     testImplementation(project(":extensions:common:http"))
-
     testImplementation(project(":extensions:common:junit"))
-
+    testImplementation(testFixtures(project(":core:common:util")))
 }
 
 

--- a/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/DataplaneSelectorApiControllerIntegrationTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/DataplaneSelectorApiControllerIntegrationTest.java
@@ -33,6 +33,7 @@ import org.eclipse.edc.junit.testfixtures.TestUtils;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.util.testfixtures.annotations.ApiTest;
 import org.eclipse.edc.web.jersey.JerseyConfiguration;
 import org.eclipse.edc.web.jersey.JerseyRestService;
 import org.eclipse.edc.web.jetty.JettyConfiguration;
@@ -53,6 +54,7 @@ import static org.eclipse.edc.connector.dataplane.selector.TestFunctions.createI
 import static org.eclipse.edc.junit.testfixtures.TestUtils.testOkHttpClient;
 import static org.mockito.Mockito.mock;
 
+@ApiTest
 class DataplaneSelectorApiControllerIntegrationTest {
 
     public static final MediaType JSON_TYPE = MediaType.parse("application/json");

--- a/extensions/data-plane/data-plane-api/build.gradle.kts
+++ b/extensions/data-plane/data-plane-api/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
 
     testImplementation(project(":extensions:common:http"))
     testImplementation(project(":extensions:common:junit"))
-    
+    testImplementation(testFixtures(project(":core:common:util")))
     testImplementation("org.glassfish.jersey.media:jersey-media-multipart:${jerseyVersion}")
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
     testImplementation("org.mock-server:mockserver-netty:${httpMockServer}:shaded")

--- a/extensions/data-plane/data-plane-api/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlaneApiIntegrationTest.java
+++ b/extensions/data-plane/data-plane-api/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlaneApiIntegrationTest.java
@@ -31,6 +31,7 @@ import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.util.testfixtures.annotations.ApiTest;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -65,6 +66,7 @@ import static org.mockito.Mockito.when;
 import static org.mockserver.matchers.Times.once;
 import static org.mockserver.stop.Stop.stopQuietly;
 
+@ApiTest
 @ExtendWith(EdcExtension.class)
 class DataPlaneApiIntegrationTest {
 


### PR DESCRIPTION
## What this PR changes/adds

Adds `@ApiTest` on all controller integration test for executing them on demand via `-DincludeTags="ApiTest"` 
and creates a separated CI job for executing them

## Why it does that

Reduce `./gradlew test` execution time

## Linked Issue(s)

Closes #2136 

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
