### PR TITLE
feat: add discord webhooks for issues, discussions and pull requests

### DIFF
--- a/.github/workflows/discord-webhook.yml
+++ b/.github/workflows/discord-webhook.yml
@@ -1,0 +1,51 @@
+name: 'Discord Webhook'
+on:
+  issues:
+    types: [ opened ]
+  pull_request_target:
+    types: [ opened, reopened ]
+  discussion:
+    types: [ created ]
+
+jobs:
+  message:
+    runs-on: ubuntu-latest
+    steps:
+      - name: New Discussion
+        uses: tsickert/discord-webhook@v5.3.0
+        if: ${{ (github.event_name == 'discussion') }}
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
+          avatar-url: https://avatars.githubusercontent.com/u/9919?s=200&v=4
+          embed-author-name: ${{ github.event.sender.login }}
+          embed-author-url: ${{ github.event.sender.html_url }}
+          embed-author-icon-url: ${{ github.event.sender.avatar_url }}
+          embed-title: ${{ github.event.discussion.title }}
+          embed-url: ${{ github.event.discussion.html_url }}
+          embed-description: A **discussion** has been created in ${{ github.repository }}.
+
+      - name: New Issue
+        uses: tsickert/discord-webhook@v5.3.0
+        if: ${{ (github.event_name == 'issues') }}
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
+          avatar-url: https://avatars.githubusercontent.com/u/9919?s=200&v=4
+          embed-author-name: ${{ github.event.sender.login }}
+          embed-author-url: ${{ github.event.sender.html_url }}
+          embed-author-icon-url: ${{ github.event.sender.avatar_url }}
+          embed-title: ${{ github.event.issue.title }}
+          embed-url: ${{ github.event.issue.html_url }}
+          embed-description: An **issue** has been opened in ${{ github.repository }}.
+
+      - name: New Pull Request
+        uses: tsickert/discord-webhook@v5.3.0
+        if: ${{ (github.event_name == 'pull_request_target') }}
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
+          avatar-url: https://avatars.githubusercontent.com/u/9919?s=200&v=4
+          embed-author-name: ${{ github.event.sender.login }}
+          embed-author-url: ${{ github.event.sender.html_url }}
+          embed-author-icon-url: ${{ github.event.sender.avatar_url }}
+          embed-title: ${{ github.event.pull_request.title }}
+          embed-url: ${{ github.event.pull_request.html_url }}
+          embed-description: A **pull request** has been opened in ${{ github.repository }}.


### PR DESCRIPTION
## What this PR changes/adds

Setup notifications to discord on new issues, PRs and discussions. 

## Why it does that

Improve working on GitHub

## Further notes

The messages include the name of the author, the title of the created item, a link to it, and information about the type and repo.

Example:
![image](https://user-images.githubusercontent.com/72392527/203932689-802cb5b6-98a7-4e83-ab89-17f96addf283.png)


## Linked Issue(s)

Relates to #1687

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
