### PR TITLE
refactor(ServiceResultHandler): changed ServiceResultHandler#mapToException

### DIFF
--- a/core/control-plane/control-plane-api/src/main/java/org/eclipse/edc/connector/api/transferprocess/TransferProcessControlApiController.java
+++ b/core/control-plane/control-plane-api/src/main/java/org/eclipse/edc/connector/api/transferprocess/TransferProcessControlApiController.java
@@ -26,7 +26,7 @@ import org.eclipse.edc.connector.api.transferprocess.model.TransferProcessFailSt
 import org.eclipse.edc.connector.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 
-import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.mapToException;
+import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
 
 
 @Consumes({ MediaType.APPLICATION_JSON })
@@ -47,21 +47,14 @@ public class TransferProcessControlApiController implements TransferProcessContr
     @Path("/{processId}/complete")
     @Override
     public void complete(@PathParam("processId") String processId) {
-        var result = transferProcessService.complete(processId);
-
-        if (result.failed()) {
-            throw mapToException(result, TransferProcess.class, processId);
-        }
+        transferProcessService.complete(processId).orElseThrow(exceptionMapper(TransferProcess.class, processId));
     }
 
     @POST
     @Path("/{processId}/fail")
     @Override
     public void fail(@PathParam("processId") String processId, @NotNull @Valid TransferProcessFailStateDto request) {
-        var result = transferProcessService.fail(processId, request.getErrorMessage());
-
-        if (result.failed()) {
-            throw mapToException(result, TransferProcess.class, processId);
-        }
+        transferProcessService.fail(processId, request.getErrorMessage()).orElseThrow(exceptionMapper(TransferProcess.class, processId));
     }
+
 }

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApiController.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApiController.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
-import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.mapToException;
+import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
 
 @Produces({ MediaType.APPLICATION_JSON })
 @Path("/contractagreements")
@@ -96,14 +96,7 @@ public class ContractAgreementApiController implements ContractAgreementApi {
 
         monitor.debug(format("get all contract agreements from %s", spec));
 
-        var queryResult = service.query(spec);
-
-        //will throw an exception
-        if (queryResult.failed()) {
-            throw mapToException(queryResult, ContractDefinition.class, null);
-        }
-
-        try (var stream = queryResult.getContent()) {
+        try (var stream = service.query(spec).orElseThrow(exceptionMapper(ContractDefinition.class, null))) {
             return stream
                     .map(it -> transformerRegistry.transform(it, ContractAgreementDto.class))
                     .filter(Result::succeeded)

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/AbstractResult.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/AbstractResult.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 /**
  * Base result type used by services to indicate success or failure.
@@ -68,7 +68,7 @@ public abstract class AbstractResult<T, F extends Failure> {
      */
     @JsonIgnore // will cause problems during JSON serialization if failure is null TODO: is this comment still valid?
     public String getFailureDetail() {
-        return failure == null ? null : String.join(", ", getFailureMessages());
+        return failure == null ? null : failure.getFailureDetail();
     }
 
     /**
@@ -98,18 +98,19 @@ public abstract class AbstractResult<T, F extends Failure> {
         return onFailure(failureAction);
     }
 
+
     /**
-     * Throws an exception supplied by the {@link Supplier} if this {@link Result} is not successful.
+     * Throws an exception returned by the mapper {@link Function} if this {@link Result} is not successful.
      *
-     * @param exceptionSupplier provides an instance of the exception to throw
+     * @param exceptionMapper The function that maps a {@link Failure} into an exception.
+     * @return T the success value
      */
-    public <X extends Throwable> AbstractResult<T, F> orElseThrow(Supplier<? extends X> exceptionSupplier) throws X {
+    public <X extends Throwable> T orElseThrow(Function<F, X> exceptionMapper) throws X {
         if (failed()) {
-            throw exceptionSupplier.get();
+            throw exceptionMapper.apply(getFailure());
         } else {
-            return this;
+            return getContent();
         }
     }
-
 
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/Failure.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/Failure.java
@@ -29,4 +29,8 @@ public class Failure {
     public List<String> getMessages() {
         return messages;
     }
+
+    public String getFailureDetail() {
+        return String.join(", ", messages);
+    }
 }

--- a/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/result/ResultTest.java
+++ b/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/result/ResultTest.java
@@ -212,11 +212,10 @@ class ResultTest {
 
     @Test
     void orElseThrow() {
-        assertThat(Result.success("foobar").orElseThrow(RuntimeException::new))
-                .extracting(AbstractResult::getContent)
+        assertThat(Result.success("foobar").orElseThrow(failure -> new RuntimeException()))
                 .isEqualTo("foobar");
 
-        assertThatThrownBy(() -> Result.failure("barbaz").orElseThrow(RuntimeException::new))
+        assertThatThrownBy(() -> Result.failure("barbaz").orElseThrow(failure -> new RuntimeException()))
                 .isInstanceOf(RuntimeException.class);
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Refactor handling the result on all service all from controllers. 

## Why it does that

Reduce duplicated code on result checking and exception mapping

## Further notes

The API `AbstractResult#orElseThrow` has been changed in order to unwrap the underlying content or throw an exception if the result is not ok.

## Linked Issue(s)

Closes #2182 

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
