### PR TITLE
refactor: use TransferProcessService in ArtifactRequestHandler

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.connector.contract.spi.definition.observe.ContractDefinit
 import org.eclipse.edc.connector.contract.spi.negotiation.ConsumerContractNegotiationManager;
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.contract.spi.offer.store.ContractDefinitionStore;
+import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
 import org.eclipse.edc.connector.policy.spi.observe.PolicyDefinitionObservableImpl;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.connector.service.asset.AssetEventListener;
@@ -88,6 +89,9 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
 
     @Inject
     private TransactionContext transactionContext;
+    
+    @Inject
+    private ContractValidationService contractValidationService;
 
     @Override
     public String name() {
@@ -132,6 +136,6 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
 
     @Provider
     public TransferProcessService transferProcessService() {
-        return new TransferProcessServiceImpl(transferProcessStore, transferProcessManager, transactionContext);
+        return new TransferProcessServiceImpl(transferProcessStore, transferProcessManager, transactionContext, contractNegotiationStore, contractValidationService);
     }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessServiceImpl.java
@@ -9,11 +9,14 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - initiate provider process
  *
  */
 
 package org.eclipse.edc.connector.service.transferprocess;
 
+import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
 import org.eclipse.edc.connector.service.query.QueryValidator;
 import org.eclipse.edc.connector.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.connector.transfer.spi.TransferProcessManager;
@@ -28,6 +31,7 @@ import org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.connector.transfer.spi.types.command.CancelTransferCommand;
 import org.eclipse.edc.connector.transfer.spi.types.command.DeprovisionRequest;
 import org.eclipse.edc.service.spi.result.ServiceResult;
+import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.AbstractResult;
 import org.eclipse.edc.transaction.spi.TransactionContext;
@@ -47,11 +51,17 @@ public class TransferProcessServiceImpl implements TransferProcessService {
     private final TransferProcessManager manager;
     private final TransactionContext transactionContext;
     private final QueryValidator queryValidator;
+    private final ContractNegotiationStore negotiationStore;
+    private final ContractValidationService contractValidationService;
 
-    public TransferProcessServiceImpl(TransferProcessStore transferProcessStore, TransferProcessManager manager, TransactionContext transactionContext) {
+    public TransferProcessServiceImpl(TransferProcessStore transferProcessStore, TransferProcessManager manager,
+                                      TransactionContext transactionContext, ContractNegotiationStore negotiationStore,
+                                      ContractValidationService contractValidationService) {
         this.transferProcessStore = transferProcessStore;
         this.manager = manager;
         this.transactionContext = transactionContext;
+        this.negotiationStore = negotiationStore;
+        this.contractValidationService = contractValidationService;
         queryValidator = new QueryValidator(TransferProcess.class, getSubtypes());
     }
 
@@ -99,7 +109,19 @@ public class TransferProcessServiceImpl implements TransferProcessService {
                     .orElse(ServiceResult.conflict("Request couldn't be initialised."));
         });
     }
-
+    
+    @Override
+    public @NotNull ServiceResult<String> initiateTransfer(DataRequest request, ClaimToken claimToken) {
+        return transactionContext.execute(() ->
+                Optional.ofNullable(negotiationStore.findContractAgreement(request.getContractId()))
+                        .filter(agreement -> contractValidationService.validateAgreement(claimToken, agreement))
+                        .map(agreement -> manager.initiateProviderRequest(request))
+                        .filter(AbstractResult::succeeded)
+                        .map(AbstractResult::getContent)
+                        .map(ServiceResult::success)
+                        .orElse(ServiceResult.conflict("Request couldn't be initialised.")));
+    }
+    
     private Map<Class<?>, List<Class<?>>> getSubtypes() {
         return Map.of(
                 ProvisionedResource.class, List.of(ProvisionedDataAddressResource.class),

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessServiceImplTest.java
@@ -9,11 +9,15 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - initiate provider process
  *
  */
 
 package org.eclipse.edc.connector.service.transferprocess;
 
+import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
 import org.eclipse.edc.connector.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.connector.transfer.spi.TransferProcessManager;
 import org.eclipse.edc.connector.transfer.spi.store.TransferProcessStore;
@@ -23,6 +27,8 @@ import org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.connector.transfer.spi.types.command.CancelTransferCommand;
 import org.eclipse.edc.connector.transfer.spi.types.command.DeprovisionRequest;
 import org.eclipse.edc.connector.transfer.spi.types.command.SingleTransferProcessCommand;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
@@ -58,8 +64,10 @@ class TransferProcessServiceImplTest {
     private final TransferProcessStore store = mock(TransferProcessStore.class);
     private final TransferProcessManager manager = mock(TransferProcessManager.class);
     private final TransactionContext transactionContext = spy(new NoopTransactionContext());
+    private final ContractNegotiationStore negotiationStore = mock(ContractNegotiationStore.class);
+    private final ContractValidationService validationService = mock(ContractValidationService.class);
 
-    private final TransferProcessService service = new TransferProcessServiceImpl(store, manager, transactionContext);
+    private final TransferProcessService service = new TransferProcessServiceImpl(store, manager, transactionContext, negotiationStore, validationService);
 
     @Test
     void findById_whenFound() {
@@ -159,7 +167,7 @@ class TransferProcessServiceImplTest {
 
     @Test
     void initiateTransfer() {
-        var dataRequest = DataRequest.Builder.newInstance().destinationType("type").build();
+        var dataRequest = dataRequest();
         String processId = "processId";
         when(manager.initiateConsumerRequest(dataRequest)).thenReturn(StatusResult.success(processId));
 
@@ -168,6 +176,35 @@ class TransferProcessServiceImplTest {
         assertThat(result.succeeded()).isTrue();
         assertThat(result.getContent()).isEqualTo(processId);
         verify(transactionContext).execute(any(TransactionContext.ResultTransactionBlock.class));
+    }
+    
+    @Test
+    void initiateTransfer_validAgreement_shouldInitiateTransfer() {
+        var dataRequest = dataRequest();
+        var claimToken = claimToken();
+        var processId = "processId";
+        when(negotiationStore.findContractAgreement(any())).thenReturn(contractAgreement());
+        when(validationService.validateAgreement(any(), any())).thenReturn(true);
+        when(manager.initiateProviderRequest(any())).thenReturn(StatusResult.success(processId));
+    
+        var result = service.initiateTransfer(dataRequest, claimToken);
+    
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent()).isEqualTo(processId);
+        verify(manager).initiateProviderRequest(dataRequest);
+    }
+    
+    @Test
+    void initiateTransfer_invalidAgreement_shouldNotInitiateTransfer() {
+        var dataRequest = dataRequest();
+        var claimToken = claimToken();
+        when(negotiationStore.findContractAgreement(any())).thenReturn(contractAgreement());
+        when(validationService.validateAgreement(any(), any())).thenReturn(false);
+    
+        var result = service.initiateTransfer(dataRequest, claimToken);
+    
+        assertThat(result.succeeded()).isFalse();
+        verifyNoInteractions(manager);
     }
 
     @ParameterizedTest
@@ -218,6 +255,28 @@ class TransferProcessServiceImplTest {
         return TransferProcess.Builder.newInstance()
                 .state(state.code())
                 .id(id)
+                .build();
+    }
+    
+    private DataRequest dataRequest() {
+        return DataRequest.Builder.newInstance()
+                .destinationType("type")
+                .build();
+    }
+    
+    private ClaimToken claimToken() {
+        return ClaimToken.Builder.newInstance()
+                .claim("key", "value")
+                .build();
+    }
+    
+    private ContractAgreement contractAgreement() {
+        return ContractAgreement.Builder.newInstance()
+                .id("agreementId")
+                .providerAgentId("provider")
+                .consumerAgentId("consumer")
+                .assetId("asset")
+                .policy(Policy.Builder.newInstance().build())
                 .build();
     }
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/IdsMultipartApiServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/IdsMultipartApiServiceExtension.java
@@ -23,7 +23,7 @@ import org.eclipse.edc.connector.contract.spi.negotiation.ProviderContractNegoti
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.contract.spi.offer.ContractOfferResolver;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
-import org.eclipse.edc.connector.transfer.spi.TransferProcessManager;
+import org.eclipse.edc.connector.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.connector.transfer.spi.edr.EndpointDataReferenceReceiverRegistry;
 import org.eclipse.edc.connector.transfer.spi.edr.EndpointDataReferenceTransformerRegistry;
 import org.eclipse.edc.protocol.ids.api.configuration.IdsApiConfiguration;
@@ -93,9 +93,6 @@ public final class IdsMultipartApiServiceExtension implements ServiceExtension {
     private ProviderContractNegotiationManager providerNegotiationManager;
 
     @Inject
-    private TransferProcessManager transferProcessManager;
-
-    @Inject
     private ContractValidationService contractValidationService;
 
     @Inject
@@ -109,6 +106,9 @@ public final class IdsMultipartApiServiceExtension implements ServiceExtension {
 
     @Inject
     private Vault vault;
+    
+    @Inject
+    private TransferProcessService transferProcessService;
 
     @Override
     public String name() {
@@ -128,7 +128,7 @@ public final class IdsMultipartApiServiceExtension implements ServiceExtension {
         // create request handlers
         var handlers = new LinkedList<Handler>();
         handlers.add(new DescriptionRequestHandler(monitor, connectorId, transformerRegistry, assetIndex, dataCatalogService, contractOfferResolver, connectorService, objectMapper));
-        handlers.add(new ArtifactRequestHandler(monitor, connectorId, objectMapper, contractNegotiationStore, contractValidationService, transferProcessManager, vault));
+        handlers.add(new ArtifactRequestHandler(monitor, connectorId, objectMapper, contractNegotiationStore, vault, transferProcessService));
         handlers.add(new EndpointDataReferenceHandler(monitor, connectorId, endpointDataReferenceReceiverRegistry, endpointDataReferenceTransformerRegistry, context.getTypeManager()));
         handlers.add(new ContractRequestHandler(monitor, connectorId, objectMapper, providerNegotiationManager, transformerRegistry, assetIndex));
         handlers.add(new ContractAgreementHandler(monitor, connectorId, objectMapper, consumerNegotiationManager, transformerRegistry));

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/util/ResponseUtilTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/util/ResponseUtilTest.java
@@ -23,6 +23,7 @@ import de.fraunhofer.iais.eis.RequestInProcessMessage;
 import de.fraunhofer.iais.eis.ResponseMessageBuilder;
 import org.eclipse.edc.protocol.ids.spi.domain.IdsConstants;
 import org.eclipse.edc.protocol.ids.spi.types.IdsId;
+import org.eclipse.edc.service.spi.result.ServiceResult;
 import org.eclipse.edc.spi.response.ResponseStatus;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.junit.jupiter.api.BeforeEach;
@@ -97,6 +98,54 @@ class ResponseUtilTest {
         var message = ResponseUtil.descriptionResponse(correlationMessage, connectorId);
 
         assertBasePropertiesMapped(message, null);
+        assertCorrelationMessagePropertiesMapped(message);
+        assertConnectorIdPropertiesMapped(message);
+    }
+    
+    @Test
+    void inProcessFromServiceResult_succeeded() {
+        var result = ServiceResult.success("success");
+        
+        var message = ResponseUtil.inProcessFromServiceResult(result, correlationMessage, connectorId);
+    
+        assertThat(message).isInstanceOf(RequestInProcessMessage.class);
+        assertBasePropertiesMapped(message, null);
+        assertCorrelationMessagePropertiesMapped(message);
+        assertConnectorIdPropertiesMapped(message);
+    }
+    
+    @Test
+    void inProcessFromServiceResult_errorNotFound() {
+        var result = ServiceResult.notFound("not found");
+    
+        var message = ResponseUtil.inProcessFromServiceResult(result, correlationMessage, connectorId);
+    
+        assertThat(message).isInstanceOf(RejectionMessage.class);
+        assertBasePropertiesMapped(message, RejectionReason.NOT_FOUND);
+        assertCorrelationMessagePropertiesMapped(message);
+        assertConnectorIdPropertiesMapped(message);
+    }
+    
+    @Test
+    void inProcessFromServiceResult_errorBadRequest() {
+        var result = ServiceResult.badRequest("bad request");
+    
+        var message = ResponseUtil.inProcessFromServiceResult(result, correlationMessage, connectorId);
+    
+        assertThat(message).isInstanceOf(RejectionMessage.class);
+        assertBasePropertiesMapped(message, RejectionReason.BAD_PARAMETERS);
+        assertCorrelationMessagePropertiesMapped(message);
+        assertConnectorIdPropertiesMapped(message);
+    }
+    
+    @Test
+    void inProcessFromServiceResult_errorConflict() {
+        var result = ServiceResult.conflict("conflict");
+    
+        var message = ResponseUtil.inProcessFromServiceResult(result, correlationMessage, connectorId);
+    
+        assertThat(message).isInstanceOf(RejectionMessage.class);
+        assertBasePropertiesMapped(message, RejectionReason.BAD_PARAMETERS);
         assertCorrelationMessagePropertiesMapped(message);
         assertConnectorIdPropertiesMapped(message);
     }

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/transferprocess/TransferProcessService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/transferprocess/TransferProcessService.java
@@ -9,13 +9,16 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - initiate provider process
  *
  */
+
 package org.eclipse.edc.connector.spi.transferprocess;
 
 import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.service.spi.result.ServiceResult;
+import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -77,11 +80,21 @@ public interface TransferProcessService {
     ServiceResult<TransferProcess> deprovision(String transferProcessId);
 
     /**
-     * Initiate transfer request.
+     * Initiate transfer request for type consumer.
      *
      * @param request for the transfer.
      * @return a result that is successful if the transfer process was initiated with id of created transferProcess.
      */
     @NotNull
     ServiceResult<String> initiateTransfer(DataRequest request);
+    
+    /**
+     * Initiate transfer request for type provider.
+     *
+     * @param request for the transfer.
+     * @param claimToken of the requesting participant.
+     * @return a result that is successful if the transfer process was initiated with id of created transferProcess.
+     */
+    @NotNull
+    ServiceResult<String> initiateTransfer(DataRequest request, ClaimToken claimToken);
 }


### PR DESCRIPTION
## What this PR changes/adds

Calls the `TransferProcessService` instead of the `TransferProcessManager` to initiate a new provider process in the `ArtifactRequestHandler`.

## Why it does that

To handle the interaction with the `TransferProcessManager` in a consistent manner.

## Further notes

Adds an additional method to the `TransferProcessService` for initiating a provider process. Since the agreement referenced for the transfer always needs to be re-evaluated on provider side before the actual transfer is started, this validation was moved from the `ArtifactRequestHandler` to that method.

## Linked Issue(s)

Closes #2180 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
