### PR TITLE
fix: avoid a security token in the response if the request is not valid

### DIFF
--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/message/MultipartResponse.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/message/MultipartResponse.java
@@ -14,11 +14,13 @@
 
 package org.eclipse.edc.protocol.ids.api.multipart.message;
 
+import de.fraunhofer.iais.eis.DynamicAttributeToken;
 import de.fraunhofer.iais.eis.Message;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
+import java.util.function.Function;
 
 /**
  * Represents an IDS multipart response. Contains the IDS message header and an optional payload.
@@ -41,6 +43,15 @@ public class MultipartResponse {
     @Nullable
     public Object getPayload() {
         return payload;
+    }
+
+    /**
+     * Sets the security token on the header created by the getToken function from the header itself.
+     *
+     * @param getToken a function that creates the security token giving the header
+     */
+    public void setSecurityToken(Function<Message, DynamicAttributeToken> getToken) {
+        getHeader().setSecurityToken(getToken.apply(getHeader()));
     }
 
     public static class Builder {

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/MultipartControllerIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/MultipartControllerIntegrationTest.java
@@ -122,14 +122,12 @@ public class MultipartControllerIntegrationTest {
 
         extension.registerSystemExtension(ServiceExtension.class, new TestExtension());
         extension.registerServiceMock(ContractOfferResolver.class, contractOfferResolver);
-        extension.registerServiceMock(ProviderContractNegotiationManager.class,
-                providerContractNegotiationManager);
-        extension.registerServiceMock(ConsumerContractNegotiationManager.class,
-                consumerContractNegotiationManager);
+        extension.registerServiceMock(ProviderContractNegotiationManager.class, providerContractNegotiationManager);
+        extension.registerServiceMock(ConsumerContractNegotiationManager.class, consumerContractNegotiationManager);
     }
 
     @Test
-    void testRequestConnectorSelfDescriptionWithoutId(OkHttpClient httpClient) throws Exception {
+    void requestConnectorSelfDescriptionWithoutId(OkHttpClient httpClient) throws Exception {
         var request = createRequest(getDescriptionRequestMessage());
 
         var response = httpClient.newCall(request).execute();
@@ -190,7 +188,7 @@ public class MultipartControllerIntegrationTest {
     }
 
     @Test
-    void testRequestConnectorSelfDescriptionWithId(OkHttpClient httpClient) throws Exception {
+    void requestConnectorSelfDescriptionWithId(OkHttpClient httpClient) throws Exception {
         var request = createRequest(getDescriptionRequestMessage(
                 IdsId.Builder.newInstance().value(CONNECTOR_ID).type(IdsType.CONNECTOR).build()
         ));
@@ -253,7 +251,7 @@ public class MultipartControllerIntegrationTest {
     }
 
     @Test
-    void testRequestDataCatalogWithAssets(OkHttpClient httpClient, AssetIndex assetIndex) throws Exception {
+    void requestDataCatalogWithAssets(OkHttpClient httpClient, AssetIndex assetIndex) throws Exception {
         var assetId = UUID.randomUUID().toString();
         var asset = Asset.Builder.newInstance()
                 .id(assetId)
@@ -338,7 +336,7 @@ public class MultipartControllerIntegrationTest {
     }
 
     @Test
-    void testRequestDataCatalogNoAssets(OkHttpClient httpClient) throws Exception {
+    void requestDataCatalogNoAssets(OkHttpClient httpClient) throws Exception {
         var request = createRequest(getDescriptionRequestMessage(
                 IdsId.Builder.newInstance().value(CATALOG_ID).type(IdsType.CATALOG).build()
         ));
@@ -387,7 +385,7 @@ public class MultipartControllerIntegrationTest {
     }
 
     @Test
-    void testRequestArtifact(OkHttpClient httpClient, AssetIndex assetIndex) throws Exception {
+    void requestArtifact(OkHttpClient httpClient, AssetIndex assetIndex) throws Exception {
         String assetId = UUID.randomUUID().toString();
         Asset asset = Asset.Builder.newInstance()
                 .id(assetId)
@@ -448,7 +446,7 @@ public class MultipartControllerIntegrationTest {
     }
 
     @Test
-    void testRequestRepresentation(OkHttpClient httpClient, AssetIndex assetIndex) throws Exception {
+    void requestRepresentation(OkHttpClient httpClient, AssetIndex assetIndex) throws Exception {
         String assetId = UUID.randomUUID().toString();
         Asset asset = Asset.Builder.newInstance()
                 .id(assetId)
@@ -513,7 +511,7 @@ public class MultipartControllerIntegrationTest {
     }
 
     @Test
-    void testRequestResource(OkHttpClient httpClient, AssetIndex assetIndex) throws Exception {
+    void requestResource(OkHttpClient httpClient, AssetIndex assetIndex) throws Exception {
         String assetId = UUID.randomUUID().toString();
         Asset asset = Asset.Builder.newInstance()
                 .id(assetId)

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/controller/MultipartControllerTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/controller/MultipartControllerTest.java
@@ -1,0 +1,133 @@
+package org.eclipse.edc.protocol.ids.api.multipart.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.fraunhofer.iais.eis.DynamicAttributeTokenBuilder;
+import de.fraunhofer.iais.eis.Message;
+import de.fraunhofer.iais.eis.RejectionMessage;
+import de.fraunhofer.iais.eis.RequestMessageBuilder;
+import de.fraunhofer.iais.eis.ResponseMessageBuilder;
+import de.fraunhofer.iais.eis.TokenFormat;
+import org.eclipse.edc.protocol.ids.api.multipart.handler.Handler;
+import org.eclipse.edc.protocol.ids.api.multipart.message.MultipartResponse;
+import org.eclipse.edc.protocol.ids.spi.service.DynamicAttributeTokenService;
+import org.eclipse.edc.protocol.ids.spi.types.IdsId;
+import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.protocol.ids.serialization.IdsTypeManagerUtil.customizeTypeManager;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MultipartControllerTest {
+
+    private final DynamicAttributeTokenService tokenService = mock(DynamicAttributeTokenService.class);
+    private final Handler handler = mock(Handler.class);
+    private ObjectMapper objectMapper;
+    private MultipartController controller;
+
+    @BeforeEach
+    void setUp() {
+        var typeManager = new TypeManager();
+        customizeTypeManager(typeManager); // TODO: api could be improved?
+        objectMapper = typeManager.getMapper("ids");
+
+        controller = new MultipartController(mock(Monitor.class), mock(IdsId.class), objectMapper, tokenService, List.of(handler), "any");
+    }
+
+    @Test
+    void shouldReturnSecurityToken_whenRequestIsAuthenticated() throws JsonProcessingException {
+        when(tokenService.verifyDynamicAttributeToken(any(), any(), any()))
+                .thenReturn(Result.success(ClaimToken.Builder.newInstance().build()));
+        when(handler.canHandle(any())).thenReturn(true);
+        when(handler.handleRequest(any())).thenReturn(MultipartResponse.Builder.newInstance()
+                .header(new ResponseMessageBuilder().build())
+                .build());
+        var requestHeader = new RequestMessageBuilder(URI.create("id"))
+                ._issuerConnector_(URI.create("issuer:connector"))
+                ._senderAgent_(URI.create("sender:agent"))
+                ._securityToken_(new DynamicAttributeTokenBuilder()._tokenValue_("token").build())
+                ._recipientConnector_(URI.create("recipient:connector"))
+                .build();
+        byte[] bytes = objectMapper.writeValueAsBytes(requestHeader);
+
+        var response = controller.request(new ByteArrayInputStream(bytes), "");
+
+        var header = extractHeader(response);
+        assertThat(header.getSecurityToken()).isNotNull();
+    }
+
+    @Test
+    void shouldReturnSecurityToken_whenMessageTypeIsNotSupported() throws JsonProcessingException {
+        when(tokenService.verifyDynamicAttributeToken(any(), any(), any()))
+                .thenReturn(Result.success(ClaimToken.Builder.newInstance().build()));
+        when(handler.canHandle(any())).thenReturn(false);
+        when(tokenService.obtainDynamicAttributeToken(any())).thenReturn(Result.success(new DynamicAttributeTokenBuilder()
+                ._tokenValue_("token")
+                ._tokenFormat_(TokenFormat.JWT)
+                .build()));
+        var requestHeader = new RequestMessageBuilder(URI.create("id"))
+                ._issuerConnector_(URI.create("issuer:connector"))
+                ._senderAgent_(URI.create("sender:agent"))
+                ._securityToken_(new DynamicAttributeTokenBuilder()._tokenValue_("token").build())
+                ._recipientConnector_(URI.create("recipient:connector"))
+                .build();
+        byte[] bytes = objectMapper.writeValueAsBytes(requestHeader);
+
+        var response = controller.request(new ByteArrayInputStream(bytes), "");
+
+        var header = extractHeader(response);
+        assertThat(header).isInstanceOf(RejectionMessage.class);
+        assertThat(header.getSecurityToken()).isNotNull();
+    }
+
+    @Test
+    void shouldNotReturnSecurityToken_whenRequestBodyIsMalformed() {
+        var response = controller.request(new ByteArrayInputStream("any".getBytes()), "");
+
+        var header = extractHeader(response);
+        assertThat(header).isInstanceOf(RejectionMessage.class);
+        assertThat(header.getSecurityToken()).isNull();
+    }
+
+    @Test
+    void shouldNotReturnSecurityToken_whenRequestIsNotAuthenticated() throws JsonProcessingException {
+        when(tokenService.verifyDynamicAttributeToken(any(), any(), any()))
+                .thenReturn(Result.failure("request not authenticated"));
+        var requestHeader = new RequestMessageBuilder(URI.create("id"))
+                ._issuerConnector_(URI.create("issuer:connector"))
+                ._senderAgent_(URI.create("sender:agent"))
+                ._securityToken_(new DynamicAttributeTokenBuilder()._tokenValue_("token").build())
+                .build();
+        byte[] bytes = objectMapper.writeValueAsBytes(requestHeader);
+
+        var response = controller.request(new ByteArrayInputStream(bytes), "");
+
+        var header = extractHeader(response);
+        assertThat(header).isInstanceOf(RejectionMessage.class);
+        assertThat(header.getSecurityToken()).isNull();
+    }
+
+    private Message extractHeader(FormDataMultiPart multiPart) {
+        var header = multiPart.getField("header");
+        var entity = (byte[]) header.getEntity();
+        try {
+            return objectMapper.readValue(entity, Message.class);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}


### PR DESCRIPTION
## What this PR changes/adds

Returns a security token in an IDS response only if the request is valid and authenticated.

## Why it does that

Avoid to create and give a valid token to a potential attacker that could use it to do authenticated malicious calls.

## Further notes
-

## Linked Issue(s)

Closes #2201

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
