### PR TITLE
feat(DataPlaneStore): implements SQL based storage for DataPlane flow requests

### DIFF
--- a/core/data-plane/data-plane-framework/build.gradle.kts
+++ b/core/data-plane/data-plane-framework/build.gradle.kts
@@ -32,6 +32,8 @@ dependencies {
 
     testImplementation(project(":core:common:junit"))
     testImplementation("org.awaitility:awaitility:${awaitility}")
+    testImplementation(testFixtures(project(":spi:data-plane:data-plane-spi")))
+
 }
 
 

--- a/core/data-plane/data-plane-framework/src/test/java/org/eclipse/edc/connector/dataplane/framework/store/InMemoryDataPlaneStoreTest.java
+++ b/core/data-plane/data-plane-framework/src/test/java/org/eclipse/edc/connector/dataplane/framework/store/InMemoryDataPlaneStoreTest.java
@@ -14,41 +14,21 @@
 
 package org.eclipse.edc.connector.dataplane.framework.store;
 
+import org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore;
+import org.eclipse.edc.connector.dataplane.spi.testfixtures.store.DataPlaneStoreTestBase;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore.State.COMPLETED;
-import static org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore.State.NOT_TRACKED;
-import static org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore.State.RECEIVED;
-
-class InMemoryDataPlaneStoreTest {
+class InMemoryDataPlaneStoreTest extends DataPlaneStoreTestBase {
     private InMemoryDataPlaneStore store;
 
-    @Test
-    void verifyOperations() {
-        assertThat(store.getState("1")).isEqualTo(NOT_TRACKED);
-        store.received("1");
-        assertThat(store.getState("1")).isEqualTo(RECEIVED);
-        store.completed("1");
-        assertThat(store.getState("1")).isEqualTo(COMPLETED);
-    }
-
-    @Test
-    void verifyResetState() {
-        store.completed("1");
-        store.received("1");
-        assertThat(store.getState("1")).isEqualTo(RECEIVED);
-    }
-
-    @Test
-    void verifyNonReceivedProcess() {
-        store.completed("1");
-        assertThat(store.getState("1")).isEqualTo(COMPLETED);
-    }
 
     @BeforeEach
     void setUp() {
         store = new InMemoryDataPlaneStore(2);
+    }
+
+    @Override
+    protected DataPlaneStore getStore() {
+        return store;
     }
 }

--- a/extensions/data-plane/store/sql/data-plane-store-sql/README.md
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/README.md
@@ -1,0 +1,28 @@
+# SQL Data Plane Store
+
+Provides SQL persistence for data flow transfer state.
+
+## Prerequisites
+
+Please apply this [schema](docs/schema.sql) to your SQL database.
+
+## Entity Diagram
+
+```plantuml
+@startuml
+entity edc_data_plane {
+  * process_id: string <<PK>>
+  * state: integer
+  --
+}
+@enduml
+
+```
+
+-->
+
+## Configuration
+
+| Key                           | Description                       | Mandatory | 
+|:------------------------------|:----------------------------------|-----------|
+| edc.datasource.dataplane.name | Datasource used by this extension | X         |

--- a/extensions/data-plane/store/sql/data-plane-store-sql/build.gradle.kts
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    `java-library`
+    `maven-publish`
+}
+
+
+dependencies {
+    api(project(":spi:common:transaction-spi"))
+    api(project(":spi:data-plane:data-plane-spi"))
+
+    implementation(project(":spi:common:transaction-datasource-spi"))
+    implementation(project(":extensions:common:sql:sql-core"))
+
+    testImplementation(project(":core:common:junit"))
+    testImplementation(testFixtures(project(":spi:data-plane:data-plane-spi")))
+    testImplementation(testFixtures(project(":extensions:common:sql:sql-core")))
+
+}
+
+
+publishing {
+    publications {
+        create<MavenPublication>("data-plane-store-sql") {
+            artifactId = "data-plane-store-sql"
+            from(components["java"])
+        }
+    }
+}

--- a/extensions/data-plane/store/sql/data-plane-store-sql/docs/schema.sql
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/docs/schema.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS edc_data_plane
+(
+    process_id           VARCHAR NOT NULL PRIMARY KEY,
+    state                INTEGER NOT NULL            ,
+    created_at           BIGINT  NOT NULL            ,
+    updated_at           BIGINT  NOT NULL
+);

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/SqlDataPlaneStore.java
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/SqlDataPlaneStore.java
@@ -1,0 +1,112 @@
+/*
+ *  Copyright (c) 2020-2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.store.sql;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore;
+import org.eclipse.edc.connector.dataplane.store.sql.schema.DataPlaneStatements;
+import org.eclipse.edc.spi.persistence.EdcPersistenceException;
+import org.eclipse.edc.sql.store.AbstractSqlStore;
+import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.time.Clock;
+
+import static org.eclipse.edc.sql.SqlQueryExecutor.executeQuery;
+import static org.eclipse.edc.sql.SqlQueryExecutor.executeQuerySingle;
+
+/**
+ * SQL implementation of {@link DataPlaneStore}
+ */
+public class SqlDataPlaneStore extends AbstractSqlStore implements DataPlaneStore {
+
+
+    private final DataPlaneStatements statements;
+
+    private final Clock clock;
+
+    public SqlDataPlaneStore(DataSourceRegistry dataSourceRegistry, String dataSourceName, TransactionContext transactionContext, DataPlaneStatements statements, ObjectMapper objectMapper, Clock clock) {
+        super(dataSourceRegistry, dataSourceName, transactionContext, objectMapper);
+        this.statements = statements;
+        this.clock = clock;
+    }
+
+    @Override
+    public void received(String processId) {
+        transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                upsert(connection, processId, State.RECEIVED);
+            } catch (Exception exception) {
+                throw new EdcPersistenceException(exception);
+            }
+        });
+    }
+
+    @Override
+    public void completed(String processId) {
+        transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                upsert(connection, processId, State.COMPLETED);
+            } catch (Exception exception) {
+                throw new EdcPersistenceException(exception);
+            }
+        });
+    }
+
+    @Override
+    public State getState(String processId) {
+        return transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                var state = stateById(connection, processId);
+                return state != null ? state : State.NOT_TRACKED;
+            } catch (Exception exception) {
+                throw new EdcPersistenceException(exception);
+            }
+        });
+
+    }
+
+    public State mapToState(ResultSet resultSet) throws Exception {
+        var stateCode = resultSet.getInt(statements.getStateColumn());
+        return State.from(stateCode);
+    }
+
+    private void upsert(Connection connection, String processId, State state) {
+        if (stateById(connection, processId) == null) {
+            insert(connection, processId, state);
+        } else {
+            update(connection, processId, state);
+        }
+    }
+
+    private State stateById(Connection connection, String processId) {
+        var sql = statements.getFindByIdTemplate();
+        return executeQuerySingle(connection, false, this::mapToState, sql, processId);
+    }
+
+    private void insert(Connection connection, String processId, State state) {
+        var sql = statements.getInsertTemplate();
+        var createdAt = clock.millis();
+        executeQuery(connection, sql, processId, state.getCode(), createdAt, createdAt);
+    }
+
+    private void update(Connection connection, String processId, State state) {
+        var sql = statements.getUpdateTemplate();
+        var updatedAt = clock.millis();
+        executeQuery(connection, sql, state.getCode(), updatedAt, processId);
+    }
+}

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/SqlDataPlaneStoreExtension.java
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/SqlDataPlaneStoreExtension.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2020-2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.store.sql;
+
+import org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore;
+import org.eclipse.edc.connector.dataplane.store.sql.schema.DataPlaneStatements;
+import org.eclipse.edc.connector.dataplane.store.sql.schema.postgres.PostgresDataPlaneStatements;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+
+import java.time.Clock;
+
+/**
+ * Provides Sql Store for Data Plane Flow Requests states
+ */
+@Extension(value = SqlDataPlaneStoreExtension.NAME)
+public class SqlDataPlaneStoreExtension implements ServiceExtension {
+
+    public static final String NAME = "Sql Data Plane Store";
+
+    @Setting(value = "Name of the datasource to use for accessing data plane store")
+    private static final String DATASOURCE_SETTING_NAME = "edc.datasource.dataplane.name";
+    private static final String DEFAULT_DATASOURCE_NAME = "dataplane";
+
+    @Inject
+    private DataSourceRegistry dataSourceRegistry;
+
+    @Inject
+    private TransactionContext transactionContext;
+
+    @Inject(required = false)
+    private DataPlaneStatements statements;
+
+    @Inject
+    private Clock clock;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Provider
+    public DataPlaneStore dataPlaneStore(ServiceExtensionContext context) {
+        return new SqlDataPlaneStore(dataSourceRegistry, getDataSourceName(context), transactionContext, getStatementImpl(), context.getTypeManager().getMapper(), clock);
+    }
+
+    /**
+     * returns an externally-provided sql statement dialect, or postgres as a default
+     */
+    private DataPlaneStatements getStatementImpl() {
+        return statements != null ? statements : new PostgresDataPlaneStatements();
+    }
+
+    private String getDataSourceName(ServiceExtensionContext context) {
+        return context.getConfig().getString(DATASOURCE_SETTING_NAME, DEFAULT_DATASOURCE_NAME);
+    }
+}

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/BaseSqlDataPlaneStatements.java
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/BaseSqlDataPlaneStatements.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.store.sql.schema;
+
+public class BaseSqlDataPlaneStatements implements DataPlaneStatements {
+
+
+    @Override
+    public String getFindByIdTemplate() {
+        return String.format("SELECT * FROM %s WHERE %s = ?", getDataPlaneTable(), getProcessIdColumn());
+    }
+
+
+    @Override
+    public String getInsertTemplate() {
+        return String.format("INSERT INTO %s (%s, %s, %s, %s) VALUES (?, ?, ?, ?)",
+                getDataPlaneTable(),
+                getProcessIdColumn(),
+                getStateColumn(),
+                getCreatedAtColumn(),
+                getUpdatedAtColumn()
+        );
+    }
+
+    @Override
+    public String getUpdateTemplate() {
+        return String.format("UPDATE %s SET %s = ?, %s = ? WHERE %s = ?",
+                getDataPlaneTable(),
+                getStateColumn(),
+                getUpdatedAtColumn(),
+                getProcessIdColumn());
+    }
+}

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/DataPlaneStatements.java
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/DataPlaneStatements.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.store.sql.schema;
+
+import org.eclipse.edc.sql.dialect.BaseSqlDialect;
+
+/**
+ * Sql Statements for DataPlane Store
+ */
+public interface DataPlaneStatements {
+
+    default String getDataPlaneTable() {
+        return "edc_data_plane";
+    }
+
+    default String getProcessIdColumn() {
+        return "process_id";
+    }
+
+    default String getCreatedAtColumn() {
+        return "created_at";
+    }
+
+    default String getUpdatedAtColumn() {
+        return "updated_at";
+    }
+
+    default String getStateColumn() {
+        return "state";
+    }
+
+    String getFindByIdTemplate();
+
+    String getInsertTemplate();
+
+    String getUpdateTemplate();
+
+
+    default String getFormatAsJsonOperator() {
+        return BaseSqlDialect.getJsonCastOperator();
+    }
+
+}
+

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/postgres/PostgresDataPlaneStatements.java
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/postgres/PostgresDataPlaneStatements.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.store.sql.schema.postgres;
+
+import org.eclipse.edc.connector.dataplane.store.sql.schema.BaseSqlDataPlaneStatements;
+import org.eclipse.edc.sql.dialect.PostgresDialect;
+
+public class PostgresDataPlaneStatements extends BaseSqlDataPlaneStatements {
+
+
+    @Override
+    public String getFormatAsJsonOperator() {
+        return PostgresDialect.getJsonCastOperator();
+    }
+}

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,16 @@
+#
+#  Copyright (c) 2020 - 2022 Microsoft Corporation
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Microsoft Corporation - initial API and implementation
+#
+#
+
+org.eclipse.edc.connector.dataplane.store.sql.SqlDataPlaneStoreExtension
+

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/test/java/org/eclipse/edc/connector/dataplane/store/sql/PostgresDataPlaneStoreTest.java
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/test/java/org/eclipse/edc/connector/dataplane/store/sql/PostgresDataPlaneStoreTest.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.store.sql;
+
+import org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore;
+import org.eclipse.edc.connector.dataplane.spi.testfixtures.store.DataPlaneStoreTestBase;
+import org.eclipse.edc.connector.dataplane.store.sql.schema.DataPlaneStatements;
+import org.eclipse.edc.connector.dataplane.store.sql.schema.postgres.PostgresDataPlaneStatements;
+import org.eclipse.edc.junit.annotations.PostgresqlDbIntegrationTest;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.sql.testfixtures.PostgresqlStoreSetupExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.sql.SQLException;
+import java.time.Clock;
+
+
+@PostgresqlDbIntegrationTest
+@ExtendWith(PostgresqlStoreSetupExtension.class)
+public class PostgresDataPlaneStoreTest extends DataPlaneStoreTestBase {
+
+    private final DataPlaneStatements statements = new PostgresDataPlaneStatements();
+
+    private SqlDataPlaneStore store;
+
+
+    @BeforeEach
+    void setUp(PostgresqlStoreSetupExtension extension) throws IOException, SQLException {
+
+        var typeManager = new TypeManager();
+
+        var clock = Clock.systemUTC();
+
+        store = new SqlDataPlaneStore(extension.getDataSourceRegistry(), extension.getDatasourceName(), extension.getTransactionContext(), statements, typeManager.getMapper(), clock);
+        var schema = Files.readString(Paths.get("./docs/schema.sql"));
+        extension.runQuery(schema);
+    }
+
+    @AfterEach
+    void tearDown(PostgresqlStoreSetupExtension extension) throws SQLException {
+        extension.runQuery("DROP TABLE " + statements.getDataPlaneTable() + " CASCADE");
+    }
+
+    @Override
+    protected DataPlaneStore getStore() {
+        return store;
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -144,6 +144,8 @@ include(":extensions:data-plane:data-plane-http")
 include(":extensions:data-plane:data-plane-aws-s3")
 include(":extensions:data-plane:data-plane-google-storage")
 include(":extensions:data-plane:data-plane-integration-tests")
+include(":extensions:data-plane:store:sql:data-plane-store-sql")
+
 
 include(":extensions:data-plane-selector:data-plane-selector-api")
 include(":extensions:data-plane-selector:data-plane-selector-client")

--- a/spi/data-plane/data-plane-spi/build.gradle.kts
+++ b/spi/data-plane/data-plane-spi/build.gradle.kts
@@ -12,12 +12,21 @@
  *
  */
 
+val jupiterVersion: String by project
+val assertj: String by project
+
 plugins {
     `java-library`
+    `java-test-fixtures`
 }
 
 dependencies {
     api(project(":spi:common:core-spi"))
+
+
+    testFixturesImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
+    testFixturesImplementation("org.junit.jupiter:junit-jupiter-params:${jupiterVersion}")
+    testFixturesImplementation("org.assertj:assertj-core:${assertj}")
 }
 
 

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/store/DataPlaneStore.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/store/DataPlaneStore.java
@@ -14,30 +14,12 @@
 
 package org.eclipse.edc.connector.dataplane.spi.store;
 
+import java.util.Arrays;
+
 /**
  * Stores states of data flow requests.
  */
 public interface DataPlaneStore {
-
-    /**
-     * Defines data flow states.
-     */
-    enum State {
-        /**
-         * There is no record of the process, i.e. one has not benn previously received.
-         */
-        NOT_TRACKED,
-
-        /**
-         * The process have been received.
-         */
-        RECEIVED,
-
-        /**
-         * The process has completed.
-         */
-        COMPLETED
-    }
 
     /**
      * Mark the process as received.
@@ -53,5 +35,39 @@ public interface DataPlaneStore {
      * Returns the state of the process. If a process is unknown, returns {@link State#NOT_TRACKED}.
      */
     State getState(String processId);
+
+    /**
+     * Defines data flow states.
+     */
+    enum State {
+        /**
+         * There is no record of the process, i.e. one has not benn previously received.
+         */
+        NOT_TRACKED(0),
+
+        /**
+         * The process have been received.
+         */
+        RECEIVED(100),
+
+        /**
+         * The process has completed.
+         */
+        COMPLETED(200);
+
+        private final int code;
+
+        State(int code) {
+            this.code = code;
+        }
+
+        public static State from(int code) {
+            return Arrays.stream(values()).filter(tps -> tps.code == code).findFirst().orElse(null);
+        }
+
+        public int getCode() {
+            return code;
+        }
+    }
 
 }

--- a/spi/data-plane/data-plane-spi/src/testFixtures/java/org/eclipse/edc/connector/dataplane/spi/testfixtures/store/DataPlaneStoreTestBase.java
+++ b/spi/data-plane/data-plane-spi/src/testFixtures/java/org/eclipse/edc/connector/dataplane/spi/testfixtures/store/DataPlaneStoreTestBase.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2020-2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.spi.testfixtures.store;
+
+import org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore.State.COMPLETED;
+import static org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore.State.NOT_TRACKED;
+import static org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore.State.RECEIVED;
+
+public abstract class DataPlaneStoreTestBase {
+
+
+    @Test
+    void verifyOperations() {
+        assertThat(getStore().getState("1")).isEqualTo(NOT_TRACKED);
+        getStore().received("1");
+        assertThat(getStore().getState("1")).isEqualTo(RECEIVED);
+        getStore().completed("1");
+        assertThat(getStore().getState("1")).isEqualTo(COMPLETED);
+    }
+
+    @Test
+    void verifyResetState() {
+        getStore().completed("1");
+        getStore().received("1");
+        assertThat(getStore().getState("1")).isEqualTo(RECEIVED);
+    }
+
+    @Test
+    void verifyNonReceivedProcess() {
+        getStore().completed("1");
+        assertThat(getStore().getState("1")).isEqualTo(COMPLETED);
+    }
+
+    protected abstract DataPlaneStore getStore();
+}


### PR DESCRIPTION
## What this PR changes/adds

Adds a SQL implementation of `DataPlaneStore`

## Why it does that

Currently one an in memory version is provided for the DataPlaneStore.

## Linked Issue(s)

Closes #2090 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
