### PR TITLE
fix: avoid default limit 50 on catalog creation

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImpl.java
@@ -76,6 +76,8 @@ public class ContractOfferResolverImpl implements ContractOfferResolver {
                     var querySpec = querySpecBuilder.build();
                     var numAssets = assetIndex.countAssets(querySpec);
 
+                    querySpecBuilder.limit((int) numAssets);
+
                     if (skip.get() > 0) {
                         querySpecBuilder.offset(skip.get());
                     }

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImpl.java
@@ -75,7 +75,7 @@ public class ContractOfferResolverImpl implements ContractOfferResolver {
                             .filter(concat(criteria.stream(), query.getAssetsCriteria().stream()).collect(Collectors.toList()));
 
                     var querySpec = querySpecBuilder.build();
-                    var numAssets = assetIndex.countAssets(querySpec);
+                    var numAssets = assetIndex.countAssets(querySpec.getFilterExpression());
 
                     querySpecBuilder.limit((int) numAssets);
 

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImpl.java
@@ -33,6 +33,7 @@ import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.jetbrains.annotations.NotNull;
 
 import java.net.URI;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -85,22 +86,26 @@ public class ContractOfferResolverImpl implements ContractOfferResolver {
                         querySpecBuilder.limit(limit);
                     }
 
-                    if (skip.get() < numAssets) {
-                        var byId = policyStore.findById(definition.getContractPolicyId());
-                        if (byId == null) { //policy not found
-                            return Stream.empty();
-                        }
-                        var assets = assetIndex.queryAssets(querySpecBuilder.build());
-                        numSeenAssets.addAndGet(numAssets);
-                        skip.addAndGet(Long.valueOf(-numAssets).intValue());
-                        return assets.map(a -> createContractOffer(definition, byId.getPolicy(), a));
-
+                    Stream<ContractOffer> offers;
+                    if (skip.get() >= numAssets) {
+                        offers = Stream.empty();
                     } else {
-                        numSeenAssets.addAndGet(numAssets);
-                        skip.addAndGet(Long.valueOf(-numAssets).intValue());
-                        return Stream.empty();
+                        offers = createContractOffers(definition, querySpecBuilder.build());
                     }
+
+                    numSeenAssets.addAndGet(numAssets);
+                    skip.addAndGet(Long.valueOf(-numAssets).intValue());
+                    return offers;
                 });
+    }
+
+    @NotNull
+    private Stream<@NotNull ContractOffer> createContractOffers(ContractDefinition definition, QuerySpec assetQuerySpec) {
+        return Optional.of(definition.getContractPolicyId())
+                .map(policyStore::findById)
+                .map(policyDefinition -> assetIndex.queryAssets(assetQuerySpec)
+                        .map(asset -> createContractOffer(definition, policyDefinition.getPolicy(), asset)))
+                .orElse(Stream.empty());
     }
 
     @NotNull

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImplTest.java
@@ -52,7 +52,6 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImplTest.java
@@ -46,6 +46,7 @@ import static java.util.stream.Stream.concat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.AdditionalMatchers.and;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -79,7 +80,7 @@ class ContractOfferResolverImplTest {
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
         when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class))).thenReturn(Stream.of(contractDefinition));
         var assetStream = Stream.of(Asset.Builder.newInstance().build(), Asset.Builder.newInstance().build());
-        when(assetIndex.countAssets(any())).thenReturn(2L);
+        when(assetIndex.countAssets(anyList())).thenReturn(2L);
         when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(assetStream);
         when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
 
@@ -113,7 +114,7 @@ class ContractOfferResolverImplTest {
 
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
         when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class))).thenAnswer(i -> contractDefinition);
-        when(assetIndex.countAssets(any())).thenReturn(100L);
+        when(assetIndex.countAssets(anyList())).thenReturn(100L);
         when(assetIndex.queryAssets(isA(QuerySpec.class))).thenAnswer(inv -> range(20, 50).mapToObj(i -> createAsset("asset" + i).build()));
         when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
 
@@ -142,7 +143,7 @@ class ContractOfferResolverImplTest {
 
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
         when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class))).thenReturn(Stream.of(contractDefinition));
-        when(assetIndex.countAssets(any())).thenReturn(40L);
+        when(assetIndex.countAssets(anyList())).thenReturn(40L);
         when(assetIndex.queryAssets(isA(QuerySpec.class))).thenAnswer(inv -> range(20, 50).mapToObj(i -> createAsset("asset" + i).build()));
         when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
 
@@ -163,7 +164,7 @@ class ContractOfferResolverImplTest {
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
         when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class))).thenAnswer(i -> contractDefinition);
         when(assetIndex.queryAssets(isA(QuerySpec.class))).thenAnswer(inv -> range(0, 10).mapToObj(i -> createAsset("asset" + i).build()));
-        when(assetIndex.countAssets(any())).thenReturn(10L);
+        when(assetIndex.countAssets(anyList())).thenReturn(10L);
         when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
 
         var from = 20;
@@ -186,7 +187,7 @@ class ContractOfferResolverImplTest {
 
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
         when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class))).thenAnswer(i -> contractDefinition);
-        when(assetIndex.countAssets(any())).thenReturn(10L);
+        when(assetIndex.countAssets(anyList())).thenReturn(10L);
         when(assetIndex.queryAssets(isA(QuerySpec.class))).thenAnswer(inv -> range(0, 10).mapToObj(i -> createAsset("asset" + i).build()));
         when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
 
@@ -210,7 +211,7 @@ class ContractOfferResolverImplTest {
 
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
         when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class))).thenAnswer(i -> contractDefinitions);
-        when(assetIndex.countAssets(any())).thenReturn(1L);
+        when(assetIndex.countAssets(anyList())).thenReturn(1L);
         when(assetIndex.queryAssets(isA(QuerySpec.class))).thenAnswer(inv -> Stream.of(createAsset("asset").build()));
         when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
 
@@ -237,7 +238,7 @@ class ContractOfferResolverImplTest {
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
         when(contractDefinitionService.definitionsFor(isA(ParticipantAgent.class))).thenReturn(Stream.of(contractDefinition));
         var assetStream = Stream.of(Asset.Builder.newInstance().build(), Asset.Builder.newInstance().build());
-        when(assetIndex.countAssets(isA(QuerySpec.class))).thenReturn(1000L);
+        when(assetIndex.countAssets(anyList())).thenReturn(1000L);
         when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(assetStream);
         when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
 

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryAssetIndex.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryAssetIndex.java
@@ -135,7 +135,7 @@ public class InMemoryAssetIndex implements AssetIndex {
 
     @Override
     public long countAssets(QuerySpec querySpec) {
-        return queryAssets(querySpec).count();
+        return queryAssets(querySpec.resetRange()).count();
     }
 
     @Override

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryAssetIndexTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryAssetIndexTest.java
@@ -205,7 +205,6 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
         var assets = IntStream.range(0, 10).mapToObj(i -> createAsset("test-asset", "id" + i))
                 .peek(a -> index.accept(a, createDataAddress(a))).collect(Collectors.toList());
 
-
         assertThat(index.queryAssets(QuerySpec.Builder.newInstance().build())).containsAll(assets);
     }
 
@@ -243,7 +242,6 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
         var spec = QuerySpec.Builder.newInstance().equalsAsContains(false).filter(Asset.PROPERTY_ID + " = id1").build();
         assertThat(index.queryAssets(spec)).hasSize(1).containsExactly(assets.get(1));
     }
-
 
     @Test
     void findAll_withFiltering_limitExceedsResultSize() {

--- a/extensions/control-plane/provision/provision-oauth2/build.gradle.kts
+++ b/extensions/control-plane/provision/provision-oauth2/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
 
     testImplementation(project(":core:control-plane:control-plane-core"))
     testImplementation(project(":extensions:common:http"))
-    testImplementation(project(":extensions:common:junit"))
+    testImplementation(project(":core:common:junit"))
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
     testImplementation("org.awaitility:awaitility:${awaitility}")
     testImplementation("org.mock-server:mockserver-netty:${httpMockServer}:shaded")

--- a/extensions/control-plane/store/cosmos/asset-index-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/CosmosAssetIndex.java
+++ b/extensions/control-plane/store/cosmos/asset-index-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/CosmosAssetIndex.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.connector.store.azure.cosmos.assetindex.model.AssetDocume
 import org.eclipse.edc.spi.asset.AssetIndex;
 import org.eclipse.edc.spi.asset.AssetSelectorExpression;
 import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.query.SortOrder;
 import org.eclipse.edc.spi.types.TypeManager;
@@ -29,6 +30,7 @@ import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.spi.types.domain.asset.AssetEntry;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -115,16 +117,9 @@ public class CosmosAssetIndex implements AssetIndex {
     }
 
     @Override
-    public long countAssets(QuerySpec querySpec) {
-        var query = querySpec.resetRange();
+    public long countAssets(List<Criterion> criteria) {
+        var sqlQuery = queryBuilder.from(criteria);
 
-        var sqlQuery = queryBuilder.from(
-                query.getFilterExpression(),
-                query.getSortField(),
-                query.getSortOrder() == SortOrder.ASC,
-                query.getLimit(),
-                query.getOffset()
-        );
         var stmt = sqlQuery.getQueryText().replace("SELECT * ", "SELECT COUNT(1) ");
         sqlQuery.setQueryText(stmt);
         return with(retryPolicy).get(() -> assetDb.queryItems(sqlQuery))

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/SqlAssetIndex.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/SqlAssetIndex.java
@@ -174,7 +174,7 @@ public class SqlAssetIndex extends AbstractSqlStore implements AssetIndex {
     @Override
     public long countAssets(QuerySpec querySpec) {
         try (var connection = getConnection()) {
-            var statement = assetStatements.createQuery(querySpec);
+            var statement = assetStatements.createQuery(querySpec.resetRange());
 
             var queryAsString = statement.getQueryAsString().replace("SELECT * ", "SELECT COUNT (*) ");
 

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/SqlAssetIndex.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/SqlAssetIndex.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.connector.store.sql.assetindex.schema.AssetStatements;
 import org.eclipse.edc.spi.asset.AssetIndex;
 import org.eclipse.edc.spi.asset.AssetSelectorExpression;
 import org.eclipse.edc.spi.persistence.EdcPersistenceException;
+import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
@@ -35,6 +36,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.AbstractMap;
+import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -172,9 +174,9 @@ public class SqlAssetIndex extends AbstractSqlStore implements AssetIndex {
     }
 
     @Override
-    public long countAssets(QuerySpec querySpec) {
+    public long countAssets(List<Criterion> criteria) {
         try (var connection = getConnection()) {
-            var statement = assetStatements.createQuery(querySpec.resetRange());
+            var statement = assetStatements.createQuery(criteria);
 
             var queryAsString = statement.getQueryAsString().replace("SELECT * ", "SELECT COUNT (*) ");
 

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/schema/AssetStatements.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/schema/AssetStatements.java
@@ -15,8 +15,11 @@
 package org.eclipse.edc.connector.store.sql.assetindex.schema;
 
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.sql.translation.SqlQueryStatement;
+
+import java.util.List;
 
 /**
  * Defines queries used by the SqlAssetIndexServiceExtension.
@@ -155,6 +158,13 @@ public interface AssetStatements {
      * @return A {@link SqlQueryStatement} that contains the SQL and statement parameters
      */
     SqlQueryStatement createQuery(QuerySpec query);
+
+    /**
+     * Generates a SQL query using sub-select statements out of the criterion.
+     *
+     * @return A {@link SqlQueryStatement} that contains the SQL and statement parameters
+     */
+    SqlQueryStatement createQuery(List<Criterion> query);
 
     /**
      * Select single asset by ID

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/asset/AssetIndex.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/asset/AssetIndex.java
@@ -16,12 +16,14 @@ package org.eclipse.edc.spi.asset;
 
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.persistence.EdcPersistenceException;
+import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.spi.types.domain.asset.AssetEntry;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 /**
@@ -86,10 +88,10 @@ public interface AssetIndex extends DataAddressResolver {
     Asset deleteById(String assetId);
 
     /**
-     * Counts all assets that are selected by the given query
+     * Counts all assets that are selected by the given criteria
      *
-     * @param querySpec the query
+     * @param criteria the criterion list
      * @return the number of assets (potentially 0)
      */
-    long countAssets(QuerySpec querySpec);
+    long countAssets(List<Criterion> criteria);
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/QuerySpec.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/QuerySpec.java
@@ -102,6 +102,16 @@ public class QuerySpec {
         return sortOrder;
     }
 
+    public QuerySpec resetRange() {
+        return QuerySpec.Builder.newInstance()
+                .limit(Integer.MAX_VALUE)
+                .offset(0)
+                .filter(this.filterExpression)
+                .sortField(this.sortField)
+                .sortOrder(this.sortOrder)
+                .build();
+    }
+
     /**
      * Checks whether any {@link Criterion} contains the given left-hand operand
      */

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/QuerySpec.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/QuerySpec.java
@@ -102,16 +102,6 @@ public class QuerySpec {
         return sortOrder;
     }
 
-    public QuerySpec resetRange() {
-        return QuerySpec.Builder.newInstance()
-                .limit(Integer.MAX_VALUE)
-                .offset(0)
-                .filter(this.filterExpression)
-                .sortField(this.sortField)
-                .sortOrder(this.sortOrder)
-                .build();
-    }
-
     /**
      * Checks whether any {@link Criterion} contains the given left-hand operand
      */

--- a/spi/common/core-spi/src/testFixtures/java/org/eclipse/edc/spi/testfixtures/asset/AssetIndexTestBase.java
+++ b/spi/common/core-spi/src/testFixtures/java/org/eclipse/edc/spi/testfixtures/asset/AssetIndexTestBase.java
@@ -149,14 +149,30 @@ public abstract class AssetIndexTestBase {
         var assets = range(0, 5).mapToObj(i -> getAsset("id" + i));
         assets.forEach(a -> getAssetIndex().accept(a, getDataAddress()));
 
-        var count = getAssetIndex().countAssets(QuerySpec.none());
+        var query = QuerySpec.none();
+
+        var count = getAssetIndex().countAssets(query);
         assertThat(count).isEqualTo(5);
     }
 
     @Test
     void count_withNoResults() {
-        var count = getAssetIndex().countAssets(QuerySpec.none());
+        var query = QuerySpec.none();
+
+        var count = getAssetIndex().countAssets(query);
+
         assertThat(count).isEqualTo(0);
+    }
+
+    @Test
+    void count_shouldIgnoreLimitAndOffset() {
+        var assets = range(0, 5).mapToObj(i -> getAsset("id" + i));
+        assets.forEach(a -> getAssetIndex().accept(a, getDataAddress()));
+        var query = QuerySpec.Builder.newInstance().offset(1).limit(3).build();
+
+        var count = getAssetIndex().countAssets(query);
+
+        assertThat(count).isEqualTo(5);
     }
 
     @Test

--- a/spi/common/core-spi/src/testFixtures/java/org/eclipse/edc/spi/testfixtures/asset/AssetIndexTestBase.java
+++ b/spi/common/core-spi/src/testFixtures/java/org/eclipse/edc/spi/testfixtures/asset/AssetIndexTestBase.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.emptyList;
 import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
@@ -148,31 +149,20 @@ public abstract class AssetIndexTestBase {
     void count_withResults() {
         var assets = range(0, 5).mapToObj(i -> getAsset("id" + i));
         assets.forEach(a -> getAssetIndex().accept(a, getDataAddress()));
+        var criteria = Collections.<Criterion>emptyList();
 
-        var query = QuerySpec.none();
+        var count = getAssetIndex().countAssets(criteria);
 
-        var count = getAssetIndex().countAssets(query);
         assertThat(count).isEqualTo(5);
     }
 
     @Test
     void count_withNoResults() {
-        var query = QuerySpec.none();
+        var criteria = Collections.<Criterion>emptyList();
 
-        var count = getAssetIndex().countAssets(query);
+        var count = getAssetIndex().countAssets(criteria);
 
         assertThat(count).isEqualTo(0);
-    }
-
-    @Test
-    void count_shouldIgnoreLimitAndOffset() {
-        var assets = range(0, 5).mapToObj(i -> getAsset("id" + i));
-        assets.forEach(a -> getAssetIndex().accept(a, getDataAddress()));
-        var query = QuerySpec.Builder.newInstance().offset(1).limit(3).build();
-
-        var count = getAssetIndex().countAssets(query);
-
-        assertThat(count).isEqualTo(5);
     }
 
     @Test
@@ -364,7 +354,7 @@ public abstract class AssetIndexTestBase {
      * lowercase!
      */
     protected Collection<String> getSupportedOperators() {
-        return Collections.emptyList();
+        return emptyList();
     }
 
     /**


### PR DESCRIPTION
## What this PR changes/adds

Avoids the default limit of 50 when requesting catalog in certain circumstances.
To achieve that:
- always set `limit` by default at the asset count retrieved by the `countAssets` call in the `ContractOfferResolverImpl.queryContractOffers` method.
- ignore `offset` and `limit` in the `countAssets` implementation, as it should count items filtering by the query, but not restricting the output with a range.

## Why it does that

Fix bug

## Further notes

- could we remove set the `QuerySpec.limit`'s default value to `Integer.MAX_VALUE`? As the "security issue" is already handled by `QuerySpecDto`.

## Linked Issue(s)

Closes #2064 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
