### PR TITLE
feat: add retry mechanism to oauth2 service

### DIFF
--- a/extensions/common/iam/oauth2/oauth2-core/build.gradle.kts
+++ b/extensions/common/iam/oauth2/oauth2-core/build.gradle.kts
@@ -16,6 +16,7 @@ plugins {
     `java-library`
 }
 
+val failsafeVersion: String by project
 val httpMockServer: String by project
 val nimbusVersion: String by project
 val okHttpVersion: String by project
@@ -23,6 +24,7 @@ val okHttpVersion: String by project
 dependencies {
     api(project(":spi:common:oauth2-spi"))
     implementation(project(":core:common:jwt-core"))
+    implementation("dev.failsafe:failsafe-okhttp:${failsafeVersion}")
 
     implementation("com.nimbusds:nimbus-jose-jwt:${nimbusVersion}")
     implementation("com.squareup.okhttp3:okhttp:${okHttpVersion}")

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2Extension.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2Extension.java
@@ -15,7 +15,9 @@
 
 package org.eclipse.edc.iam.oauth2;
 
+import dev.failsafe.RetryPolicy;
 import okhttp3.OkHttpClient;
+import okhttp3.Response;
 import org.eclipse.edc.iam.oauth2.identity.IdentityProviderKeyResolver;
 import org.eclipse.edc.iam.oauth2.identity.IdentityProviderKeyResolverConfiguration;
 import org.eclipse.edc.iam.oauth2.identity.Oauth2ServiceImpl;
@@ -89,6 +91,9 @@ public class Oauth2Extension implements ServiceExtension {
     @Inject
     private CredentialsRequestAdditionalParametersProvider credentialsRequestAdditionalParametersProvider;
 
+    @Inject
+    private RetryPolicy<Response> retryPolicy;
+
     @Override
     public String name() {
         return NAME;
@@ -115,9 +120,11 @@ public class Oauth2Extension implements ServiceExtension {
         var privateKey = configuration.getPrivateKeyResolver().resolvePrivateKey(privateKeyAlias, PrivateKey.class);
 
         var oauth2Service = new Oauth2ServiceImpl(
+                context.getMonitor(),
                 configuration,
                 new TokenGenerationServiceImpl(privateKey),
                 okHttpClient,
+                retryPolicy,
                 jwtDecoratorRegistry,
                 context.getTypeManager(),
                 new TokenValidationServiceImpl(configuration.getIdentityProviderKeyResolver(), validationRulesRegistry),

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/identity/Oauth2ServiceImpl.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/identity/Oauth2ServiceImpl.java
@@ -17,25 +17,31 @@
 
 package org.eclipse.edc.iam.oauth2.identity;
 
+import dev.failsafe.RetryPolicy;
 import okhttp3.FormBody;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.Response;
 import org.eclipse.edc.iam.oauth2.Oauth2Configuration;
 import org.eclipse.edc.iam.oauth2.spi.CredentialsRequestAdditionalParametersProvider;
 import org.eclipse.edc.jwt.spi.JwtDecorator;
 import org.eclipse.edc.jwt.spi.JwtDecoratorRegistry;
 import org.eclipse.edc.jwt.spi.TokenGenerationService;
 import org.eclipse.edc.jwt.spi.TokenValidationService;
-import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.iam.IdentityService;
 import org.eclipse.edc.spi.iam.TokenParameters;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.TypeManager;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
-import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static dev.failsafe.okhttp.FailsafeCall.with;
+import static java.lang.String.format;
 
 /**
  * Implements the OAuth2 client credentials flow and bearer token validation.
@@ -44,10 +50,13 @@ public class Oauth2ServiceImpl implements IdentityService {
 
     private static final String GRANT_TYPE = "client_credentials";
     private static final String ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
-    private static final String CONTENT_TYPE = "application/x-www-form-urlencoded";
+    private static final String FORM_URLENCODED = "application/x-www-form-urlencoded";
+    public static final String CONTENT_TYPE = "Content-Type";
 
+    private final Monitor monitor;
     private final Oauth2Configuration configuration;
     private final OkHttpClient httpClient;
+    private final RetryPolicy<Response> retryPolicy;
     private final TypeManager typeManager;
     private final JwtDecoratorRegistry jwtDecoratorRegistry;
     private final TokenGenerationService tokenGenerationService;
@@ -57,17 +66,23 @@ public class Oauth2ServiceImpl implements IdentityService {
     /**
      * Creates a new instance of the OAuth2 Service
      *
+     * @param monitor                                        The monitor
      * @param configuration                                  The configuration
      * @param tokenGenerationService                         Service used to generate the signed tokens;
      * @param client                                         Http client
+     * @param retryPolicy                                    Retry policy
      * @param jwtDecoratorRegistry                           Registry containing the decorator for build the JWT
      * @param typeManager                                    Type manager
      * @param tokenValidationService                         Service used for token validation
      * @param credentialsRequestAdditionalParametersProvider Provides additional form parameters
      */
-    public Oauth2ServiceImpl(Oauth2Configuration configuration, TokenGenerationService tokenGenerationService, OkHttpClient client, JwtDecoratorRegistry jwtDecoratorRegistry, TypeManager typeManager,
-                             TokenValidationService tokenValidationService, CredentialsRequestAdditionalParametersProvider credentialsRequestAdditionalParametersProvider) {
+    public Oauth2ServiceImpl(Monitor monitor, Oauth2Configuration configuration, TokenGenerationService tokenGenerationService,
+                             OkHttpClient client, RetryPolicy<Response> retryPolicy, JwtDecoratorRegistry jwtDecoratorRegistry,
+                             TypeManager typeManager, TokenValidationService tokenValidationService,
+                             CredentialsRequestAdditionalParametersProvider credentialsRequestAdditionalParametersProvider) {
+        this.monitor = monitor;
         this.configuration = configuration;
+        this.retryPolicy = retryPolicy;
         this.typeManager = typeManager;
         httpClient = client;
         this.jwtDecoratorRegistry = jwtDecoratorRegistry;
@@ -78,13 +93,26 @@ public class Oauth2ServiceImpl implements IdentityService {
 
     @Override
     public Result<TokenRepresentation> obtainClientCredentials(TokenParameters parameters) {
-        var jwtCreationResult = tokenGenerationService.generate(jwtDecoratorRegistry.getAll().toArray(JwtDecorator[]::new));
-        if (jwtCreationResult.failed()) {
-            return jwtCreationResult;
-        }
+        return generateClientAssertion()
+                .map(assertion -> createRequestBody(parameters, assertion))
+                .map(this::createRequest)
+                .compose(this::requestToken);
+    }
 
-        var assertion = jwtCreationResult.getContent().getToken();
+    @Override
+    public Result<ClaimToken> verifyJwtToken(TokenRepresentation tokenRepresentation, String audience) {
+        return tokenValidationService.validate(tokenRepresentation);
+    }
 
+    @NotNull
+    private Result<String> generateClientAssertion() {
+        var decorators = jwtDecoratorRegistry.getAll().toArray(JwtDecorator[]::new);
+        return tokenGenerationService.generate(decorators)
+                .map(TokenRepresentation::getToken);
+    }
+
+    @NotNull
+    private FormBody createRequestBody(TokenParameters parameters, String assertion) {
         var requestBodyBuilder = new FormBody.Builder()
                 .add("client_assertion_type", ASSERTION_TYPE)
                 .add("grant_type", GRANT_TYPE)
@@ -93,36 +121,61 @@ public class Oauth2ServiceImpl implements IdentityService {
 
         credentialsRequestAdditionalParametersProvider.provide(parameters).forEach(requestBodyBuilder::add);
 
-        var request = new Request.Builder()
+        return requestBodyBuilder.build();
+    }
+
+    @NotNull
+    private Request createRequest(@NotNull FormBody requestBody) {
+        return new Request.Builder()
                 .url(configuration.getTokenUrl())
-                .addHeader("Content-Type", CONTENT_TYPE)
-                .post(requestBodyBuilder.build())
+                .addHeader(CONTENT_TYPE, FORM_URLENCODED)
+                .post(requestBody)
                 .build();
+    }
 
-        try (var response = httpClient.newCall(request).execute()) {
-            try (var body = response.body()) {
-                if (!response.isSuccessful()) {
-                    var message = body == null ? "<empty body>" : body.string();
-                    return Result.failure(message);
-                }
+    @NotNull
+    private Result<TokenRepresentation> requestToken(Request request) {
+        try (
+                var response = with(retryPolicy).compose(httpClient.newCall(request)).execute();
+                var body = response.body()
+        ) {
+            if (body == null) {
+                return failure("Response body is null");
+            }
 
-                if (body == null) {
-                    return Result.failure("<empty token body>");
-                }
+            if (!response.isSuccessful()) {
+                return failure(format("Server responded with %s: %s", response.code(), body.string()));
+            }
 
-                var responsePayload = body.string();
-                var deserialized = typeManager.readValue(responsePayload, LinkedHashMap.class);
+            var responseBody = body.string();
+
+            try {
+                var deserialized = typeManager.readValue(responseBody, Map.class);
                 var token = (String) deserialized.get("access_token");
                 var tokenRepresentation = TokenRepresentation.Builder.newInstance().token(token).build();
                 return Result.success(tokenRepresentation);
+            } catch (Exception e) {
+                return failure(format("Response body is not a valid json %s", responseBody), e);
             }
         } catch (IOException e) {
-            throw new EdcException(e);
+            return failure(e.getMessage(), e);
         }
     }
 
-    @Override
-    public Result<ClaimToken> verifyJwtToken(TokenRepresentation tokenRepresentation, String audience) {
-        return tokenValidationService.validate(tokenRepresentation);
+    @NotNull
+    private Result<TokenRepresentation> failure(String message) {
+        return Result.failure(failureMessage(message));
+    }
+
+    @NotNull
+    private Result<TokenRepresentation> failure(String message, Exception e) {
+        var fullMessage = failureMessage(message);
+        monitor.severe(fullMessage, e);
+        return Result.failure(fullMessage);
+    }
+
+    @NotNull
+    private String failureMessage(String message) {
+        return format("Error requesting oauth2 token from %s: %s", configuration.getTokenUrl(), message);
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/Result.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/Result.java
@@ -137,6 +137,20 @@ public class Result<T> extends AbstractResult<T, Failure> {
     }
 
     /**
+     * If the result is successful maps the content into a Result applying the mapping function, otherwise do nothing.
+     *
+     * @param mappingFunction a function converting this result into another
+     * @return the result of the mapping function
+     */
+    public <U> Result<U> compose(Function<T, Result<U>> mappingFunction) {
+        if (succeeded()) {
+            return mappingFunction.apply(getContent());
+        } else {
+            return mapTo();
+        }
+    }
+
+    /**
      * Converts this result into an {@link Optional}. When this result is failed, or there is no content,
      * {@link Optional#isEmpty()} is returned, otherwise the content is the {@link Optional}'s value
      *


### PR DESCRIPTION
## What this PR changes/adds

Adds the retry mechanism through `Failsafe` to `Oauth2ServiceImpl`

## Why it does that

To improve resiliency.

## Further notes

- took the opportunity to improve error reporting and refactoring the service a bit 
- add a `compose` method on `Result` that maps the content to another result as it was missing, but it is useful in cases like this.

## Linked Issue(s)

Closes #2171

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
