### PR TITLE
feat: make default_iteration_wait on state_machines configurable

### DIFF
--- a/core/control-plane/contract-core/README.md
+++ b/core/control-plane/contract-core/README.md
@@ -2,13 +2,13 @@
 
 ## Configuration
 
-| Parameter name                                      | Description                                                                                               | Mandatory | Default value |
-|-----------------------------------------------------|-----------------------------------------------------------------------------------------------------------|-----------|---------------|
-| `edc.negotiation.consumer.state-machine.batch-size` | the size of the batch of entity fetched for every consumer `ContractNegotiation` state machine iteration. | false     | 5             |
-| `edc.negotiation.provider.state-machine.batch-size` | the size of the batch of entity fetched for every provider `ContractNegotiation` state machine iteration. | false     | 5             |
-| `edc.negotiation.consumer.send.retry.limit`         | the limit of retries in case of consumer `ContractNegotiation` sending failure.                           | false     | 7             |
-| `edc.negotiation.provider.send.retry.limit`         | the limit of retries in case of provider `ContractNegotiation` sending failure.                           | false     | 7             |
-| `edc.negotiation.consumer.send.retry.base-delay.ms` | the base ms delay value for consumer `ContractNegotiation` sending retrial.                               | false     | 100           |
-| `edc.negotiation.provider.send.retry.base-delay.ms` | the base ms delay value for consumer `ContractNegotiation` sending retrial.                               | false     | 100           |
-| `edc.negotiation.iteration-delay`                   | the iteration wait time in milliseconds on the state machine while creating a `WaitStrategy` variable     | false     | 5000          |
+| Parameter name                                        | Description                                                                                               | Mandatory | Default value |
+|-------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|-----------|---------------|
+| `edc.negotiation.consumer.state-machine.batch-size`   | the size of the batch of entity fetched for every consumer `ContractNegotiation` state machine iteration. | false     | 5             |
+| `edc.negotiation.provider.state-machine.batch-size`   | the size of the batch of entity fetched for every provider `ContractNegotiation` state machine iteration. | false     | 5             |
+| `edc.negotiation.consumer.send.retry.limit`           | the limit of retries in case of consumer `ContractNegotiation` sending failure.                           | false     | 7             |
+| `edc.negotiation.provider.send.retry.limit`           | the limit of retries in case of provider `ContractNegotiation` sending failure.                           | false     | 7             |
+| `edc.negotiation.consumer.send.retry.base-delay.ms`   | the base ms delay value for consumer `ContractNegotiation` sending retrial.                               | false     | 100           |
+| `edc.negotiation.provider.send.retry.base-delay.ms`   | the base ms delay value for consumer `ContractNegotiation` sending retrial.                               | false     | 100           |
+| `edc.negotiation.state-machine.iteration-wait-millis` | the iteration wait time in milliseconds on the state machine while creating a `WaitStrategy` variable     | false     | 5000          |
  

--- a/core/control-plane/contract-core/README.md
+++ b/core/control-plane/contract-core/README.md
@@ -10,3 +10,5 @@
 | `edc.negotiation.provider.send.retry.limit`         | the limit of retries in case of provider `ContractNegotiation` sending failure.                           | false     | 7             |
 | `edc.negotiation.consumer.send.retry.base-delay.ms` | the base ms delay value for consumer `ContractNegotiation` sending retrial.                               | false     | 100           |
 | `edc.negotiation.provider.send.retry.base-delay.ms` | the base ms delay value for consumer `ContractNegotiation` sending retrial.                               | false     | 100           |
+| `edc.negotiation.iteration-delay`                   | the iteration wait time in milliseconds on the state machine while creating a `WaitStrategy` variable     | false     | 5000          |
+ 

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
@@ -164,7 +164,8 @@ public class ContractServiceExtension implements ServiceExtension {
         var validationService = new ContractValidationServiceImpl(agentService, definitionService, assetIndex, policyStore, clock, policyEngine, policyEquality);
         context.registerService(ContractValidationService.class, validationService);
 
-        var waitStrategy = context.hasService(NegotiationWaitStrategy.class) ? context.getService(NegotiationWaitStrategy.class) : new ExponentialWaitStrategy(context.getSetting(NEGOTIATION_STATE_MACHINE_ITERATION_WAIT_MILLIS, 5000));
+        var iterationWaitMillis = context.getSetting(NEGOTIATION_STATE_MACHINE_ITERATION_WAIT_MILLIS, 5000);
+        var waitStrategy = context.hasService(NegotiationWaitStrategy.class) ? context.getService(NegotiationWaitStrategy.class) : new ExponentialWaitStrategy(iterationWaitMillis);
 
         CommandQueue<ContractNegotiationCommand> commandQueue = new BoundedCommandQueue<>(10);
         CommandRunner<ContractNegotiationCommand> commandRunner = new CommandRunner<>(commandHandlerRegistry, monitor);

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
@@ -71,24 +71,33 @@ import java.time.Clock;
 @CoreExtension
 public class ContractServiceExtension implements ServiceExtension {
 
-    private static final int DEFAULT_ITERATION_WAIT = 5000;
+    private static final long DEFAULT_ITERATION_WAIT = 5000;
+
     @Setting(value = "the iteration wait time in milliseconds on the state machine. Default value 5000")
     private static final String NEGOTIATION_STATE_MACHINE_ITERATION_WAIT_MILLIS = "edc.negotiation.state-machine.iteration-wait-millis";
+
     @Setting
     private static final String NEGOTIATION_CONSUMER_STATE_MACHINE_BATCH_SIZE = "edc.negotiation.consumer.state-machine.batch-size";
+
     @Setting
     private static final String NEGOTIATION_PROVIDER_STATE_MACHINE_BATCH_SIZE = "edc.negotiation.provider.state-machine.batch-size";
+
     @Setting
     private static final String NEGOTIATION_CONSUMER_SEND_RETRY_LIMIT = "edc.negotiation.consumer.send.retry.limit";
+
     @Setting
     private static final String NEGOTIATION_PROVIDER_SEND_RETRY_LIMIT = "edc.negotiation.provider.send.retry.limit";
+
     @Setting
     private static final String NEGOTIATION_CONSUMER_SEND_RETRY_BASE_DELAY_MS = "edc.negotiation.consumer.send.retry.base-delay.ms";
+
     @Setting
     private static final String NEGOTIATION_PROVIDER_SEND_RETRY_BASE_DELAY_MS = "edc.negotiation.provider.send.retry.base-delay.ms";
 
     private ConsumerContractNegotiationManagerImpl consumerNegotiationManager;
+
     private ProviderContractNegotiationManagerImpl providerNegotiationManager;
+
     @Inject
     private AssetIndex assetIndex;
 
@@ -164,7 +173,7 @@ public class ContractServiceExtension implements ServiceExtension {
         var validationService = new ContractValidationServiceImpl(agentService, definitionService, assetIndex, policyStore, clock, policyEngine, policyEquality);
         context.registerService(ContractValidationService.class, validationService);
 
-        var iterationWaitMillis = context.getSetting(NEGOTIATION_STATE_MACHINE_ITERATION_WAIT_MILLIS, 5000);
+        var iterationWaitMillis = context.getSetting(NEGOTIATION_STATE_MACHINE_ITERATION_WAIT_MILLIS, DEFAULT_ITERATION_WAIT);
         var waitStrategy = context.hasService(NegotiationWaitStrategy.class) ? context.getService(NegotiationWaitStrategy.class) : new ExponentialWaitStrategy(iterationWaitMillis);
 
         CommandQueue<ContractNegotiationCommand> commandQueue = new BoundedCommandQueue<>(10);

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
@@ -71,7 +71,8 @@ import java.time.Clock;
 @CoreExtension
 public class ContractServiceExtension implements ServiceExtension {
 
-    private static final long DEFAULT_ITERATION_WAIT = 5000; // millis
+    @Setting
+    private static final String DEFAULT_ITERATION_WAIT = "edc.negotiation.iteration-delay";
     @Setting
     private static final String NEGOTIATION_CONSUMER_STATE_MACHINE_BATCH_SIZE = "edc.negotiation.consumer.state-machine.batch-size";
     @Setting
@@ -162,7 +163,7 @@ public class ContractServiceExtension implements ServiceExtension {
         var validationService = new ContractValidationServiceImpl(agentService, definitionService, assetIndex, policyStore, clock, policyEngine, policyEquality);
         context.registerService(ContractValidationService.class, validationService);
 
-        var waitStrategy = context.hasService(NegotiationWaitStrategy.class) ? context.getService(NegotiationWaitStrategy.class) : new ExponentialWaitStrategy(DEFAULT_ITERATION_WAIT);
+        var waitStrategy = context.hasService(NegotiationWaitStrategy.class) ? context.getService(NegotiationWaitStrategy.class) : new ExponentialWaitStrategy(context.getSetting(DEFAULT_ITERATION_WAIT, 5000));
 
         CommandQueue<ContractNegotiationCommand> commandQueue = new BoundedCommandQueue<>(10);
         CommandRunner<ContractNegotiationCommand> commandRunner = new CommandRunner<>(commandHandlerRegistry, monitor);

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
@@ -72,7 +72,7 @@ import java.time.Clock;
 public class ContractServiceExtension implements ServiceExtension {
 
     private static final int DEFAULT_ITERATION_WAIT = 5000;
-    @Setting()
+    @Setting(value = "the iteration wait time in milliseconds on the state machine. Default value 5000")
     private static final String NEGOTIATION_STATE_MACHINE_ITERATION_WAIT_MILLIS = "edc.negotiation.state-machine.iteration-wait-millis";
     @Setting
     private static final String NEGOTIATION_CONSUMER_STATE_MACHINE_BATCH_SIZE = "edc.negotiation.consumer.state-machine.batch-size";

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
@@ -71,8 +71,9 @@ import java.time.Clock;
 @CoreExtension
 public class ContractServiceExtension implements ServiceExtension {
 
-    @Setting
-    private static final String DEFAULT_ITERATION_WAIT = "edc.negotiation.iteration-delay";
+    private static final int DEFAULT_ITERATION_WAIT = 5000;
+    @Setting()
+    private static final String NEGOTIATION_STATE_MACHINE_ITERATION_WAIT_MILLIS = "edc.negotiation.state-machine.iteration-wait-millis";
     @Setting
     private static final String NEGOTIATION_CONSUMER_STATE_MACHINE_BATCH_SIZE = "edc.negotiation.consumer.state-machine.batch-size";
     @Setting
@@ -163,7 +164,7 @@ public class ContractServiceExtension implements ServiceExtension {
         var validationService = new ContractValidationServiceImpl(agentService, definitionService, assetIndex, policyStore, clock, policyEngine, policyEquality);
         context.registerService(ContractValidationService.class, validationService);
 
-        var waitStrategy = context.hasService(NegotiationWaitStrategy.class) ? context.getService(NegotiationWaitStrategy.class) : new ExponentialWaitStrategy(context.getSetting(DEFAULT_ITERATION_WAIT, 5000));
+        var waitStrategy = context.hasService(NegotiationWaitStrategy.class) ? context.getService(NegotiationWaitStrategy.class) : new ExponentialWaitStrategy(context.getSetting(NEGOTIATION_STATE_MACHINE_ITERATION_WAIT_MILLIS, 5000));
 
         CommandQueue<ContractNegotiationCommand> commandQueue = new BoundedCommandQueue<>(10);
         CommandRunner<ContractNegotiationCommand> commandRunner = new CommandRunner<>(commandHandlerRegistry, monitor);

--- a/core/control-plane/transfer-core/README.md
+++ b/core/control-plane/transfer-core/README.md
@@ -2,6 +2,9 @@
 
 ## Configuration
 
-* `edc.transfer.state-machine.batch-size` 
-  * the size of the batch of entity fetched for every `TransferProcess` state machine iteration. 
-  * _Default value_: 5
+* `edc.transfer.state-machine.batch-size`
+    * the size of the batch of entity fetched for every `TransferProcess` state machine iteration.
+    * _Default value_: 5
+* `edc.transfer.contract-service.iteration-wait`
+    * the iteration wait time in milliseconds on the state machine while creating a `WaitStrategy` variable
+    * _Default value_: 5000

--- a/core/control-plane/transfer-core/README.md
+++ b/core/control-plane/transfer-core/README.md
@@ -5,6 +5,6 @@
 * `edc.transfer.state-machine.batch-size`
     * the size of the batch of entity fetched for every `TransferProcess` state machine iteration.
     * _Default value_: 5
-* `edc.transfer.contract-service.iteration-wait`
+* `edc.transfer.state-machine.iteration-wait-millis`
     * the iteration wait time in milliseconds on the state machine while creating a `WaitStrategy` variable
     * _Default value_: 5000

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
@@ -75,7 +75,7 @@ public class CoreTransferExtension implements ServiceExtension {
     public static final String NAME = "Core Transfer";
 
     private static final int DEFAULT_ITERATION_WAIT = 5000;
-    @Setting
+    @Setting(value = "the iteration wait time in milliseconds on the state machine. Default value 5000")
     private static final String TRANSFER_STATE_MACHINE_ITERATION_WAIT_MILIS = "edc.transfer.state-machine.iteration-wait-millis";
     @Setting
     private static final String TRANSFER_STATE_MACHINE_BATCH_SIZE = "edc.transfer.state-machine.batch-size";

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
@@ -139,7 +139,8 @@ public class CoreTransferExtension implements ServiceExtension {
         var provisionManager = new ProvisionManagerImpl(monitor);
         context.registerService(ProvisionManager.class, provisionManager);
 
-        var waitStrategy = context.hasService(TransferWaitStrategy.class) ? context.getService(TransferWaitStrategy.class) : new ExponentialWaitStrategy(context.getSetting(TRANSFER_STATE_MACHINE_ITERATION_WAIT_MILIS, 5000));
+        var iterationWaitMillis = context.getSetting(TRANSFER_STATE_MACHINE_ITERATION_WAIT_MILIS, 5000);
+        var waitStrategy = context.hasService(TransferWaitStrategy.class) ? context.getService(TransferWaitStrategy.class) : new ExponentialWaitStrategy(iterationWaitMillis);
 
         var endpointDataReferenceReceiverRegistry = new EndpointDataReferenceReceiverRegistryImpl();
         context.registerService(EndpointDataReferenceReceiverRegistry.class, endpointDataReferenceReceiverRegistry);

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
@@ -73,8 +73,10 @@ import java.time.Clock;
 @Extension(value = CoreTransferExtension.NAME)
 public class CoreTransferExtension implements ServiceExtension {
     public static final String NAME = "Core Transfer";
+
+    private static final int DEFAULT_ITERATION_WAIT = 5000;
     @Setting
-    private static final String DEFAULT_ITERATION_WAIT = "edc.transfer.contract-service.iteration-wait";
+    private static final String TRANSFER_STATE_MACHINE_ITERATION_WAIT_MILIS = "edc.transfer.state-machine.iteration-wait-millis";
     @Setting
     private static final String TRANSFER_STATE_MACHINE_BATCH_SIZE = "edc.transfer.state-machine.batch-size";
     @Setting
@@ -137,7 +139,7 @@ public class CoreTransferExtension implements ServiceExtension {
         var provisionManager = new ProvisionManagerImpl(monitor);
         context.registerService(ProvisionManager.class, provisionManager);
 
-        var waitStrategy = context.hasService(TransferWaitStrategy.class) ? context.getService(TransferWaitStrategy.class) : new ExponentialWaitStrategy(context.getSetting(DEFAULT_ITERATION_WAIT, 5000));
+        var waitStrategy = context.hasService(TransferWaitStrategy.class) ? context.getService(TransferWaitStrategy.class) : new ExponentialWaitStrategy(context.getSetting(TRANSFER_STATE_MACHINE_ITERATION_WAIT_MILIS, 5000));
 
         var endpointDataReferenceReceiverRegistry = new EndpointDataReferenceReceiverRegistryImpl();
         context.registerService(EndpointDataReferenceReceiverRegistry.class, endpointDataReferenceReceiverRegistry);

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
@@ -72,17 +72,23 @@ import java.time.Clock;
         EndpointDataReferenceReceiverRegistry.class, EndpointDataReferenceTransformerRegistry.class })
 @Extension(value = CoreTransferExtension.NAME)
 public class CoreTransferExtension implements ServiceExtension {
+
     public static final String NAME = "Core Transfer";
 
-    private static final int DEFAULT_ITERATION_WAIT = 5000;
+    private static final long DEFAULT_ITERATION_WAIT = 5000;
+
     @Setting(value = "the iteration wait time in milliseconds on the state machine. Default value 5000")
     private static final String TRANSFER_STATE_MACHINE_ITERATION_WAIT_MILIS = "edc.transfer.state-machine.iteration-wait-millis";
+
     @Setting
     private static final String TRANSFER_STATE_MACHINE_BATCH_SIZE = "edc.transfer.state-machine.batch-size";
+
     @Setting
     private static final String TRANSFER_SEND_RETRY_LIMIT = "edc.transfer.send.retry.limit";
+
     @Setting
     private static final String TRANSFER_SEND_RETRY_BASE_DELAY_MS = "edc.transfer.send.retry.base-delay.ms";
+
     @Inject
     private TransferProcessStore transferProcessStore;
 
@@ -139,7 +145,7 @@ public class CoreTransferExtension implements ServiceExtension {
         var provisionManager = new ProvisionManagerImpl(monitor);
         context.registerService(ProvisionManager.class, provisionManager);
 
-        var iterationWaitMillis = context.getSetting(TRANSFER_STATE_MACHINE_ITERATION_WAIT_MILIS, 5000);
+        var iterationWaitMillis = context.getSetting(TRANSFER_STATE_MACHINE_ITERATION_WAIT_MILIS, DEFAULT_ITERATION_WAIT);
         var waitStrategy = context.hasService(TransferWaitStrategy.class) ? context.getService(TransferWaitStrategy.class) : new ExponentialWaitStrategy(iterationWaitMillis);
 
         var endpointDataReferenceReceiverRegistry = new EndpointDataReferenceReceiverRegistryImpl();

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
@@ -73,7 +73,8 @@ import java.time.Clock;
 @Extension(value = CoreTransferExtension.NAME)
 public class CoreTransferExtension implements ServiceExtension {
     public static final String NAME = "Core Transfer";
-    private static final long DEFAULT_ITERATION_WAIT = 5000; // millis
+    @Setting
+    private static final String DEFAULT_ITERATION_WAIT = "edc.transfer.contract-service.iteration-wait";
     @Setting
     private static final String TRANSFER_STATE_MACHINE_BATCH_SIZE = "edc.transfer.state-machine.batch-size";
     @Setting
@@ -136,7 +137,7 @@ public class CoreTransferExtension implements ServiceExtension {
         var provisionManager = new ProvisionManagerImpl(monitor);
         context.registerService(ProvisionManager.class, provisionManager);
 
-        var waitStrategy = context.hasService(TransferWaitStrategy.class) ? context.getService(TransferWaitStrategy.class) : new ExponentialWaitStrategy(DEFAULT_ITERATION_WAIT);
+        var waitStrategy = context.hasService(TransferWaitStrategy.class) ? context.getService(TransferWaitStrategy.class) : new ExponentialWaitStrategy(context.getSetting(DEFAULT_ITERATION_WAIT, 5000));
 
         var endpointDataReferenceReceiverRegistry = new EndpointDataReferenceReceiverRegistryImpl();
         context.registerService(EndpointDataReferenceReceiverRegistry.class, endpointDataReferenceReceiverRegistry);


### PR DESCRIPTION
## What this PR changes/adds

Makes the State machines iteration wait times to be configurable.

## Why it does that

Currently the iteration wait times on the state machines is hardcoded to 5 seconds, would be good to have them configurable

## Linked Issue(s)

Closes #2093 

## Checklist

- [x] performed checkstyle check locally?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
