### PR TITLE
build: Remove issue type paragraph

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -19,6 +19,3 @@ _Are there any requirements?_
 
 ## Solution Proposal
 _If possible, provide a (brief!) solution proposal._
-
-## Type of Issue
-_i.e., new feature, improvement, cleanup, etc._


### PR DESCRIPTION
## What this PR changes/adds

Remove "Type of issue" paragraph from `feature_request.md`

## Why it does that

cleanup

## Further notes

-

## Linked Issue(s)

Closes #2196

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
