### PR TITLE
feat(DataPlaneStore): adds Cosmos implementation for DataPlaneStore

### DIFF
--- a/extensions/data-plane/store/cosmos/data-plane-store-cosmos/README.md
+++ b/extensions/data-plane/store/cosmos/data-plane-store-cosmos/README.md
@@ -1,0 +1,14 @@
+# CosmosDB implementation of `DataPlaneStore`
+
+This extension provides a persistent implementation of a the `DataPlaneStore` using a CosmosDB container.
+
+The configuration values of this extension are listed below:
+
+| Parameter name                               | Description                                                                                                                                                                                                                                        | Mandatory | Default value      |
+|:---------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------|:-------------------|
+| `edc.cosmos.partition-key`                   | This is the partition key that CosmosDB uses for r/w distribution. Contrary to what CosmosDB suggests, this key should be the same for all local (=clustered) connectors, otherwise queries in stored procedures might produce incomplete results. | false     | dataspaceconnector |
+| `edc.cosmos.query-metrics-enabled`           | Enable metrics for query execution                                                                                                                                                                                                                 | false     | true               |
+| `edc.dataplanestore.cosmos.account-name`     | Account name                                                                                                                                                                                                                                       | true      | null               |
+| `edc.dataplanestore.cosmos.database-name`    | Name of the DB                                                                                                                                                                                                                                     | true      | null               |
+| `edc.dataplanestore.cosmos.preferred-region` | Preferred region for Cosmos client instance                                                                                                                                                                                                        | false     | westeurope         |
+| `edc.dataplanestore.cosmos.container-name`   | Name of container used to store Data Flow Requests                                                                                                                                                                                                 | true      | null               |

--- a/extensions/data-plane/store/cosmos/data-plane-store-cosmos/build.gradle.kts
+++ b/extensions/data-plane/store/cosmos/data-plane-store-cosmos/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    `java-library`
+    `maven-publish`
+}
+
+
+dependencies {
+    api(project(":spi:data-plane:data-plane-spi"))
+    api(project(":extensions:common:azure:azure-cosmos-core"))
+
+    implementation(libs.azure.cosmos)
+    implementation(libs.failsafe.core)
+
+    testImplementation(testFixtures(project(":extensions:common:azure:azure-test")))
+    testImplementation(testFixtures(project(":spi:data-plane:data-plane-spi")))
+
+}
+
+
+
+publishing {
+    publications {
+        create<MavenPublication>("data-plane-store-cosmos") {
+            artifactId = "data-plane-store-cosmos"
+            from(components["java"])
+        }
+    }
+}

--- a/extensions/data-plane/store/cosmos/data-plane-store-cosmos/src/main/java/org/eclipse/edc/connector/dataplane/store/cosmos/CosmosDataPlaneStore.java
+++ b/extensions/data-plane/store/cosmos/data-plane-store-cosmos/src/main/java/org/eclipse/edc/connector/dataplane/store/cosmos/CosmosDataPlaneStore.java
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (c) 2020-2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.store.cosmos;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.failsafe.RetryPolicy;
+import org.eclipse.edc.azure.cosmos.CosmosDbApi;
+import org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore;
+import org.eclipse.edc.connector.dataplane.store.cosmos.model.DataFlowRequestDocument;
+import org.eclipse.edc.spi.EdcException;
+
+import java.time.Clock;
+import java.util.Optional;
+
+import static dev.failsafe.Failsafe.with;
+
+public class CosmosDataPlaneStore implements DataPlaneStore {
+
+    private final CosmosDbApi cosmosDbApi;
+    private final ObjectMapper objectMapper;
+    private final RetryPolicy<Object> retryPolicy;
+    private final String partitionKey;
+
+
+    private final Clock clock;
+
+    public CosmosDataPlaneStore(CosmosDbApi cosmosDbApi, ObjectMapper objectMapper, RetryPolicy<Object> retryPolicy, String partitionKey, Clock clock) {
+        this.cosmosDbApi = cosmosDbApi;
+        this.objectMapper = objectMapper;
+        this.retryPolicy = retryPolicy;
+        this.partitionKey = partitionKey;
+        this.clock = clock;
+    }
+
+    @Override
+    public void received(String processId) {
+        upsert(processId, State.RECEIVED);
+    }
+
+    @Override
+    public void completed(String processId) {
+        upsert(processId, State.COMPLETED);
+    }
+
+    @Override
+    public State getState(String processId) {
+        return Optional.ofNullable(findByIdInternal(processId)).map(DataFlowRequestDocument::getState).orElse(State.NOT_TRACKED);
+    }
+
+    private void upsert(String processId, State state) {
+        var request = findByIdInternal(processId);
+        var ts = clock.millis();
+        if (request == null) {
+            save(new DataFlowRequestDocument(processId, state, ts, ts, partitionKey));
+        } else {
+            save(new DataFlowRequestDocument(request.getId(), state, request.getCreatedAt(), ts, partitionKey));
+        }
+    }
+
+    private void save(DataFlowRequestDocument doc) {
+        with(retryPolicy).run(() -> cosmosDbApi.saveItem(doc));
+    }
+
+    private DataFlowRequestDocument findByIdInternal(String processorId) {
+        var request = with(retryPolicy).get(() -> cosmosDbApi.queryItemById(processorId));
+        return request != null ? convert(request) : null;
+    }
+
+
+    private DataFlowRequestDocument convert(Object object) {
+        String json = null;
+        try {
+            json = objectMapper.writeValueAsString(object);
+            return objectMapper.readValue(json, DataFlowRequestDocument.class);
+
+        } catch (JsonProcessingException e) {
+            throw new EdcException(e);
+        }
+    }
+}

--- a/extensions/data-plane/store/cosmos/data-plane-store-cosmos/src/main/java/org/eclipse/edc/connector/dataplane/store/cosmos/CosmosDataPlaneStoreConfig.java
+++ b/extensions/data-plane/store/cosmos/data-plane-store-cosmos/src/main/java/org/eclipse/edc/connector/dataplane/store/cosmos/CosmosDataPlaneStoreConfig.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.store.cosmos;
+
+import org.eclipse.edc.azure.cosmos.AbstractCosmosConfig;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+
+public class CosmosDataPlaneStoreConfig extends AbstractCosmosConfig {
+
+    @Setting(required = true, value = "CosmosDB account name for DataPlane Store")
+    private static final String COSMOS_ACCOUNTNAME_SETTING = "edc.dataplanestore.cosmos.account-name";
+    @Setting(required = true, value = "CosmosDB database name for DataPlane Store")
+    private static final String COSMOS_DBNAME_SETTING = "edc.dataplanestore.cosmos.database-name";
+    @Setting(value = "CosmosDB preferred region for DataPlane Store")
+    private static final String COSMOS_PREFERRED_REGION_SETTING = "edc.dataplanestore.cosmos.preferred-region";
+    @Setting(value = "CosmosDB container name for DataPlane Store")
+    private static final String COSMOS_CONTAINER_NAME_SETTING = "edc.dataplanestore.cosmos.container-name";
+
+    /**
+     * Create a config object to interact with a Cosmos database.
+     *
+     * @param context Service extension context
+     */
+    protected CosmosDataPlaneStoreConfig(ServiceExtensionContext context) {
+        super(context);
+    }
+
+    @Override
+    protected String getAccountNameSetting() {
+        return COSMOS_ACCOUNTNAME_SETTING;
+    }
+
+    @Override
+    protected String getDbNameSetting() {
+        return COSMOS_DBNAME_SETTING;
+    }
+
+    @Override
+    protected String getCosmosPreferredRegionSetting() {
+        return COSMOS_PREFERRED_REGION_SETTING;
+    }
+
+    @Override
+    protected String getContainerNameSetting() {
+        return COSMOS_CONTAINER_NAME_SETTING;
+    }
+}

--- a/extensions/data-plane/store/cosmos/data-plane-store-cosmos/src/main/java/org/eclipse/edc/connector/dataplane/store/cosmos/CosmosDataPlaneStoreExtension.java
+++ b/extensions/data-plane/store/cosmos/data-plane-store-cosmos/src/main/java/org/eclipse/edc/connector/dataplane/store/cosmos/CosmosDataPlaneStoreExtension.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2020-2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.store.cosmos;
+
+import dev.failsafe.RetryPolicy;
+import org.eclipse.edc.azure.cosmos.CosmosClientProvider;
+import org.eclipse.edc.azure.cosmos.CosmosDbApiImpl;
+import org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore;
+import org.eclipse.edc.connector.dataplane.store.cosmos.model.DataFlowRequestDocument;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.health.HealthCheckService;
+import org.eclipse.edc.spi.types.TypeManager;
+
+import java.time.Clock;
+
+@Extension(value = CosmosDataPlaneStoreExtension.NAME)
+public class CosmosDataPlaneStoreExtension implements ServiceExtension {
+
+    public static final String NAME = "CosmosDB Data Plane Store";
+
+    @Inject
+    private Vault vault;
+    @Inject
+    private CosmosClientProvider clientProvider;
+    @Inject
+    private RetryPolicy<Object> retryPolicy;
+    @Inject
+    private TypeManager typeManager;
+    @Inject
+    private HealthCheckService healthCheckService;
+    @Inject
+    private Clock clock;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        context.getTypeManager().registerTypes(DataFlowRequestDocument.class);
+    }
+
+    @Provider
+    public DataPlaneStore dataPlaneStore(ServiceExtensionContext context) {
+
+        var configuration = new CosmosDataPlaneStoreConfig(context);
+        var client = clientProvider.createClient(vault, configuration);
+        var cosmosDbApi = new CosmosDbApiImpl(configuration, client);
+        var store = new CosmosDataPlaneStore(cosmosDbApi, typeManager.getMapper(), retryPolicy, configuration.getPartitionKey(), clock);
+        healthCheckService.addReadinessProvider(() -> cosmosDbApi.get().forComponent(name()));
+
+        return store;
+    }
+
+}

--- a/extensions/data-plane/store/cosmos/data-plane-store-cosmos/src/main/java/org/eclipse/edc/connector/dataplane/store/cosmos/model/DataFlowRequestDocument.java
+++ b/extensions/data-plane/store/cosmos/data-plane-store-cosmos/src/main/java/org/eclipse/edc/connector/dataplane/store/cosmos/model/DataFlowRequestDocument.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2020-2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.store.cosmos.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.eclipse.edc.azure.cosmos.CosmosDocument;
+import org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+
+@JsonTypeName("dataspaceconnector:dataflowrequestdocument")
+public class DataFlowRequestDocument extends CosmosDocument<Map<String, Object>> {
+
+    private final String id;
+    private final long createdAt;
+    private final long updatedAt;
+
+    private final DataPlaneStore.State state;
+
+    public DataFlowRequestDocument(String processId,
+                                   DataPlaneStore.State state,
+                                   long createdAt,
+                                   long updatedAt,
+                                   String partitionKey) {
+        this(buildProperties(processId, state), partitionKey, createdAt, updatedAt);
+    }
+
+    @JsonCreator
+    public DataFlowRequestDocument(@JsonProperty("wrappedInstance") Map<String, Object> wrappedInstance,
+                                   @JsonProperty("partitionKey") String partitionKey,
+                                   @JsonProperty("createdAt") long createdAt, @JsonProperty("updatedAt") long updatedAt) {
+        super(wrappedInstance, partitionKey);
+        id = wrappedInstance.get("processId").toString();
+        Integer stateCode = (Integer) wrappedInstance.get("state");
+        state = DataPlaneStore.State.from(stateCode);
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    @NotNull
+    private static Map<String, Object> buildProperties(String processId, DataPlaneStore.State state) {
+        return Map.of("processId", processId, "state", state.getCode());
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    public long getCreatedAt() {
+        return createdAt;
+    }
+
+    public long getUpdatedAt() {
+        return updatedAt;
+    }
+
+
+    public DataPlaneStore.State getState() {
+        return state;
+    }
+}

--- a/extensions/data-plane/store/cosmos/data-plane-store-cosmos/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/data-plane/store/cosmos/data-plane-store-cosmos/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,16 @@
+#
+#  Copyright (c) 2020 - 2022 Microsoft Corporation
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Microsoft Corporation - initial API and implementation
+#
+#
+
+org.eclipse.edc.connector.dataplane.store.cosmos.CosmosDataPlaneStoreExtension
+

--- a/extensions/data-plane/store/cosmos/data-plane-store-cosmos/src/test/java/org/eclipse/edc/connector/dataplane/store/cosmos/CosmosDataPlaneStoreIntegrationTest.java
+++ b/extensions/data-plane/store/cosmos/data-plane-store-cosmos/src/test/java/org/eclipse/edc/connector/dataplane/store/cosmos/CosmosDataPlaneStoreIntegrationTest.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (c) 2020-2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.store.cosmos;
+
+import com.azure.cosmos.CosmosContainer;
+import com.azure.cosmos.CosmosDatabase;
+import com.azure.cosmos.models.CosmosContainerResponse;
+import com.azure.cosmos.models.CosmosDatabaseResponse;
+import dev.failsafe.RetryPolicy;
+import org.eclipse.edc.azure.cosmos.CosmosDbApiImpl;
+import org.eclipse.edc.azure.testfixtures.CosmosTestClient;
+import org.eclipse.edc.azure.testfixtures.annotations.AzureCosmosDbIntegrationTest;
+import org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore;
+import org.eclipse.edc.connector.dataplane.spi.testfixtures.store.DataPlaneStoreTestBase;
+import org.eclipse.edc.connector.dataplane.store.cosmos.model.DataFlowRequestDocument;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.time.Clock;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@AzureCosmosDbIntegrationTest
+public class CosmosDataPlaneStoreIntegrationTest extends DataPlaneStoreTestBase {
+
+    private static final String TEST_ID = UUID.randomUUID().toString();
+    private static final String DATABASE_NAME = "connector-itest-" + TEST_ID;
+    private static final String CONTAINER_PREFIX = "DataPlaneStore-";
+    private static final String TEST_PARTITION_KEY = "test-part-key";
+    private static CosmosContainer container;
+    private static CosmosDatabase database;
+    private static TypeManager typeManager;
+
+    private DataPlaneStore store;
+
+    @BeforeAll
+    static void prepareCosmosClient() {
+        var client = CosmosTestClient.createClient();
+        typeManager = new TypeManager();
+        typeManager.registerTypes(DataFlowRequestDocument.class);
+
+        CosmosDatabaseResponse response = client.createDatabaseIfNotExists(DATABASE_NAME);
+        database = client.getDatabase(response.getProperties().getId());
+    }
+
+    @AfterAll
+    static void deleteDatabase() {
+        if (database != null) {
+            CosmosDatabaseResponse delete = database.delete();
+            assertThat(delete.getStatusCode()).isGreaterThanOrEqualTo(200).isLessThan(300);
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        var containerName = CONTAINER_PREFIX + UUID.randomUUID();
+        CosmosContainerResponse containerIfNotExists = database.createContainerIfNotExists(containerName, "/partitionKey");
+        container = database.getContainer(containerIfNotExists.getProperties().getId());
+        assertThat(database).describedAs("CosmosDB database is null - did something go wrong during initialization?").isNotNull();
+
+        var cosmosDbApi = new CosmosDbApiImpl(container, true);
+        var retryPolicy = RetryPolicy.builder().withMaxRetries(3).withBackoff(1, 5, ChronoUnit.SECONDS).build();
+        store = new CosmosDataPlaneStore(cosmosDbApi, typeManager.getMapper(), retryPolicy, TEST_PARTITION_KEY, Clock.systemUTC());
+    }
+
+    @Override
+    protected DataPlaneStore getStore() {
+        return store;
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -161,6 +161,8 @@ include(":extensions:data-plane:data-plane-aws-s3")
 include(":extensions:data-plane:data-plane-google-storage")
 include(":extensions:data-plane:data-plane-integration-tests")
 include(":extensions:data-plane:store:sql:data-plane-store-sql")
+include(":extensions:data-plane:store:cosmos:data-plane-store-cosmos")
+
 
 
 include(":extensions:data-plane-selector:data-plane-selector-api")


### PR DESCRIPTION
## What this PR changes/adds

Adds a Cosmos implementation of `DataPlaneStore`

## Linked Issue(s)

Closes #2091 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
