### PR TITLE
feat(HttpProvisioner): use TransferProcessService in the controller

### DIFF
--- a/extensions/control-plane/provision/provision-http/build.gradle.kts
+++ b/extensions/control-plane/provision/provision-http/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 
 dependencies {
     api(project(":spi:control-plane:transfer-spi"))
+    api(project(":spi:control-plane:control-plane-spi"))
     api(project(":spi:common:web-spi"))
     implementation(project(":extensions:common:api:api-core"))
     implementation(project(":extensions:common:api:management-api-configuration"))

--- a/extensions/control-plane/provision/provision-http/src/main/java/org/eclipse/edc/connector/provision/http/HttpWebhookExtension.java
+++ b/extensions/control-plane/provision/provision-http/src/main/java/org/eclipse/edc/connector/provision/http/HttpWebhookExtension.java
@@ -18,7 +18,7 @@ import org.eclipse.edc.api.auth.spi.AuthenticationRequestFilter;
 import org.eclipse.edc.api.auth.spi.AuthenticationService;
 import org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration;
 import org.eclipse.edc.connector.provision.http.webhook.HttpProvisionerWebhookApiController;
-import org.eclipse.edc.connector.transfer.spi.TransferProcessManager;
+import org.eclipse.edc.connector.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
 import org.eclipse.edc.spi.EdcException;
@@ -66,7 +66,7 @@ public class HttpWebhookExtension implements ServiceExtension {
     private AuthenticationService authService;
 
     @Inject
-    private TransferProcessManager transferProcessManager;
+    private TransferProcessService transferProcessService;
 
     @Inject
     private WebServiceConfigurer configurator;
@@ -93,7 +93,7 @@ public class HttpWebhookExtension implements ServiceExtension {
 
         registerCallbackUrl(context, webServiceConfiguration.getPath(), webServiceConfiguration.getPort());
 
-        webService.registerResource(webServiceConfiguration.getContextAlias(), new HttpProvisionerWebhookApiController(transferProcessManager));
+        webService.registerResource(webServiceConfiguration.getContextAlias(), new HttpProvisionerWebhookApiController(transferProcessService));
         webService.registerResource(webServiceConfiguration.getContextAlias(), new AuthenticationRequestFilter(authService));
 
     }

--- a/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/webhook/HttpWebhookExtensionTest.java
+++ b/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/webhook/HttpWebhookExtensionTest.java
@@ -19,7 +19,7 @@ import org.eclipse.edc.api.auth.spi.AuthenticationService;
 import org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration;
 import org.eclipse.edc.connector.provision.http.HttpProvisionerWebhookUrl;
 import org.eclipse.edc.connector.provision.http.HttpWebhookExtension;
-import org.eclipse.edc.connector.transfer.spi.TransferProcessManager;
+import org.eclipse.edc.connector.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.Hostname;
@@ -69,7 +69,7 @@ class HttpWebhookExtensionTest {
         context.registerService(WebServer.class, webServer);
         context.registerService(WebService.class, webService);
         context.registerService(Hostname.class, () -> "localhost");
-        context.registerService(TransferProcessManager.class, mock(TransferProcessManager.class));
+        context.registerService(TransferProcessService.class, mock(TransferProcessService.class));
         context.registerService(AuthenticationService.class, mock(AuthenticationService.class));
         context.registerService(WebServiceConfigurer.class, webServiceConfigurer);
         context.registerService(ManagementApiConfiguration.class, new ManagementApiConfiguration(webServiceConfiguration));

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/transferprocess/TransferProcessService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/transferprocess/TransferProcessService.java
@@ -16,6 +16,8 @@
 package org.eclipse.edc.connector.spi.transferprocess;
 
 import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
+import org.eclipse.edc.connector.transfer.spi.types.DeprovisionedResource;
+import org.eclipse.edc.connector.transfer.spi.types.ProvisionResponse;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.service.spi.result.ServiceResult;
 import org.eclipse.edc.spi.iam.ClaimToken;
@@ -111,7 +113,7 @@ public interface TransferProcessService {
      */
     @NotNull
     ServiceResult<String> initiateTransfer(DataRequest request);
-    
+
     /**
      * Initiate transfer request for type provider.
      *
@@ -121,4 +123,24 @@ public interface TransferProcessService {
      */
     @NotNull
     ServiceResult<String> initiateTransfer(DataRequest request, ClaimToken claimToken);
+
+
+    /**
+     * Asynchronously informs the system that the {@link DeprovisionedResource} has been provisioned
+     *
+     * @param transferProcessId The transfer process id
+     * @param resource The {@link DeprovisionedResource} to deprovision
+     * @return a result that is successful if the transfer process was found
+     */
+    ServiceResult<TransferProcess> completeDeprovision(String transferProcessId, DeprovisionedResource resource);
+
+    /**
+     * Asynchronously handles a {@link ProvisionResponse} received from an external system
+     *
+     * @param transferProcessId The transfer process id
+     * @param response The {@link ProvisionResponse} to handle
+     * @return a result that is successful if the transfer process was found
+     */
+    ServiceResult<TransferProcess> addProvisionedResource(String transferProcessId, ProvisionResponse response);
+
 }


### PR DESCRIPTION
## What this PR changes/adds

Use the `TransferProcessService` instead of interacting directly with the `TransferProcessManager`

## Why it does that

Encapsulate checks and business logic inside the `TransferProcessService`

## Linked Issue(s)

Closes #2193 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
