### PR TITLE
feat: improve catalog request error detail

### DIFF
--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/edc/protocol/ids/message/FutureCallback.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/edc/protocol/ids/message/FutureCallback.java
@@ -42,6 +42,11 @@ public class FutureCallback<T> implements Callback {
 
     @Override
     public void onResponse(@NotNull Call call, @NotNull Response response) {
-        future.complete(handler.apply(response));
+        try (response) {
+            var result = handler.apply(response);
+            future.complete(result);
+        } catch (Exception e) {
+            future.completeExceptionally(e);
+        }
     }
 }

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/edc/protocol/ids/message/FutureCallbackTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/edc/protocol/ids/message/FutureCallbackTest.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.ids.message;
+
+import okhttp3.Call;
+import okhttp3.MediaType;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class FutureCallbackTest {
+
+    @Test
+    void onResponse_completesFutureWithResult() {
+        var future = new CompletableFuture<>();
+        var futureCallback = new FutureCallback<>(future, response -> "result");
+
+        futureCallback.onResponse(mock(Call.class), successfulResponse());
+
+        assertThat(future).succeedsWithin(10, SECONDS).isEqualTo("result");
+    }
+
+    @Test
+    void onResponse_failsFutureWhenHandlerThrowsException() {
+        var future = new CompletableFuture<>();
+        var futureCallback = new FutureCallback<>(future, response -> {
+            throw new RuntimeException("an error");
+        });
+
+        futureCallback.onResponse(mock(Call.class), successfulResponse());
+
+        assertThat(future).failsWithin(10, SECONDS)
+                .withThrowableOfType(ExecutionException.class)
+                .withCauseInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void onFailure_failsFuture() {
+        var future = new CompletableFuture<>();
+        var futureCallback = new FutureCallback<>(future, response -> {
+            throw new RuntimeException("an error");
+        });
+
+        futureCallback.onFailure(mock(Call.class), new IOException());
+
+        assertThat(future).failsWithin(10, SECONDS)
+                .withThrowableOfType(ExecutionException.class)
+                .withCauseInstanceOf(IOException.class);
+    }
+
+    private Response successfulResponse() {
+        return new Response.Builder()
+                .code(200)
+                .body(ResponseBody.create("{}", MediaType.get("application/json")))
+                .message("Test message")
+                .protocol(Protocol.HTTP_1_1)
+                .request(new Request.Builder().url("http://test.some.url").build())
+                .build();
+    }
+}

--- a/extensions/common/http/jersey-core/src/main/java/org/eclipse/edc/web/jersey/mapper/EdcApiExceptionMapper.java
+++ b/extensions/common/http/jersey-core/src/main/java/org/eclipse/edc/web/jersey/mapper/EdcApiExceptionMapper.java
@@ -19,6 +19,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import org.eclipse.edc.web.spi.ApiErrorDetail;
 import org.eclipse.edc.web.spi.exception.AuthenticationFailedException;
+import org.eclipse.edc.web.spi.exception.BadGatewayException;
 import org.eclipse.edc.web.spi.exception.EdcApiException;
 import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 import org.eclipse.edc.web.spi.exception.NotAuthorizedException;
@@ -28,6 +29,7 @@ import org.eclipse.edc.web.spi.exception.ObjectNotModifiableException;
 
 import java.util.Map;
 
+import static jakarta.ws.rs.core.Response.Status.BAD_GATEWAY;
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 import static jakarta.ws.rs.core.Response.Status.CONFLICT;
 import static jakarta.ws.rs.core.Response.Status.FORBIDDEN;
@@ -49,7 +51,8 @@ public class EdcApiExceptionMapper implements ExceptionMapper<EdcApiException> {
                 InvalidRequestException.class, BAD_REQUEST,
                 ObjectNotFoundException.class, NOT_FOUND,
                 ObjectExistsException.class, CONFLICT,
-                ObjectNotModifiableException.class, CONFLICT
+                ObjectNotModifiableException.class, CONFLICT,
+                BadGatewayException.class, BAD_GATEWAY
         );
     }
 

--- a/extensions/common/http/jersey-core/src/test/java/org/eclipse/edc/web/jersey/mapper/EdcApiExceptionMapperTest.java
+++ b/extensions/common/http/jersey-core/src/test/java/org/eclipse/edc/web/jersey/mapper/EdcApiExceptionMapperTest.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.web.jersey.mapper;
 
 import org.eclipse.edc.web.spi.ApiErrorDetail;
 import org.eclipse.edc.web.spi.exception.AuthenticationFailedException;
+import org.eclipse.edc.web.spi.exception.BadGatewayException;
 import org.eclipse.edc.web.spi.exception.EdcApiException;
 import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 import org.eclipse.edc.web.spi.exception.NotAuthorizedException;
@@ -64,7 +65,8 @@ class EdcApiExceptionMapperTest {
                     Arguments.of(new ObjectExistsException(Object.class, "test-object-id"), 409),
                     Arguments.of(new ObjectNotFoundException(Object.class, "test-object-id"), 404),
                     Arguments.of(new NotAuthorizedException(), 403),
-                    Arguments.of(new InvalidRequestException(List.of("detail")), 400)
+                    Arguments.of(new InvalidRequestException(List.of("detail")), 400),
+                    Arguments.of(new BadGatewayException("something happened"), 502)
             );
         }
     }

--- a/extensions/control-plane/api/data-management-api/catalog-api/src/main/java/org/eclipse/edc/connector/api/datamanagement/catalog/CatalogApiController.java
+++ b/extensions/control-plane/api/data-management-api/catalog-api/src/main/java/org/eclipse/edc/connector/api/datamanagement/catalog/CatalogApiController.java
@@ -28,8 +28,10 @@ import org.eclipse.edc.api.query.QuerySpecDto;
 import org.eclipse.edc.api.transformer.DtoTransformerRegistry;
 import org.eclipse.edc.connector.api.datamanagement.catalog.model.CatalogRequestDto;
 import org.eclipse.edc.connector.api.datamanagement.catalog.service.CatalogService;
+import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.web.spi.exception.BadGatewayException;
 import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 import org.jetbrains.annotations.NotNull;
 
@@ -87,7 +89,11 @@ public class CatalogApiController implements CatalogApi {
                     if (throwable == null) {
                         response.resume(content);
                     } else {
-                        response.resume(throwable);
+                        if (throwable instanceof EdcException) {
+                            response.resume(new BadGatewayException(throwable.getMessage()));
+                        } else {
+                            response.resume(throwable);
+                        }
                     }
                 });
     }

--- a/extensions/control-plane/api/data-management-api/catalog-api/src/main/java/org/eclipse/edc/connector/api/datamanagement/catalog/CatalogApiController.java
+++ b/extensions/control-plane/api/data-management-api/catalog-api/src/main/java/org/eclipse/edc/connector/api/datamanagement/catalog/CatalogApiController.java
@@ -89,7 +89,7 @@ public class CatalogApiController implements CatalogApi {
                     if (throwable == null) {
                         response.resume(content);
                     } else {
-                        if (throwable instanceof EdcException) {
+                        if (throwable instanceof EdcException || throwable.getCause() instanceof EdcException) {
                             response.resume(new BadGatewayException(throwable.getMessage()));
                         } else {
                             response.resume(throwable);

--- a/extensions/control-plane/api/data-management-api/catalog-api/src/test/java/org/eclipse/edc/connector/api/datamanagement/catalog/CatalogApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/data-management-api/catalog-api/src/test/java/org/eclipse/edc/connector/api/datamanagement/catalog/CatalogApiControllerIntegrationTest.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.junit.extensions.EdcExtension;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
+import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.message.MessageContext;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcher;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
@@ -44,6 +45,7 @@ import java.util.UUID;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.api.datamanagement.catalog.TestFunctions.createCriterionDto;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
@@ -211,6 +213,36 @@ public class CatalogApiControllerIntegrationTest {
                 .statusCode(400);
     }
 
+    @Test
+    void postCatalogRequest_whenDispatcherFailsReturnsBadGatewayWithDetail() {
+        when(dispatcher.send(any(), any(), any()))
+                .thenReturn(failedFuture(new EdcException("Something happened with the provider connector")));
+
+        var request = CatalogRequestDto.Builder.newInstance().providerUrl("http://provider/url").build();
+
+        baseRequest()
+                .contentType("application/json")
+                .body(request)
+                .post("/catalog/request")
+                .then()
+                .statusCode(502)
+                .body("message[0]", is("Something happened with the provider connector"));
+    }
+
+    @Test
+    void postCatalogRequest_whenDispatcherFailsWithGenericExceptionReturns500() {
+        when(dispatcher.send(any(), any(), any()))
+                .thenReturn(failedFuture(new RuntimeException("any error")));
+
+        var request = CatalogRequestDto.Builder.newInstance().providerUrl("http://provider/url").build();
+
+        baseRequest()
+                .contentType("application/json")
+                .body(request)
+                .post("/catalog/request")
+                .then()
+                .statusCode(500);
+    }
 
     private RequestSpecification baseRequest() {
         return given()

--- a/spi/common/web-spi/src/main/java/org/eclipse/edc/web/spi/exception/BadGatewayException.java
+++ b/spi/common/web-spi/src/main/java/org/eclipse/edc/web/spi/exception/BadGatewayException.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial implementation
+ *
+ */
+
+package org.eclipse.edc.web.spi.exception;
+
+/**
+ * Indicates that something happened while proxying a call to an external endpoint
+ */
+public class BadGatewayException extends EdcApiException {
+
+    public BadGatewayException(String message) {
+        super(message);
+    }
+
+    @Override
+    public String getType() {
+        return "BadGateway";
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

Improve the error detail when a catalog is requested and the provider connector respond with an error.

## Why it does that

Helps debugging

## Further notes

- test covered and refactored the `FutureCallback` class.

## Linked Issue(s)

Closes #2152 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
