### PR TITLE
chore: replace deprecated EdcSetting annotation

### DIFF
--- a/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/selector/store/sql/SqlDataPlaneInstanceStoreExtension.java
+++ b/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/selector/store/sql/SqlDataPlaneInstanceStoreExtension.java
@@ -17,11 +17,11 @@ package org.eclipse.edc.connector.dataplane.selector.store.sql;
 import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceStore;
 import org.eclipse.edc.connector.dataplane.selector.store.sql.schema.DataPlaneInstanceStatements;
 import org.eclipse.edc.connector.dataplane.selector.store.sql.schema.postgres.PostgresDataPlaneInstanceStatements;
-import org.eclipse.edc.runtime.metamodel.annotation.EdcSetting;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
@@ -35,7 +35,7 @@ import org.eclipse.edc.transaction.spi.TransactionContext;
 public class SqlDataPlaneInstanceStoreExtension implements ServiceExtension {
     public static final String NAME = "Sql Data Plane Instance Store";
 
-    @EdcSetting(value = "Name of the datasource to use for accessing data plane instances")
+    @Setting(value = "Name of the datasource to use for accessing data plane instances")
     private static final String DATASOURCE_SETTING_NAME = "edc.datasource.dataplaneinstance.name";
     private static final String DEFAULT_DATASOURCE_NAME = "dataplaneinstance";
     @Inject


### PR DESCRIPTION
## What this PR changes/adds

Replaces the last occurence of the deprecated annotation `@EdcSetting` with `@Setting`.

## Why it does that

So that the deprecated annotations can safely be removed.

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
