### PR TITLE
fix: remove usages of Apache Commons Lang

### DIFF
--- a/system-tests/tests/src/test/java/org/eclipse/edc/test/system/remote/FileTransferAsClientSimulation.java
+++ b/system-tests/tests/src/test/java/org/eclipse/edc/test/system/remote/FileTransferAsClientSimulation.java
@@ -15,10 +15,7 @@
 package org.eclipse.edc.test.system.remote;
 
 import io.gatling.javaapi.core.Simulation;
-import org.apache.commons.lang3.StringUtils;
 import org.eclipse.edc.test.system.FileTransferSimulationConfiguration;
-
-import java.util.Objects;
 
 import static io.gatling.javaapi.core.CoreDsl.atOnceUsers;
 import static io.gatling.javaapi.core.CoreDsl.global;
@@ -51,6 +48,11 @@ public class FileTransferAsClientSimulation extends Simulation {
     }
 
     private static String getFromEnv(String env) {
-        return Objects.requireNonNull(StringUtils.trimToNull(System.getenv(env)), env);
+        var val = System.getenv(env);
+        if (val == null || val.trim().isEmpty()) {
+            throw new RuntimeException(env + " must be set.");
+        } else {
+            return val.trim();
+        }
     }
 }

--- a/system-tests/tests/src/test/java/org/eclipse/edc/test/system/remote/FileTransferAsClientSimulation.java
+++ b/system-tests/tests/src/test/java/org/eclipse/edc/test/system/remote/FileTransferAsClientSimulation.java
@@ -17,6 +17,8 @@ package org.eclipse.edc.test.system.remote;
 import io.gatling.javaapi.core.Simulation;
 import org.eclipse.edc.test.system.FileTransferSimulationConfiguration;
 
+import java.util.Objects;
+
 import static io.gatling.javaapi.core.CoreDsl.atOnceUsers;
 import static io.gatling.javaapi.core.CoreDsl.global;
 import static io.gatling.javaapi.core.CoreDsl.scenario;
@@ -48,11 +50,6 @@ public class FileTransferAsClientSimulation extends Simulation {
     }
 
     private static String getFromEnv(String env) {
-        var val = System.getenv(env);
-        if (val == null || val.trim().isEmpty()) {
-            throw new RuntimeException(env + " must be set.");
-        } else {
-            return val.trim();
-        }
+        return Objects.requireNonNull(System.getenv(env), env + " must be set.");
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

removing usage of org.apache.commons:commons-lang3:3.12.0 pulled as transitive dependency of org.mock-server:mockserver-netty:5.14.0.

## Why it does that

Relying on transitive dependency should be avoided.

## Linked Issue(s)

Closes #1747

## Checklist

- [n/a] added appropriate tests?
- [x] performed checkstyle check locally?
- [n/a] added/updated copyright headers?
- [n/a] documented public classes/methods?
- [n/a] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
