### PR TITLE
feat(oauth2): adds configuration of TOKEN_EXPIRATION

### DIFF
--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2Configuration.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2Configuration.java
@@ -35,6 +35,8 @@ public class Oauth2Configuration {
     private int notBeforeValidationLeeway;
     private String endpointAudience;
 
+    private Long tokenExpiration;
+
     private Oauth2Configuration() {
 
     }
@@ -77,6 +79,10 @@ public class Oauth2Configuration {
 
     public String getEndpointAudience() {
         return endpointAudience;
+    }
+
+    public Long getTokenExpiration() {
+        return tokenExpiration;
     }
 
     public static class Builder {
@@ -142,6 +148,11 @@ public class Oauth2Configuration {
 
         public Builder endpointAudience(String endpointAudience) {
             configuration.endpointAudience = endpointAudience;
+            return this;
+        }
+
+        public Builder tokenExpiration(long tokenExpiration) {
+            configuration.tokenExpiration = tokenExpiration;
             return this;
         }
 


### PR DESCRIPTION
## What this PR changes/adds

Add configurable TOKEN_EXPIRATION in oauth2 extension

## Why it does that

The token expiration was hard-coded to 5 mins

## Linked Issue(s)

Closes #2144 

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
