### PR TITLE
refactor(controlPlaneApi): Adds usage of TranferProcessService 

### DIFF
--- a/core/control-plane/control-plane-api/src/main/java/org/eclipse/edc/connector/api/ControlPlaneApiExtension.java
+++ b/core/control-plane/control-plane-api/src/main/java/org/eclipse/edc/connector/api/ControlPlaneApiExtension.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.connector.api;
 
 import org.eclipse.edc.connector.api.transferprocess.TransferProcessControlApiController;
 import org.eclipse.edc.connector.api.transferprocess.model.TransferProcessFailStateDto;
-import org.eclipse.edc.connector.transfer.spi.TransferProcessManager;
+import org.eclipse.edc.connector.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.connector.transfer.spi.callback.ControlPlaneApiUrl;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -52,14 +52,15 @@ public class ControlPlaneApiExtension implements ServiceExtension {
     private WebServer webServer;
     @Inject
     private WebService webService;
-    @Inject
-    private TransferProcessManager transferProcessManager;
+
     @Inject
     private Hostname hostname;
 
     @Inject
     private WebServiceConfigurer configurator;
 
+    @Inject
+    private TransferProcessService transferProcessService;
 
     private WebServiceConfiguration configuration;
 
@@ -81,7 +82,7 @@ public class ControlPlaneApiExtension implements ServiceExtension {
         configuration = configurator.configure(context, webServer, settings);
         context.getTypeManager().registerTypes(TransferProcessFailStateDto.class);
 
-        webService.registerResource(configuration.getContextAlias(), new TransferProcessControlApiController(transferProcessManager));
+        webService.registerResource(configuration.getContextAlias(), new TransferProcessControlApiController(transferProcessService));
     }
 
 

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiController.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiController.java
@@ -47,7 +47,7 @@ import java.util.stream.Stream;
 import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
-import static org.eclipse.edc.api.ServiceResultHandler.mapToException;
+import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.mapToException;
 
 @Consumes({ MediaType.APPLICATION_JSON })
 @Produces({ MediaType.APPLICATION_JSON })

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApiController.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApiController.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
-import static org.eclipse.edc.api.ServiceResultHandler.mapToException;
+import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.mapToException;
 
 @Produces({ MediaType.APPLICATION_JSON })
 @Path("/contractagreements")

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApiController.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApiController.java
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
-import static org.eclipse.edc.api.ServiceResultHandler.mapToException;
+import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.mapToException;
 
 @Produces({ MediaType.APPLICATION_JSON })
 @Path("/contractdefinitions")

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiController.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiController.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
-import static org.eclipse.edc.api.ServiceResultHandler.mapToException;
+import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.mapToException;
 
 @Consumes({ MediaType.APPLICATION_JSON })
 @Produces({ MediaType.APPLICATION_JSON })

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiController.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiController.java
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
-import static org.eclipse.edc.api.ServiceResultHandler.mapToException;
+import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.mapToException;
 
 @Produces({ MediaType.APPLICATION_JSON })
 @Consumes({ MediaType.APPLICATION_JSON })

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApiController.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApiController.java
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
-import static org.eclipse.edc.api.ServiceResultHandler.mapToException;
+import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.mapToException;
 
 @Produces({ MediaType.APPLICATION_JSON })
 @Consumes({ MediaType.APPLICATION_JSON })

--- a/spi/common/web-spi/build.gradle.kts
+++ b/spi/common/web-spi/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
 publishing {
     dependencies {
         api(project(":spi:common:core-spi"))
+        api(project(":spi:common:aggregate-service-spi"))
     }
 
     publications {

--- a/spi/common/web-spi/src/main/java/org/eclipse/edc/web/spi/exception/ServiceResultHandler.java
+++ b/spi/common/web-spi/src/main/java/org/eclipse/edc/web/spi/exception/ServiceResultHandler.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Microsoft Corporation
+ *  Copyright (c) 2020-2022 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,14 +12,11 @@
  *
  */
 
-package org.eclipse.edc.api;
+package org.eclipse.edc.web.spi.exception;
 
 import org.eclipse.edc.service.spi.result.ServiceFailure;
 import org.eclipse.edc.service.spi.result.ServiceResult;
 import org.eclipse.edc.spi.EdcException;
-import org.eclipse.edc.web.spi.exception.InvalidRequestException;
-import org.eclipse.edc.web.spi.exception.ObjectExistsException;
-import org.eclipse.edc.web.spi.exception.ObjectNotFoundException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/transferprocess/TransferProcessService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/transferprocess/TransferProcessService.java
@@ -64,6 +64,30 @@ public interface TransferProcessService {
     @NotNull
     ServiceResult<TransferProcess> cancel(String transferProcessId);
 
+
+    /**
+     * Asynchronously requests completion of the transfer process.
+     * <p>
+     * The return result status only reflects the successful submission of the command.
+     *
+     * @param transferProcessId id of the transferProcess
+     * @return a result that is successful if the transfer process was found and is in a state that can be completed
+     */
+    @NotNull
+    ServiceResult<TransferProcess> complete(String transferProcessId);
+
+    /**
+     * Asynchronously requests failure of the transfer process.
+     * <p>
+     * The return result status only reflects the successful submission of the command.
+     *
+     * @param transferProcessId id of the transferProcess
+     * @param errorDetail the reason of the failure
+     * @return a result that is successful if the transfer process was found and is in a state that can be failed
+     */
+    @NotNull
+    ServiceResult<TransferProcess> fail(String transferProcessId, String errorDetail);
+
     /**
      * Asynchronously requests deprovisioning of the transfer process.
      * <p>


### PR DESCRIPTION
## What this PR changes/adds

Adds usage of `TranferProcessService` in `TransferProcessControlApiController` instead of interacting directly
with the `TransferProcessManager`

## Why it does that

Make the interaction with transfer processes more consistent.

## Further notes

In order to reuse some exception mapping the `ServiceResultHandler` has been moved from `api-core` to `web-spi`

## Linked Issue(s)

Closes #2175 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
