### PR TITLE
refactor(apiExtensions): removes duplicated code when configuring an API extension

### DIFF
--- a/core/control-plane/control-plane-api-client/src/test/java/org/eclipse/edc/connector/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
+++ b/core/control-plane/control-plane-api-client/src/test/java/org/eclipse/edc/connector/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.connector.api.client.transferprocess;
 
-import org.eclipse.edc.connector.api.ControlPlaneApiExtension;
 import org.eclipse.edc.connector.dataplane.spi.manager.DataPlaneManager;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.TransferService;
 import org.eclipse.edc.connector.dataplane.spi.registry.TransferServiceRegistry;
@@ -44,6 +43,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.eclipse.edc.connector.api.ControlPlaneApiExtension.DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH;
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates.COMPLETED;
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates.ERROR;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
@@ -70,7 +70,7 @@ public class TransferProcessHttpClientIntegrationTest {
                 "web.http.port", String.valueOf(getFreePort()),
                 "web.http.path", "/api",
                 "web.http.controlplane.port", String.valueOf(port),
-                "web.http.controlplane.path", ControlPlaneApiExtension.DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH
+                "web.http.controlplane.path", DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH
         ));
 
         extension.registerSystemExtension(ServiceExtension.class, new TransferServiceMockExtension(service));

--- a/core/control-plane/control-plane-api/src/main/java/org/eclipse/edc/connector/api/ControlPlaneApiExtension.java
+++ b/core/control-plane/control-plane-api/src/main/java/org/eclipse/edc/connector/api/ControlPlaneApiExtension.java
@@ -27,12 +27,13 @@ import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.web.spi.WebServer;
 import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.WebServiceConfiguration;
+import org.eclipse.edc.web.spi.configuration.WebServiceConfigurer;
+import org.eclipse.edc.web.spi.configuration.WebServiceSettings;
 import org.jetbrains.annotations.NotNull;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-
-import static java.lang.String.format;
 
 /**
  * {@link ControlPlaneApiExtension } exposes HTTP endpoints for internal interaction with the Control Plane
@@ -44,12 +45,8 @@ public class ControlPlaneApiExtension implements ServiceExtension {
 
     public static final String CONTROL_PLANE_API_CONFIG = "web.http.controlplane";
     public static final String CONTROL_PLANE_CONTEXT_ALIAS = "controlplane";
-
     public static final int DEFAULT_CONTROL_PLANE_API_PORT = 8384;
     public static final String DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH = "/api/v1/controlplane";
-
-    private int port = DEFAULT_CONTROL_PLANE_API_PORT;
-    private String path = DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH;
 
     @Inject
     private WebServer webServer;
@@ -60,6 +57,12 @@ public class ControlPlaneApiExtension implements ServiceExtension {
     @Inject
     private Hostname hostname;
 
+    @Inject
+    private WebServiceConfigurer configurator;
+
+
+    private WebServiceConfiguration configuration;
+
     @Override
     public String name() {
         return NAME;
@@ -67,24 +70,18 @@ public class ControlPlaneApiExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var monitor = context.getMonitor();
-        var alias = CONTROL_PLANE_CONTEXT_ALIAS;
+        var settings = WebServiceSettings.Builder.newInstance()
+                .apiConfigKey(CONTROL_PLANE_API_CONFIG)
+                .contextAlias(CONTROL_PLANE_CONTEXT_ALIAS)
+                .defaultPath(DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH)
+                .defaultPort(DEFAULT_CONTROL_PLANE_API_PORT)
+                .name(NAME)
+                .build();
 
-        var config = context.getConfig(CONTROL_PLANE_API_CONFIG);
-        if (config.getEntries().isEmpty()) {
-            monitor.warning(format("Settings for [%s] and/or [%s] were not provided. Using default" +
-                    " value(s) instead.", CONTROL_PLANE_API_CONFIG + ".path", CONTROL_PLANE_API_CONFIG + ".path"));
-            webServer.addPortMapping(alias, port, path);
-        } else {
-            path = config.getString("path", path);
-            port = config.getInteger("port", port);
-        }
-
+        configuration = configurator.configure(context, webServer, settings);
         context.getTypeManager().registerTypes(TransferProcessFailStateDto.class);
 
-        monitor.info(format("Control Plane API will be available at [path=%s], [port=%s].", path, port));
-
-        webService.registerResource(alias, new TransferProcessControlApiController(transferProcessManager));
+        webService.registerResource(configuration.getContextAlias(), new TransferProcessControlApiController(transferProcessManager));
     }
 
 
@@ -102,7 +99,7 @@ public class ControlPlaneApiExtension implements ServiceExtension {
 
     @NotNull
     private String getApiUrl() {
-        return String.format("http://%s:%s%s", hostname.get(), port, path);
+        return String.format("http://%s:%s%s", hostname.get(), configuration.getPort(), configuration.getPath());
     }
 
 

--- a/core/control-plane/control-plane-api/src/test/java/org/eclipse/edc/connector/api/TransferProcessControlApiControllerIntegrationTest.java
+++ b/core/control-plane/control-plane-api/src/test/java/org/eclipse/edc/connector/api/TransferProcessControlApiControllerIntegrationTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.eclipse.edc.connector.api.ControlPlaneApiExtension.DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH;
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates.COMPLETED;
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates.ERROR;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
@@ -47,7 +48,7 @@ class TransferProcessControlApiControllerIntegrationTest {
                 "web.http.port", String.valueOf(getFreePort()),
                 "web.http.path", "/api",
                 "web.http.controlplane.port", String.valueOf(port),
-                "web.http.controlplane.path", ControlPlaneApiExtension.DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH
+                "web.http.controlplane.path", DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH
         ));
     }
 
@@ -134,7 +135,7 @@ class TransferProcessControlApiControllerIntegrationTest {
     private RequestSpecification baseRequest() {
         return given()
                 .baseUri("http://localhost:" + port)
-                .basePath(ControlPlaneApiExtension.DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH)
+                .basePath(DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH)
                 .when();
     }
 

--- a/extensions/common/http/jetty-core/src/main/java/org/eclipse/edc/web/jetty/JettyExtension.java
+++ b/extensions/common/http/jetty-core/src/main/java/org/eclipse/edc/web/jetty/JettyExtension.java
@@ -14,12 +14,15 @@
 
 package org.eclipse.edc.web.jetty;
 
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.web.spi.WebServer;
+import org.eclipse.edc.web.spi.configuration.WebServiceConfigurer;
+import org.eclipse.edc.web.spi.configuration.WebServiceConfigurerImpl;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -82,6 +85,11 @@ public class JettyExtension implements ServiceExtension {
         if (jettyService != null) {
             jettyService.shutdown();
         }
+    }
+
+    @Provider
+    public WebServiceConfigurer webServiceContextConfigurator() {
+        return new WebServiceConfigurerImpl();
     }
 
 }

--- a/extensions/control-plane/api/data-management-api/data-management-api-configuration/src/main/java/org/eclipse/edc/connector/api/datamanagement/configuration/DataManagementApiConfigurationExtension.java
+++ b/extensions/control-plane/api/data-management-api/data-management-api-configuration/src/main/java/org/eclipse/edc/connector/api/datamanagement/configuration/DataManagementApiConfigurationExtension.java
@@ -21,22 +21,36 @@ import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.web.spi.WebServer;
 import org.eclipse.edc.web.spi.WebService;
-
-import static java.lang.String.format;
+import org.eclipse.edc.web.spi.configuration.WebServiceConfigurer;
+import org.eclipse.edc.web.spi.configuration.WebServiceSettings;
 
 @Provides(DataManagementApiConfiguration.class)
 @Extension(value = DataManagementApiConfigurationExtension.NAME)
 public class DataManagementApiConfigurationExtension implements ServiceExtension {
 
-    public static final String WEB_DATA_CONFIG = "web.http.data";
     public static final String NAME = "Data Management API configuration";
-    private static final String DEFAULT_DATAMANAGEMENT_ALIAS = "default";
+
+    public static final String DATA_MANAGEMENT_API_CONFIG = "web.http.data";
+    public static final String DATA_MANAGEMENT_CONTEXT_ALIAS = "data";
+    public static final int DEFAULT_DATA_MANAGEMENT_API_PORT = 8181;
+    public static final String DEFAULT_DATA_MANAGEMENT_API_CONTEXT_PATH = "/api";
+
+    public static final String WEB_SERVICE_NAME = "Data Management API";
+
+
     @Inject
     private WebService webService;
 
     @Inject
+    private WebServer webServer;
+
+    @Inject
     private AuthenticationService authenticationService;
+
+    @Inject
+    private WebServiceConfigurer configurator;
 
     @Override
     public String name() {
@@ -45,29 +59,20 @@ public class DataManagementApiConfigurationExtension implements ServiceExtension
 
     @Override
     public void initialize(ServiceExtensionContext context) {
+        var settings = WebServiceSettings.Builder.newInstance()
+                .apiConfigKey(DATA_MANAGEMENT_API_CONFIG)
+                .contextAlias(DATA_MANAGEMENT_CONTEXT_ALIAS)
+                .defaultPath(DEFAULT_DATA_MANAGEMENT_API_CONTEXT_PATH)
+                .defaultPort(DEFAULT_DATA_MANAGEMENT_API_PORT)
+                .useDefaultContext(true)
+                .name(WEB_SERVICE_NAME)
+                .build();
 
-        var contextAlias = DEFAULT_DATAMANAGEMENT_ALIAS;
-
-        // if no dedicated web.http.data.[port|path] config exists, we'll expose it under the default mapping
-        var monitor = context.getMonitor();
-        var port = 8181;
-        var path = "/api";
-        var config = context.getConfig(WEB_DATA_CONFIG);
-        if (config.getEntries().isEmpty()) {
-            monitor.warning("No [web.http.data.port] or [web.http.data.path] configuration has been provided, therefore the default will be used. " +
-                    "This means that the AuthenticationRequestFilter and the EdcApiExceptionMapper " + "will also be registered for the default context and fire for EVERY request on that context!");
-        } else {
-            contextAlias = "data";
-            port = config.getInteger("port", port);
-            path = config.getString("path", path);
-
-        }
-
-        monitor.info(format("The DataManagementApi will be available under port=%s, path=%s", port, path));
+        var config = configurator.configure(context, webServer, settings);
 
         // the DataManagementApiConfiguration tells all DataManagementApi controllers under which context alias
         // they need to register their resources: either `default` or `data`
-        context.registerService(DataManagementApiConfiguration.class, new DataManagementApiConfiguration(contextAlias));
-        webService.registerResource(contextAlias, new AuthenticationRequestFilter(authenticationService));
+        context.registerService(DataManagementApiConfiguration.class, new DataManagementApiConfiguration(config.getContextAlias()));
+        webService.registerResource(config.getContextAlias(), new AuthenticationRequestFilter(authenticationService));
     }
 }

--- a/extensions/control-plane/provision/provision-http/src/main/java/org/eclipse/edc/connector/provision/http/HttpWebhookExtension.java
+++ b/extensions/control-plane/provision/provision-http/src/main/java/org/eclipse/edc/connector/provision/http/HttpWebhookExtension.java
@@ -26,20 +26,22 @@ import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.web.spi.WebServer;
 import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.WebServiceConfigurer;
+import org.eclipse.edc.web.spi.configuration.WebServiceSettings;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import static java.lang.String.format;
-
 @Provides(HttpProvisionerWebhookUrl.class)
 public class HttpWebhookExtension implements ServiceExtension {
-    //not a Setting, because it is only the first part of the config path
+
     public static final String PROVISIONER_WEBHOOK_CONFIG = "web.http.provisioner";
     public static final String PROVISIONER_CONTEXT_ALIAS = "provisioner";
 
     public static final int DEFUALT_WEBHOOK_PORT = 8383;
     public static final String DEFAULT_PROVISIONER_CONTEXT_PATH = "/api/v1/provisioner";
+
+    public static final String NAME = "Provisioner API";
 
     @Inject
     private WebServer webServer;
@@ -54,31 +56,28 @@ public class HttpWebhookExtension implements ServiceExtension {
     private TransferProcessManager transferProcessManager;
 
     @Inject
+    private WebServiceConfigurer configurator;
+
+    @Inject
     private Hostname hostname;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var monitor = context.getMonitor();
-        var alias = PROVISIONER_CONTEXT_ALIAS;
-        var path = DEFAULT_PROVISIONER_CONTEXT_PATH;
-        var port = DEFUALT_WEBHOOK_PORT;
 
-        var config = context.getConfig(PROVISIONER_WEBHOOK_CONFIG);
-        if (config.getEntries().isEmpty()) {
-            monitor.warning(format("Settings for [%s] and/or [%s] were not provided. Using default" +
-                    " value(s) instead.", PROVISIONER_WEBHOOK_CONFIG + ".path", PROVISIONER_WEBHOOK_CONFIG + ".path"));
-            webServer.addPortMapping(alias, port, path);
-        } else {
-            path = config.getString("path", path);
-            port = config.getInteger("port", port);
-        }
+        var settings = WebServiceSettings.Builder.newInstance()
+                .apiConfigKey(PROVISIONER_WEBHOOK_CONFIG)
+                .contextAlias(PROVISIONER_CONTEXT_ALIAS)
+                .defaultPath(DEFAULT_PROVISIONER_CONTEXT_PATH)
+                .defaultPort(DEFUALT_WEBHOOK_PORT)
+                .name(NAME)
+                .build();
 
-        registerCallbackUrl(context, path, port);
+        var config = configurator.configure(context, webServer, settings);
 
-        monitor.info(format("IDS API will be available at [path=%s], [port=%s].", path, port));
+        registerCallbackUrl(context, config.getPath(), config.getPort());
 
-        webService.registerResource(alias, new HttpProvisionerWebhookApiController(transferProcessManager));
-        webService.registerResource(alias, new AuthenticationRequestFilter(authService));
+        webService.registerResource(config.getContextAlias(), new HttpProvisionerWebhookApiController(transferProcessManager));
+        webService.registerResource(config.getContextAlias(), new AuthenticationRequestFilter(authService));
     }
 
     private void registerCallbackUrl(ServiceExtensionContext context, String path, int port) {

--- a/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/webhook/HttpWebhookExtensionTest.java
+++ b/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/webhook/HttpWebhookExtensionTest.java
@@ -26,6 +26,8 @@ import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.eclipse.edc.spi.system.injection.ObjectFactory;
 import org.eclipse.edc.web.spi.WebServer;
 import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.WebServiceConfigurer;
+import org.eclipse.edc.web.spi.configuration.WebServiceConfigurerImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -61,6 +63,7 @@ class HttpWebhookExtensionTest {
         context.registerService(Hostname.class, () -> "localhost");
         context.registerService(TransferProcessManager.class, mock(TransferProcessManager.class));
         context.registerService(AuthenticationService.class, mock(AuthenticationService.class));
+        context.registerService(WebServiceConfigurer.class, new WebServiceConfigurerImpl());
 
         this.context = spy(context); //used to inject the config
         when(this.context.getMonitor()).thenReturn(mock(Monitor.class));

--- a/spi/common/web-spi/src/main/java/org/eclipse/edc/web/spi/WebServer.java
+++ b/spi/common/web-spi/src/main/java/org/eclipse/edc/web/spi/WebServer.java
@@ -22,6 +22,9 @@ import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 @ExtensionPoint
 public interface WebServer {
 
+    String DEFAULT_CONTEXT_NAME = "default";
+
+
     /**
      * Adds a new port mapping and thus a new API context to this web server.
      *
@@ -30,5 +33,13 @@ public interface WebServer {
      * @param path        the path of the API context.
      */
     void addPortMapping(String contextName, int port, String path);
+
+
+    /**
+     * Returns the default context name
+     */
+    default String getDefaultContextName() {
+        return DEFAULT_CONTEXT_NAME;
+    }
 
 }

--- a/spi/common/web-spi/src/main/java/org/eclipse/edc/web/spi/configuration/WebServiceConfiguration.java
+++ b/spi/common/web-spi/src/main/java/org/eclipse/edc/web/spi/configuration/WebServiceConfiguration.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (c) 2020-2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.web.spi.configuration;
+
+import java.util.Objects;
+
+/**
+ * WebService configuration returned from {@link WebServiceConfigurer#configure}
+ */
+public class WebServiceConfiguration {
+
+    private String contextAlias;
+    private Integer port;
+    private String path;
+
+
+    private WebServiceConfiguration() {
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public String getContextAlias() {
+        return contextAlias;
+    }
+
+
+    public static class Builder {
+        private final WebServiceConfiguration config;
+
+
+        private Builder() {
+            config = new WebServiceConfiguration();
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+
+        public Builder path(String path) {
+            config.path = path;
+            return this;
+        }
+
+        public Builder contextAlias(String contextAlias) {
+            config.contextAlias = contextAlias;
+            return this;
+        }
+
+        public Builder port(int port) {
+            config.port = port;
+            return this;
+        }
+
+        public WebServiceConfiguration build() {
+            Objects.requireNonNull(config.contextAlias);
+            Objects.requireNonNull(config.path);
+            Objects.requireNonNull(config.port);
+            return config;
+        }
+    }
+}

--- a/spi/common/web-spi/src/main/java/org/eclipse/edc/web/spi/configuration/WebServiceConfigurer.java
+++ b/spi/common/web-spi/src/main/java/org/eclipse/edc/web/spi/configuration/WebServiceConfigurer.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2020-2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.web.spi.configuration;
+
+
+import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.web.spi.WebServer;
+
+/**
+ * Configure an API extension
+ */
+@ExtensionPoint
+public interface WebServiceConfigurer {
+
+    /**
+     * Build the configuration for an API
+     *
+     * @param context The context
+     * @param webServer The WebServer
+     * @param settings WebService settings
+     * @return The final webservice configuration
+     */
+    WebServiceConfiguration configure(ServiceExtensionContext context, WebServer webServer, WebServiceSettings settings);
+}

--- a/spi/common/web-spi/src/main/java/org/eclipse/edc/web/spi/configuration/WebServiceConfigurerImpl.java
+++ b/spi/common/web-spi/src/main/java/org/eclipse/edc/web/spi/configuration/WebServiceConfigurerImpl.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2020-2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.web.spi.configuration;
+
+
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.web.spi.WebServer;
+
+import static java.lang.String.format;
+
+public class WebServiceConfigurerImpl implements WebServiceConfigurer {
+
+
+    @Override
+    public WebServiceConfiguration configure(ServiceExtensionContext context, WebServer webServer, WebServiceSettings settings) {
+
+        var apiConfig = settings.apiConfigKey();
+        var config = context.getConfig(apiConfig);
+        var port = settings.getDefaultPort();
+        var path = settings.getDefaultPath();
+        var contextAlias = settings.getContextAlias();
+        var monitor = context.getMonitor();
+
+        if (!config.getEntries().isEmpty()) {
+            port = config.getInteger("port", port);
+            path = config.getString("path", path);
+        } else {
+            monitor.warning(format("Settings for [%s] and/or [%s] were not provided. Using default" +
+                    " value(s) instead.", apiConfig + ".path", apiConfig + ".path"));
+
+            if (settings.useDefaultContext()) {
+                contextAlias = webServer.getDefaultContextName();
+            } else {
+                webServer.addPortMapping(contextAlias, port, path);
+            }
+        }
+
+        monitor.info(format("%s will be available under port=%s, path=%s", settings.getName(), port, path));
+
+        return WebServiceConfiguration.Builder.newInstance()
+                .path(path)
+                .contextAlias(contextAlias)
+                .port(port)
+                .build();
+
+    }
+}

--- a/spi/common/web-spi/src/main/java/org/eclipse/edc/web/spi/configuration/WebServiceSettings.java
+++ b/spi/common/web-spi/src/main/java/org/eclipse/edc/web/spi/configuration/WebServiceSettings.java
@@ -1,0 +1,137 @@
+/*
+ *  Copyright (c) 2020-2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.web.spi.configuration;
+
+import org.eclipse.edc.web.spi.WebServer;
+
+import java.util.Objects;
+
+public class WebServiceSettings {
+
+
+    private boolean useDefaultContext = false;
+    private String apiConfigKey;
+    private Integer defaultPort;
+    private String defaultPath;
+    private String contextAlias;
+    private String name;
+
+    private WebServiceSettings() {
+
+    }
+
+    /**
+     * Returns the key for the ws config key eg `web.http.data`
+     */
+    String apiConfigKey() {
+        return apiConfigKey;
+    }
+
+    /**
+     * The default port if the config {@link WebServiceSettings#apiConfigKey()} is not found in {@link org.eclipse.edc.spi.system.ServiceExtensionContext#getConfig}
+     */
+    public Integer getDefaultPort() {
+        return defaultPort;
+    }
+
+    /**
+     * The default path if the config {@link WebServiceSettings#apiConfigKey()} is not found in {@link org.eclipse.edc.spi.system.ServiceExtensionContext#getConfig}
+     */
+
+    public String getDefaultPath() {
+        return defaultPath;
+    }
+
+    /**
+     * The name of the API context
+     */
+
+    public String getContextAlias() {
+        return contextAlias;
+    }
+
+
+    /**
+     * Implementors can override this if they want to use the {@link WebServer#getDefaultContextName()}
+     * if the config {@link WebServiceSettings#apiConfigKey()} is not found in {@link org.eclipse.edc.spi.system.ServiceExtensionContext#getConfig}
+     */
+    public boolean useDefaultContext() {
+        return useDefaultContext;
+    }
+
+
+    /**
+     * The name of the API settings. It's intended only for displaying the name of the Web Extension that
+     * will be configured by {@link WebServiceConfigurer}.
+     */
+    public String getName() {
+        return name;
+    }
+
+
+    public static class Builder {
+
+        private final WebServiceSettings settings;
+
+
+        private Builder() {
+            settings = new WebServiceSettings();
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder contextAlias(String contextAlias) {
+            settings.contextAlias = contextAlias;
+            return this;
+        }
+
+        public Builder defaultPath(String defaultPath) {
+            settings.defaultPath = defaultPath;
+            return this;
+        }
+
+        public Builder apiConfigKey(String apiConfigKey) {
+            settings.apiConfigKey = apiConfigKey;
+            return this;
+        }
+
+        public Builder name(String name) {
+            settings.name = name;
+            return this;
+        }
+
+        public Builder defaultPort(int defaultPort) {
+            settings.defaultPort = defaultPort;
+            return this;
+        }
+
+        public Builder useDefaultContext(boolean useDefaultContext) {
+            settings.useDefaultContext = useDefaultContext;
+            return this;
+        }
+
+        public WebServiceSettings build() {
+            Objects.requireNonNull(settings.apiConfigKey);
+            Objects.requireNonNull(settings.defaultPath);
+            Objects.requireNonNull(settings.defaultPort);
+            Objects.requireNonNull(settings.name);
+
+            return settings;
+        }
+
+    }
+}

--- a/spi/common/web-spi/src/test/java/org/eclipse/edc/web/spi/configuration/WebServiceConfigurerImplTest.java
+++ b/spi/common/web-spi/src/test/java/org/eclipse/edc/web/spi/configuration/WebServiceConfigurerImplTest.java
@@ -1,0 +1,141 @@
+/*
+ *  Copyright (c) 2020-2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.web.spi.configuration;
+
+import org.eclipse.edc.spi.monitor.ConsoleMonitor;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.eclipse.edc.web.spi.WebServer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+public class WebServiceConfigurerImplTest {
+
+
+    private static final String CONFIG = "web.http.test";
+    private static final String PATH = "/api";
+    private static final String ALIAS = "test";
+    private static final int PORT = 8080;
+    private ServiceExtensionContext context;
+    private WebServer server;
+
+    private WebServiceConfigurerImpl configurator;
+
+    @Test
+    void verifyConfigure_whenDefaultConfig() {
+
+        var config = ConfigFactory.fromMap(new HashMap<>());
+        when(context.getConfig(CONFIG)).thenReturn(config);
+        when(context.getMonitor()).thenReturn(new ConsoleMonitor());
+
+        var settings = WebServiceSettings.Builder.newInstance()
+                .apiConfigKey(CONFIG)
+                .contextAlias(ALIAS)
+                .defaultPath(PATH)
+                .defaultPort(PORT)
+                .useDefaultContext(false)
+                .name("TEST")
+                .build();
+
+        var actualConfig = configurator.configure(context, server, settings);
+
+        verify(server, times(1))
+                .addPortMapping(ALIAS, PORT, PATH);
+
+        assertThat(actualConfig.getContextAlias()).isEqualTo(ALIAS);
+        assertThat(actualConfig.getPort()).isEqualTo(PORT);
+        assertThat(actualConfig.getPath()).isEqualTo(PATH);
+
+    }
+
+    @Test
+    void verifyConfigure_whenDefaultAlias() {
+
+        var config = ConfigFactory.fromMap(new HashMap<>());
+        when(context.getConfig(CONFIG)).thenReturn(config);
+        String defValue = "default";
+        when(server.getDefaultContextName()).thenReturn(defValue);
+        when(context.getMonitor()).thenReturn(new ConsoleMonitor());
+
+        var settings = WebServiceSettings.Builder.newInstance()
+                .apiConfigKey(CONFIG)
+                .contextAlias(ALIAS)
+                .defaultPath(PATH)
+                .defaultPort(PORT)
+                .useDefaultContext(true)
+                .name("TEST")
+                .build();
+
+        var actualConfig = configurator.configure(context, server, settings);
+
+        verify(server, times(1))
+                .getDefaultContextName();
+
+        assertThat(actualConfig.getContextAlias()).isEqualTo(defValue);
+        assertThat(actualConfig.getPort()).isEqualTo(PORT);
+        assertThat(actualConfig.getPath()).isEqualTo(PATH);
+
+    }
+
+    @Test
+    void verifyConfigure_whenExternalConfig() {
+
+        var path = "/api/custom";
+        var port = 8765;
+        var apiConfig = new HashMap<String, String>();
+        apiConfig.put("port", String.valueOf(port));
+        apiConfig.put("path", path);
+
+        var config = ConfigFactory.fromMap(apiConfig);
+        when(context.getConfig(CONFIG)).thenReturn(config);
+        when(context.getMonitor()).thenReturn(new ConsoleMonitor());
+
+        var settings = WebServiceSettings.Builder.newInstance()
+                .apiConfigKey(CONFIG)
+                .contextAlias(ALIAS)
+                .defaultPath(PATH)
+                .defaultPort(PORT)
+                .useDefaultContext(false)
+                .name("TEST")
+                .build();
+
+        var actualConfig = configurator.configure(context, server, settings);
+
+        verifyNoInteractions(server);
+        assertThat(actualConfig.getContextAlias()).isEqualTo(ALIAS);
+        assertThat(actualConfig.getPort()).isEqualTo(port);
+        assertThat(actualConfig.getPath()).isEqualTo(path);
+
+    }
+
+
+    @BeforeEach
+    void setup() {
+        context = mock(ServiceExtensionContext.class);
+        server = mock(WebServer.class);
+        configurator = new WebServiceConfigurerImpl();
+    }
+
+
+}


### PR DESCRIPTION
## What this PR changes/adds

Extract duplicated code when configuring an API extension

## Why it does that

removes duplicated code

## Further notes

The common logic/ the default impl for the configurator has been placed in `web::spi` since we don't have yet a common module for web. 

## Linked Issue(s)

Closes #2128 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
