### PR TITLE
feat(samples): adds consumer status checker on file for sample 4

### DIFF
--- a/samples/04.0-file-transfer/README.md
+++ b/samples/04.0-file-transfer/README.md
@@ -20,6 +20,7 @@ Also, in order to keep things organized, the code in this example has been separ
 
 * `[consumer|provider]`: contains the configuration and build files for both the consumer and the provider connector
 * `transfer-file`: contains all the code necessary for the file transfer, integrated on provider side
+* `status-checker`: contains the code for checking if the file has been transfer, integrated on the consumer side
 
 ## Create the file transfer extension
 
@@ -93,6 +94,15 @@ as well as respective factories for both. The factories are registered with the 
 [FileTransferExtension](transfer-file/src/main/java/org/eclipse/edc/sample/extension/api/FileTransferExtension.java),
 thus making them available when a data request is processed.
 
+## Create the status checker extension
+
+The consumer needs to know when the file transfer has been completed. For doing that, in the extension
+we are going to implement a custom `StatusChecker` that will be registered with the `StatusCheckerRegistry` in the
+[SampleStatusCheckerExtension](status-checker/src/main/java/org/eclipse/edc/sample/extension/checker/SampleStatusCheckerExtension.java)
+The custom status checker will handle the check for the destination type `File` and it will check that the path
+specified in the data requests exists. The code is available in the
+class [SampleFileStatusChecker](status-checker/src/main/java/org/eclipse/edc/sample/extension/checker/SampleFileStatusChecker.java)
+
 ## Create the connectors
 
 After creating the required extensions, we next need to create the two connectors. For both of them we need a gradle
@@ -141,6 +151,13 @@ endpoints from the EDC's data management API in this sample and integrated the e
 authentication. Therefore, we add the property `edc.api.auth.key` and set it to e.g. `password`. And last, we also need
 to configure the consumer's webhook address. We expose the IDS API endpoints on a different port and path than other
 endpoints, so the property `ids.webhook.address` is adjusted to match the IDS API port.
+
+The consumer connector also needs the `status-checker` extension for marking the transfer as completed on the consumer
+side.
+
+```kotlin
+implementation(project(":samples:04.0-file-transfer:status-checker"))
+```
 
 ## Run the sample
 

--- a/samples/04.0-file-transfer/consumer/build.gradle.kts
+++ b/samples/04.0-file-transfer/consumer/build.gradle.kts
@@ -35,6 +35,9 @@ dependencies {
     implementation(project(":extensions:control-plane:api:data-management-api"))
 
     implementation(project(":data-protocols:ids"))
+
+    implementation(project(":samples:04.0-file-transfer:status-checker"))
+
 }
 
 application {

--- a/samples/04.0-file-transfer/integration-tests/src/test/java/org/eclipse/edc/sample/extension/FileTransferSampleTest.java
+++ b/samples/04.0-file-transfer/integration-tests/src/test/java/org/eclipse/edc/sample/extension/FileTransferSampleTest.java
@@ -64,8 +64,10 @@ public class FileTransferSampleTest {
 
         testUtils.initiateContractNegotiation();
         testUtils.lookUpContractAgreementId();
-        testUtils.requestTransferFile();
+        var transferProcessId = testUtils.requestTransferFile();
         testUtils.assertDestinationFileContent();
+
+        testUtils.assertTransferProcessStatusConsumerSide(transferProcessId);
     }
 
     @AfterEach

--- a/samples/04.0-file-transfer/integration-tests/src/testFixtures/java/org/eclipse/edc/sample/extension/FileTransferSampleTestCommon.java
+++ b/samples/04.0-file-transfer/integration-tests/src/testFixtures/java/org/eclipse/edc/sample/extension/FileTransferSampleTestCommon.java
@@ -21,6 +21,7 @@ import io.restassured.path.json.JsonPath;
 import org.apache.http.HttpStatus;
 import org.eclipse.edc.connector.api.datamanagement.transferprocess.model.TransferProcessDto;
 import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.junit.testfixtures.TestUtils;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.jetbrains.annotations.NotNull;
@@ -72,10 +73,18 @@ public class FileTransferSampleTestCommon {
      */
     public FileTransferSampleTestCommon(@NotNull String sampleAssetFilePath, @NotNull String destinationFilePath) {
         this.sampleAssetFilePath = sampleAssetFilePath;
-        this.sampleAssetFile  = getFileFromRelativePath(sampleAssetFilePath);
+        sampleAssetFile = getFileFromRelativePath(sampleAssetFilePath);
 
         this.destinationFilePath = sampleAssetFilePath;
-        this.destinationFile  = getFileFromRelativePath(destinationFilePath);
+        destinationFile = getFileFromRelativePath(destinationFilePath);
+    }
+
+    /**
+     * Resolves a {@link File} instance from a relative path.
+     */
+    @NotNull
+    public static File getFileFromRelativePath(String relativePath) {
+        return new File(TestUtils.findBuildRoot(), relativePath);
     }
 
     /**
@@ -90,17 +99,8 @@ public class FileTransferSampleTestCommon {
      * Remove files created while running the tests.
      * The copied file will be deleted.
      */
-    @SuppressWarnings("ResultOfMethodCallIgnored")
     void cleanTemporaryTestFiles() {
         destinationFile.delete();
-    }
-
-    /**
-     * Resolves a {@link File} instance from a relative path.
-     */
-    @NotNull
-    public static File getFileFromRelativePath(String relativePath) {
-        return new File(TestUtils.findBuildRoot(), relativePath);
     }
 
     /**
@@ -113,18 +113,30 @@ public class FileTransferSampleTestCommon {
     }
 
     /**
+     * Assert that the transfer process state on the consumer is completed.
+     */
+    void assertTransferProcessStatusConsumerSide(String transferProcessId) {
+        await().atMost(timeout).pollInterval(pollInterval).untilAsserted(()
+                -> {
+            var transferProcess = getTransferProcessById(transferProcessId);
+
+            assertThat(transferProcess).extracting(TransferProcessDto::getState).isEqualTo(TransferProcessStates.COMPLETED.toString());
+        });
+    }
+
+    /**
      * Assert that a POST request to initiate a contract negotiation is successful.
      * This method corresponds to the command in the sample: {@code curl -X POST -H "Content-Type: application/json" -H "X-Api-Key: password" -d @samples/04.0-file-transfer/contractoffer.json "http://localhost:9192/api/v1/data/contractnegotiations"}
      */
     void initiateContractNegotiation() {
         contractNegotiationId = RestAssured
-            .given()
+                .given()
                 .headers(API_KEY_HEADER_KEY, API_KEY_HEADER_VALUE)
                 .contentType(ContentType.JSON)
                 .body(new File(TestUtils.findBuildRoot(), CONTRACT_OFFER_FILE_PATH))
-            .when()
+                .when()
                 .post(INITIATE_CONTRACT_NEGOTIATION_URI)
-            .then()
+                .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body("id", not(emptyString()))
                 .extract()
@@ -140,11 +152,26 @@ public class FileTransferSampleTestCommon {
     public TransferProcessDto getTransferProcess() {
         return RestAssured.given()
                 .headers(API_KEY_HEADER_KEY, API_KEY_HEADER_VALUE)
-            .when()
+                .when()
                 .get(TRANSFER_PROCESS_URI)
-            .then()
+                .then()
                 .statusCode(HttpStatus.SC_OK)
                 .extract().jsonPath().getObject("[0]", TransferProcessDto.class);
+    }
+
+    /**
+     * Gets the transfer process by ID.
+     *
+     * @return The transfer process.
+     */
+    public TransferProcessDto getTransferProcessById(String processId) {
+        return RestAssured.given()
+                .headers(API_KEY_HEADER_KEY, API_KEY_HEADER_VALUE)
+                .when()
+                .get(String.format("%s/%s", TRANSFER_PROCESS_URI, processId))
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .extract().body().as(TransferProcessDto.class);
     }
 
     /**
@@ -153,18 +180,16 @@ public class FileTransferSampleTestCommon {
      */
     void lookUpContractAgreementId() {
         // Wait for transfer to be completed.
-        await().atMost(timeout).pollInterval(pollInterval)
-                .untilAsserted(() ->
-                contractAgreementId = RestAssured
-                    .given()
-                        .headers(API_KEY_HEADER_KEY, API_KEY_HEADER_VALUE)
-                    .when()
-                        .get(LOOK_UP_CONTRACT_AGREEMENT_URI, contractNegotiationId)
-                    .then()
-                        .statusCode(HttpStatus.SC_OK)
-                        .body("state", equalTo("CONFIRMED"))
-                        .body("contractAgreementId", not(emptyString()))
-                        .extract().body().jsonPath().getString("contractAgreementId")
+        await().atMost(timeout).pollInterval(pollInterval).untilAsserted(() -> contractAgreementId = RestAssured
+                .given()
+                .headers(API_KEY_HEADER_KEY, API_KEY_HEADER_VALUE)
+                .when()
+                .get(LOOK_UP_CONTRACT_AGREEMENT_URI, contractNegotiationId)
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body("state", equalTo("CONFIRMED"))
+                .body("contractAgreementId", not(emptyString()))
+                .extract().body().jsonPath().getString("contractAgreementId")
         );
     }
 
@@ -174,26 +199,28 @@ public class FileTransferSampleTestCommon {
      *
      * @throws IOException Thrown if there was an error accessing the transfer request file defined in {@link FileTransferSampleTestCommon#TRANSFER_FILE_PATH}.
      */
-    void requestTransferFile() throws IOException {
+    String requestTransferFile() throws IOException {
         var transferJsonFile = getFileFromRelativePath(TRANSFER_FILE_PATH);
         DataRequest sampleDataRequest = readAndUpdateDataRequestFromJsonFile(transferJsonFile, contractAgreementId);
 
         JsonPath jsonPath = RestAssured
                 .given()
-                    .headers(API_KEY_HEADER_KEY, API_KEY_HEADER_VALUE)
-                    .contentType(ContentType.JSON)
-                    .body(sampleDataRequest)
+                .headers(API_KEY_HEADER_KEY, API_KEY_HEADER_VALUE)
+                .contentType(ContentType.JSON)
+                .body(sampleDataRequest)
                 .when()
-                    .post(TRANSFER_PROCESS_URI)
+                .post(TRANSFER_PROCESS_URI)
                 .then()
-                    .statusCode(HttpStatus.SC_OK)
-                    .body("id", not(emptyString()))
-                    .extract()
-                    .jsonPath();
+                .statusCode(HttpStatus.SC_OK)
+                .body("id", not(emptyString()))
+                .extract()
+                .jsonPath();
 
         String transferProcessId = jsonPath.get("id");
 
         assertThat(transferProcessId).isNotEmpty();
+
+        return transferProcessId;
     }
 
     /**

--- a/samples/04.0-file-transfer/status-checker/build.gradle.kts
+++ b/samples/04.0-file-transfer/status-checker/build.gradle.kts
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2020-2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+
+
+dependencies {
+    api(project(":spi:control-plane:control-plane-spi"))
+}

--- a/samples/04.0-file-transfer/status-checker/src/main/java/org/eclipse/edc/sample/extension/checker/SampleFileStatusChecker.java
+++ b/samples/04.0-file-transfer/status-checker/src/main/java/org/eclipse/edc/sample/extension/checker/SampleFileStatusChecker.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2020-2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.sample.extension.checker;
+
+import org.eclipse.edc.connector.transfer.spi.types.ProvisionedResource;
+import org.eclipse.edc.connector.transfer.spi.types.StatusChecker;
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Optional;
+
+public class SampleFileStatusChecker implements StatusChecker {
+    @Override
+    public boolean isComplete(TransferProcess transferProcess, List<ProvisionedResource> resources) {
+        var destination = transferProcess.getDataRequest().getDataDestination();
+        var path = destination.getProperty("path");
+        return Optional.ofNullable(path)
+                .map(this::checkPath)
+                .orElse(false);
+    }
+
+    private boolean checkPath(String path) {
+        return Files.exists(Paths.get(path));
+    }
+}

--- a/samples/04.0-file-transfer/status-checker/src/main/java/org/eclipse/edc/sample/extension/checker/SampleStatusCheckerExtension.java
+++ b/samples/04.0-file-transfer/status-checker/src/main/java/org/eclipse/edc/sample/extension/checker/SampleStatusCheckerExtension.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2020-2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.sample.extension.checker;
+
+import org.eclipse.edc.connector.transfer.spi.status.StatusCheckerRegistry;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+
+@Extension(value = SampleStatusCheckerExtension.NAME)
+public class SampleStatusCheckerExtension implements ServiceExtension {
+
+    public static final String NAME = "Sample status checker";
+
+    @Inject
+    private StatusCheckerRegistry checkerRegistry;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        checkerRegistry.register("File", new SampleFileStatusChecker());
+    }
+}

--- a/samples/04.0-file-transfer/status-checker/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/samples/04.0-file-transfer/status-checker/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2020-2022 Microsoft Corporation
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Microsoft Corporation - initial API and implementation
+#
+#
+
+org.eclipse.edc.sample.extension.checker.SampleStatusCheckerExtension

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -165,6 +165,8 @@ include(":samples:04.0-file-transfer:consumer")
 include(":samples:04.0-file-transfer:provider")
 include(":samples:04.0-file-transfer:integration-tests")
 include(":samples:04.0-file-transfer:transfer-file")
+include(":samples:04.0-file-transfer:status-checker")
+
 
 include(":samples:04.1-file-transfer-listener:consumer")
 include(":samples:04.1-file-transfer-listener:file-transfer-listener-integration-tests")


### PR DESCRIPTION
## What this PR changes/adds

Adds a status checker for the file transfer consumer side

## Why it does that

Consistent lifecycle of the file transfer on the consumer side.

## Linked Issue(s)

Closes #1337 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
